### PR TITLE
metrics-3.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -154,7 +154,7 @@ project(':spectator-reg-metrics2') {
 project(':spectator-reg-metrics3') {
   dependencies {
     compile project(':spectator-api')
-    compile 'com.codahale.metrics:metrics-core:3.0.2'
+    compile 'io.dropwizard.metrics:metrics-core:3.1.0'
     jmh project(':spectator-api')
   }
 }


### PR DESCRIPTION
Unfortunately the org changed, so gradle won't be able to properly dedup if other dependencies pull in a 3.x version. 
