### PR TITLE
set properties explicitly for ExtendedRegistryTest

### DIFF
--- a/spectator-api/src/test/java/com/netflix/spectator/api/ExtendedRegistryTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/ExtendedRegistryTest.java
@@ -16,6 +16,7 @@
 package com.netflix.spectator.api;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,6 +27,12 @@ import java.util.concurrent.atomic.AtomicLong;
 
 @RunWith(JUnit4.class)
 public class ExtendedRegistryTest {
+
+  @Before
+  public void init() {
+    System.setProperty("spectator.api.propagateWarnings", "true");
+    System.setProperty("spectator.api.maxNumberOfMeters", "10000");
+  }
 
   @Test
   public void testCreateIdArray() {


### PR DESCRIPTION
Currently the test will fail if DefaultRegistryTest happens to run first because the max limit is set to 1. Fixes issue #9.
