### PR TITLE
add check for negative values

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/DefaultDistributionSummary.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/DefaultDistributionSummary.java
@@ -49,8 +49,10 @@ final class DefaultDistributionSummary implements DistributionSummary {
   }
 
   @Override public void record(long amount) {
-    totalAmount.addAndGet(amount);
-    count.incrementAndGet();
+    if (amount >= 0) {
+      totalAmount.addAndGet(amount);
+      count.incrementAndGet();
+    }
   }
 
   @Override public Iterable<Measurement> measure() {

--- a/spectator-api/src/main/java/com/netflix/spectator/api/DefaultTimer.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/DefaultTimer.java
@@ -51,9 +51,11 @@ final class DefaultTimer implements Timer {
   }
 
   @Override public void record(long amount, TimeUnit unit) {
-    final long nanos = TimeUnit.NANOSECONDS.convert(amount, unit);
-    totalTime.addAndGet(nanos);
-    count.incrementAndGet();
+    if (amount >= 0) {
+      final long nanos = TimeUnit.NANOSECONDS.convert(amount, unit);
+      totalTime.addAndGet(nanos);
+      count.incrementAndGet();
+    }
   }
 
   @Override public Iterable<Measurement> measure() {

--- a/spectator-api/src/test/java/com/netflix/spectator/api/DefaultDistributionSummaryTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/DefaultDistributionSummaryTest.java
@@ -41,6 +41,22 @@ public class DefaultDistributionSummaryTest {
   }
 
   @Test
+  public void testRecordNegative() {
+    DistributionSummary t = new DefaultDistributionSummary(clock, NoopId.INSTANCE);
+    t.record(-42);
+    Assert.assertEquals(t.count(), 0L);
+    Assert.assertEquals(t.totalAmount(), 0L);
+  }
+
+  @Test
+  public void testRecordZero() {
+    DistributionSummary t = new DefaultDistributionSummary(clock, NoopId.INSTANCE);
+    t.record(0);
+    Assert.assertEquals(t.count(), 1L);
+    Assert.assertEquals(t.totalAmount(), 0L);
+  }
+
+  @Test
   public void testMeasure() {
     DistributionSummary t = new DefaultDistributionSummary(clock, new DefaultId("foo"));
     t.record(42);

--- a/spectator-api/src/test/java/com/netflix/spectator/api/DefaultTimerTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/DefaultTimerTest.java
@@ -44,6 +44,22 @@ public class DefaultTimerTest {
   }
 
   @Test
+  public void testRecordNegative() {
+    Timer t = new DefaultTimer(clock, NoopId.INSTANCE);
+    t.record(-42, TimeUnit.MILLISECONDS);
+    Assert.assertEquals(t.count(), 0L);
+    Assert.assertEquals(t.totalTime(), 0L);
+  }
+
+  @Test
+  public void testRecordZero() {
+    Timer t = new DefaultTimer(clock, NoopId.INSTANCE);
+    t.record(0, TimeUnit.MILLISECONDS);
+    Assert.assertEquals(t.count(), 1L);
+    Assert.assertEquals(t.totalTime(), 0L);
+  }
+
+  @Test
   public void testRecordCallable() throws Exception {
     Timer t = new DefaultTimer(clock, NoopId.INSTANCE);
     clock.setMonotonicTime(100L);

--- a/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoDistributionSummary.java
+++ b/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoDistributionSummary.java
@@ -73,12 +73,14 @@ class ServoDistributionSummary implements DistributionSummary, ServoMeter {
   }
 
   @Override public void record(long amount) {
-    totalAmount.addAndGet(amount);
-    count.incrementAndGet();
-    servoTotal.increment(amount);
-    servoTotalOfSquares.increment(amount * amount);
-    servoCount.increment();
-    servoMax.update(amount);
+    if (amount >= 0) {
+      totalAmount.addAndGet(amount);
+      count.incrementAndGet();
+      servoTotal.increment(amount);
+      servoTotalOfSquares.increment(amount * amount);
+      servoCount.increment();
+      servoMax.update(amount);
+    }
   }
 
   @Override public Iterable<Measurement> measure() {

--- a/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoTimer.java
+++ b/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoTimer.java
@@ -77,13 +77,15 @@ class ServoTimer implements Timer, ServoMeter {
   }
 
   @Override public void record(long amount, TimeUnit unit) {
-    final long nanos = unit.toNanos(amount);
-    totalTime.addAndGet(nanos);
-    count.incrementAndGet();
-    servoTotal.increment(nanos);
-    servoTotalOfSquares.increment(nanos * nanos);
-    servoCount.increment();
-    servoMax.update(nanos);
+    if (amount >= 0) {
+      final long nanos = unit.toNanos(amount);
+      totalTime.addAndGet(nanos);
+      count.incrementAndGet();
+      servoTotal.increment(nanos);
+      servoTotalOfSquares.increment(nanos * nanos);
+      servoCount.increment();
+      servoMax.update(nanos);
+    }
   }
 
   @Override public Iterable<Measurement> measure() {


### PR DESCRIPTION
DistributionSummary and Timer types are only
intended for non-negative values. In particular
stats like MAX init to 0 and will not work
correctly with negative amounts. The javadoc
for record already states that values
less than 0 will be dropped. This change just
makes that true.
