### PR TITLE
use default logger

### DIFF
--- a/spectator-ext-sandbox/src/main/java/com/netflix/spectator/sandbox/HttpLogEntry.java
+++ b/spectator-ext-sandbox/src/main/java/com/netflix/spectator/sandbox/HttpLogEntry.java
@@ -96,7 +96,11 @@ public class HttpLogEntry {
     log(LOGGER, CLIENT, entry);
   }
 
-  /** Log a client request. */
+  /**
+   * Log a client request.
+   * @deprecated Use {@link #logClientRequest(HttpLogEntry)} instead.
+   */
+  @Deprecated
   public static void logClientRequest(Logger logger, HttpLogEntry entry) {
     log(logger, CLIENT, entry);
   }
@@ -106,7 +110,11 @@ public class HttpLogEntry {
     log(LOGGER, SERVER, entry);
   }
 
-  /** Log a request received by a server. */
+  /**
+   * Log a request received by a server.
+   * @deprecated Use {@link #logServerRequest(HttpLogEntry)} instead.
+   */
+  @Deprecated
   public static void logServerRequest(Logger logger, HttpLogEntry entry) {
     log(logger, SERVER, entry);
   }

--- a/spectator-nflx-plugin/src/main/java/com/netflix/spectator/http/RxHttp.java
+++ b/spectator-nflx-plugin/src/main/java/com/netflix/spectator/http/RxHttp.java
@@ -36,8 +36,6 @@ import iep.io.reactivex.netty.protocol.http.client.HttpClientBuilder;
 import iep.io.reactivex.netty.protocol.http.client.HttpClientPipelineConfigurator;
 import iep.io.reactivex.netty.protocol.http.client.HttpClientRequest;
 import iep.io.reactivex.netty.protocol.http.client.HttpClientResponse;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import iep.rx.Observable;
 import iep.rx.functions.Action0;
 import iep.rx.functions.Action1;
@@ -64,8 +62,6 @@ public final class RxHttp {
 
   private RxHttp() {
   }
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(RxHttp.class);
 
   private static final Pattern NIWS_URI = Pattern.compile("niws://([^/]+).*");
 

--- a/spectator-nflx-plugin/src/main/java/com/netflix/spectator/http/RxHttp.java
+++ b/spectator-nflx-plugin/src/main/java/com/netflix/spectator/http/RxHttp.java
@@ -442,13 +442,13 @@ public final class RxHttp {
         .doOnNext(new Action1<HttpClientResponse<ByteBuf>>() {
           @Override public void call(HttpClientResponse<ByteBuf> res) {
             update(entry, res);
-            HttpLogEntry.logClientRequest(LOGGER, entry);
+            HttpLogEntry.logClientRequest(entry);
           }
         })
         .doOnError(new Action1<Throwable>() {
           @Override public void call(Throwable throwable) {
             update(entry, throwable);
-            HttpLogEntry.logClientRequest(LOGGER, entry);
+            HttpLogEntry.logClientRequest(entry);
           }
         })
         .doOnTerminate(new Action0() {


### PR DESCRIPTION
It is convenient to have a single logger name
for setting up a logging config. The specific
source class can be added as part of the entry
later if there is a sufficient need.