### PR TITLE
add helper for adding appender to root logger

### DIFF
--- a/spectator-ext-log4j2/src/main/java/com/netflix/spectator/log4j/SpectatorAppender.java
+++ b/spectator-ext-log4j2/src/main/java/com/netflix/spectator/log4j/SpectatorAppender.java
@@ -18,11 +18,18 @@ package com.netflix.spectator.log4j;
 import com.netflix.spectator.api.ExtendedRegistry;
 import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Spectator;
-import com.netflix.spectator.api.Tag;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.ConfigurationListener;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.config.Reconfigurable;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.config.plugins.PluginAttribute;
 import org.apache.logging.log4j.core.config.plugins.PluginElement;
@@ -38,11 +45,48 @@ import java.io.Serializable;
 @Plugin(name = "Spectator", category = "Core", elementType = "appender", printObject = true)
 public final class SpectatorAppender extends AbstractAppender {
 
+  private static void addToRootLogger(final Appender appender) {
+    LoggerContext context = (LoggerContext) LogManager.getContext(false);
+    Configuration config = context.getConfiguration();
+    LoggerConfig loggerConfig = config.getLoggerConfig(LogManager.ROOT_LOGGER_NAME);
+    loggerConfig.addAppender(appender, Level.ALL, null);
+    context.updateLoggers(config);
+  }
+
+  /**
+   * Add the spectator appender to the root logger. This method is intended to be called once
+   * as part of the applications initialization process.
+   *
+   * @param registry
+   *     Spectator registry to use for the appender.
+   * @param name
+   *     Name for the appender.
+   * @param ignoreExceptions
+   *     If set to true then the stack trace metrics are disabled.
+   */
+  public static void addToRootLogger(
+      ExtendedRegistry registry,
+      String name,
+      boolean ignoreExceptions) {
+    final Appender appender = new SpectatorAppender(registry, name, null, null, ignoreExceptions);
+    appender.start();
+
+    LoggerContext context = (LoggerContext) LogManager.getContext(false);
+    Configuration config = context.getConfiguration();
+
+    addToRootLogger(appender);
+    config.addListener(new ConfigurationListener() {
+      @Override public void onChange(Reconfigurable reconfigurable) {
+        addToRootLogger(appender);
+      }
+    });
+  }
+
   private static final long serialVersionUID = 42L;
 
   private final transient ExtendedRegistry registry;
-  private final transient Id numMessages;
-  private final transient Id numStackTraces;
+  private transient Id[] numMessages;
+  private transient Id[] numStackTraces;
 
   /** Create a new instance of the appender. */
   SpectatorAppender(
@@ -53,8 +97,6 @@ public final class SpectatorAppender extends AbstractAppender {
       boolean ignoreExceptions) {
     super(name, filter, layout, ignoreExceptions);
     this.registry = registry;
-    numMessages = registry.createId("log4j.numMessages").withTag("appender", name);
-    numStackTraces = registry.createId("log4j.numStackTraces").withTag("appender", name);
   }
 
   /** Create a new instance of the appender using the global spectator registry. */
@@ -73,13 +115,27 @@ public final class SpectatorAppender extends AbstractAppender {
     return new SpectatorAppender(Spectator.registry(), name, filter, layout, ignoreExceptions);
   }
 
+  @Override public void start() {
+    final LevelTag[] levels = LevelTag.values();
+    numMessages = new Id[levels.length];
+    numStackTraces = new Id[levels.length];
+    for (int i = 0; i < levels.length; ++i) {
+      numMessages[i] = registry.createId("log4j.numMessages")
+          .withTag("appender", getName())
+          .withTag(levels[i]);
+      numStackTraces[i] = registry.createId("log4j.numStackTraces")
+          .withTag("appender", getName())
+          .withTag(levels[i]);
+    }
+    super.start();
+  }
+
   @Override public void append(LogEvent event) {
-    final Tag level = LevelTag.get(event.getLevel());
-    registry.counter(numMessages.withTag(level)).increment();
+    final LevelTag level = LevelTag.get(event.getLevel());
+    registry.counter(numMessages[level.ordinal()]).increment();
     if (!ignoreExceptions() && event.getThrown() != null) {
       final String file = (event.getSource() == null) ? "unknown" : event.getSource().getFileName();
-      Id stackTraceId = numStackTraces
-          .withTag(level)
+      Id stackTraceId = numStackTraces[level.ordinal()]
           .withTag("exception", event.getThrown().getClass().getSimpleName())
           .withTag("file", file);
       registry.counter(stackTraceId).increment();

--- a/spectator-ext-log4j2/src/test/java/com/netflix/spectator/log4j/SpectatorAppenderTest.java
+++ b/spectator-ext-log4j2/src/test/java/com/netflix/spectator/log4j/SpectatorAppenderTest.java
@@ -47,6 +47,7 @@ public class SpectatorAppenderTest {
   public void before() {
     registry = new ExtendedRegistry(new DefaultRegistry());
     appender = new SpectatorAppender(registry, "foo", null, null, false);
+    appender.start();
   }
 
   @Test
@@ -92,6 +93,7 @@ public class SpectatorAppenderTest {
   @Test
   public void ignoreExceptions() {
     appender = new SpectatorAppender(registry, "foo", null, null, true);
+    appender.start();
     Counter c = registry.counter("log4j.numStackTraces",
         "appender", "foo",
         "loglevel", "5_DEBUG",


### PR DESCRIPTION
The spectator appender needs to get a registry and
the registry loading tries to log. This creates a
problem where the slf4j loggers created before log4j2
successfully configures don't work properly and we
lose the logging.

We can delay the registry hook, but this can lead to
recursive calls to the appender or a misleading logger
name if we configure the logging to not send the
spectator messages to the spectator appender.

To work around this there is now a helper that can be
called as part of the application init to add the
SpectatorAppender to the root logger. It will also
listen for configuration change events and re-add the
appender as needed.

```java
SpectatorAppender.addToRootLogger(
  Spectator.registry(),
  "spectator",  // Appender name
  false)        // Ignore exceptions?
```

If more flexibility is needed you can still specify
the appender in the log4j config, but you will be missing
certain log events from spectator.

Also note, that the registry should not return an
implementation of a counter that will log on increment
as this would create a loop.