### PR TITLE
Add helper for double distribution summary.

### DIFF
--- a/spectator-ext-sandbox/src/test/java/com/netflix/spectator/sandbox/DoubleDistributionSummaryTest.java
+++ b/spectator-ext-sandbox/src/test/java/com/netflix/spectator/sandbox/DoubleDistributionSummaryTest.java
@@ -170,4 +170,12 @@ public class DoubleDistributionSummaryTest {
     }
   }
 
+  @Test
+  public void staticGet() {
+    Id id = registry.createId("foo");
+    DoubleDistributionSummary t = DoubleDistributionSummary.get(registry, id);
+    Assert.assertSame(t, DoubleDistributionSummary.get(registry, id));
+    Assert.assertNotNull(registry.get(id));
+  }
+
 }


### PR DESCRIPTION
Simplifies getting a common registered instance
of a DoubleDistributionSummary. Will update some
more in the future to make it step based and
see if we can create a better mechanism in the
registry to support this type of extension.
