### PR TITLE
set the rx client name based on the config name

### DIFF
--- a/spectator-nflx-plugin/src/main/java/com/netflix/spectator/http/RxHttp.java
+++ b/spectator-nflx-plugin/src/main/java/com/netflix/spectator/http/RxHttp.java
@@ -426,6 +426,7 @@ public final class RxHttp {
         RxNetty.<ByteBuf, ByteBuf>newHttpClientBuilder(server.host(), server.port())
             .pipelineConfigurator(pipelineCfg)
             .config(config)
+            .withName(clientCfg.name())
             .channelOption(ChannelOption.CONNECT_TIMEOUT_MILLIS, clientCfg.connectTimeout());
 
     if (server.isSecure()) {


### PR DESCRIPTION
When reporting stats rxnetty is using the name as
the value for the `id` tag. If no name is specified
it is creating a unique id per client.