### PR TITLE
Turn off doclint on java 8.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ allprojects {
   apply plugin: 'idea'
   apply plugin: 'me.champeau.gradle.jmh'
 
-  repositories { 
+  repositories {
     mavenLocal()
     mavenCentral()
   }
@@ -41,6 +41,13 @@ subprojects {
 
   tasks.withType(Compile) { 
     options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation" 
+  }
+
+  if (System.getProperty("java.version").startsWith("1.8.")) {
+    tasks.withType(Javadoc) {
+      // http://blog.joda.org/2014/02/turning-off-doclint-in-jdk-8-javadoc.html
+      options.addStringOption('Xdoclint:none', '-quiet')
+    }
   }
 
   javadoc {


### PR DESCRIPTION
For now turn off doclint if running on java 8. There is a
separate ticket (https://github.com/Netflix/spectator/issues/27)
to track fixing the warnings if it is deemed to be worthwhile.
