### PR TITLE
fix auto bind plugin

### DIFF
--- a/codequality/pmd.xml
+++ b/codequality/pmd.xml
@@ -64,6 +64,7 @@
     <exclude name="TooManyMethods"/>
     <exclude name="UncommentedEmptyMethod"/>
     <exclude name="UnusedPrivateMethod"/>
+    <exclude name="UnnecessaryConstructor"/>
     <exclude name="UnnecessaryParentheses"/>
     <exclude name="UseConcurrentHashMap"/>
     <exclude name="UseIndexOfChar"/>

--- a/spectator-nflx/src/main/java/com/netflix/spectator/nflx/AutoPlugin.java
+++ b/spectator-nflx/src/main/java/com/netflix/spectator/nflx/AutoPlugin.java
@@ -17,23 +17,13 @@ package com.netflix.spectator.nflx;
 
 import com.netflix.governator.annotations.AutoBindSingleton;
 
-import javax.inject.Inject;
-
 /**
  * Auto bind wrapper around the base plugin.
  */
 @AutoBindSingleton
-public final class AutoPlugin {
-
-  private final Plugin plugin;
-
-  /** Create a new instance for the plugin. */
-  @Inject public AutoPlugin(Plugin plugin) {
-    this.plugin = plugin;
-  }
-
-  /** Returns the plugin instance that was injected. */
-  public Plugin getPlugin() {
-    return plugin;
+public final class AutoPlugin extends SpectatorModule {
+  /** Create a new instance. */
+  public AutoPlugin() {
+    super();
   }
 }

--- a/spectator-nflx/src/test/java/com/netflix/spectator/nflx/AutoPluginTest.java
+++ b/spectator-nflx/src/test/java/com/netflix/spectator/nflx/AutoPluginTest.java
@@ -19,6 +19,7 @@ import com.google.inject.Injector;
 import com.netflix.config.ConfigurationManager;
 import com.netflix.governator.guice.LifecycleInjector;
 import com.netflix.governator.lifecycle.LifecycleManager;
+import org.apache.commons.configuration.AbstractConfiguration;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -30,20 +31,19 @@ public class AutoPluginTest {
 
   @Before
   public void init() {
-    ConfigurationManager.getConfigInstance().setProperty("spectator.nflx.enabled", "false");
+    AbstractConfiguration cfg = ConfigurationManager.getConfigInstance();
+    cfg.setProperty("spectator.nflx.enabled", "false");
   }
 
   @Test
   public void inject() throws Exception {
     Injector injector = LifecycleInjector.builder()
         .usingBasePackages("com.netflix")
-        .withModules(new TestModule())
         .build()
         .createInjector();
     LifecycleManager lcMgr = injector.getInstance(LifecycleManager.class);
     lcMgr.start();
-    AutoPlugin ap = injector.getInstance(AutoPlugin.class);
-    Assert.assertEquals(ap.getPlugin(), injector.getInstance(Plugin.class));
+    Assert.assertNotNull(injector.getInstance(Plugin.class));
     lcMgr.close();
   }
 

--- a/spectator-nflx/src/test/resources/eureka-client.properties
+++ b/spectator-nflx/src/test/resources/eureka-client.properties
@@ -1,0 +1,21 @@
+#
+# Copyright 2015 Netflix, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+eureka.validateInstanceId=false
+eureka.datacenter=default
+eureka.shouldUseDns=false
+eureka.shouldFetchRegistry=false
+eureka.serviceUrl.default=http://localhost/eureka/v2/


### PR DESCRIPTION
Recent changes were causing the auto bind plugin
to fail with exceptions like:

```
2015-02-23 22:29:06,322 INFO  com.netflix.governator.guice.InternalAutoBindModule:187 [localhost-startStop-1] [bindAutoBindSingleton] Installing @AutoBindSingleton com.netflix.cag.client.AlertClientManager
java.lang.RuntimeException: com.google.inject.CreationException: Guice creation errors:

1) No implementation for com.netflix.spectator.http.ServerRegistry was bound.
  while locating com.netflix.spectator.http.ServerRegistry
    for parameter 0 at com.netflix.spectator.http.RxHttp.<init>(RxHttp.java:90)
  while locating com.netflix.spectator.http.RxHttp
    for parameter 0 at com.netflix.spectator.nflx.Plugin.<init>(Plugin.java:50)
  while locating com.netflix.spectator.nflx.Plugin
    for parameter 0 at com.netflix.spectator.nflx.AutoPlugin.<init>(AutoPlugin.java:31)
  at com.netflix.governator.guice.InternalAutoBindModule.getCurrentStackElement(InternalAutoBindModule.java:261)
```

This changes the auto bind to pull in the spectator
module rather than a separate singleton class. Also
removes the TestModule which prevented the test case
from failing with the same exception.