### PR TITLE
add versions plugin and update dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ allprojects {
   apply plugin: 'jacoco'
   apply plugin: 'idea'
   apply plugin: 'me.champeau.gradle.jmh'
+  apply plugin: 'com.github.ben-manes.versions'
 
   repositories {
     mavenLocal()

--- a/gradle/buildscript.gradle
+++ b/gradle/buildscript.gradle
@@ -8,5 +8,7 @@ dependencies {
   classpath 'com.mapvine:gradle-cobertura-plugin:0.1'
   classpath 'gradle-release:gradle-release:1.1.5'
   classpath 'org.ajoberstar:gradle-git:0.5.0'
-  classpath 'me.champeau.gradle:jmh-gradle-plugin:0.1'
+  classpath 'me.champeau.gradle:jmh-gradle-plugin:0.1.3'
+  classpath 'com.github.ben-manes:gradle-versions-plugin:0.5'
+  classpath 'org.codehaus.groovy:groovy-backports-compat23:2.3.5'
 }


### PR DESCRIPTION
For equalsverifier, staying with 1.4.1 because
upgrading this is causing an
IncompatibleClassChangeError from the tests for
AutoPlugin. I think it is due to asm issues as
equalsverifier uses asm5 directly but depends
on cglib which needs asm4. Not important enough
for me to spend more time investigating right now.

For rxjava staying on rc.8 until rc.9 is working
from the internal repo.
