### PR TITLE
default prop for client

### DIFF
--- a/spectator-nflx-plugin/src/main/java/com/netflix/spectator/http/ClientConfig.java
+++ b/spectator-nflx-plugin/src/main/java/com/netflix/spectator/http/ClientConfig.java
@@ -35,8 +35,27 @@ class ClientConfig {
     this.uri = uri;
   }
 
+  private String dfltProp(String k) {
+    return "niws.client." + k;
+  }
+
   private String prop(String k) {
-    return name + ".niws.client." + k;
+    return name + "." + dfltProp(k);
+  }
+
+  private String getString(String k, String dflt) {
+    String v = Spectator.config().get(prop(k));
+    return (v == null) ? Spectator.config().get(dfltProp(k), dflt) : v;
+  }
+
+  private int getInt(String k, int dflt) {
+    String v = getString(k, null);
+    return (v == null) ? dflt : Integer.parseInt(v);
+  }
+
+  private boolean getBoolean(String k, boolean dflt) {
+    String v = getString(k, null);
+    return (v == null) ? dflt : Boolean.parseBoolean(v);
   }
 
   /** Name of the client. */
@@ -56,28 +75,28 @@ class ClientConfig {
 
   /** Port to use for the connection. */
   int port(int dflt) {
-    return Spectator.config().getInt(prop("Port"), dflt);
+    return getInt("Port", dflt);
   }
 
   /** Maximum time to wait for a connection attempt in milliseconds. */
   int connectTimeout() {
-    return Spectator.config().getInt(prop("ConnectTimeout"), 1000);
+    return getInt("ConnectTimeout", 1000);
   }
 
   /** Maximum time to wait for reading data in milliseconds. */
   int readTimeout() {
-    return Spectator.config().getInt(prop("ReadTimeout"), 30000);
+    return getInt("ReadTimeout", 30000);
   }
 
   /** Maximum number of redirects to follow. Set to 0 to disable. */
   int followRedirects() {
-    return Spectator.config().getInt(prop("FollowRedirects"), 3);
+    return getInt("FollowRedirects", 3);
   }
 
   /** Should HTTPS be used for the request? */
   boolean isSecure() {
     final boolean https = "https".equals(uri.getScheme());
-    return https || Spectator.config().getBoolean(prop("IsSecure"), false);
+    return https || getBoolean("IsSecure", false);
   }
 
   /**
@@ -85,7 +104,7 @@ class ClientConfig {
    * default is to use the ip address and avoid the dns lookup.
    */
   boolean useIpAddress() {
-    return Spectator.config().getBoolean(prop("UseIpAddress"), false);
+    return getBoolean("UseIpAddress", false);
   }
 
   /**
@@ -93,12 +112,12 @@ class ClientConfig {
    * body?
    */
   boolean gzipEnabled() {
-    return Spectator.config().getBoolean(prop("GzipEnabled"), true);
+    return getBoolean("GzipEnabled", true);
   }
 
   /** Max number of retries. */
   int numRetries() {
-    return Spectator.config().getInt(prop("MaxAutoRetriesNextServer"), 2);
+    return getInt("MaxAutoRetriesNextServer", 2);
   }
 
   /**
@@ -106,23 +125,23 @@ class ClientConfig {
    * delay will be doubled between each throttled attempt.
    */
   int retryDelay() {
-    return Spectator.config().getInt(prop("RetryDelay"), 500);
+    return getInt("RetryDelay", 500);
   }
 
   /** Max size of the request body. Defaults to 10MB. */
   int aggregationLimit() {
-    return Spectator.config().getInt(prop("AggregationLimit"), 10 * 1024 * 1024);
+    return getInt("AggregationLimit", 10 * 1024 * 1024);
   }
 
   /** User agent string to use when making the request. */
   String userAgent() {
-    return Spectator.config().get(prop("UserAgent"), "RxHttp");
+    return getString("UserAgent", "RxHttp");
   }
 
   /** VIP used to lookup a set of servers in eureka. */
   String vip() {
     return (vipAddress == null)
-        ? Spectator.config().get(prop("DeploymentContextBasedVipAddresses"))
+        ? getString("DeploymentContextBasedVipAddresses", null)
         : vipAddress;
   }
 }

--- a/spectator-nflx-plugin/src/test/java/com/netflix/spectator/http/ClientConfigTest.java
+++ b/spectator-nflx-plugin/src/test/java/com/netflix/spectator/http/ClientConfigTest.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.http;
+
+import com.netflix.config.ConfigurationManager;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.net.URI;
+
+@RunWith(JUnit4.class)
+public class ClientConfigTest {
+
+  private static void clear(String k) {
+    ConfigurationManager.getConfigInstance().clearProperty(k);
+  }
+
+  private static void set(String k, String v) {
+    ConfigurationManager.getConfigInstance().setProperty(k, v);
+  }
+
+  private ClientConfig cfg;
+
+  @Before
+  public void before() {
+    clear("foo.niws.client.UseIpAddress");
+    clear("niws.client.UseIpAddress");
+    final URI uri = URI.create("/test");
+    cfg = new ClientConfig("foo", "foo:7001", uri, uri);
+  }
+
+  @Test
+  public void useIpAddressNoProp() {
+    Assert.assertEquals(cfg.useIpAddress(), false);
+  }
+
+  @Test
+  public void useIpAddressDefaultProp() {
+    set("niws.client.UseIpAddress", "true");
+    Assert.assertEquals(cfg.useIpAddress(), true);
+  }
+
+  @Test
+  public void useIpAddressNamedProp() {
+    set("foo.niws.client.UseIpAddress", "true");
+    Assert.assertEquals(cfg.useIpAddress(), true);
+  }
+
+  @Test
+  public void useIpAddressNamedOverridesDefaultProp() {
+    set("niws.client.UseIpAddress", "true");
+    set("foo.niws.client.UseIpAddress", "false");
+    Assert.assertEquals(cfg.useIpAddress(), false);
+  }
+}


### PR DESCRIPTION
If the named property isn't set then check for the
default property. Matches behavior of internal rest
client.