### PR TITLE
use http urls for maven

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,9 @@ ext.githubProjectName = 'spectator'
 buildscript {
   repositories {
     mavenLocal()
-    mavenCentral()
-    jcenter()
+    // http://stackoverflow.com/questions/26675814/gradle-could-not-head-https-pom-peer-not-authenticated
+    maven { url "http://repo1.maven.org/maven2" }
+    jcenter { url "http://jcenter.bintray.com/" }
   }
   apply from: file('gradle/buildscript.gradle'), to: buildscript 
 }
@@ -19,7 +20,7 @@ allprojects {
 
   repositories {
     mavenLocal()
-    mavenCentral()
+    maven { url "http://repo1.maven.org/maven2" }
   }
 }
 


### PR DESCRIPTION
Upgrading to 2.2.1 causes an error on some
of our build machines:

```
* What went wrong:
Could not resolve all dependencies for configuration ':spectator-api:checkstyle'.
> Could not resolve com.puppycrawl.tools:checkstyle:5.7.
  Required by:
      com.netflix.spectator:spectator-api:0.16-SNAPSHOT
   > Could not GET 'https://repo1.maven.org/maven2/com/puppycrawl/tools/checkstyle/5.7/checkstyle-5.7.pom'.
      > peer not authenticated
```

Seems to be a known issue:

http://stackoverflow.com/questions/26675814/gradle-could-not-head-https-pom-peer-not-authenticated
