### PR TITLE
Update to rx-netty-0.3.16

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -134,10 +134,10 @@ project(':spectator-nflx-plugin') {
     compile 'com.jcraft:jzlib:1.1.3'
     compile 'com.netflix.archaius:archaius-core:0.6.2'
     compile 'com.netflix.eureka:eureka-client:1.1.142'
-    compile 'com.netflix.rxnetty:rx-netty:0.3.15'
-    compile 'com.netflix.rxnetty:rx-netty-contexts:0.3.15'
-    compile 'com.netflix.rxnetty:rx-netty-servo:0.3.15'
-    compile 'io.reactivex:rxjava:1.0.0-rc.8'
+    compile 'com.netflix.rxnetty:rx-netty:0.3.16'
+    compile 'com.netflix.rxnetty:rx-netty-contexts:0.3.16'
+    compile 'com.netflix.rxnetty:rx-netty-servo:0.3.16'
+    compile 'io.reactivex:rxjava:1.0.0-rc.9'
   }
 }
 

--- a/spectator-nflx-plugin/src/test/java/com/netflix/spectator/nflx/RxHttpTest.java
+++ b/spectator-nflx-plugin/src/test/java/com/netflix/spectator/nflx/RxHttpTest.java
@@ -173,7 +173,7 @@ public class RxHttpTest {
     server.createContext("/absoluteRedirect", new HttpHandler() {
       @Override
       public void handle(HttpExchange exchange) throws IOException {
-        String host = "http://" + exchange.getRequestHeaders().getFirst("Host") + ":" + port;
+        String host = "http://" + exchange.getRequestHeaders().getFirst("Host");
         ignore(exchange.getRequestBody());
         if (redirects.get() <= 0) {
           statusCounts.incrementAndGet(302);


### PR DESCRIPTION
This version fixes the host header when
a port other than 80 is used. Corresponding
unit test was upated to reflect that.
