### PR TITLE
set UseIpAddress default to false

### DIFF
--- a/spectator-nflx-plugin/src/main/java/com/netflix/spectator/nflx/RxHttp.java
+++ b/spectator-nflx-plugin/src/main/java/com/netflix/spectator/nflx/RxHttp.java
@@ -733,7 +733,7 @@ public final class RxHttp {
      * default is to use the ip address and avoid the dns lookup.
      */
     boolean useIpAddress() {
-      return Spectator.config().getBoolean(prop("UseIpAddress"), true);
+      return Spectator.config().getBoolean(prop("UseIpAddress"), false);
     }
 
     /**


### PR DESCRIPTION
In some cases such as calls from vpc
to classic the host name needs to
get used so it is the safer choice.
Use IP can be explicitly set on clients
that want to avoid the DNS lookup.
