### PR TITLE
remove symlinks

### DIFF
--- a/spectator-reg-metrics2/src/jmh
+++ b/spectator-reg-metrics2/src/jmh
@@ -1,1 +1,0 @@
-../../spectator-api/src/jmh

--- a/spectator-reg-metrics3/src/jmh
+++ b/spectator-reg-metrics3/src/jmh
@@ -1,1 +1,0 @@
-../../spectator-api/src/jmh

--- a/spectator-reg-servo/src/jmh
+++ b/spectator-reg-servo/src/jmh
@@ -1,1 +1,0 @@
-../../spectator-api/src/jmh


### PR DESCRIPTION
The jgit version used with the cloudbees released job
is marking the workspace as dirty due to the symlinks.
For now just removing them and we'll revisit later.