### PR TITLE
registry for reporting t-digests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,8 +77,12 @@ subprojects {
     configFile = rootProject.file('codequality/checkstyle.xml')
     sourceSets = [sourceSets.main]
   }
+  tasks.withType(Checkstyle) {
+    exclude '**/tdunning/**'
+  }
   
   findbugs {
+    excludeFilter = rootProject.file('codequality/findbugs-exclude.xml')
     ignoreFailures = false
     sourceSets = [sourceSets.main]
   }
@@ -95,6 +99,9 @@ subprojects {
     sourceSets = [sourceSets.main]
     ruleSets = []
     ruleSetFiles = rootProject.files("codequality/pmd.xml")
+  }
+  tasks.withType(Pmd) {
+    exclude '**/tdunning/**'
   }
 
   task copyDepsToBuild << {

--- a/codequality/findbugs-exclude.xml
+++ b/codequality/findbugs-exclude.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+  <Match>
+    <Package name="~com\.tdunning\..*"/>
+  </Match>
+</FindBugsFilter>

--- a/codequality/pmd.xml
+++ b/codequality/pmd.xml
@@ -19,9 +19,11 @@
     <exclude name="AvoidFinalLocalVariable"/>
     <exclude name="AvoidInstantiatingObjectsInLoops"/>
     <exclude name="AvoidLiteralsInIfCondition"/>
+    <exclude name="AvoidPrefixingMethodParameters"/>
     <exclude name="AvoidSynchronizedAtMethodLevel"/>
     <exclude name="AvoidThrowingNullPointerException"/>
     <exclude name="AvoidThrowingRawExceptionTypes"/>
+    <exclude name="AvoidUsingShortType"/>
     <exclude name="BeanMembersShouldSerialize"/>
     <exclude name="CommentRequired"/>
     <exclude name="CommentSize"/>
@@ -32,6 +34,7 @@
     <exclude name="DefaultPackage"/>
     <exclude name="DoNotUseThreads"/>
     <exclude name="DuplicateImports"/>
+    <exclude name="EmptyMethodInAbstractClassShouldBeAbstract"/>
     <exclude name="ExcessiveImports"/>
     <exclude name="FieldDeclarationsShouldBeAtStartOfClass"/>
     <exclude name="ForLoopsMustUseBraces"/>

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,4 +7,5 @@ include 'spectator-api',
         'spectator-ext-sandbox',
         'spectator-reg-metrics2',
         'spectator-reg-metrics3',
-        'spectator-reg-servo'
+        'spectator-reg-servo',
+        'spectator-reg-tdigest'

--- a/spectator-api/src/main/java/com/netflix/spectator/api/CompositeRegistry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/CompositeRegistry.java
@@ -35,6 +35,19 @@ final class CompositeRegistry implements Registry {
     this.registries = registries;
   }
 
+  /**
+   * Find the first registry in the composite that is an instance of {@code c}. If no match is
+   * found then null will be returned.
+   */
+  <T extends Registry> T find(Class<T> c) {
+    for (Registry r : registries) {
+      if (c.isAssignableFrom(r.getClass())) {
+        return (T) r;
+      }
+    }
+    return null;
+  }
+
   @Override public Clock clock() {
     return clock;
   }

--- a/spectator-api/src/main/java/com/netflix/spectator/api/DefaultId.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/DefaultId.java
@@ -20,7 +20,7 @@ import com.netflix.spectator.impl.Preconditions;
 import java.util.*;
 
 /** Id implementation for the default registry. */
-final class DefaultId implements Id {
+public final class DefaultId implements Id {
 
   private static final Set<String> EMPTY = new HashSet<>();
 
@@ -28,7 +28,7 @@ final class DefaultId implements Id {
   private final TagList tags;
 
   /** Create a new instance. */
-  DefaultId(String name) {
+  public DefaultId(String name) {
     this(name, TagList.EMPTY);
   }
 

--- a/spectator-api/src/main/java/com/netflix/spectator/api/ExtendedRegistry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/ExtendedRegistry.java
@@ -44,6 +44,19 @@ public final class ExtendedRegistry implements Registry {
     return impl;
   }
 
+  /**
+   * Returns the first underlying registry that is an instance of {@code c}.
+   */
+  public <T extends Registry> T underlying(Class<T> c) {
+    if (c.isAssignableFrom(impl.getClass())) {
+      return (T) impl;
+    } else if (impl instanceof CompositeRegistry) {
+      return ((CompositeRegistry) impl).find(c);
+    } else {
+      return null;
+    }
+  }
+
   @Override public Clock clock() {
     return impl.clock();
   }

--- a/spectator-reg-tdigest/build.gradle
+++ b/spectator-reg-tdigest/build.gradle
@@ -1,0 +1,9 @@
+dependencies {
+  compile project(':spectator-api')
+  compile project(':spectator-nflx-plugin')
+  compile 'com.amazonaws:aws-java-sdk-kinesis:1.9.22'
+  compile 'com.fasterxml.jackson.core:jackson-core:2.5.0'
+  compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.5.0'
+  // Older version
+  //compile 'com.tdunning:t-digest:3.0'
+}

--- a/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/ByteBufferOutputStream.java
+++ b/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/ByteBufferOutputStream.java
@@ -1,0 +1,148 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.tdigest;
+
+import java.io.DataOutput;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+
+/**
+ * Output stream with an underlying ByteBuffer. If the amount of data written exceeds the
+ * capacity of the buffer, then the overflow flag will be set.
+ */
+final class ByteBufferOutputStream extends OutputStream implements DataOutput {
+
+  private final ByteBuffer buf;
+  private final int reserve;
+  private boolean overflow;
+
+  /**
+   * Create a new instance.
+   *
+   * @param buf
+   *     Buffer to write data into.
+   * @param reserve
+   *     Amount of space to reserve when checking the capacity of the buffer. The common use-case
+   *     is for writing records that can be at most size X. The reserve param is used to indicate
+   *     how much space is needed for closing the record, e.g., to add the ']' to terminate a
+   *     a json array.
+   */
+  ByteBufferOutputStream(ByteBuffer buf, int reserve) {
+    super();
+    this.buf = buf;
+    this.reserve = reserve;
+    reset();
+  }
+
+  /** Return the underlying buffer. */
+  ByteBuffer buffer() {
+    return buf;
+  }
+
+  /** Clear the buffer and overflow flag. */
+  void reset() {
+    buf.clear();
+    overflow = false;
+  }
+
+  /** Returns true if the amount of data written exceeds the capacity of the buffer. */
+  boolean overflow() {
+    return overflow;
+  }
+
+  private boolean checkCapacity(int size) {
+    if (buf.remaining() < size + reserve) {
+      overflow = true;
+    }
+    return !overflow;
+  }
+
+  @Override public void writeBoolean(boolean v) throws IOException {
+    if (checkCapacity(1)) {
+      buf.put((byte) (v ? 1 : 0));
+    }
+  }
+
+  @Override public void writeByte(int v) throws IOException {
+    if (checkCapacity(1)) {
+      buf.put((byte) v);
+    }
+  }
+
+  @Override public void writeShort(int v) throws IOException {
+    if (checkCapacity(2)) {
+      buf.putShort((short) v);
+    }
+  }
+
+  @Override public void writeChar(int v) throws IOException {
+    if (checkCapacity(2)) {
+      buf.putChar((char) v);
+    }
+  }
+
+  @Override public void writeInt(int v) throws IOException {
+    if (checkCapacity(4)) {
+      buf.putInt((int) v);
+    }
+  }
+
+  @Override public void writeLong(long v) throws IOException {
+    if (checkCapacity(8)) {
+      buf.putLong((long) v);
+    }
+  }
+
+  @Override public void writeFloat(float v) throws IOException {
+    if (checkCapacity(4)) {
+      buf.putFloat((float) v);
+    }
+  }
+
+  @Override public void writeDouble(double v) throws IOException {
+    if (checkCapacity(8)) {
+      buf.putDouble((double) v);
+    }
+  }
+
+  @Override public void writeBytes(String s) throws IOException {
+    writeUTF(s);
+  }
+
+  @Override public void writeChars(String s) throws IOException {
+    writeUTF(s);
+  }
+
+  @Override public void writeUTF(String s) throws IOException {
+    byte[] data = s.getBytes("UTF-8");
+    if (checkCapacity(4 + data.length)) {
+      buf.putInt(data.length);
+      buf.put(data);
+    }
+  }
+
+  @Override public void write(int b) throws IOException {
+    if (checkCapacity(1)) {
+      buf.put((byte) b);
+    }
+  }
+
+  /** Flip the buffer so it is ready to be consumed. */
+  @Override public void close() throws IOException {
+    buf.flip();
+  }
+}

--- a/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/FileTDigestReader.java
+++ b/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/FileTDigestReader.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.tdigest;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+
+/**
+ * Reader for measurements stored in a file.
+ */
+public class FileTDigestReader extends StreamTDigestReader {
+  /** Create a new instance. */
+  public FileTDigestReader(File f) throws FileNotFoundException {
+    super(new FileInputStream(f));
+  }
+}

--- a/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/FileTDigestWriter.java
+++ b/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/FileTDigestWriter.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.tdigest;
+
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * Write measurements to a file. Each call to write will open the file, append the data, and
+ * close the file. This class is mostly used for testing.
+ */
+public class FileTDigestWriter extends TDigestWriter {
+
+  private final File file;
+  private final byte[] buf = new byte[BUFFER_SIZE];
+
+  /** Create a new instance. */
+  public FileTDigestWriter(File file) {
+    super();
+    this.file = file;
+  }
+
+  @Override void write(ByteBuffer data) throws IOException {
+    try (DataOutputStream out = new DataOutputStream(new FileOutputStream(file, true))) {
+      int len = data.limit();
+      data.get(buf, 0, len);
+      out.writeInt(data.limit());
+      out.write(buf, 0, len);
+    }
+  }
+
+  @Override public void close() throws IOException {
+  }
+}

--- a/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/Json.java
+++ b/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/Json.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.tdigest;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.dataformat.smile.SmileFactory;
+import com.fasterxml.jackson.dataformat.smile.SmileGenerator;
+import com.fasterxml.jackson.dataformat.smile.SmileParser;
+import com.netflix.spectator.api.DefaultId;
+import com.netflix.spectator.api.Tag;
+import com.tdunning.math.stats.AVLTreeDigest;
+import com.tdunning.math.stats.TDigest;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Helper for encoding and decoding digest measurements.
+ */
+final class Json {
+
+  private static final SmileFactory FACTORY = new SmileFactory();
+
+  static {
+    FACTORY
+        .enable(SmileGenerator.Feature.WRITE_HEADER)
+        .disable(SmileGenerator.Feature.WRITE_END_MARKER)
+        .enable(SmileGenerator.Feature.CHECK_SHARED_NAMES)
+        .enable(SmileGenerator.Feature.CHECK_SHARED_STRING_VALUES)
+        .disable(SmileParser.Feature.REQUIRE_HEADER);
+  }
+
+  private Json() {
+  }
+
+  /** Create a new generator for the output stream. */
+  static JsonGenerator newGenerator(OutputStream out) throws IOException {
+    return FACTORY.createGenerator(out);
+  }
+
+  /** Encode the measurement using the generator. */
+  static void encode(TDigestMeasurement m, JsonGenerator gen) throws IOException {
+    TDigest digest = m.value();
+    digest.compress();
+    ByteBuffer buf = ByteBuffer.allocate(digest.byteSize());
+    digest.asBytes(buf);
+
+    gen.writeStartArray();
+    gen.writeStartObject();
+    gen.writeStringField("name", m.id().name());
+    for (Tag t : m.id().tags()) {
+      gen.writeStringField(t.key(), t.value());
+    }
+    gen.writeEndObject();
+    gen.writeNumber(m.timestamp());
+    gen.writeBinary(buf.array());
+    gen.writeEndArray();
+  }
+
+  /** Encode the measurements using the generator. */
+  static void encode(List<TDigestMeasurement> ms, JsonGenerator gen) throws IOException {
+    gen.writeStartArray();
+    for (TDigestMeasurement m : ms) {
+      encode(m, gen);
+    }
+    gen.writeEndArray();
+  }
+
+  /** Return a byte-array with the encoded measurements. */
+  static byte[] encode(List<TDigestMeasurement> ms) throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (JsonGenerator gen = FACTORY.createGenerator(baos)) {
+      encode(ms, gen);
+    }
+    return baos.toByteArray();
+  }
+
+  private static void require(boolean condition, String msg) {
+    if (!condition) {
+      throw new IllegalArgumentException(msg);
+    }
+  }
+
+  private static void expect(JsonParser parser, JsonToken expected) throws IOException {
+    JsonToken t = parser.nextToken();
+    if (t != expected) {
+      String msg = String.format("expected %s, but found %s", expected, t);
+      throw new IllegalArgumentException(msg);
+    }
+  }
+
+  private static TDigestMeasurement decode(JsonParser parser) throws IOException {
+    expect(parser, JsonToken.START_OBJECT);
+    require("name".equals(parser.nextFieldName()), "expected name");
+    DefaultId id = new DefaultId(parser.nextTextValue());
+    while (parser.nextToken() == JsonToken.FIELD_NAME) {
+      id = id.withTag(parser.getText(), parser.nextTextValue());
+    }
+    long t = parser.nextLongValue(-1L);
+    expect(parser, JsonToken.VALUE_EMBEDDED_OBJECT);
+    TDigest v = AVLTreeDigest.fromBytes(ByteBuffer.wrap(parser.getBinaryValue()));
+    expect(parser, JsonToken.END_ARRAY);
+    return new TDigestMeasurement(id, t, v);
+  }
+
+  /** Decode a list of measurements from a byte array. */
+  static List<TDigestMeasurement> decode(byte[] data) throws IOException {
+    return decode(data, 0, data.length);
+  }
+
+  /** Decode a list of measurements from a range of a byte array. */
+  static List<TDigestMeasurement> decode(byte[] data, int offset, int length) throws IOException {
+    JsonParser parser = FACTORY.createParser(data, offset, length);
+    List<TDigestMeasurement> ms = new ArrayList<>();
+    expect(parser, JsonToken.START_ARRAY);
+    while (parser.nextToken() == JsonToken.START_ARRAY) {
+      ms.add(decode(parser));
+    }
+    return ms;
+  }
+}

--- a/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/KinesisTDigestReader.java
+++ b/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/KinesisTDigestReader.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.tdigest;
+
+import com.amazonaws.services.kinesis.AmazonKinesisClient;
+import com.amazonaws.services.kinesis.model.GetRecordsRequest;
+import com.amazonaws.services.kinesis.model.GetRecordsResult;
+import com.amazonaws.services.kinesis.model.GetShardIteratorRequest;
+import com.amazonaws.services.kinesis.model.GetShardIteratorResult;
+import com.amazonaws.services.kinesis.model.Record;
+import com.amazonaws.services.kinesis.model.ShardIteratorType;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Reader to consume data from a single shard of a Kinesis stream. The records should have been
+ * written by {@link com.netflix.spectator.tdigest.KinesisTDigestWriter}.
+ */
+public class KinesisTDigestReader implements TDigestReader {
+
+  private final AmazonKinesisClient client;
+  private final GetShardIteratorRequest iterRequest;
+
+  private GetRecordsRequest recRequest;
+
+  /**
+   * Create a new instance that reads from the beginning of the shard. The iterator type is
+   * set to {@code TRIM_HORIZON}.
+   *
+   * @param client
+   *     Client for interacting with the Kinesis service.
+   * @param stream
+   *     Name of the stream to read from.
+   * @param shard
+   *     Id of the shard to consume.
+   */
+  public KinesisTDigestReader(AmazonKinesisClient client, String stream, String shard) {
+    this(client, new GetShardIteratorRequest()
+        .withStreamName(stream)
+        .withShardId(shard)
+        .withShardIteratorType(ShardIteratorType.TRIM_HORIZON));
+  }
+
+  /**
+   * Create a new instance.
+   *
+   * @param client
+   *     Client for interacting with the Kinesis service.
+   * @param iterRequest
+   *     Request for getting the initial shard iterator.
+   */
+  public KinesisTDigestReader(AmazonKinesisClient client, GetShardIteratorRequest iterRequest) {
+    this.client = client;
+    this.iterRequest = iterRequest;
+    this.recRequest = null;
+  }
+
+  private void init() {
+    if (recRequest == null) {
+      GetShardIteratorResult result = client.getShardIterator(iterRequest);
+      recRequest = new GetRecordsRequest()
+          .withLimit(10)
+          .withShardIterator(result.getShardIterator());
+    }
+  }
+
+  @Override public List<TDigestMeasurement> read() throws IOException {
+    init();
+    if (recRequest.getShardIterator() == null) {
+      return Collections.emptyList();
+    } else {
+      List<TDigestMeasurement> ms = new ArrayList<>();
+      GetRecordsResult result = client.getRecords(recRequest);
+      recRequest.setShardIterator(result.getNextShardIterator());
+      for (Record r : result.getRecords()) {
+        ByteBuffer data = r.getData();
+        ms.addAll(Json.decode(data.array()));
+      }
+      return ms;
+    }
+  }
+
+  @Override public void close() throws IOException {
+  }
+}

--- a/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/KinesisTDigestWriter.java
+++ b/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/KinesisTDigestWriter.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.tdigest;
+
+import com.amazonaws.services.kinesis.AmazonKinesisClient;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Random;
+
+/**
+ * Writer that sends the measurements to a Kinesis stream. The measurements will be grouped
+ * to try and keep the record size close to 50k will have random partition keys.
+ */
+public class KinesisTDigestWriter extends TDigestWriter {
+
+  private final Random random = new Random();
+
+  private final AmazonKinesisClient client;
+  private final String stream;
+
+  /**
+   * Create a new instance.
+   *
+   * @param client
+   *     Client for sending data to Kinesis.
+   * @param stream
+   *     Name of the stream to use for writing.
+   */
+  public KinesisTDigestWriter(AmazonKinesisClient client, String stream) {
+    super();
+    this.client = client;
+    this.stream = stream;
+  }
+
+  private String partitionKey() {
+    StringBuilder buf = new StringBuilder(8);
+    for (int i = 0; i < 8; ++i) {
+      buf.append((char) '0' + random.nextInt('z' - '0'));
+    }
+    return buf.toString();
+  }
+
+  @Override void write(ByteBuffer data) throws IOException {
+    client.putRecord(stream, data, partitionKey());
+  }
+
+  @Override public void close() throws IOException {
+  }
+}

--- a/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/StepDigest.java
+++ b/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/StepDigest.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.tdigest;
+
+import com.netflix.spectator.api.Clock;
+import com.netflix.spectator.api.Id;
+import com.tdunning.math.stats.TDigest;
+
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Utility class for managing a set of TDigest instances mapped to a particular step interval.
+ * The current implementation keeps an array of with two items where one is the current value
+ * being updated and the other is the value from the previous interval and is only available for
+ * polling.
+ */
+class StepDigest {
+
+  private final double init;
+  private final Clock clock;
+  private final long step;
+
+  private final AtomicReference<TDigest> previous;
+  private final AtomicReference<TDigest> current;
+
+  private final AtomicLong lastPollTime;
+
+  private final AtomicLong lastInitPos;
+
+  /** Create a new instance. */
+  StepDigest(double init, Clock clock, long step) {
+    this.init = init;
+    this.clock = clock;
+    this.step = step;
+    lastInitPos = new AtomicLong(0L);
+    lastPollTime = new AtomicLong(0L);
+    previous = new AtomicReference<TDigest>(TDigest.createDigest(init));
+    current = new AtomicReference<TDigest>(TDigest.createDigest(init));
+  }
+
+  private void roll(long now) {
+    final long stepTime = now / step;
+    final long lastInit = lastInitPos.get();
+    if (lastInit < stepTime && lastInitPos.compareAndSet(lastInit, stepTime)) {
+      previous.set(current.getAndSet(TDigest.createDigest(init)));
+    }
+  }
+
+  /** Return the previous digest. */
+  TDigest previous() {
+    roll(clock.wallTime());
+    return previous.get();
+  }
+
+  /** Return the current digest. */
+  TDigest current() {
+    roll(clock.wallTime());
+    return current.get();
+  }
+
+  /** Get the value for the last completed interval. */
+  TDigest poll() {
+    final long now = clock.wallTime();
+
+    roll(now);
+    final TDigest value = previous.get();
+
+    final long last = lastPollTime.getAndSet(now);
+    final long missed = (now - last) / step - 1;
+
+    if (last / step == now / step) {
+      return value;
+    } else if (last > 0L && missed > 0L) {
+      return null;
+    } else {
+      return value;
+    }
+  }
+
+  /** Get the value for the last completed interval. */
+  TDigestMeasurement measure(Id id) {
+    final long t = clock.wallTime() / step * step;
+    return new TDigestMeasurement(id, t, poll());
+  }
+
+  @Override public String toString() {
+    return "StepDigest{init=" + init
+        + ", step=" + step
+        + ", lastPollTime=" + lastPollTime.get()
+        + ", lastInitPos=" + lastInitPos.get() + '}';
+  }
+}

--- a/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/StreamTDigestReader.java
+++ b/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/StreamTDigestReader.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.tdigest;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Reader based on an underlying {@link java.io.InputStream}.
+ */
+public class StreamTDigestReader implements TDigestReader {
+
+  private final DataInputStream in;
+
+  private final byte[] buf = new byte[TDigestWriter.BUFFER_SIZE];
+
+  /** Create a new instance. */
+  public StreamTDigestReader(InputStream in) {
+    this.in = new DataInputStream(in);
+  }
+
+  /** Create a new instance. */
+  public StreamTDigestReader(DataInputStream in) {
+    this.in = in;
+  }
+
+  @Override public List<TDigestMeasurement> read() throws IOException {
+    if (in.available() == 0) {
+      return Collections.emptyList();
+    } else {
+      int size = in.readInt();
+      if (size > buf.length) {
+        throw new IOException("buffer exceeds max size (" + size + " > " + buf.length + ")");
+      }
+      int length = in.read(buf, 0, size);
+      if (length != size) {
+        throw new IOException("unexpected end of stream");
+      }
+      return Json.decode(buf, 0, length);
+    }
+  }
+
+  @Override public void close() throws IOException {
+    in.close();
+  }
+}

--- a/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestDistributionSummary.java
+++ b/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestDistributionSummary.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.tdigest;
+
+import com.netflix.spectator.api.Clock;
+import com.netflix.spectator.api.DistributionSummary;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Measurement;
+
+import java.util.Collections;
+
+/**
+ * Timer that updates a T-Digest with recorded values.
+ */
+public class TDigestDistributionSummary implements TDigestMeter, DistributionSummary {
+
+  private final Id id;
+  private final StepDigest digest;
+
+  /** Create a new instance. */
+  TDigestDistributionSummary(Clock clock, Id id) {
+    this.id = id;
+    this.digest = new StepDigest(100.0, clock, 60000L);
+  }
+
+  @Override public void record(long amount) {
+    if (amount >= 0L) {
+      digest.current().add(amount);
+    }
+  }
+
+  /**
+   * Return a percentile from the last complete digest.
+   *
+   * @param p
+   *     Percentile to retrieve. The value should be in the interval [0.0, 100.0].
+   * @return
+   *     The {@code p}th percentile of the last complete digest.
+   */
+  public double percentile(double p) {
+    if (p < 0.0 || p > 100.0) {
+      throw new IllegalArgumentException("p should be in [0.0, 100.0], got " + p);
+    }
+    final double q = p / 100.0;
+    return digest.poll().quantile(q);
+  }
+
+  @Override public long count() {
+    return -1L;
+  }
+
+  @Override public long totalAmount() {
+    return -1L;
+  }
+
+  @Override public Id id() {
+    return id;
+  }
+
+  @Override public Iterable<Measurement> measure() {
+    return Collections.emptyList();
+  }
+
+  @Override public boolean hasExpired() {
+    return false;
+  }
+
+  @Override public TDigestMeasurement measureDigest() {
+    return digest.measure(id());
+  }
+}

--- a/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestMeasurement.java
+++ b/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestMeasurement.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.tdigest;
+
+import com.netflix.spectator.api.Id;
+import com.tdunning.math.stats.TDigest;
+
+/**
+ * A measurement sampled from a meter.
+ */
+public final class TDigestMeasurement {
+
+  private final Id id;
+  private final long timestamp;
+  private final TDigest value;
+
+  /** Create a new instance. */
+  public TDigestMeasurement(Id id, long timestamp, TDigest value) {
+    this.id = id;
+    this.timestamp = timestamp;
+    this.value = value;
+  }
+
+  /** Identifier for the measurement. */
+  public Id id() {
+    return id;
+  }
+
+  /**
+   * The timestamp in milliseconds since the epoch for when the measurement was taken.
+   */
+  public long timestamp() {
+    return timestamp;
+  }
+
+  /** Value for the measurement. */
+  public TDigest value() {
+    return value;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) return true;
+    if (obj == null || !(obj instanceof TDigestMeasurement)) return false;
+    TDigestMeasurement other = (TDigestMeasurement) obj;
+    return id.equals(other.id)
+        && timestamp == other.timestamp
+        && value.equals(other.value);
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int hc = prime;
+    hc = prime * hc + id.hashCode();
+    hc = prime * hc + Long.valueOf(timestamp).hashCode();
+    hc = prime * hc + value.hashCode();
+    return hc;
+  }
+
+  @Override
+  public String toString() {
+    return "TDigestMeasurement(" + id.toString() + "," + timestamp + "," + value + ")";
+  }
+}

--- a/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestMeter.java
+++ b/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestMeter.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.tdigest;
+
+import com.netflix.spectator.api.Meter;
+
+/**
+ * Meter type for collecting a digest measurment.
+ */
+public interface TDigestMeter extends Meter {
+  /** Returns the measurement for the last completed interval. */
+  TDigestMeasurement measureDigest();
+}

--- a/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestModule.java
+++ b/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestModule.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.tdigest;
+
+import com.amazonaws.services.kinesis.AmazonKinesisClient;
+import com.google.inject.AbstractModule;
+import com.netflix.config.ConfigurationManager;
+import com.netflix.spectator.api.Spectator;
+import org.apache.commons.configuration.AbstractConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+/**
+ * Guice module to configure the plugin.
+ */
+public class TDigestModule extends AbstractModule {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(TDigestModule.class);
+
+  private static final String ENDPOINT_PROP = "spectator.tdigest.kinesis.endpoint";
+  private static final String STREAM_PROP = "spectator.tdigest.kinesis.stream";
+
+  private void loadProperties(String name) {
+    try {
+      ConfigurationManager.loadCascadedPropertiesFromResources(name);
+    } catch (IOException e) {
+      LOGGER.warn("failed to load properties for '" + name + "'");
+    }
+  }
+
+  private AmazonKinesisClient newKinesisClient(AbstractConfiguration cfg) {
+    String endpoint = cfg.getString(ENDPOINT_PROP);
+    AmazonKinesisClient client = new AmazonKinesisClient();
+    client.setEndpoint(endpoint);
+    return client;
+  }
+
+  @Override protected void configure() {
+    loadProperties("spectator-tdigest");
+    AbstractConfiguration cfg = ConfigurationManager.getConfigInstance();
+    String stream = cfg.getString(STREAM_PROP);
+    if (stream == null) {
+      throw new IllegalStateException("stream name property, " + STREAM_PROP + ", is not set");
+    }
+
+    TDigestRegistry registry = Spectator.registry().underlying(TDigestRegistry.class);
+    if (registry == null) {
+      throw new IllegalStateException("TDigestRegistry is not being used");
+    }
+
+    KinesisTDigestWriter writer = new KinesisTDigestWriter(newKinesisClient(cfg), stream);
+    TDigestPlugin plugin = new TDigestPlugin(registry, writer);
+    plugin.init();
+    bind(TDigestPlugin.class).toInstance(plugin);
+  }
+}

--- a/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestPlugin.java
+++ b/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestPlugin.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.tdigest;
+
+import com.netflix.spectator.api.Meter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Plugin for managing the collection of digest measurements.
+ */
+@Singleton
+public class TDigestPlugin {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(TDigestPlugin.class);
+
+  private final TDigestRegistry registry;
+  private final TDigestWriter writer;
+
+  private ScheduledExecutorService executor;
+
+  /** Create a new instance. */
+  @Inject
+  public TDigestPlugin(TDigestRegistry registry, TDigestWriter writer) {
+    this.registry = registry;
+    this.writer = writer;
+  }
+
+  /**
+   * Setup the background threads for collecting the digest measurements and sending to the
+   * writer. The thread names will start with {@code TDigestPlugin}.
+   */
+  @PostConstruct
+  public void init() {
+    executor = Executors.newSingleThreadScheduledExecutor(new ThreadFactory() {
+        @Override public Thread newThread(Runnable r) {
+          return new Thread(r, "TDigestPlugin");
+        }
+      });
+
+    Runnable task = new Runnable() {
+      @Override public void run() {
+        try {
+          writeData();
+        } catch (Exception e) {
+          LOGGER.error("failed to publish percentile data", e);
+        }
+      }
+    };
+
+    executor.scheduleWithFixedDelay(task, 0L, 40L, TimeUnit.SECONDS);
+  }
+
+  /**
+   * Shutdown the thread pools for collecting digest measurements.
+   */
+  @PreDestroy
+  public void shutdown() {
+    executor.shutdown();
+    try {
+      writer.close();
+    } catch (IOException e) {
+      LOGGER.error("failed to close writer", e);
+    }
+  }
+
+  /** Collect the data for the current interval and send to the writer. */
+  void writeData() {
+    LOGGER.debug("starting collection of digests");
+    List<TDigestMeasurement> ms = new ArrayList<>();
+    for (Meter m : registry) {
+      if (m instanceof TDigestMeter) {
+        TDigestMeasurement measurement = ((TDigestMeter) m).measureDigest();
+        ms.add(measurement);
+      }
+    }
+    if (!ms.isEmpty()) {
+      LOGGER.debug("writing {} measurements", ms.size());
+      try {
+        writer.write(ms);
+      } catch (IOException e) {
+        LOGGER.error("failed to write measurements", e);
+      }
+    } else {
+      LOGGER.debug("no digest measurements found, nothing to do");
+    }
+  }
+}

--- a/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestReader.java
+++ b/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestReader.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.tdigest;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Reader for consuming T-Digest measurements.
+ */
+public interface TDigestReader extends AutoCloseable {
+  /**
+   * Return a list of measurments. If the stream is empty and closed then an empty list will
+   * be returned.
+   */
+  List<TDigestMeasurement> read() throws IOException;
+
+  /** Release any resources associated with the reader. */
+  void close() throws IOException;
+}

--- a/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestRegistry.java
+++ b/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestRegistry.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.tdigest;
+
+import com.netflix.spectator.api.*;
+import com.netflix.spectator.api.Counter;
+
+
+/** Registry that maps spectator types to servo. */
+public class TDigestRegistry extends AbstractRegistry {
+
+  private static final Registry NOOP = new NoopRegistry();
+
+  /** Create a new instance. */
+  public TDigestRegistry() {
+    this(Clock.SYSTEM);
+  }
+
+  /** Create a new instance. */
+  public TDigestRegistry(Clock clock) {
+    super(clock);
+  }
+
+  @Override protected Counter newCounter(Id id) {
+    return NOOP.counter(id);
+  }
+
+  @Override protected TDigestDistributionSummary newDistributionSummary(Id id) {
+    return new TDigestDistributionSummary(clock(), id);
+  }
+
+  @Override protected TDigestTimer newTimer(Id id) {
+    return new TDigestTimer(clock(), id);
+  }
+}

--- a/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestTimer.java
+++ b/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestTimer.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.tdigest;
+
+import com.netflix.spectator.api.Clock;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.Timer;
+
+import java.util.Collections;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Timer that updates a T-Digest with recorded values.
+ */
+public class TDigestTimer implements TDigestMeter, Timer {
+
+  private final Clock clock;
+  private final Id id;
+  private final StepDigest digest;
+
+  /** Create a new instance. */
+  TDigestTimer(Clock clock, Id id) {
+    this.clock = clock;
+    this.id = id;
+    this.digest = new StepDigest(100.0, clock, 60000L);
+  }
+
+  @Override public void record(long amount, TimeUnit unit) {
+    if (amount >= 0L) {
+      final long nanos = unit.toNanos(amount);
+      digest.current().add(nanos / 1e9);
+    }
+  }
+
+  @Override public <T> T record(Callable<T> f) throws Exception {
+    final long start = clock.monotonicTime();
+    try {
+      return f.call();
+    } finally {
+      record(clock.monotonicTime() - start, TimeUnit.NANOSECONDS);
+    }
+  }
+
+  @Override public void record(Runnable f) {
+    final long start = clock.monotonicTime();
+    try {
+      f.run();
+    } finally {
+      record(clock.monotonicTime() - start, TimeUnit.NANOSECONDS);
+    }
+  }
+
+  /**
+   * Return a percentile from the last complete digest.
+   *
+   * @param p
+   *     Percentile to retrieve. The value should be in the interval [0.0, 100.0].
+   * @return
+   *     The {@code p}th percentile of the last complete digest.
+   */
+  public double percentile(double p) {
+    if (p < 0.0 || p > 100.0) {
+      throw new IllegalArgumentException("p should be in [0.0, 100.0], got " + p);
+    }
+    final double q = p / 100.0;
+    return digest.poll().quantile(q);
+  }
+
+  @Override public long count() {
+    return -1L;
+  }
+
+  @Override public long totalTime() {
+    return -1L;
+  }
+
+  @Override public Id id() {
+    return id;
+  }
+
+  @Override public Iterable<Measurement> measure() {
+    return Collections.emptyList();
+  }
+
+  @Override public boolean hasExpired() {
+    return false;
+  }
+
+  @Override public TDigestMeasurement measureDigest() {
+    return digest.measure(id());
+  }
+}

--- a/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestWriter.java
+++ b/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestWriter.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.tdigest;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+
+/**
+ * Base-class for TDigestWriter implementations. This class will take care of mapping a set of
+ * measurements into capped-size byte buffers.
+ */
+abstract class TDigestWriter implements AutoCloseable {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(TDigestWriter.class);
+
+  /** Kinesis has a 50k limit for the record size. */
+  static final int BUFFER_SIZE = 50000;
+
+  /**
+   * Minimum amount of free space for the buffer to try and write another measurement. If less
+   * space is available, go ahead and flush the buffer.
+   */
+  static final int MIN_FREE = 4096;
+
+  /**
+   * Writes a buffer of data.
+   *
+   * @param buf
+   *     Buffer to write to the underlying storage. The buffer will be setup so it is ready to
+   *     consume, i.e., position=0 and limit=N where N is the amount of data to write. No
+   *     guarantees are made about data in the remaining part of the buffer. The buffer will be
+   *     reused when this method returns.
+   */
+  abstract void write(ByteBuffer buf) throws IOException;
+
+  /**
+   * Write a list of measurements to some underlying storage.
+   */
+  void write(List<TDigestMeasurement> measurements) throws IOException {
+    ByteBuffer buf = ByteBuffer.allocate(BUFFER_SIZE);
+    ByteBufferOutputStream out = new ByteBufferOutputStream(buf, 2);
+    JsonGenerator gen = Json.newGenerator(out);
+    gen.writeStartArray();
+    gen.flush();
+    int pos = buf.position();
+    for (TDigestMeasurement m : measurements) {
+      Json.encode(m, gen);
+      gen.flush();
+
+      if (out.overflow()) {
+        // Ignore the last entry written to the buffer
+        buf.position(pos);
+        gen.writeEndArray();
+        gen.close();
+        write(buf);
+
+        // Reuse the buffer and write the current entry
+        out.reset();
+        gen = Json.newGenerator(out);
+        gen.writeStartArray();
+        Json.encode(m, gen);
+        gen.flush();
+
+        // If a single entry is too big, then drop it
+        if (out.overflow()) {
+          LOGGER.warn("dropping measurement {}, serialized size exceeds the buffer cap", m.id());
+          out.reset();
+          gen = Json.newGenerator(out);
+          gen.writeStartArray();
+          gen.flush();
+        }
+
+        pos = buf.position();
+      } else if (buf.remaining() < MIN_FREE) {
+        // Not enough free-space, go ahead and write
+        gen.writeEndArray();
+        gen.close();
+        write(buf);
+
+        // Reuse the buffer
+        out.reset();
+        gen = Json.newGenerator(out);
+        gen.writeStartArray();
+        gen.flush();
+        pos = buf.position();
+      }
+    }
+
+    // Write any data that is still in the buffer
+    if (buf.position() > 1) {
+      gen.writeEndArray();
+      gen.close();
+      write(buf);
+    }
+  }
+
+  // This is needed to avoid issues with AutoCloseable.close throwing Exception
+  @Override public void close() throws IOException {
+  }
+}

--- a/spectator-reg-tdigest/src/main/java/com/tdunning/math/stats/AVLGroupTree.java
+++ b/spectator-reg-tdigest/src/main/java/com/tdunning/math/stats/AVLGroupTree.java
@@ -1,0 +1,292 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tdunning.math.stats;
+
+import java.util.AbstractCollection;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * A tree of t-digest centroids.
+ */
+final class AVLGroupTree extends AbstractCollection<Centroid> {
+
+    /* For insertions into the tree */
+    private double centroid;
+    private int count;
+    private List<Double> data;
+
+    private double[] centroids;
+    private int[] counts;
+    private List<Double>[] datas;
+    private int[] aggregatedCounts;
+    private final IntAVLTree tree;
+
+    AVLGroupTree(final boolean record) {
+        tree = new IntAVLTree() {
+
+            @Override
+            protected void resize(int newCapacity) {
+                super.resize(newCapacity);
+                centroids = Arrays.copyOf(centroids, newCapacity);
+                counts = Arrays.copyOf(counts, newCapacity);
+                aggregatedCounts = Arrays.copyOf(aggregatedCounts, newCapacity);
+                if (datas != null) {
+                    datas = Arrays.copyOf(datas, newCapacity);
+                }
+            }
+
+            @Override
+            protected void merge(int node) {
+                // two nodes are never considered equal
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            protected void copy(int node) {
+                centroids[node] = centroid;
+                counts[node] = count;
+                if (datas != null) {
+                    if (data == null) {
+                        if (count != 1) {
+                            throw new IllegalStateException();
+                        }
+                        data = new ArrayList<Double>();
+                        data.add(centroid);
+                    }
+                    datas[node] = data;
+                }
+            }
+
+            @Override
+            protected int compare(int node) {
+                if (centroid < centroids[node]) {
+                    return -1;
+                } else {
+                    // upon equality, the newly added node is considered greater
+                    return 1;
+                }
+            }
+
+            @Override
+            protected void fixAggregates(int node) {
+                super.fixAggregates(node);
+                aggregatedCounts[node] = counts[node] + aggregatedCounts[left(node)] + aggregatedCounts[right(node)];
+            }
+
+        };
+        centroids = new double[tree.capacity()];
+        counts = new int[tree.capacity()];
+        aggregatedCounts = new int[tree.capacity()];
+        if (record) {
+            @SuppressWarnings("unchecked")
+            final List<Double>[] datas = new List[tree.capacity()];
+            this.datas = datas;
+        }
+    }
+
+    /**
+     * Return the number of centroids in the tree.
+     */
+    public int size() {
+        return tree.size();
+    }
+
+    /**
+     * Return the previous node.
+     */
+    public int prev(int node) {
+        return tree.prev(node);
+    }
+
+    /**
+     * Return the next node.
+     */
+    public int next(int node) {
+        return tree.next(node);
+    }
+
+    /**
+     * Return the mean for the provided node.
+     */
+    public double mean(int node) {
+        return centroids[node];
+    }
+
+    /**
+     * Return the count for the provided node.
+     */
+    public int count(int node) {
+        return counts[node];
+    }
+
+    /**
+     * Return the data for the provided node.
+     */
+    public List<Double> data(int node) {
+        return datas == null ? null : datas[node];
+    }
+
+    /**
+     * Add the provided centroid to the tree.
+     */
+    public void add(double centroid, int count, List<Double> data) {
+        this.centroid = centroid;
+        this.count = count;
+        this.data = data;
+        tree.add();
+    }
+
+    @Override
+    public boolean add(Centroid centroid) {
+        add(centroid.mean(), centroid.count(), centroid.data());
+        return true;
+    }
+
+    /**
+     * Update values associated with a node, readjusting the tree if necessary.
+     */
+    public void update(int node, double centroid, int count, List<Double> data) {
+        this.centroid = centroid;
+        this.count = count;
+        this.data = data;
+        tree.update(node);
+    }
+
+    /**
+     * Return the last node whose centroid is less than <code>centroid</code>.
+     */
+    public int floor(double centroid) {
+        int floor = IntAVLTree.NIL;
+        for (int node = tree.root(); node != IntAVLTree.NIL; ) {
+            final int cmp = Double.compare(centroid, mean(node));
+            if (cmp <= 0) {
+                node = tree.left(node);
+            } else {
+                floor = node;
+                node = tree.right(node);
+            }
+        }
+        return floor;
+    }
+
+    /**
+     * Return the last node so that the sum of counts of nodes that are before
+     * it is less than or equal to <code>sum</code>.
+     */
+    public int floorSum(long sum) {
+        int floor = IntAVLTree.NIL;
+        for (int node = tree.root(); node != IntAVLTree.NIL; ) {
+            final int left = tree.left(node);
+            final long leftCount = aggregatedCounts[left];
+            if (leftCount <= sum) {
+                floor = node;
+                sum -= leftCount + count(node);
+                node = tree.right(node);
+            } else {
+                node = tree.left(node);
+            }
+        }
+        return floor;
+    }
+
+    /**
+     * Return the least node in the tree.
+     */
+    public int first() {
+        return tree.first(tree.root());
+    }
+
+    /**
+     * Compute the number of elements and sum of counts for every entry that
+     * is strictly before <code>node</code>.
+     */
+    public long headSum(int node) {
+        final int left = tree.left(node);
+        long sum = aggregatedCounts[left];
+        for (int n = node, p = tree.parent(node); p != IntAVLTree.NIL; n = p, p = tree.parent(n)) {
+            if (n == tree.right(p)) {
+                final int leftP = tree.left(p);
+                sum += counts[p] + aggregatedCounts[leftP];
+            }
+        }
+        return sum;
+    }
+
+    @Override
+    public Iterator<Centroid> iterator() {
+        return iterator(first());
+    }
+
+    private Iterator<Centroid> iterator(final int startNode) {
+        return new Iterator<Centroid>() {
+
+            int nextNode = startNode;
+
+            @Override
+            public boolean hasNext() {
+                return nextNode != IntAVLTree.NIL;
+            }
+
+            @Override
+            public Centroid next() {
+                final Centroid next = new Centroid(mean(nextNode), count(nextNode));
+                final List<Double> data = data(nextNode);
+                if (data != null) {
+                    for (Double x : data) {
+                        next.insertData(x);
+                    }
+                }
+                nextNode = tree.next(nextNode);
+                return next;
+            }
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException("Read-only iterator");
+            }
+
+        };
+    }
+
+    /**
+     * Return the total count of points that have been added to the tree.
+     */
+    public int sum() {
+        return aggregatedCounts[tree.root()];
+    }
+
+    void checkBalance() {
+        tree.checkBalance(tree.root());
+    }
+
+    void checkAggregates() {
+        checkAggregates(tree.root());
+    }
+
+    private void checkAggregates(int node) {
+        assert aggregatedCounts[node] == counts[node] + aggregatedCounts[tree.left(node)] + aggregatedCounts[tree.right(node)];
+        if (node != IntAVLTree.NIL) {
+            checkAggregates(tree.left(node));
+            checkAggregates(tree.right(node));
+        }
+    }
+
+}

--- a/spectator-reg-tdigest/src/main/java/com/tdunning/math/stats/AVLTreeDigest.java
+++ b/spectator-reg-tdigest/src/main/java/com/tdunning/math/stats/AVLTreeDigest.java
@@ -1,0 +1,404 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tdunning.math.stats;
+
+import java.nio.ByteBuffer;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ *
+ */
+public class AVLTreeDigest extends AbstractTDigest {
+
+    private double compression;
+    private AVLGroupTree summary;
+    long count = 0; // package private for testing
+
+    /**
+     * A histogram structure that will record a sketch of a distribution.
+     *
+     * @param compression How should accuracy be traded for size?  A value of N here will give quantile errors
+     *                    almost always less than 3/N with considerably smaller errors expected for extreme
+     *                    quantiles.  Conversely, you should expect to track about 5 N centroids for this
+     *                    accuracy.
+     */
+    public AVLTreeDigest(double compression) {
+        this.compression = compression;
+        summary = new AVLGroupTree(false);
+    }
+
+    @Override
+    public TDigest recordAllData() {
+        if (summary.size() != 0) {
+            throw new IllegalStateException("Can only ask to record added data on an empty summary");
+        }
+        summary = new AVLGroupTree(true);
+        return super.recordAllData();
+    }
+
+    @Override
+    void add(double x, int w, Centroid base) {
+        if (x != base.mean() || w != base.count()) {
+            throw new IllegalArgumentException();
+        }
+        add(x, w, base.data());
+    }
+
+    @Override
+    public void add(double x, int w) {
+        add(x, w, (List<Double>) null);
+    }
+
+    public void add(double x, int w, List<Double> data) {
+        checkValue(x);
+        int start = summary.floor(x);
+        if (start == IntAVLTree.NIL) {
+            start = summary.first();
+        }
+
+        if (start == IntAVLTree.NIL) { // empty summary
+            assert summary.size() == 0;
+            summary.add(x, w, data);
+            count = w;
+        } else {
+            double minDistance = Double.MAX_VALUE;
+            int lastNeighbor = IntAVLTree.NIL;
+            for (int neighbor = start; neighbor != IntAVLTree.NIL; neighbor = summary.next(neighbor)) {
+                double z = Math.abs(summary.mean(neighbor) - x);
+                if (z < minDistance) {
+                    start = neighbor;
+                    minDistance = z;
+                } else if (z > minDistance) {
+                    // as soon as z increases, we have passed the nearest neighbor and can quit
+                    lastNeighbor = neighbor;
+                    break;
+                }
+            }
+
+            int closest = IntAVLTree.NIL;
+            long sum = summary.headSum(start);
+            double n = 0;
+            for (int neighbor = start; neighbor != lastNeighbor; neighbor = summary.next(neighbor)) {
+                assert minDistance == Math.abs(summary.mean(neighbor) - x);
+                double q = count == 1 ? 0.5 : (sum + (summary.count(neighbor) - 1) / 2.0) / (count - 1);
+                double k = 4 * count * q * (1 - q) / compression;
+
+                // this slightly clever selection method improves accuracy with lots of repeated points
+                if (summary.count(neighbor) + w <= k) {
+                    n++;
+                    if (gen.nextDouble() < 1 / n) {
+                        closest = neighbor;
+                    }
+                }
+                sum += summary.count(neighbor);
+            }
+
+            if (closest == IntAVLTree.NIL) {
+                summary.add(x, w, data);
+            } else {
+                // if the nearest point was not unique, then we may not be modifying the first copy
+                // which means that ordering can change
+                double centroid = summary.mean(closest);
+                int count = summary.count(closest);
+                List<Double> d = summary.data(closest);
+                if (d != null) {
+                    if (w == 1) {
+                        d.add(x);
+                    } else {
+                        d.addAll(data);
+                    }
+                }
+                centroid = weightedAverage(centroid, count, x, w);
+                count += w;
+                summary.update(closest, centroid, count, d);
+            }
+            count += w;
+
+            if (summary.size() > 20 * compression) {
+                // may happen in case of sequential points
+                compress();
+            }
+        }
+    }
+
+    @Override
+    public void compress() {
+        if (summary.size() <= 1) {
+            return;
+        }
+
+        AVLGroupTree centroids = summary;
+        this.summary = new AVLGroupTree(recordAllData);
+
+        final int[] nodes = new int[centroids.size()];
+        nodes[0] = centroids.first();
+        for (int i = 1; i < nodes.length; ++i) {
+            nodes[i] = centroids.next(nodes[i-1]);
+            assert nodes[i] != IntAVLTree.NIL;
+        }
+        assert centroids.next(nodes[nodes.length - 1]) == IntAVLTree.NIL;
+
+        for (int i = centroids.size() - 1; i > 0; --i) {
+            final int other = gen.nextInt(i + 1);
+            final int tmp = nodes[other];
+            nodes[other] = nodes[i];
+            nodes[i] = tmp;
+        }
+
+        for (int node : nodes) {
+            add(centroids.mean(node), centroids.count(node), centroids.data(node));
+        }
+    }
+
+    /**
+     * Returns the number of samples represented in this histogram.  If you want to know how many
+     * centroids are being used, try centroids().size().
+     *
+     * @return the number of samples that have been added.
+     */
+    @Override
+    public long size() {
+        return count;
+    }
+
+    /**
+     * @param x the value at which the CDF should be evaluated
+     * @return the approximate fraction of all samples that were less than or equal to x.
+     */
+    @Override
+    public double cdf(double x) {
+        AVLGroupTree values = summary;
+        if (values.size() == 0) {
+            return Double.NaN;
+        } else if (values.size() == 1) {
+            return x < values.mean(values.first()) ? 0 : 1;
+        } else {
+            double r = 0;
+
+            // we scan a across the centroids
+            Iterator<Centroid> it = values.iterator();
+            Centroid a = it.next();
+
+            // b is the look-ahead to the next centroid
+            Centroid b = it.next();
+
+            // initially, we set left width equal to right width
+            double left = (b.mean() - a.mean()) / 2;
+            double right = left;
+
+            // scan to next to last element
+            while (it.hasNext()) {
+                if (x < a.mean() + right) {
+                    return (r + a.count() * interpolate(x, a.mean() - left, a.mean() + right)) / count;
+                }
+                r += a.count();
+
+                a = b;
+                b = it.next();
+
+                left = right;
+                right = (b.mean() - a.mean()) / 2;
+            }
+
+            // for the last element, assume right width is same as left
+            left = right;
+            a = b;
+            if (x < a.mean() + right) {
+                return (r + a.count() * interpolate(x, a.mean() - left, a.mean() + right)) / count;
+            } else {
+                return 1;
+            }
+        }
+    }
+
+    /**
+     * @param q The quantile desired.  Can be in the range [0,1].
+     * @return The minimum value x such that we think that the proportion of samples is <= x is q.
+     */
+    @Override
+    public double quantile(double q) {
+        if (q < 0 || q > 1) {
+            throw new IllegalArgumentException("q should be in [0,1], got " + q);
+        }
+
+        AVLGroupTree values = summary;
+        if (values.size() == 0) {
+            return Double.NaN;
+        } else if (values.size() == 1) {
+            return values.iterator().next().mean();
+        }
+
+        // if values were stored in a sorted array, index would be the offset we are interested in
+        final double index = q * (count - 1);
+
+        double previousMean = Double.NaN, previousIndex = 0;
+        int next = values.floorSum((long) index);
+        assert next != IntAVLTree.NIL;
+        long total = values.headSum(next);
+        final int prev = values.prev(next);
+        if (prev != IntAVLTree.NIL) {
+            previousMean = values.mean(prev);
+            previousIndex = total - (values.count(prev) + 1.0) / 2;
+        }
+
+        while (true) {
+            final double nextIndex = total + (values.count(next) - 1.0) / 2;
+            if (nextIndex >= index) {
+                if (Double.isNaN(previousMean)) {
+                    // special case 1: the index we are interested in is before the 1st centroid
+                    assert total == 0 : total;
+                    if (nextIndex == previousIndex) {
+                        return values.mean(next);
+                    }
+                    // assume values grow linearly between index previousIndex=0 and nextIndex2
+                    int next2 = values.next(next);
+                    final double nextIndex2 = total + values.count(next) + (values.count(next2) - 1.0) / 2;
+                    previousMean = (nextIndex2 * values.mean(next) - nextIndex * values.mean(next2)) / (nextIndex2 - nextIndex);
+                }
+                // common case: we found two centroids previous and next so that the desired quantile is
+                // after 'previous' but before 'next'
+                return quantile(previousIndex, index, nextIndex, previousMean, values.mean(next));
+            } else if (values.next(next) == IntAVLTree.NIL) {
+                // special case 2: the index we are interested in is beyond the last centroid
+                // again, assume values grow linearly between index previousIndex and (count - 1)
+                // which is the highest possible index
+                final double nextIndex2 = count - 1;
+                final double nextMean2 = (values.mean(next) * (nextIndex2 - previousIndex) - previousMean * (nextIndex2 - nextIndex)) / (nextIndex - previousIndex);
+                return quantile(nextIndex, index, nextIndex2, values.mean(next), nextMean2);
+            }
+            total += values.count(next);
+            previousMean = values.mean(next);
+            previousIndex = nextIndex;
+            next = values.next(next);
+        }
+    }
+
+    @Override
+    public Collection<Centroid> centroids() {
+        return Collections.unmodifiableCollection(summary);
+    }
+
+    @Override
+    public double compression() {
+        return compression;
+    }
+
+    /**
+     * Returns an upper bound on the number bytes that will be required to represent this histogram.
+     */
+    @Override
+    public int byteSize() {
+        return 4 + 8 + 4 + summary.size() * 12;
+    }
+
+    /**
+     * Returns an upper bound on the number of bytes that will be required to represent this histogram in
+     * the tighter representation.
+     */
+    @Override
+    public int smallByteSize() {
+        int bound = byteSize();
+        ByteBuffer buf = ByteBuffer.allocate(bound);
+        asSmallBytes(buf);
+        return buf.position();
+    }
+
+    public final static int VERBOSE_ENCODING = 1;
+    public final static int SMALL_ENCODING = 2;
+
+    /**
+     * Outputs a histogram as bytes using a particularly cheesy encoding.
+     */
+    @Override
+    public void asBytes(ByteBuffer buf) {
+        buf.putInt(VERBOSE_ENCODING);
+        buf.putDouble(compression());
+        buf.putInt(summary.size());
+        for (Centroid centroid : summary) {
+            buf.putDouble(centroid.mean());
+        }
+
+        for (Centroid centroid : summary) {
+            buf.putInt(centroid.count());
+        }
+    }
+
+    @Override
+    public void asSmallBytes(ByteBuffer buf) {
+        buf.putInt(SMALL_ENCODING);
+        buf.putDouble(compression());
+        buf.putInt(summary.size());
+
+        double x = 0;
+        for (Centroid centroid : summary) {
+            double delta = centroid.mean() - x;
+            x = centroid.mean();
+            buf.putFloat((float) delta);
+        }
+
+        for (Centroid centroid : summary) {
+            int n = centroid.count();
+            encode(buf, n);
+        }
+    }
+
+    /**
+     * Reads a histogram from a byte buffer
+     *
+     * @return The new histogram structure
+     */
+    public static AVLTreeDigest fromBytes(ByteBuffer buf) {
+        int encoding = buf.getInt();
+        if (encoding == VERBOSE_ENCODING) {
+            double compression = buf.getDouble();
+            AVLTreeDigest r = new AVLTreeDigest(compression);
+            int n = buf.getInt();
+            double[] means = new double[n];
+            for (int i = 0; i < n; i++) {
+                means[i] = buf.getDouble();
+            }
+            for (int i = 0; i < n; i++) {
+                r.add(means[i], buf.getInt());
+            }
+            return r;
+        } else if (encoding == SMALL_ENCODING) {
+            double compression = buf.getDouble();
+            AVLTreeDigest r = new AVLTreeDigest(compression);
+            int n = buf.getInt();
+            double[] means = new double[n];
+            double x = 0;
+            for (int i = 0; i < n; i++) {
+                double delta = buf.getFloat();
+                x += delta;
+                means[i] = x;
+            }
+
+            for (int i = 0; i < n; i++) {
+                int z = decode(buf);
+                r.add(means[i], z);
+            }
+            return r;
+        } else {
+            throw new IllegalStateException("Invalid format for serialized histogram");
+        }
+    }
+
+}

--- a/spectator-reg-tdigest/src/main/java/com/tdunning/math/stats/AbstractTDigest.java
+++ b/spectator-reg-tdigest/src/main/java/com/tdunning/math/stats/AbstractTDigest.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tdunning.math.stats;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+
+public abstract class AbstractTDigest extends TDigest {
+    protected Random gen = new Random();
+    protected boolean recordAllData = false;
+
+    /**
+     * Same as {@link #weightedAverageSorted(double, int, double, int)} but flips
+     * the order of the variables if <code>x2</code> is greater than
+     * <code>x1</code>.
+     */
+    public static double weightedAverage(double x1, int w1, double x2, int w2) {
+        if (x1 <= x2) {
+            return weightedAverageSorted(x1, w1, x2, w2);
+        } else {
+            return weightedAverageSorted(x2, w2, x1, w1);
+        }
+    }
+
+    /**
+     * Compute the weighted average between <code>x1</code> with a weight of
+     * <code>w1</code> and <code>x2</code> with a weight of <code>w2</code>.
+     * This expects <code>x1</code> to be less than or equal to <code>x2</code>
+     * and is guaranteed to return a number between <code>x1</code> and
+     * <code>x2</code>.
+     */
+    public static double weightedAverageSorted(double x1, int w1, double x2, int w2) {
+        assert x1 <= x2;
+        final double x = (x1 * w1 + x2 * w2) / (w1 + w2);
+        return Math.max(x1, Math.min(x, x2));
+    }
+
+    public static double interpolate(double x, double x0, double x1) {
+        return (x - x0) / (x1 - x0);
+    }
+
+    public static void encode(ByteBuffer buf, int n) {
+        int k = 0;
+        while (n < 0 || n > 0x7f) {
+            byte b = (byte) (0x80 | (0x7f & n));
+            buf.put(b);
+            n = n >>> 7;
+            k++;
+            if (k >= 6) {
+                throw new IllegalStateException("Size is implausibly large");
+            }
+        }
+        buf.put((byte) n);
+    }
+
+    public static int decode(ByteBuffer buf) {
+        int v = buf.get();
+        int z = 0x7f & v;
+        int shift = 7;
+        while ((v & 0x80) != 0) {
+            if (shift > 28) {
+                throw new IllegalStateException("Shift too large in decode");
+            }
+            v = buf.get();
+            z += (v & 0x7f) << shift;
+            shift += 7;
+        }
+        return z;
+    }
+
+    abstract void add(double x, int w, Centroid base);
+
+    protected static TDigest merge(Iterable<TDigest> subData, Random gen, TDigest r) {
+        List<Centroid> centroids = new ArrayList<Centroid>();
+        boolean recordAll = false;
+        for (TDigest digest : subData) {
+            for (Centroid centroid : digest.centroids()) {
+                centroids.add(centroid);
+            }
+            recordAll |= digest.isRecording();
+        }
+        Collections.shuffle(centroids, gen);
+        if (recordAll) {
+            r.recordAllData();
+        }
+
+        for (Centroid c : centroids) {
+            if (r.isRecording()) {
+                // TODO should do something better here.
+            }
+            ((AbstractTDigest) r).add(c.mean(), c.count(), c);
+        }
+        return r;
+    }
+
+    static double quantile(double previousIndex, double index, double nextIndex, double previousMean, double nextMean) {
+        final double delta = nextIndex - previousIndex;
+        final double previousWeight = (nextIndex - index) / delta;
+        final double nextWeight = (index - previousIndex) / delta;
+        return previousMean * previousWeight + nextMean * nextWeight;
+    }
+
+    /**
+     * Sets up so that all centroids will record all data assigned to them.  For testing only, really.
+     */
+    @Override
+    public TDigest recordAllData() {
+        recordAllData = true;
+        return this;
+    }
+
+    @Override
+    public boolean isRecording() {
+        return recordAllData;
+    }
+
+    /**
+     * Adds a sample to a histogram.
+     *
+     * @param x The value to add.
+     */
+    @Override
+    public void add(double x) {
+        add(x, 1);
+    }
+
+    @Override
+    public void add(TDigest other) {
+        List<Centroid> tmp = new ArrayList<Centroid>();
+        for (Centroid centroid : other.centroids()) {
+            tmp.add(centroid);
+        }
+
+        Collections.shuffle(tmp, gen);
+        for (Centroid centroid : tmp) {
+            add(centroid.mean(), centroid.count(), centroid);
+        }
+    }
+
+    protected Centroid createCentroid(double mean, int id) {
+        return new Centroid(mean, id, recordAllData);
+    }
+}

--- a/spectator-reg-tdigest/src/main/java/com/tdunning/math/stats/ArrayDigest.java
+++ b/spectator-reg-tdigest/src/main/java/com/tdunning/math/stats/ArrayDigest.java
@@ -1,0 +1,897 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tdunning.math.stats;
+
+import java.nio.ByteBuffer;
+import java.util.AbstractCollection;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+/**
+ * Array based implementation of a TDigest.
+ * <p/>
+ * This implementation is essentially a one-level b-tree in which nodes are collected into
+ * pages typically with 32 values per page.  Commonly, an ArrayDigest contains 500-3000
+ * centroids.  With 32 values per page, we have about 32 values per page and about 30 pages
+ * which seems to give a nice balance for speed.  Sizes from 4 to 100 are plausible, however.
+ */
+public class ArrayDigest extends AbstractTDigest {
+    private final int pageSize;
+
+    private List<Page> data = new ArrayList<Page>();
+    private long totalWeight = 0;
+    private int centroidCount = 0;
+    private double compression = 100;
+
+    public ArrayDigest(int pageSize, double compression) {
+        if (pageSize > 3) {
+            this.pageSize = pageSize;
+            this.compression = compression;
+        } else {
+            throw new IllegalArgumentException("Must have page size of 4 or more");
+        }
+    }
+
+    @Override
+    public void add(double x, int w) {
+        checkValue(x);
+        Index start = floor(x);
+        if (start == null) {
+            start = ceiling(x);
+        }
+
+        if (start == null) {
+            addRaw(x, w);
+        } else {
+            Iterable<Index> neighbors = inclusiveTail(start);
+            double minDistance = Double.MAX_VALUE;
+            int lastNeighbor = 0;
+            int i = 0;
+            for (Index neighbor : neighbors) {
+                double z = Math.abs(mean(neighbor) - x);
+                if (z <= minDistance) {
+                    minDistance = z;
+                    lastNeighbor = i;
+                } else {
+                    // as soon as z exceeds the minimum, we have passed the nearest neighbor and can quit
+                    break;
+                }
+                i++;
+            }
+
+            Index closest = null;
+            long sum = headSum(start);
+            i = 0;
+            double n = 0;
+            for (Index neighbor : neighbors) {
+                if (i > lastNeighbor) {
+                    break;
+                }
+                double z = Math.abs(mean(neighbor) - x);
+                double q = (sum + count(neighbor) / 2.0) / totalWeight;
+                double k = 4 * totalWeight * q * (1 - q) / compression;
+
+                // this slightly clever selection method improves accuracy with lots of repeated points
+                if (z == minDistance && count(neighbor) + w <= k) {
+                    n++;
+                    if (gen.nextDouble() < 1 / n) {
+                        closest = neighbor;
+                    }
+                }
+                sum += count(neighbor);
+                i++;
+            }
+
+            if (closest == null) {
+                addRaw(x, w);
+            } else {
+                if (n == 1) {
+                    // if the nearest point was unique, centroid ordering cannot change
+                    Page p = data.get(closest.page);
+                    p.centroids[closest.subPage] = weightedAverage(p.centroids[closest.subPage], p.counts[closest.subPage], x, w);
+                    p.counts[closest.subPage] += w;
+                    p.totalCount += w;
+                    if (p.history != null && p.history.get(closest.subPage) != null) {
+                        p.history.get(closest.subPage).add(x);
+                    }
+                    totalWeight += w;
+                    assert p.sorted();
+                } else {
+                    // if the nearest point was not unique, then we may not be modifying the first copy
+                    // which means that ordering can change
+                    int weight = count(closest) + w;
+                    double center = mean(closest);
+                    center = center + (x - center) / weight;
+
+                    if (mean(increment(closest, -1)) <= center && mean(increment(closest, 1)) >= center) {
+                        // if order doesn't change, we can short-cut the process
+                        Page p = data.get(closest.page);
+                        p.counts[closest.subPage] = weight;
+                        p.centroids[closest.subPage] = center;
+
+                        p.totalCount += w;
+                        totalWeight += w;
+                        if (p.history != null && p.history.get(closest.subPage) != null) {
+                            p.history.get(closest.subPage).add(x);
+                        }
+                    } else {
+                        delete(closest);
+
+                        List<Double> history = history(closest);
+                        if (history != null) {
+                            history.add(x);
+                        }
+
+                        addRaw(center, weight, history);
+                    }
+
+                }
+            }
+
+            if (centroidCount > 20 * compression) {
+                // something such as sequential ordering of data points
+                // has caused a pathological expansion of our summary.
+                // To fight this, we simply replay the current centroids
+                // in random order.
+
+                // this causes us to forget the diagnostic recording of data points
+                compress();
+            }
+        }
+    }
+
+    public long headSum(Index limit) {
+        long r = 0;
+
+        for (int i = 0; limit != null && i < limit.page; i++) {
+            r += data.get(i).totalCount;
+        }
+
+        if (limit != null && limit.page < data.size()) {
+            for (int j = 0; j < limit.subPage; j++) {
+                r += data.get(limit.page).counts[j];
+            }
+        }
+
+        return r;
+    }
+
+    public double mean(Index index) {
+        return data.get(index.page).centroids[index.subPage];
+    }
+
+    public int count(Index index) {
+        return data.get(index.page).counts[index.subPage];
+    }
+
+    @Override
+    public void compress() {
+        ArrayDigest reduced = new ArrayDigest(pageSize, compression);
+        if (recordAllData) {
+            reduced.recordAllData();
+        }
+        List<Index> tmp = new ArrayList<Index>();
+        Iterator<Index> ix = this.iterator(0, 0);
+        while (ix.hasNext()) {
+            tmp.add(ix.next());
+        }
+
+        Collections.shuffle(tmp, gen);
+        for (Index index : tmp) {
+            reduced.add(mean(index), count(index));
+        }
+
+        data = reduced.data;
+        centroidCount = reduced.centroidCount;
+    }
+
+    @Override
+    public long size() {
+        return totalWeight;
+    }
+
+    @Override
+    public double cdf(double x) {
+        if (size() == 0) {
+            return Double.NaN;
+        } else if (size() == 1) {
+            return x < data.get(0).centroids[0] ? 0 : 1;
+        } else {
+            double r = 0;
+
+            // we scan a across the centroids
+            Iterator<Index> it = iterator(0, 0);
+            Index a = it.next();
+
+            // b is the look-ahead to the next centroid
+            Index b = it.next();
+
+            // initially, we set left width equal to right width
+            double left = (b.mean() - a.mean()) / 2;
+            double right = left;
+
+            // scan to next to last element
+            while (it.hasNext()) {
+                if (x < a.mean() + right) {
+                    return (r + a.count() * AbstractTDigest.interpolate(x, a.mean() - left, a.mean() + right)) / totalWeight;
+                }
+                r += a.count();
+
+                a = b;
+                b = it.next();
+
+                left = right;
+                right = (b.mean() - a.mean()) / 2;
+            }
+
+            // for the last element, assume right width is same as left
+            left = right;
+            a = b;
+            if (x < a.mean() + right) {
+                return (r + a.count() * AbstractTDigest.interpolate(x, a.mean() - left, a.mean() + right)) / totalWeight;
+            } else {
+                return 1;
+            }
+        }
+    }
+
+    @Override
+    public double quantile(double q) {
+        if (q < 0 || q > 1) {
+            throw new IllegalArgumentException("q should be in [0,1], got " + q);
+        }
+
+        if (centroidCount == 0) {
+            return Double.NaN;
+        } else if (centroidCount == 1) {
+            return data.get(0).centroids[0];
+        }
+
+        // if values were stored in a sorted array, index would be the offset we are interested in
+        final double index = q * (size() - 1);
+
+        double previousMean = Double.NaN, previousIndex = 0;
+        long total = 0;
+        // Jump over pages until we reach the page containing the quantile we are interested in
+        int firstPage = 0;
+        while (firstPage < data.size() && total + data.get(firstPage).totalCount < index) {
+            total += data.get(firstPage++).totalCount;
+        }
+        Iterator<Index> it;
+        if (firstPage == 0) {
+            // start from the beginning
+            it = iterator(0, 0);
+        } else {
+            final int previousPageIndex = firstPage - 1;
+            final Page previousPage = data.get(previousPageIndex);
+            assert previousPage.active > 0;
+            final int lastSubPage = previousPage.active - 1;
+            previousMean = previousPage.centroids[lastSubPage];
+            previousIndex = total - (previousPage.counts[lastSubPage] + 1.0) / 2;
+            it = iterator(firstPage, 0);
+        }
+        Index next;
+        while (true) {
+            next = it.next();
+            final double nextIndex = total + (next.count() - 1.0) / 2;
+            if (nextIndex >= index) {
+                if (Double.isNaN(previousMean)) {
+                    assert total == 0;
+                    // special case 1: the index we are interested in is before the 1st centroid
+                    if (nextIndex == previousIndex) {
+                        return next.mean();
+                    }
+                    // assume values grow linearly between index previousIndex=0 and nextIndex2
+                    Index next2 = it.next();
+                    final double nextIndex2 = total + next.count() + (next2.count() - 1.0) / 2;
+                    previousMean = (nextIndex2 * next.mean() - nextIndex * next2.mean()) / (nextIndex2 - nextIndex);
+                }
+                // common case: we found two centroids previous and next so that the desired quantile is
+                // after 'previous' but before 'next'
+                return quantile(previousIndex, index, nextIndex, previousMean, next.mean());
+            } else if (!it.hasNext()) {
+                // special case 2: the index we are interested in is beyond the last centroid
+                // again, assume values grow linearly between index previousIndex and (count - 1)
+                // which is the highest possible index
+                final double nextIndex2 = size() - 1;
+                final double nextMean2 = (next.mean() * (nextIndex2 - previousIndex) - previousMean * (nextIndex2 - nextIndex)) / (nextIndex - previousIndex);
+                return quantile(nextIndex, index, nextIndex2, next.mean(), nextMean2);
+            }
+            total += next.count();
+            previousMean = next.mean();
+            previousIndex = nextIndex;
+        }
+    }
+
+    @Override
+    public Collection<Centroid> centroids() {
+        return new AbstractCollection<Centroid>() {
+
+            @Override
+            public Iterator<Centroid> iterator() {
+                final Iterator<Index> ix = ArrayDigest.this.iterator(0, 0);
+                return new Iterator<Centroid>() {
+
+                    @Override
+                    public boolean hasNext() {
+                        return ix.hasNext();
+                    }
+
+                    @Override
+                    public Centroid next() {
+                        final Index index = ix.next();
+                        final Page current = data.get(index.page);
+                        Centroid centroid = new Centroid(current.centroids[index.subPage], current.counts[index.subPage]);
+                        if (current.history != null) {
+                            for (double x : current.history.get(index.subPage)) {
+                                centroid.insertData(x);
+                            }
+                        }
+                        return centroid;
+                    }
+
+                    @Override
+                    public void remove() {
+                        throw new UnsupportedOperationException();
+                    }
+                };
+            }
+
+            @Override
+            public int size() {
+                return centroidCount;
+            }
+        };
+    }
+
+    public Iterator<Index> allAfter(double x) {
+        if (data.size() == 0) {
+            return iterator(0, 0);
+        } else {
+
+            for (int i = 1; i < data.size(); i++) {
+                if (data.get(i).centroids[0] >= x) {
+                    Page previous = data.get(i - 1);
+                    for (int j = 0; j < previous.active; j++) {
+                        if (previous.centroids[j] > x) {
+                            return iterator(i - 1, j);
+                        }
+                    }
+                    return iterator(i, 0);
+                }
+            }
+
+            Page last = data.get(data.size() - 1);
+            for (int j = 0; j < last.active; j++) {
+                if (last.centroids[j] > x) {
+                    return iterator(data.size() - 1, j);
+                }
+            }
+            return iterator(data.size(), 0);
+        }
+    }
+
+    /**
+     * Returns a cursor pointing to the first element <= x.  Exposed only for testing.
+     * @param x The value used to find the cursor.
+     * @return The cursor.
+     */
+    public Index floor(double x) {
+        Iterator<Index> rx = allBefore(x);
+        if (!rx.hasNext()) {
+            return null;
+        }
+        Index r = rx.next();
+        Index z = r;
+        while (rx.hasNext() && mean(z) == x) {
+            r = z;
+            z = rx.next();
+        }
+        return r;
+    }
+
+    public Index ceiling(double x) {
+        Iterator<Index> r = allAfter(x);
+        return r.hasNext() ? r.next() : null;
+    }
+
+    /**
+     * Returns an iterator which will give each element <= to x in non-increasing order.
+     *
+     * @param x The upper bound of all returned elements
+     * @return An iterator that returns elements in non-increasing order.
+     */
+    public Iterator<Index> allBefore(double x) {
+        if (data.size() == 0) {
+            return iterator(0, 0);
+        } else {
+            for (int i = 1; i < data.size(); i++) {
+                if (data.get(i).centroids[0] > x) {
+                    Page previous = data.get(i - 1);
+                    for (int j = 0; j < previous.active; j++) {
+                        if (previous.centroids[j] > x) {
+                            return reverse(i - 1, j - 1);
+                        }
+                    }
+                    return reverse(i, -1);
+                }
+            }
+            Page last = data.get(data.size() - 1);
+            for (int j = 0; j < last.active; j++) {
+                if (last.centroids[j] > x) {
+                    return reverse(data.size() - 1, j - 1);
+                }
+            }
+            return reverse(data.size(), -1);
+        }
+    }
+
+    public Index increment(Index x, int delta) {
+        int i = x.page;
+        int j = x.subPage + delta;
+
+        while (i < data.size() && j >= data.get(i).active) {
+            j -= data.get(i).active;
+            i++;
+        }
+
+        while (i > 0 && j < 0) {
+            i--;
+            j += data.get(i).active;
+        }
+        return new Index(i, j);
+    }
+
+    @Override
+    public double compression() {
+        return compression;
+    }
+
+    /**
+     * Returns an upper bound on the number bytes that will be required to represent this histogram.
+     */
+    @Override
+    public int byteSize() {
+        return 4 + 8 + 8 + centroidCount * 12;
+    }
+
+    /**
+     * Returns an upper bound on the number of bytes that will be required to represent this histogram in
+     * the tighter representation.
+     */
+    @Override
+    public int smallByteSize() {
+        int bound = byteSize();
+        ByteBuffer buf = ByteBuffer.allocate(bound);
+        asSmallBytes(buf);
+        return buf.position();
+    }
+
+    /**
+     * Outputs a histogram as bytes using a particularly cheesy encoding.
+     */
+    @Override
+    public void asBytes(ByteBuffer buf) {
+        buf.putInt(VERBOSE_ARRAY_DIGEST);
+        buf.putDouble(compression());
+        buf.putInt(pageSize);
+        buf.putInt(centroidCount);
+        for (Page page : data) {
+            for (int i = 0; i < page.active; i++) {
+                buf.putDouble(page.centroids[i]);
+            }
+        }
+        for (Page page : data) {
+            for (int i = 0; i < page.active; i++) {
+                buf.putInt(page.counts[i]);
+            }
+        }
+    }
+
+    @Override
+    public void asSmallBytes(ByteBuffer buf) {
+        buf.putInt(SMALL_ARRAY_DIGEST);
+        buf.putDouble(compression());
+        buf.putInt(pageSize);
+        buf.putInt(centroidCount);
+
+        double x = 0;
+        for (Page page : data) {
+            for (int i = 0; i < page.active; i++) {
+                double mean = page.centroids[i];
+                double delta = mean - x;
+                x = mean;
+                buf.putFloat((float) delta);
+            }
+        }
+        for (Page page : data) {
+            for (int i = 0; i < page.active; i++) {
+                int n = page.counts[i];
+                encode(buf, n);
+            }
+        }
+    }
+
+    /**
+     * Reads a histogram from a byte buffer
+     *
+     * @return The new histogram structure
+     */
+    public static ArrayDigest fromBytes(ByteBuffer buf) {
+        int encoding = buf.getInt();
+        if (encoding == VERBOSE_ENCODING || encoding == VERBOSE_ARRAY_DIGEST) {
+            double compression = buf.getDouble();
+            int pageSize = 32;
+            if (encoding == VERBOSE_ARRAY_DIGEST) {
+                pageSize = buf.getInt();
+            }
+            ArrayDigest r = new ArrayDigest(pageSize, compression);
+            int n = buf.getInt();
+            double[] means = new double[n];
+            for (int i = 0; i < n; i++) {
+                means[i] = buf.getDouble();
+            }
+            for (int i = 0; i < n; i++) {
+                r.add(means[i], buf.getInt());
+            }
+            return r;
+        } else if (encoding == SMALL_ENCODING || encoding == SMALL_ARRAY_DIGEST) {
+            double compression = buf.getDouble();
+            int pageSize = 32;
+            if (encoding == SMALL_ARRAY_DIGEST) {
+                pageSize = buf.getInt();
+            }
+            ArrayDigest r = new ArrayDigest(pageSize, compression);
+            int n = buf.getInt();
+            double[] means = new double[n];
+            double x = 0;
+            for (int i = 0; i < n; i++) {
+                double delta = buf.getFloat();
+                x += delta;
+                means[i] = x;
+            }
+
+            for (int i = 0; i < n; i++) {
+                int z = decode(buf);
+                r.add(means[i], z);
+            }
+            return r;
+        } else {
+            throw new IllegalStateException("Invalid format for serialized histogram");
+        }
+    }
+
+    private List<Double> history(Index index) {
+        List<List<Double>> h = data.get(index.page).history;
+        return h == null ? null : h.get(index.subPage);
+    }
+
+    private void delete(Index index) {
+        // don't want to delete empty pages here because other indexes would be screwed up.
+        // this should almost never happen anyway since deletes only cause small ordering
+        // changes
+        totalWeight -= count(index);
+        centroidCount--;
+        data.get(index.page).delete(index.subPage);
+    }
+
+    private Iterable<Index> inclusiveTail(final Index start) {
+        return new Iterable<Index>() {
+            @Override
+            public Iterator<Index> iterator() {
+                return ArrayDigest.this.iterator(start.page, start.subPage);
+            }
+        };
+    }
+
+    void addRaw(double x, int w) {
+        List<Double> tmp = new ArrayList<Double>();
+        tmp.add(x);
+        addRaw(x, w, recordAllData ? tmp : null);
+    }
+
+    void addRaw(double x, int w, List<Double> history) {
+        if (centroidCount == 0) {
+            Page page = new Page(pageSize, recordAllData);
+            page.add(x, w, history);
+            totalWeight += w;
+            centroidCount++;
+            data.add(page);
+        } else {
+            for (int i = 1; i < data.size(); i++) {
+                if (data.get(i).centroids[0] > x) {
+                    Page newPage = data.get(i - 1).add(x, w, history);
+                    totalWeight += w;
+                    centroidCount++;
+                    if (newPage != null) {
+                        data.add(i, newPage);
+                    }
+                    return;
+                }
+            }
+            Page newPage = data.get(data.size() - 1).add(x, w, history);
+            totalWeight += w;
+            centroidCount++;
+            if (newPage != null) {
+                data.add(data.size(), newPage);
+            }
+        }
+    }
+
+    @Override
+    void add(double x, int w, Centroid base) {
+        addRaw(x, w, base.data());
+    }
+
+    private Iterator<Index> iterator(final int startPage, final int startSubPage) {
+        return new Iterator<Index>() {
+            int page = startPage;
+            int subPage = startSubPage;
+            Index end = new Index(-1, -1);
+            Index next = null;
+
+            @Override
+            public boolean hasNext() {
+                if (next == null) {
+                    next = computeNext();
+                }
+                return next != end;
+            }
+
+            @Override
+            public Index next() {
+                if (hasNext()) {
+                    Index r = next;
+                    next = null;
+                    return r;
+                } else {
+                    throw new NoSuchElementException("Can't iterate past end of data");
+                }
+            }
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException("Default operation");
+            }
+
+            protected Index computeNext() {
+                if (page >= data.size()) {
+                    return end;
+                } else {
+                    Page current = data.get(page);
+                    if (subPage >= current.active) {
+                        subPage = 0;
+                        page++;
+                        return computeNext();
+                    } else {
+                        Index r = new Index(page, subPage);
+                        subPage++;
+                        return r;
+                    }
+                }
+            }
+        };
+    }
+
+    private Iterator<Index> reverse(final int startPage, final int startSubPage) {
+        return new Iterator<Index>() {
+            int page = startPage;
+            int subPage = startSubPage;
+
+            Index end = new Index(-1, -1);
+            Index next = null;
+
+            @Override
+            public boolean hasNext() {
+                if (next == null) {
+                    next = computeNext();
+                }
+                return next != end;
+            }
+
+            @Override
+            public Index next() {
+                if (hasNext()) {
+                    Index r = next;
+                    next = null;
+                    return r;
+                } else {
+                    throw new NoSuchElementException("Can't reverse iterate before beginning of data");
+                }
+            }
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException("Default operation");
+            }
+
+            protected Index computeNext() {
+                if (page < 0) {
+                    return end;
+                } else {
+                    if (subPage < 0) {
+                        page--;
+                        if (page >= 0) {
+                            subPage = data.get(page).active - 1;
+                        }
+                        return computeNext();
+                    } else {
+                        Index r = new Index(page, subPage);
+                        subPage--;
+                        return r;
+                    }
+                }
+            }
+        };
+    }
+
+    public final static int VERBOSE_ENCODING = 1;
+    public final static int SMALL_ENCODING = 2;
+    public final static int VERBOSE_ARRAY_DIGEST = 3;
+    public final static int SMALL_ARRAY_DIGEST = 4;
+
+    class Index {
+        final int page, subPage;
+
+        private Index(int page, int subPage) {
+            this.page = page;
+            this.subPage = subPage;
+        }
+
+        double mean() {
+            return data.get(page).centroids[subPage];
+        }
+
+        int count() {
+            return data.get(page).counts[subPage];
+        }
+    }
+
+    private static class Page {
+        private final boolean recordAllData;
+        private final int pageSize;
+
+        long totalCount;
+        int active;
+        double[] centroids;
+        int[] counts;
+        List<List<Double>> history;
+
+        private Page(int pageSize, boolean recordAllData) {
+            this.pageSize = pageSize;
+            this.recordAllData = recordAllData;
+            centroids = new double[this.pageSize];
+            counts = new int[this.pageSize];
+            history = this.recordAllData ? new ArrayList<List<Double>>() : null;
+        }
+
+        boolean sorted() {
+            for (int i = 1; i < active; ++i) {
+                if (centroids[i] < centroids[i - 1]) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        public Page add(double x, int w, List<Double> history) {
+            for (int i = 0; i < active; i++) {
+                if (centroids[i] >= x) {
+                    // insert at i
+                    if (active >= pageSize) {
+                        // split page
+                        Page newPage = split();
+                        if (i < pageSize / 2) {
+                            addAt(i, x, w, history);
+                        } else {
+                            newPage.addAt(i - pageSize / 2, x, w, history);
+                        }
+                        assert sorted();
+                        assert newPage.sorted();
+                        return newPage;
+                    } else {
+                        addAt(i, x, w, history);
+                        assert sorted();
+                        return null;
+                    }
+                }
+            }
+
+            // insert at end
+            if (active >= pageSize) {
+                // split page
+                Page newPage = split();
+                newPage.addAt(newPage.active, x, w, history);
+                assert sorted();
+                assert newPage.sorted();
+                return newPage;
+            } else {
+                addAt(active, x, w, history);
+                assert sorted();
+                return null;
+            }
+        }
+
+        private void addAt(int i, double x, int w, List<Double> history) {
+            if (i < active) {
+                // shift data to make room
+                System.arraycopy(centroids, i, centroids, i + 1, active - i);
+                System.arraycopy(counts, i, counts, i + 1, active - i);
+                if (this.history != null) {
+                    this.history.add(i, history);
+                }
+                centroids[i] = x;
+                counts[i] = w;
+            } else {
+                assert i == active;
+                centroids[active] = x;
+                counts[active] = w;
+                if (this.history != null) {
+                    this.history.add(history);
+                }
+            }
+            active++;
+            totalCount += w;
+        }
+
+        private Page split() {
+            assert active == pageSize;
+            final int half = pageSize / 2;
+            Page newPage = new Page(pageSize, recordAllData);
+            System.arraycopy(centroids, half, newPage.centroids, 0, pageSize - half);
+            System.arraycopy(counts, half, newPage.counts, 0, pageSize - half);
+            if (history != null) {
+                newPage.history = new ArrayList<List<Double>>();
+                newPage.history.addAll(history.subList(half, pageSize));
+
+                List<List<Double>> tmp = new ArrayList<List<Double>>();
+                tmp.addAll(history.subList(0, half));
+                history = tmp;
+            }
+            active = half;
+            newPage.active = pageSize - half;
+
+            newPage.totalCount = totalCount;
+            totalCount = 0;
+            for (int i = 0; i < half; i++) {
+                totalCount += counts[i];
+                newPage.totalCount -= counts[i];
+            }
+
+            return newPage;
+        }
+
+        public void delete(int i) {
+            int w = counts[i];
+            if (i != active - 1) {
+                System.arraycopy(centroids, i + 1, centroids, i, active - i - 1);
+                System.arraycopy(counts, i + 1, counts, i, active - i - 1);
+                if (history != null) {
+                    history.remove(i);
+                }
+            }
+            active--;
+            totalCount -= w;
+            assert sorted();
+        }
+    }
+}

--- a/spectator-reg-tdigest/src/main/java/com/tdunning/math/stats/Centroid.java
+++ b/spectator-reg-tdigest/src/main/java/com/tdunning/math/stats/Centroid.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tdunning.math.stats;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A single centroid which represents a number of data points.
+ */
+public class Centroid implements Comparable<Centroid> {
+    private static final AtomicInteger uniqueCount = new AtomicInteger(1);
+
+    private double centroid = 0;
+    private int count = 0;
+    private int id;
+
+    private List<Double> actualData = null;
+
+    Centroid(boolean record) {
+        id = uniqueCount.getAndIncrement();
+        if (record) {
+            actualData = new ArrayList<Double>();
+        }
+    }
+
+    public Centroid(double x) {
+        this(false);
+        start(x, 1, uniqueCount.getAndIncrement());
+    }
+
+    public Centroid(double x, int w) {
+        this(false);
+        start(x, w, uniqueCount.getAndIncrement());
+    }
+
+    public Centroid(double x, int w, int id) {
+        this(false);
+        start(x, w, id);
+    }
+
+    public Centroid(double x, int id, boolean record) {
+        this(record);
+        start(x, 1, id);
+    }
+
+    private void start(double x, int w, int id) {
+        this.id = id;
+        add(x, w);
+    }
+
+    public void add(double x, int w) {
+        if (actualData != null) {
+            actualData.add(x);
+        }
+        count += w;
+        centroid += w * (x - centroid) / count;
+    }
+
+    public double mean() {
+        return centroid;
+    }
+
+    public int count() {
+        return count;
+    }
+
+    public int id() {
+        return id;
+    }
+
+    @Override
+    public String toString() {
+        return "Centroid{" +
+                "centroid=" + centroid +
+                ", count=" + count +
+                '}';
+    }
+
+    @Override
+    public int hashCode() {
+        return id;
+    }
+
+    @Override
+    public int compareTo(Centroid o) {
+        int r = Double.compare(centroid, o.centroid);
+        if (r == 0) {
+            r = id - o.id;
+        }
+        return r;
+    }
+
+    public List<Double> data() {
+        return actualData;
+    }
+
+    public void insertData(double x) {
+        if (actualData == null) {
+            actualData = new ArrayList<Double>();
+        }
+        actualData.add(x);
+    }
+
+    public static Centroid createWeighted(double x, int w, Iterable<? extends Double> data) {
+        Centroid r = new Centroid(data != null);
+        r.add(x, w, data);
+        return r;
+    }
+
+    public void add(double x, int w, Iterable<? extends Double> data) {
+        if (actualData != null) {
+            if (data != null) {
+                for (Double old : data) {
+                    actualData.add(old);
+                }
+            } else {
+                actualData.add(x);
+            }
+        }
+        centroid = AbstractTDigest.weightedAverage(centroid, count, x, w);
+        count += w;
+    }
+}

--- a/spectator-reg-tdigest/src/main/java/com/tdunning/math/stats/GroupTree.java
+++ b/spectator-reg-tdigest/src/main/java/com/tdunning/math/stats/GroupTree.java
@@ -1,0 +1,438 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tdunning.math.stats;
+
+import java.util.AbstractCollection;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * A tree containing TDigest.Centroid.  This adds to the normal NavigableSet the
+ * ability to sum up the size of elements to the left of a particular group.
+ */
+public class GroupTree extends AbstractCollection<Centroid> {
+    private long count;
+    private int size;
+    private int depth;
+    private Centroid leaf;
+    private GroupTree left, right;
+
+    public GroupTree() {
+        count = size = depth = 0;
+        leaf = null;
+        left = right = null;
+    }
+
+    public GroupTree(Centroid leaf) {
+        size = depth = 1;
+        this.leaf = leaf;
+        count = leaf.count();
+        left = right = null;
+    }
+
+    public GroupTree(GroupTree left, GroupTree right) {
+        this.left = left;
+        this.right = right;
+        count = left.count + right.count;
+        size = left.size + right.size;
+        rebalance();
+        leaf = this.right.first();
+    }
+
+    public boolean add(Centroid centroid) {
+        if (size == 0) {
+            leaf = centroid;
+            depth = 1;
+            count = centroid.count();
+            size = 1;
+            return true;
+        } else if (size == 1) {
+            int order = centroid.compareTo(leaf);
+            if (order < 0) {
+                left = new GroupTree(centroid);
+                right = new GroupTree(leaf);
+            } else if (order > 0) {
+                left = new GroupTree(leaf);
+                right = new GroupTree(centroid);
+                leaf = centroid;
+            }
+        } else if (centroid.compareTo(leaf) < 0) {
+            left.add(centroid);
+        } else {
+            right.add(centroid);
+        }
+        count += centroid.count();
+        size++;
+        depth = Math.max(left.depth, right.depth) + 1;
+
+        rebalance();
+        return true;
+    }
+
+    /**
+     * Modify an existing value in the tree subject to the constraint that the change will not alter the
+     * ordering of the tree.
+     * @param x         New value to add to Centroid
+     * @param count     Weight of new value
+     * @param v         The value to modify
+     * @param data      The recorded data
+     */
+    public void move(double x, int count, Centroid v, Iterable<? extends Double> data) {
+        if (size <= 0) {
+            throw new IllegalStateException("Cannot move element of empty tree");
+        }
+
+        if (size == 1) {
+            if(leaf != v) {
+                throw new IllegalStateException("Cannot move element that is not in tree");
+            }
+            leaf.add(x, count, data);
+        } else if (v.compareTo(leaf) < 0) {
+            left.move(x, count, v, data);
+        } else {
+            right.move(x, count, v, data);
+        }
+        this.count += count;
+    }
+
+    private void rebalance() {
+        int l = left.depth();
+        int r = right.depth();
+        if (l > r + 1) {
+            if (left.left.depth() > left.right.depth()) {
+                rotate(left.left.left, left.left.right, left.right, right);
+            } else {
+                rotate(left.left, left.right.left, left.right.right, right);
+            }
+        } else if (r > l + 1) {
+            if (right.left.depth() > right.right.depth()) {
+                rotate(left, right.left.left, right.left.right, right.right);
+            } else {
+                rotate(left, right.left, right.right.left, right.right.right);
+            }
+        } else {
+            depth = Math.max(left.depth(), right.depth()) + 1;
+        }
+    }
+
+    private void rotate(GroupTree a, GroupTree b, GroupTree c, GroupTree d) {
+        left = new GroupTree(a, b);
+        right = new GroupTree(c, d);
+        count = left.count + right.count;
+        size = left.size + right.size;
+        depth = Math.max(left.depth(), right.depth()) + 1;
+        leaf = right.first();
+    }
+
+    private int depth() {
+        return depth;
+    }
+
+    public int size() {
+        return size;
+    }
+
+    /**
+     * @return the number of items strictly before the current element
+     */
+    public int headCount(Centroid base) {
+        if (size == 0) {
+            return 0;
+        } else if (left == null) {
+            return leaf.compareTo(base) < 0 ? 1 : 0;
+        } else {
+            if (base.compareTo(leaf) < 0) {
+                return left.headCount(base);
+            } else {
+                return left.size + right.headCount(base);
+            }
+        }
+    }
+
+    /**
+     * @return the sum of the size() function for all elements strictly before the current element.
+     */
+    public long headSum(Centroid base) {
+        if (size == 0) {
+            return 0;
+        } else if (left == null) {
+            return leaf.compareTo(base) < 0 ? count : 0;
+        } else {
+            if (base.compareTo(leaf) <= 0) {
+                return left.headSum(base);
+            } else {
+                return left.count + right.headSum(base);
+            }
+        }
+    }
+
+    /**
+     * @return the first Centroid in this set
+     */
+    public Centroid first() {
+        if(size <= 0) {
+            throw new IllegalStateException("No first element of empty set");
+        }
+        if (left == null) {
+            return leaf;
+        } else {
+            return left.first();
+        }
+    }
+
+    /**
+     * Iteratres through all groups in the tree.
+     */
+    public Iterator<Centroid> iterator() {
+        return iterator(null);
+    }
+
+    /**
+     * Iterates through all of the Groups in this tree in ascending order of means
+     * @param start  The place to start this subset.  Remember that Groups are ordered by mean *and* id.
+     * @return An iterator that goes through the groups in order of mean and id starting at or after the
+     * specified Centroid.
+     */
+    private Iterator<Centroid> iterator(final Centroid start) {
+        return new Iterator<Centroid>() {
+            {
+                stack = new ArrayDeque<GroupTree>();
+                push(GroupTree.this, start);
+            }
+
+            Centroid end = new Centroid(0, 0, -1);
+            Centroid next = null;
+
+            Deque<GroupTree> stack;
+
+            @Override
+            public boolean hasNext() {
+                if (next == null) {
+                    next = computeNext();
+                }
+                return next != null && next != end;
+            }
+
+            @Override
+            public Centroid next() {
+                if (hasNext()) {
+                    Centroid r = next;
+                    next = null;
+                    return r;
+                } else {
+                    throw new NoSuchElementException("Can't iterate past end of data");
+                }
+            }
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException("Default operation");
+            }
+
+            // recurses down to the leaf that is >= start
+            // pending right hand branches on the way are put on the stack
+            private void push(GroupTree z, Centroid start) {
+                while (z.left != null) {
+                    if (start == null || start.compareTo(z.leaf) < 0) {
+                        // remember we will have to process the right hand branch later
+                        stack.push(z.right);
+                        // note that there is no guarantee that z.left has any good data
+                        z = z.left;
+                    } else {
+                        // if the left hand branch doesn't contain start, then no push
+                        z = z.right;
+                    }
+                }
+                // put the leaf value on the stack if it is valid
+                if (start == null || z.leaf.compareTo(start) >= 0) {
+                    stack.push(z);
+                }
+            }
+
+            protected Centroid computeNext() {
+                GroupTree r = stack.poll();
+                while (r != null && r.left != null) {
+                    // unpack r onto the stack
+                    push(r, start);
+                    r = stack.poll();
+                }
+
+                // at this point, r == null or r.left == null
+                // if r == null, stack is empty and we are done
+                // if r != null, then r.left != null and we have a result
+                if (r != null) {
+                    return r.leaf;
+                }
+                return end;
+            }
+        };
+    }
+
+    public void remove(Centroid base) {
+        if(size <= 0) {
+            throw new IllegalStateException("Cannot remove from empty set");
+        }
+        if (size == 1) {
+            if(base.compareTo(leaf) != 0) {
+                throw new IllegalStateException(String.format("Element %s not found", base));
+            }
+            count = size = 0;
+            leaf = null;
+        } else {
+            if (base.compareTo(leaf) < 0) {
+                if (left.size > 1) {
+                    left.remove(base);
+                    count -= base.count();
+                    size--;
+                    rebalance();
+                } else {
+                    size = right.size;
+                    count = right.count;
+                    depth = right.depth;
+                    leaf = right.leaf;
+                    left = right.left;
+                    right = right.right;
+                }
+            } else {
+                if (right.size > 1) {
+                    right.remove(base);
+                    leaf = right.first();
+                    count -= base.count();
+                    size--;
+                    rebalance();
+                } else {
+                    size = left.size;
+                    count = left.count;
+                    depth = left.depth;
+                    leaf = left.leaf;
+                    right = left.right;
+                    left = left.left;
+                }
+            }
+        }
+    }
+
+    /**
+     * @return the largest element less than or equal to base
+     */
+    public Centroid floor(Centroid base) {
+        if (size == 0) {
+            return null;
+        } else {
+            if (size == 1) {
+                return base.compareTo(leaf) >= 0 ? leaf : null;
+            } else {
+                if (base.compareTo(leaf) < 0) {
+                    return left.floor(base);
+                } else {
+                    Centroid floor = right.floor(base);
+                    if (floor == null) {
+                        floor = left.last();
+                    }
+                    return floor;
+                }
+            }
+        }
+    }
+
+    public Centroid last() {
+        if(size <= 0) {
+            throw new IllegalStateException("Cannot find last element of empty set");
+        }
+        if (size == 1) {
+            return leaf;
+        } else {
+            return right.last();
+        }
+    }
+
+    /**
+     * @return the smallest element greater than or equal to base.
+     */
+    public Centroid ceiling(Centroid base) {
+        if (size == 0) {
+            return null;
+        } else if (size == 1) {
+            return base.compareTo(leaf) <= 0 ? leaf : null;
+        } else {
+            if (base.compareTo(leaf) < 0) {
+                Centroid r = left.ceiling(base);
+                if (r == null) {
+                    r = right.first();
+                }
+                return r;
+            } else {
+                return right.ceiling(base);
+            }
+        }
+    }
+
+    /**
+     * @return the subset of elements equal to or greater than base.
+     */
+    public Iterable<Centroid> tailSet(final Centroid start) {
+        return new Iterable<Centroid>() {
+            @Override
+            public Iterator<Centroid> iterator() {
+                return GroupTree.this.iterator(start);
+            }
+        };
+    }
+
+    public long sum() {
+        return count;
+    }
+
+    public void checkBalance() {
+        if (left != null) {
+            if(Math.abs(left.depth() - right.depth()) >= 2) {
+                throw new IllegalStateException("Imbalanced");
+            }
+            int l = left.depth();
+            int r = right.depth();
+            if(depth != Math.max(l, r) + 1){
+                throw new IllegalStateException( "Depth doesn't match children");
+            }
+            if(size != left.size + right.size){
+                throw new IllegalStateException( "Sizes don't match children");
+            }
+            if(count != left.count + right.count){
+                throw new IllegalStateException( "Counts don't match children");
+            }
+            if(leaf.compareTo(right.first()) != 0){
+                throw new IllegalStateException(String.format( "Split is wrong %.5f != %.5f or %d != %d", leaf.mean(), right.first().mean(), leaf.id(), right.first().id()));
+            }
+            left.checkBalance();
+            right.checkBalance();
+        }
+    }
+
+    public void print(int depth) {
+        for (int i = 0; i < depth; i++) {
+            System.out.printf("| ");
+        }
+        int imbalance = Math.abs((left != null ? left.depth : 1) - (right != null ? right.depth : 1));
+        System.out.printf("%s%s, %d, %d, %d\n", (imbalance > 1 ? "* " : "") + (right != null && leaf.compareTo(right.first()) != 0 ? "+ " : ""), leaf, size, count, this.depth);
+        if (left != null) {
+            left.print(depth + 1);
+            right.print(depth + 1);
+        }
+    }
+}

--- a/spectator-reg-tdigest/src/main/java/com/tdunning/math/stats/IntAVLTree.java
+++ b/spectator-reg-tdigest/src/main/java/com/tdunning/math/stats/IntAVLTree.java
@@ -1,0 +1,567 @@
+package com.tdunning.math.stats;
+
+import java.util.Arrays;
+
+
+/**
+ * An AVL-tree structure stored in parallel arrays.
+ * This class only stores the tree structure, so you need to extend it if you
+ * want to add data to the nodes, typically by using arrays and node
+ * identifiers as indices.
+ */
+abstract class IntAVLTree {
+
+    /**
+     * We use <tt>0</tt> instead of <tt>-1</tt> so that left(NIL) works without
+     * condition.
+     */
+    protected static final int NIL = 0;
+
+    /** Grow a size by 1/8. */
+    static int oversize(int size) {
+        return size + (size >>> 3);
+    }
+
+    private final NodeAllocator nodeAllocator;
+    private int root;
+    private int[] parent;
+    private int[] left;
+    private int[] right;
+    private byte[] depth;
+
+    IntAVLTree(int initialCapacity) {
+        nodeAllocator = new NodeAllocator();
+        root = NIL;
+        parent = new int[initialCapacity];
+        left = new int[initialCapacity];
+        right = new int[initialCapacity];
+        depth = new byte[initialCapacity];
+    }
+
+    IntAVLTree() {
+        this(16);
+    }
+
+    /**
+     * Return the current root of the tree.
+     */
+    public int root() {
+        return root;
+    }
+
+    /**
+     * Return the current capacity, which is the number of nodes that this tree
+     * can hold.
+     */
+    public int capacity() {
+        return parent.length;
+    }
+
+    /**
+     * Resize internal storage in order to be able to store data for nodes up to
+     * <code>newCapacity</code> (excluded).
+     */
+    protected void resize(int newCapacity) {
+        parent = Arrays.copyOf(parent, newCapacity);
+        left = Arrays.copyOf(left, newCapacity);
+        right = Arrays.copyOf(right, newCapacity);
+        depth = Arrays.copyOf(depth, newCapacity);
+    }
+
+    /**
+     * Return the size of this tree.
+     */
+    public int size() {
+        return nodeAllocator.size();
+    }
+
+    /**
+     * Return the parent of the provided node.
+     */
+    public int parent(int node) {
+        return parent[node];
+    }
+
+    /**
+     * Return the left child of the provided node.
+     */
+    public int left(int node) {
+        return left[node];
+    }
+
+    /**
+     * Return the right child of the provided node.
+     */
+    public int right(int node) {
+        return right[node];
+    }
+
+    /**
+     * Return the depth nodes that are stored below <code>node</code> including itself.
+     */
+    public int depth(int node) {
+        return depth[node];
+    }
+
+    /**
+     * Return the least node under <code>node</code>.
+     */
+    public int first(int node) {
+        if (node == NIL) {
+            return NIL;
+        }
+        while (true) {
+            final int left = left(node);
+            if (left == NIL) {
+                break;
+            }
+            node = left;
+        }
+        return node;
+    }
+
+    /**
+     * Return the largest node under <code>node</code>.
+     */
+    public int last(int node) {
+        while (true) {
+            final int right = right(node);
+            if (right == NIL) {
+                break;
+            }
+            node = right;
+        }
+        return node;
+    }
+
+    /**
+     * Return the least node that is strictly greater than <code>node</code>.
+     */
+    public final int next(int node) {
+        final int right = right(node);
+        if (right != NIL) {
+            return first(right);
+        } else {
+            int parent = parent(node);
+            while (parent != NIL && node == right(parent)) {
+                node = parent;
+                parent = parent(parent);
+            }
+            return parent;
+        }
+    }
+
+    /**
+     * Return the highest node that is strictly less than <code>node</code>.
+     */
+    public final int prev(int node) {
+        final int left = left(node);
+        if (left != NIL) {
+            return last(left);
+        } else {
+            int parent = parent(node);
+            while (parent != NIL && node == left(parent)) {
+                node = parent;
+                parent = parent(parent);
+            }
+            return parent;
+        }
+    }
+
+    /**
+     * Compare data against data which is stored in <code>node</code>.
+     */
+    protected abstract int compare(int node);
+
+    /**
+     * Compare data into <code>node</code>.
+     */
+    protected abstract void copy(int node);
+
+    /**
+     * Merge data into <code>node</code>.
+     */
+    protected abstract void merge(int node);
+
+
+    /**
+     * Add current data to the tree and return <tt>true</tt> if a new node was added
+     * to the tree or <tt>false</tt> if the node was merged into an existing node.
+     */
+    public boolean add() {
+        if (root == NIL) {
+            root = nodeAllocator.newNode();
+            copy(root);
+            fixAggregates(root);
+            return true;
+        } else {
+            int node = root; assert parent(root) == NIL;
+            int parent = NIL;
+            int cmp;
+            do {
+                cmp = compare(node);
+                if (cmp < 0) {
+                    parent = node;
+                    node = left(node);
+                } else if (cmp > 0) {
+                    parent = node;
+                    node = right(node);
+                } else {
+                    merge(node);
+                    return false;
+                }
+            } while (node != NIL);
+
+            node = nodeAllocator.newNode();
+            if (node >= capacity()) {
+                resize(oversize(node + 1));
+            }
+            copy(node);
+            parent(node, parent);
+            if (cmp < 0) {
+                left(parent, node);
+            } else {
+                assert cmp > 0;
+                right(parent, node);
+            }
+
+            rebalance(node);
+
+            return true;
+        }
+    }
+
+    /**
+     * Find a node in this tree.
+     */
+    public int find() {
+        for (int node = root; node != NIL; ) {
+            final int cmp = compare(node);
+            if (cmp < 0) {
+                node = left(node);
+            } else if (cmp > 0) {
+                node = right(node);
+            } else {
+                return node;
+            }
+        }
+        return NIL;
+    }
+
+    /**
+     * Update <code>node</code> with the current data.
+     */
+    public void update(int node) {
+        final int prev = prev(node);
+        final int next = next(node);
+        if ((prev == NIL || compare(prev) > 0) && (next == NIL || compare(next) < 0)) {
+            // Update can be done in-place
+            copy(node);
+            for (int n = node; n != NIL; n = parent(n)) {
+                fixAggregates(n);
+            }
+        } else {
+            // TODO: it should be possible to find the new node position without
+            // starting from scratch
+            remove(node);
+            add();
+        }
+    }
+
+    /**
+     * Remove the specified node from the tree.
+     */
+    public void remove(int node) {
+        if (node == NIL) {
+            throw new IllegalArgumentException();
+        }
+        if (left(node) != NIL && right(node) != NIL) {
+            // inner node
+            final int next = next(node);
+            assert next != NIL;
+            swap(node, next);
+        }
+        assert left(node) == NIL || right(node) == NIL;
+
+        final int parent = parent(node);
+        int child = left(node);
+        if (child == NIL) {
+            child = right(node);
+        }
+
+        if (child == NIL) {
+            // no children
+            if (node == root) {
+                assert size() == 1 : size();
+                root = NIL;
+            } else {
+                if (node == left(parent)) {
+                    left(parent, NIL);
+                } else {
+                    assert node == right(parent);
+                    right(parent, NIL);
+                }
+            }
+        } else {
+            // one single child
+            if (node == root) {
+                assert size() == 2;
+                root = child;
+            } else if (node == left(parent)) {
+                left(parent, child);
+            } else {
+                assert node == right(parent);
+                right(parent, child);
+            }
+            parent(child, parent);
+        }
+
+        release(node);
+        rebalance(parent);
+    }
+
+    private void release(int node) {
+        left(node, NIL);
+        right(node, NIL);
+        parent(node, NIL);
+        nodeAllocator.release(node);
+    }
+
+    private void swap(int node1, int node2) {
+        final int parent1 = parent(node1);
+        final int parent2 = parent(node2);
+        if (parent1 != NIL) {
+            if (node1 == left(parent1)) {
+                left(parent1, node2);
+            } else {
+                assert node1 == right(parent1);
+                right(parent1, node2);
+            }
+        } else {
+            assert root == node1;
+            root = node2;
+        }
+        if (parent2 != NIL) {
+            if (node2 == left(parent2)) {
+                left(parent2, node1);
+            } else {
+                assert node2 == right(parent2);
+                right(parent2, node1);
+            }
+        } else {
+            assert root == node2;
+            root = node1;
+        }
+        parent(node1, parent2);
+        parent(node2, parent1);
+
+        final int left1 = left(node1);
+        final int left2 = left(node2);
+        left(node1, left2);
+        if (left2 != NIL) {
+            parent(left2, node1);
+        }
+        left(node2, left1);
+        if (left1 != NIL) {
+            parent(left1, node2);
+        }
+
+        final int right1 = right(node1);
+        final int right2 = right(node2);
+        right(node1, right2);
+        if (right2 != NIL) {
+            parent(right2, node1);
+        }
+        right(node2, right1);
+        if (right1 != NIL) {
+            parent(right1, node2);
+        }
+
+        final int depth1 = depth(node1);
+        final int depth2 = depth(node2);
+        depth(node1, depth2);
+        depth(node2, depth1);
+    }
+
+    private int balanceFactor(int node) {
+        return depth(left(node)) - depth(right(node));
+    }
+
+    private void rebalance(int node) {
+        for (int n = node; n != NIL; ) {
+            final int p = parent(n);
+
+            fixAggregates(n);
+
+            switch (balanceFactor(n)) {
+            case -2:
+                final int right = right(n);
+                if (balanceFactor(right) == 1) {
+                    rotateRight(right);
+                }
+                rotateLeft(n);
+                break;
+            case 2:
+                final int left = left(n);
+                if (balanceFactor(left) == -1) {
+                    rotateLeft(left);
+                }
+                rotateRight(n);
+                break;
+            case -1:
+            case 0:
+            case 1:
+                break; // ok
+            default:
+                throw new AssertionError();
+            }
+
+            n = p;
+        }
+    }
+
+    protected void fixAggregates(int node) {
+        depth(node, 1 + Math.max(depth(left(node)), depth(right(node))));
+    }
+
+    /** Rotate left the subtree under <code>n</code> */
+    private void rotateLeft(int n) {
+        final int r = right(n);
+        final int lr = left(r);
+        right(n, lr);
+        if (lr != NIL) {
+            parent(lr, n);
+        }
+        final int p = parent(n);
+        parent(r, p);
+        if (p == NIL) {
+            root = r;
+        } else if (left(p) == n) {
+            left(p, r);
+        } else {
+            assert right(p) == n;
+            right(p, r);
+        }
+        left(r, n);
+        parent(n, r);
+        fixAggregates(n);
+        fixAggregates(parent(n));
+    }
+
+    /** Rotate right the subtree under <code>n</code> */
+    private void rotateRight(int n) {
+        final int l = left(n);
+        final int rl = right(l);
+        left(n, rl);
+        if (rl != NIL) {
+            parent(rl, n);
+        }
+        final int p = parent(n);
+        parent(l, p);
+        if (p == NIL) {
+            root = l;
+        } else if (right(p) == n) {
+            right(p, l);
+        } else {
+            assert left(p) == n;
+            left(p, l);
+        }
+        right(l, n);
+        parent(n, l);
+        fixAggregates(n);
+        fixAggregates(parent(n));
+    }
+
+    private void parent(int node, int parent) {
+        assert node != NIL;
+        this.parent[node] = parent;
+    }
+
+    private void left(int node, int left) {
+        assert node != NIL;
+        this.left[node] = left;
+    }
+
+    private void right(int node, int right) {
+        assert node != NIL;
+        this.right[node] = right;
+    }
+
+    private void depth(int node, int depth) {
+        assert node != NIL;
+        assert depth >= 0 && depth <= Byte.MAX_VALUE;
+        this.depth[node] = (byte) depth;
+    }
+
+    void checkBalance(int node) {
+        if (node == NIL) {
+            assert depth(node) == 0;
+        } else {
+            assert depth(node) == 1 + Math.max(depth(left(node)), depth(right(node)));
+            assert Math.abs(depth(left(node)) - depth(right(node))) <= 1;
+            checkBalance(left(node));
+            checkBalance(right(node));
+        }
+    }
+
+    /**
+     * A stack of int values.
+     */
+    private static class IntStack {
+
+        private int[] stack;
+        private int size;
+
+        IntStack() {
+            stack = new int[0];
+            size = 0;
+        }
+
+        int size() {
+            return size;
+        }
+
+        int pop() {
+            return stack[--size];
+        }
+
+        void push(int v) {
+            if (size >= stack.length) {
+                final int newLength = oversize(size + 1);
+                stack = Arrays.copyOf(stack, newLength);
+            }
+            stack[size++] = v;
+        }
+
+    }
+
+    private static class NodeAllocator {
+
+        private int nextNode;
+        private final IntStack releasedNodes;
+
+        NodeAllocator() {
+            nextNode = NIL + 1;
+            releasedNodes = new IntStack();
+        }
+
+        int newNode() {
+            if (releasedNodes.size() > 0) {
+                return releasedNodes.pop();
+            } else {
+                return nextNode++;
+            }
+        }
+
+        void release(int node) {
+            assert node < nextNode;
+            releasedNodes.push(node);
+        }
+
+        int size() {
+            return nextNode - releasedNodes.size() - 1;
+        }
+
+    }
+
+}

--- a/spectator-reg-tdigest/src/main/java/com/tdunning/math/stats/TDigest.java
+++ b/spectator-reg-tdigest/src/main/java/com/tdunning/math/stats/TDigest.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tdunning.math.stats;
+
+import java.nio.ByteBuffer;
+import java.util.Collection;
+
+/**
+ * Adaptive histogram based on something like streaming k-means crossed with Q-digest.
+ * <p/>
+ * The special characteristics of this algorithm are:
+ * <p/>
+ * a) smaller summaries than Q-digest
+ * <p/>
+ * b) works on doubles as well as integers.
+ * <p/>
+ * c) provides part per million accuracy for extreme quantiles and typically <1000 ppm accuracy for middle quantiles
+ * <p/>
+ * d) fast
+ * <p/>
+ * e) simple
+ * <p/>
+ * f) test coverage > 90%
+ * <p/>
+ * g) easy to adapt for use with map-reduce
+ */
+public abstract class TDigest {
+    /**
+     * Creates an ArrayDigest with default page size.
+     *
+     * @param compression The compression parameter.  100 is a common value for normal uses.  1000 is extremely large.
+     *                    The number of centroids retained will be a smallish (usually less than 10) multiple of this number.
+     * @return the ArrayDigest
+     */
+    public static ArrayDigest createArrayDigest(double compression) {
+        return new ArrayDigest(32, compression);
+    }
+
+    /**
+     * Creates an ArrayDigest with specified page size.
+     *
+     * @param pageSize    The internal page size to use.  This should be about sqrt(10*compression)
+     * @param compression The compression parameter.  100 is a common value for normal uses.  1000 is extremely large.
+     *                    The number of centroids retained will be a smallish (usually less than 10) multiple of this number.
+     * @return the ArrayDigest
+     */
+    public static ArrayDigest createArrayDigest(int pageSize, double compression) {
+        return new ArrayDigest(pageSize, compression);
+    }
+
+    /**
+     * Creates a TreeDigest.  Going forward, AVLTreeDigest should be preferred to the TreeDigest since they are
+     * uniformly faster and require less memory while producing nearly identical results.
+     *
+     * @param compression The compression parameter.  100 is a common value for normal uses.  1000 is extremely large.
+     *                    The number of centroids retained will be a smallish (usually less than 10) multiple of this number.
+     * @return the TreeDigest
+     */
+    public static TDigest createTreeDigest(double compression) {
+        return new TreeDigest(compression);
+    }
+
+    /**
+     * Creates an AVLTreeDigest.  AVLTreeDigest is generally the best known implementation right now.
+     *
+     * @param compression The compression parameter.  100 is a common value for normal uses.  1000 is extremely large.
+     *                    The number of centroids retained will be a smallish (usually less than 10) multiple of this number.
+     * @return the TreeDigest
+     */
+    public static TDigest createAvlTreeDigest(double compression) {
+        return new AVLTreeDigest(compression);
+    }
+
+    /**
+     * Creates a TreeDigest of whichever type is the currently recommended type.  AVLTreeDigest is generally the best
+     * known implementation right now.
+     *
+     * @param compression The compression parameter.  100 is a common value for normal uses.  1000 is extremely large.
+     *                    The number of centroids retained will be a smallish (usually less than 10) multiple of this number.
+     * @return the TreeDigest
+     */
+    public static TDigest createDigest(double compression) {
+        return createAvlTreeDigest(compression);
+    }
+
+    /**
+     * Adds a sample to a histogram.
+     *
+     * @param x The value to add.
+     * @param w The weight of this point.
+     */
+    public abstract void add(double x, int w);
+
+    protected final void checkValue(double x) {
+        if (Double.isNaN(x)) {
+            throw new IllegalArgumentException("Cannot add NaN");
+        }
+    }
+
+    /**
+     * Re-examines a t-digest to determine whether some centroids are redundant.  If your data are
+     * perversely ordered, this may be a good idea.  Even if not, this may save 20% or so in space.
+     * <p/>
+     * The cost is roughly the same as adding as many data points as there are centroids.  This
+     * is typically < 10 * compression, but could be as high as 100 * compression.
+     * <p/>
+     * This is a destructive operation that is not thread-safe.
+     */
+    public abstract void compress();
+
+    /**
+     * Returns the number of points that have been added to this TDigest.
+     *
+     * @return The sum of the weights on all centroids.
+     */
+    public abstract long size();
+
+    /**
+     * Returns the fraction of all points added which are <= x.
+     */
+    public abstract double cdf(double x);
+
+    /**
+     * Returns an estimate of the cutoff such that a specified fraction of the data
+     * added to this TDigest would be less than or equal to the cutoff.
+     *
+     * @param q The desired fraction
+     * @return The value x such that cdf(x) == q
+     */
+    public abstract double quantile(double q);
+
+    /**
+     * A {@link Collection} that lets you go through the centroids in ascending order by mean.  Centroids
+     * returned will not be re-used, but may or may not share storage with this TDigest.
+     *
+     * @return The centroids in the form of a Collection.
+     */
+    public abstract Collection<Centroid> centroids();
+
+    /**
+     * Returns the current compression factor.
+     *
+     * @return The compression factor originally used to set up the TDigest.
+     */
+    public abstract double compression();
+
+    /**
+     * Returns the number of bytes required to encode this TDigest using #asBytes().
+     *
+     * @return The number of bytes required.
+     */
+    public abstract int byteSize();
+
+    /**
+     * Returns the number of bytes required to encode this TDigest using #asSmallBytes().
+     *
+     * @return The number of bytes required.
+     */
+    public abstract int smallByteSize();
+
+    /**
+     * Serialize this TDigest into a byte buffer.  Note that the serialization used is
+     * very straightforward and is considerably larger than strictly necessary.
+     *
+     * @param buf The byte buffer into which the TDigest should be serialized.
+     */
+    public abstract void asBytes(ByteBuffer buf);
+
+    /**
+     * Serialize this TDigest into a byte buffer.  Some simple compression is used
+     * such as using variable byte representation to store the centroid weights and
+     * using delta-encoding on the centroid means so that floats can be reasonably
+     * used to store the centroid means.
+     *
+     * @param buf The byte buffer into which the TDigest should be serialized.
+     */
+    public abstract void asSmallBytes(ByteBuffer buf);
+
+    /**
+     * Tell this TDigest to record the original data as much as possible for test
+     * purposes.
+     *
+     * @return This TDigest so that configurations can be done in fluent style.
+     */
+    public abstract TDigest recordAllData();
+
+    public abstract boolean isRecording();
+
+    /**
+     * Add a sample to this TDigest.
+     *
+     * @param x The data value to add
+     */
+    public abstract void add(double x);
+
+    /**
+     * Add all of the centroids of another TDigest to this one.
+     *
+     * @param other The other TDigest
+     */
+    public abstract void add(TDigest other);
+}

--- a/spectator-reg-tdigest/src/main/java/com/tdunning/math/stats/TreeDigest.java
+++ b/spectator-reg-tdigest/src/main/java/com/tdunning/math/stats/TreeDigest.java
@@ -1,0 +1,394 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tdunning.math.stats;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+
+/**
+ * Adaptive histogram based on something like streaming k-means crossed with Q-digest.
+ * <p/>
+ * The special characteristics of this algorithm are:
+ * <p/>
+ * a) smaller summaries than Q-digest
+ * <p/>
+ * b) works on doubles as well as integers.
+ * <p/>
+ * c) provides part per million accuracy for extreme quantiles and typically <1000 ppm accuracy for middle quantiles
+ * <p/>
+ * d) fast
+ * <p/>
+ * e) simple
+ * <p/>
+ * f) test coverage > 90%
+ * <p/>
+ * g) easy to adapt for use with map-reduce
+ */
+public class TreeDigest extends AbstractTDigest {
+
+    private double compression = 100;
+    private GroupTree summary = new GroupTree();
+    long count = 0; // package private for testing
+
+    /**
+     * A histogram structure that will record a sketch of a distribution.
+     *
+     * @param compression How should accuracy be traded for size?  A value of N here will give quantile errors
+     *                    almost always less than 3/N with considerably smaller errors expected for extreme
+     *                    quantiles.  Conversely, you should expect to track about 5 N centroids for this
+     *                    accuracy.
+     */
+    public TreeDigest(double compression) {
+        this.compression = compression;
+    }
+
+    @Override
+    public void add(double x, int w) {
+        // note that because of a zero id, this will be sorted *before* any existing Centroid with the same mean
+        add(x, w, createCentroid(x, 0));
+    }
+
+    @Override
+    public void add(double x, int w, Centroid base) {
+        checkValue(x);
+        Centroid start = summary.floor(base);
+        if (start == null) {
+            start = summary.ceiling(base);
+        }
+
+        if (start == null) {
+            summary.add(Centroid.createWeighted(x, w, base.data()));
+            count = w;
+        } else {
+            Iterable<Centroid> neighbors = summary.tailSet(start);
+            double minDistance = Double.MAX_VALUE;
+            int lastNeighbor = 0;
+            int i = 0;
+            for (Centroid neighbor : neighbors) {
+                double z = Math.abs(neighbor.mean() - x);
+                if (z <= minDistance) {
+                    minDistance = z;
+                    lastNeighbor = i;
+                } else {
+                    // as soon as z increases, we have passed the nearest neighbor and can quit
+                    break;
+                }
+                i++;
+            }
+
+            Centroid closest = null;
+            long sum = summary.headSum(start);
+            i = 0;
+            double n = 1;
+            for (Centroid neighbor : neighbors) {
+                if (i > lastNeighbor) {
+                    break;
+                }
+                double z = Math.abs(neighbor.mean() - x);
+                double q = (sum + neighbor.count() / 2.0) / count;
+                double k = 4 * count * q * (1 - q) / compression;
+
+                // this slightly clever selection method improves accuracy with lots of repeated points
+                if (z == minDistance && neighbor.count() + w <= k) {
+                    if (gen.nextDouble() < 1 / n) {
+                        closest = neighbor;
+                    }
+                    n++;
+                }
+                sum += neighbor.count();
+                i++;
+            }
+
+            if (closest == null) {
+                summary.add(Centroid.createWeighted(x, w, base.data()));
+            } else {
+                // if the nearest point was not unique, then we may not be modifying the first copy
+                // which means that ordering can change
+                summary.remove(closest);
+                closest.add(x, w, base.data());
+                summary.add(closest);
+            }
+            count += w;
+
+            if (summary.size() > 20 * compression) {
+                // something such as sequential ordering of data points
+                // has caused a pathological expansion of our summary.
+                // To fight this, we simply replay the current centroids
+                // in random order.
+
+                // this causes us to forget the diagnostic recording of data points
+                compress();
+            }
+        }
+    }
+
+    public static TDigest merge(double compression, Iterable<TDigest> subData, Random gen) {
+        TreeDigest r = new TreeDigest(compression);
+        return merge(subData, gen, r);
+    }
+
+    @Override
+    public void compress() {
+        TreeDigest reduced = new TreeDigest(compression);
+        if (recordAllData) {
+            reduced.recordAllData();
+        }
+        List<Centroid> tmp = new ArrayList<Centroid>();
+        for (Centroid centroid : summary) {
+            tmp.add(centroid);
+        }
+        Collections.shuffle(tmp, gen);
+        for (Centroid centroid : tmp) {
+            reduced.add(centroid.mean(), centroid.count(), centroid);
+        }
+
+        summary = reduced.summary;
+    }
+
+    /**
+     * Returns the number of samples represented in this histogram.  If you want to know how many
+     * centroids are being used, try centroids().size().
+     *
+     * @return the number of samples that have been added.
+     */
+    @Override
+    public long size() {
+        return count;
+    }
+
+    /**
+     * @param x the value at which the CDF should be evaluated
+     * @return the approximate fraction of all samples that were less than or equal to x.
+     */
+    @Override
+    public double cdf(double x) {
+        GroupTree values = summary;
+        if (values.size() == 0) {
+            return Double.NaN;
+        } else if (values.size() == 1) {
+            return x < values.first().mean() ? 0 : 1;
+        } else {
+            double r = 0;
+
+            // we scan a across the centroids
+            Iterator<Centroid> it = values.iterator();
+            Centroid a = it.next();
+
+            // b is the look-ahead to the next centroid
+            Centroid b = it.next();
+
+            // initially, we set left width equal to right width
+            double left = (b.mean() - a.mean()) / 2;
+            double right = left;
+
+            // scan to next to last element
+            while (it.hasNext()) {
+                if (x < a.mean() + right) {
+                    return (r + a.count() * interpolate(x, a.mean() - left, a.mean() + right)) / count;
+                }
+                r += a.count();
+
+                a = b;
+                b = it.next();
+
+                left = right;
+                right = (b.mean() - a.mean()) / 2;
+            }
+
+            // for the last element, assume right width is same as left
+            left = right;
+            a = b;
+            if (x < a.mean() + right) {
+                return (r + a.count() * interpolate(x, a.mean() - left, a.mean() + right)) / count;
+            } else {
+                return 1;
+            }
+        }
+    }
+
+    /**
+     * @param q The quantile desired.  Can be in the range [0,1].
+     * @return The minimum value x such that we think that the proportion of samples is <= x is q.
+     */
+    @Override
+    public double quantile(double q) {
+        if (q < 0 || q > 1) {
+            throw new IllegalArgumentException("q should be in [0,1], got " + q);
+        }
+
+        GroupTree values = summary;
+        if (values.size() == 0) {
+            return Double.NaN;
+        } else if (values.size() == 1) {
+            return values.iterator().next().mean();
+        }
+
+        // if values were stored in a sorted array, index would be the offset we are interested in
+        final double index = q * (count - 1);
+
+        double previousMean = Double.NaN, previousIndex = 0;
+        long total = 0;
+        Centroid next;
+        Iterator<? extends Centroid> it = centroids().iterator();
+        while (true) {
+            next = it.next();
+            final double nextIndex = total + (next.count() - 1.0) / 2;
+            if (nextIndex >= index) {
+                if (Double.isNaN(previousMean)) {
+                    // special case 1: the index we are interested in is before the 1st centroid
+                    if (nextIndex == previousIndex) {
+                        return next.mean();
+                    }
+                    // assume values grow linearly between index previousIndex=0 and nextIndex2
+                    Centroid next2 = it.next();
+                    final double nextIndex2 = total + next.count() + (next2.count() - 1.0) / 2;
+                    previousMean = (nextIndex2 * next.mean() - nextIndex * next2.mean()) / (nextIndex2 - nextIndex);
+                }
+                // common case: we found two centroids previous and next so that the desired quantile is
+                // after 'previous' but before 'next'
+                return quantile(previousIndex, index, nextIndex, previousMean, next.mean());
+            } else if (!it.hasNext()) {
+                // special case 2: the index we are interested in is beyond the last centroid
+                // again, assume values grow linearly between index previousIndex and (count - 1)
+                // which is the highest possible index
+                final double nextIndex2 = count - 1;
+                final double nextMean2 = (next.mean() * (nextIndex2 - previousIndex) - previousMean * (nextIndex2 - nextIndex)) / (nextIndex - previousIndex);
+                return quantile(nextIndex, index, nextIndex2, next.mean(), nextMean2);
+            }
+            total += next.count();
+            previousMean = next.mean();
+            previousIndex = nextIndex;
+        }
+    }
+
+    @Override
+    public Collection<Centroid> centroids() {
+        return Collections.unmodifiableCollection(summary);
+    }
+
+    @Override
+    public double compression() {
+        return compression;
+    }
+
+    /**
+     * Returns an upper bound on the number bytes that will be required to represent this histogram.
+     */
+    @Override
+    public int byteSize() {
+        return 4 + 8 + 4 + summary.size() * 12;
+    }
+
+    /**
+     * Returns an upper bound on the number of bytes that will be required to represent this histogram in
+     * the tighter representation.
+     */
+    @Override
+    public int smallByteSize() {
+        int bound = byteSize();
+        ByteBuffer buf = ByteBuffer.allocate(bound);
+        asSmallBytes(buf);
+        return buf.position();
+    }
+
+    public final static int VERBOSE_ENCODING = 1;
+    public final static int SMALL_ENCODING = 2;
+
+    /**
+     * Outputs a histogram as bytes using a particularly cheesy encoding.
+     */
+    @Override
+    public void asBytes(ByteBuffer buf) {
+        buf.putInt(VERBOSE_ENCODING);
+        buf.putDouble(compression());
+        buf.putInt(summary.size());
+        for (Centroid centroid : summary) {
+            buf.putDouble(centroid.mean());
+        }
+
+        for (Centroid centroid : summary) {
+            buf.putInt(centroid.count());
+        }
+    }
+
+    @Override
+    public void asSmallBytes(ByteBuffer buf) {
+        buf.putInt(SMALL_ENCODING);
+        buf.putDouble(compression());
+        buf.putInt(summary.size());
+
+        double x = 0;
+        for (Centroid centroid : summary) {
+            double delta = centroid.mean() - x;
+            x = centroid.mean();
+            buf.putFloat((float) delta);
+        }
+
+        for (Centroid centroid : summary) {
+            int n = centroid.count();
+            encode(buf, n);
+        }
+    }
+
+    /**
+     * Reads a histogram from a byte buffer
+     *
+     * @return The new histogram structure
+     */
+    public static TreeDigest fromBytes(ByteBuffer buf) {
+        int encoding = buf.getInt();
+        if (encoding == VERBOSE_ENCODING) {
+            double compression = buf.getDouble();
+            TreeDigest r = new TreeDigest(compression);
+            int n = buf.getInt();
+            double[] means = new double[n];
+            for (int i = 0; i < n; i++) {
+                means[i] = buf.getDouble();
+            }
+            for (int i = 0; i < n; i++) {
+                r.add(means[i], buf.getInt());
+            }
+            return r;
+        } else if (encoding == SMALL_ENCODING) {
+            double compression = buf.getDouble();
+            TreeDigest r = new TreeDigest(compression);
+            int n = buf.getInt();
+            double[] means = new double[n];
+            double x = 0;
+            for (int i = 0; i < n; i++) {
+                double delta = buf.getFloat();
+                x += delta;
+                means[i] = x;
+            }
+
+            for (int i = 0; i < n; i++) {
+                int z = decode(buf);
+                r.add(means[i], z);
+            }
+            return r;
+        } else {
+            throw new IllegalStateException("Invalid format for serialized histogram");
+        }
+    }
+
+}

--- a/spectator-reg-tdigest/src/main/resources/spectator-tdigest.properties
+++ b/spectator-reg-tdigest/src/main/resources/spectator-tdigest.properties
@@ -1,0 +1,2 @@
+spectator.tdigest.kinesis.endpoint=kinesis.${EC2_REGION}.amazonaws.com
+spectator.tdigest.kinesis.stream=spectator-tdigest

--- a/spectator-reg-tdigest/src/test/java/com/netflix/spectator/tdigest/TDigestPluginTest.java
+++ b/spectator-reg-tdigest/src/test/java/com/netflix/spectator/tdigest/TDigestPluginTest.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.tdigest;
+
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.ManualClock;
+import com.netflix.spectator.api.Registry;
+import com.tdunning.math.stats.TDigest;
+import com.tdunning.math.stats.TreeDigest;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@RunWith(JUnit4.class)
+public class TDigestPluginTest {
+
+  private final ManualClock clock = new ManualClock();
+
+  @Before
+  public void before() {
+    clock.setWallTime(0L);
+    clock.setMonotonicTime(0L);
+  }
+
+  private Map<Long, List<TDigestMeasurement>> readFromFile(File f) throws IOException {
+    Map<Long, List<TDigestMeasurement>> result = new HashMap<>();
+    try (TDigestReader in = new FileTDigestReader(f)) {
+      List<TDigestMeasurement> ms;
+      while (!(ms = in.read()).isEmpty()) {
+        for (TDigestMeasurement m : ms) {
+          List<TDigestMeasurement> tmp = result.get(m.timestamp());
+          if (tmp == null) {
+            tmp = new ArrayList<>();
+            result.put(m.timestamp(), tmp);
+          }
+          tmp.add(m);
+        }
+      }
+    }
+    return result;
+  }
+
+  @Test
+  public void writeData() throws Exception {
+    final File f = new File("build/TDigestPlugin_writeData.out");
+    f.getParentFile().mkdirs();
+    if (f.exists()) f.delete();
+    final TDigestRegistry r = new TDigestRegistry(clock);
+    final TDigestPlugin p = new TDigestPlugin(r, new FileTDigestWriter(f));
+
+    // Adding a bunch of tags to test the effect of setting
+    // SmileGenerator.Feature.CHECK_SHARED_STRING_VALUES.
+    //
+    //            |   true |  false | savings |
+    // recorded   | 151150 | 157225 |    3.9% |
+    // empty      |   5030 |  11465 |   56.1% |
+    //
+    // With many recorded values the size of the digest is likely much bigger than the tags
+    // and the overall benefit is small. However, with few recorded values it leads to a big
+    // reduction.
+    Id one = r.createId("one");
+    Id many = r.createId("many")
+        .withTag("region", "us-east-1")
+        .withTag("zone", "us-east-1a")
+        .withTag("ami", "ami-12345")
+        .withTag("node", "i-123456789")
+        .withTag("app", "foo")
+        .withTag("cluster", "foo-bar")
+        .withTag("asg",     "foo-bar-v001");
+    for (int i = 0; i < 10000; ++i) {
+      r.timer(one).record(i, TimeUnit.MILLISECONDS);
+      r.timer(many.withTag("i", "" + (i / 100))).record(i, TimeUnit.MILLISECONDS);
+    }
+
+    clock.setWallTime(61000);
+    p.writeData();
+
+    clock.setWallTime(121000);
+    p.writeData();
+
+    Map<Long, List<TDigestMeasurement>> result = readFromFile(f);
+    Assert.assertEquals(2, result.size());
+    Assert.assertNotNull(result.get(60000L));
+    Assert.assertNotNull(result.get(120000L));
+    for (List<TDigestMeasurement> m : result.values()) {
+      checkRecord(r, m);
+    }
+  }
+
+  private void checkRecord(Registry r, List<TDigestMeasurement> ms) {
+    Random random = new Random();
+    TDigest one = null;
+    TDigest many = TDigest.createDigest(100.0);
+    for (TDigestMeasurement m : ms) {
+      if ("one".equals(m.id().name())) {
+        one = m.value();
+      } else {
+        List<TDigest> vs = new ArrayList<>(2);
+        vs.add(many);
+        vs.add(m.value());
+        many = TreeDigest.merge(100.0, vs, random);
+      }
+    }
+    for (int i = 0; i < 1000; ++i) {
+      double q = i / 1000.0;
+      //System.err.printf("%f == %f%n", one.quantile(q), many.quantile(q));
+      Assert.assertEquals(one.quantile(q), many.quantile(q), 1e-1);
+    }
+  }
+}

--- a/spectator-reg-tdigest/src/test/java/com/netflix/spectator/tdigest/TDigestTimerTest.java
+++ b/spectator-reg-tdigest/src/test/java/com/netflix/spectator/tdigest/TDigestTimerTest.java
@@ -1,0 +1,148 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.tdigest;
+
+import com.netflix.spectator.api.ManualClock;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+@RunWith(JUnit4.class)
+public class TDigestTimerTest {
+
+  private final ManualClock clock = new ManualClock();
+
+  private TDigestTimer newTimer(String name) {
+    final TDigestRegistry r = new TDigestRegistry(clock);
+    return (TDigestTimer) r.timer(r.createId(name));
+  }
+
+  @Before
+  public void before() {
+    clock.setWallTime(0L);
+    clock.setMonotonicTime(0L);
+  }
+
+  @Test
+  public void testInit() {
+    TDigestTimer t = newTimer("foo");
+    Assert.assertEquals(t.percentile(99.9), Double.NaN, 1e-12);
+  }
+
+  @Test
+  public void testRecord() {
+    TDigestTimer t = newTimer("foo");
+    for (int i = 0; i < 99; ++i) {
+      t.record(42, TimeUnit.MILLISECONDS);
+    }
+    t.record(1000, TimeUnit.MILLISECONDS);
+    clock.setWallTime(61000);
+    for (int i = 0; i <= 99; ++i) {
+      final double p = i / 10.0;
+      Assert.assertEquals(t.percentile(p), 42 / 1000.0, 1e-12);
+    }
+    Assert.assertEquals(t.percentile(100.0), 1.0, 1e-12);
+  }
+
+  @Test
+  public void testRecordNegative() {
+    TDigestTimer t = newTimer("foo");
+    t.record(-42, TimeUnit.MILLISECONDS);
+    clock.setWallTime(61000);
+    Assert.assertEquals(t.percentile(1.0), Double.NaN, 1e-12);
+  }
+
+  @Test
+  public void testRecordZero() {
+    TDigestTimer t = newTimer("foo");
+    t.record(0, TimeUnit.MILLISECONDS);
+    clock.setWallTime(61000);
+    Assert.assertEquals(t.percentile(1.0), 0.0, 1e-12);
+  }
+
+  @Test
+  public void testRecordCallable() throws Exception {
+    TDigestTimer t = newTimer("foo");
+    clock.setMonotonicTime(100L);
+    int v = t.record(new Callable<Integer>() {
+      public Integer call() throws Exception {
+        clock.setMonotonicTime(500L);
+        return 42;
+      }
+    });
+    clock.setWallTime(61000);
+    Assert.assertEquals(v, 42);
+    Assert.assertEquals(t.percentile(100.0), 400 / 1e9, 1e-12);
+  }
+
+  @Test
+  public void testRecordCallableException() throws Exception {
+    TDigestTimer t = newTimer("foo");
+    clock.setMonotonicTime(100L);
+    boolean seen = false;
+    try {
+      t.record(new Callable<Integer>() {
+        public Integer call() throws Exception {
+          clock.setMonotonicTime(500L);
+          throw new RuntimeException("foo");
+        }
+      });
+    } catch (Exception e) {
+      seen = true;
+    }
+    Assert.assertTrue(seen);
+    clock.setWallTime(61000);
+    Assert.assertEquals(t.percentile(100.0), 400 / 1e9, 1e-12);
+  }
+
+  @Test
+  public void testRecordRunnable() throws Exception {
+    TDigestTimer t = newTimer("foo");
+    clock.setMonotonicTime(100L);
+    t.record(new Runnable() {
+      public void run() {
+        clock.setMonotonicTime(500L);
+      }
+    });
+    clock.setWallTime(61000);
+    Assert.assertEquals(t.percentile(100.0), 400 / 1e9, 1e-12);
+  }
+
+  @Test
+  public void testRecordRunnableException() throws Exception {
+    TDigestTimer t = newTimer("foo");
+    clock.setMonotonicTime(100L);
+    boolean seen = false;
+    try {
+      t.record(new Runnable() {
+        public void run() {
+          clock.setMonotonicTime(500L);
+          throw new RuntimeException("foo");
+        }
+      });
+    } catch (Exception e) {
+      seen = true;
+    }
+    Assert.assertTrue(seen);
+    clock.setWallTime(61000);
+    Assert.assertEquals(t.percentile(100.0), 400 / 1e9, 1e-12);
+  }
+}


### PR DESCRIPTION
This is an initial version of a registry that records
values for timers and distribution summaries to T-digests.

https://github.com/tdunning/t-digest

This gives us a compact structure we can leverage later
on to compute aggregate percentiles.

This is still experimental and not recommended for general
use. The version of the tdigest lib in maven central is old
and doesn't have recent fixes we need. For now I'm including
the tdigest code in the library directly.