### PR TITLE
rxnetty-0.4.6

### DIFF
--- a/spectator-nflx-plugin/build.gradle
+++ b/spectator-nflx-plugin/build.gradle
@@ -9,8 +9,8 @@ dependencies {
   compile 'com.jcraft:jzlib:1.1.3'
   compile 'com.netflix.archaius:archaius-core:0.6.5'
   compile 'com.netflix.eureka:eureka-client:1.1.147'
-  compile 'com.netflix.iep-shadow:iep-rxnetty:0.4.5'
-  compile 'com.netflix.iep-shadow:iep-rxnetty-contexts:0.4.5'
-  compile 'com.netflix.iep-shadow:iep-rxjava:1.0.4'
+  compile 'com.netflix.iep-shadow:iep-rxnetty:0.4.6'
+  compile 'com.netflix.iep-shadow:iep-rxnetty-contexts:0.4.6'
+  compile 'com.netflix.iep-shadow:iep-rxjava:1.0.6'
   testCompile 'com.netflix.governator:governator:1.3.3'
 }


### PR DESCRIPTION
Fixes bug that can lead to many spurious metrics if
unnamed clients are used.