### PR TITLE
Reduce the overhead of servo counter increment.

### DIFF
--- a/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoRegistry.java
+++ b/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoRegistry.java
@@ -60,8 +60,8 @@ public class ServoRegistry extends AbstractRegistry implements CompositeMonitor<
 
   @Override protected Counter newCounter(Id id) {
     MonitorConfig cfg = toMonitorConfig(id);
-    StepCounter counter = new StepCounter(cfg);
-    return new ServoCounter(clock(), new ServoId(cfg), counter);
+    BasicCounter counter = new BasicCounter(cfg);
+    return new ServoCounter(clock(), counter);
   }
 
   @Override protected DistributionSummary newDistributionSummary(Id id) {


### PR DESCRIPTION
```
Benchmark                                   Mode   Samples        Score  Score error    Units

Before
c.n.s.p.Counters.cachedIncrement           thrpt        50  6459942.488   114405.812    ops/s
c.n.s.p.Counters.lookupIncrement           thrpt        50  4263431.761   230666.831    ops/s

After
c.n.s.p.Counters.cachedIncrement           thrpt        50 91665534.073  1472861.228    ops/s
c.n.s.p.Counters.lookupIncrement           thrpt        50  8900934.904   149807.211    ops/s
```
