### PR TITLE
Disable cloudbees pullrequest job creation/existence

### DIFF
--- a/.netflixoss
+++ b/.netflixoss
@@ -1,0 +1,1 @@
+pullrequest_cloudbees=false


### PR DESCRIPTION
This will cause our job DSL to not create and also remove the cloudbees pull request job.