### PR TITLE
Use StepCounter instead of BasicCounter

### DIFF
--- a/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoRegistry.java
+++ b/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoRegistry.java
@@ -60,7 +60,7 @@ public class ServoRegistry extends AbstractRegistry implements CompositeMonitor<
 
   @Override protected Counter newCounter(Id id) {
     MonitorConfig cfg = toMonitorConfig(id);
-    BasicCounter counter = new BasicCounter(cfg);
+    StepCounter counter = new StepCounter(cfg, new ServoClock(clock()));
     return new ServoCounter(clock(), counter);
   }
 


### PR DESCRIPTION
StepCounter has more overhead, but the
normalization and sampling of BasicCounter
can lead to rate variations when aggregating
across many counters. Example of from
counters that should all be the same:

atlas_2014_22_10_15_42_01_951.log.gz

  1.618458   ReciprocalRank
  1.545702   Rank
  1.672844   RankFraction
  1.763815   BinaryDiscountedCumulativeGain

atlas_2014_22_10_15_42_57_012.log.gz

  1.284395   ReciprocalRank
  1.248162   Rank
  1.248178   RankFraction
  1.356733   BinaryDiscountedCumulativeGain

atlas_2014_22_10_15_43_52_066.log.gz

  2.111525   ReciprocalRank
  1.856574   Rank
  1.983977   RankFraction
  2.220634   BinaryDiscountedCumulativeGain

atlas_2014_22_10_15_44_47_197.log.gz

  1.832837   ReciprocalRank
  1.742114   Rank
  1.760254   RankFraction
  1.941755   BinaryDiscountedCumulativeGain

atlas_2014_22_10_15_45_42_452.log.gz

  2.210017   ReciprocalRank
  2.064924   Rank
  2.264092   RankFraction
  2.336758   BinaryDiscountedCumulativeGain
