### PR TITLE
change log level for gc events to debug

### DIFF
--- a/spectator-ext-gc/src/main/java/com/netflix/spectator/gc/GcLogger.java
+++ b/spectator-ext-gc/src/main/java/com/netflix/spectator/gc/GcLogger.java
@@ -192,8 +192,8 @@ public final class GcLogger {
   private void processGcEvent(GarbageCollectionNotificationInfo info) {
     GcEvent event = new GcEvent(info, jvmStartTime + info.getGcInfo().getStartTime());
     gcLogs.get(info.getGcName()).add(event);
-    if (LOGGER.isInfoEnabled()) {
-      LOGGER.info(event.toString());
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug(event.toString());
     }
 
     // Update pause timer for the action and cause...


### PR DESCRIPTION
The INFO level is a bit noisy for some users when
enabled by default with the SpectatorModule. Users
that want it can explicity whitelist by enabling
debug level for:

```
com.netflix.spectator.gc.GcLogger
```