### PR TITLE
bump versions of deps

### DIFF
--- a/spectator-nflx-plugin/build.gradle
+++ b/spectator-nflx-plugin/build.gradle
@@ -4,12 +4,13 @@ dependencies {
   compile project(':spectator-ext-jvm')
   compile project(':spectator-ext-sandbox')
   compile project(':spectator-reg-servo')
+  compile 'com.fasterxml.jackson.core:jackson-databind:2.5.0'
   compile 'com.google.inject:guice:3.0'
   compile 'com.jcraft:jzlib:1.1.3'
-  compile 'com.netflix.archaius:archaius-core:0.6.3'
-  compile 'com.netflix.eureka:eureka-client:1.1.146'
-  compile 'com.netflix.iep-shadow:iep-rxnetty:0.4.4'
-  compile 'com.netflix.iep-shadow:iep-rxnetty-contexts:0.4.4'
-  compile 'com.netflix.iep-shadow:iep-rxjava:1.0.2'
-  testCompile 'com.netflix.governator:governator:1.2.20'
+  compile 'com.netflix.archaius:archaius-core:0.6.5'
+  compile 'com.netflix.eureka:eureka-client:1.1.147'
+  compile 'com.netflix.iep-shadow:iep-rxnetty:0.4.5'
+  compile 'com.netflix.iep-shadow:iep-rxnetty-contexts:0.4.5'
+  compile 'com.netflix.iep-shadow:iep-rxjava:1.0.4'
+  testCompile 'com.netflix.governator:governator:1.3.3'
 }

--- a/spectator-nflx-plugin/src/main/java/com/netflix/spectator/nflx/ChronosGcEventListener.java
+++ b/spectator-nflx-plugin/src/main/java/com/netflix/spectator/nflx/ChronosGcEventListener.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.spectator.nflx;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.config.DynamicBooleanProperty;
 import com.netflix.config.DynamicPropertyFactory;
 import com.netflix.config.DynamicStringProperty;
@@ -27,7 +28,6 @@ import com.netflix.spectator.http.RxHttp;
 import com.sun.management.GcInfo;
 import io.netty.buffer.ByteBuf;
 import iep.io.reactivex.netty.protocol.http.client.HttpClientResponse;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import iep.rx.functions.Action0;


### PR DESCRIPTION
Mainly to get rxnetty 0.4.5. Also found that we
were using jackson, but didn't have an explicit
dependency so archaius moving from jackson 1 to 2
caused a failure. Spectator moved to 2 and the
dependency is now explicit.