### PR TITLE
fix sporadic gaps on gauges reported to servo

### DIFF
--- a/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoGauge.java
+++ b/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoGauge.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.servo;
+
+import com.netflix.servo.monitor.AbstractMonitor;
+import com.netflix.servo.monitor.MonitorConfig;
+import com.netflix.servo.monitor.NumericMonitor;
+
+/**
+ * Reports a constant value passed into the constructor.
+ */
+final class ServoGauge<T extends Number> extends AbstractMonitor<Double>
+    implements NumericMonitor<Double> {
+  private final double value;
+
+  /**
+   * Create a new monitor that returns {@code value}.
+   */
+  ServoGauge(MonitorConfig config, double value) {
+    super(config);
+    this.value = value;
+  }
+
+  @Override public Double getValue(int pollerIndex) {
+    return value;
+  }
+}

--- a/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoRegistry.java
+++ b/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoRegistry.java
@@ -121,7 +121,7 @@ public class ServoRegistry extends AbstractRegistry implements CompositeMonitor<
         }
       } else {
         for (Measurement m : meter.measure()) {
-          monitors.add(new NumberGauge(toMonitorConfig(m.id()), m.value()));
+          monitors.add(new ServoGauge(toMonitorConfig(m.id()), m.value()));
         }
       }
     }


### PR DESCRIPTION
Gauges were getting passed to servo by creating an
instance of NumberGauge when getMonitors is called.
NumberGauge keeps a weak reference to the number so
it will not prevent collection. Since spectator doesn't
hold onto a reference to the number passed to the
gauge it can get collected before the value is actually
read.

This change adds a simple ServoGauge monitor type that
keeps a strong reference to the value to report.