### PR TITLE
prevent concurrent updates of the digest

### DIFF
--- a/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestDistributionSummary.java
+++ b/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestDistributionSummary.java
@@ -33,12 +33,12 @@ public class TDigestDistributionSummary implements TDigestMeter, DistributionSum
   /** Create a new instance. */
   TDigestDistributionSummary(Clock clock, Id id) {
     this.id = id;
-    this.digest = new StepDigest(100.0, clock, 60000L);
+    this.digest = new StepDigest(id, 100.0, clock, 60000L);
   }
 
   @Override public void record(long amount) {
     if (amount >= 0L) {
-      digest.current().add(amount);
+      digest.add(amount);
     }
   }
 
@@ -79,6 +79,6 @@ public class TDigestDistributionSummary implements TDigestMeter, DistributionSum
   }
 
   @Override public TDigestMeasurement measureDigest() {
-    return digest.measure(id());
+    return digest.measure();
   }
 }

--- a/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestTimer.java
+++ b/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestTimer.java
@@ -37,13 +37,13 @@ public class TDigestTimer implements TDigestMeter, Timer {
   TDigestTimer(Clock clock, Id id) {
     this.clock = clock;
     this.id = id;
-    this.digest = new StepDigest(100.0, clock, 60000L);
+    this.digest = new StepDigest(id, 100.0, clock, 60000L);
   }
 
   @Override public void record(long amount, TimeUnit unit) {
     if (amount >= 0L) {
       final long nanos = unit.toNanos(amount);
-      digest.current().add(nanos / 1e9);
+      digest.add(nanos / 1e9);
     }
   }
 
@@ -102,6 +102,6 @@ public class TDigestTimer implements TDigestMeter, Timer {
   }
 
   @Override public TDigestMeasurement measureDigest() {
-    return digest.measure(id());
+    return digest.measure();
   }
 }


### PR DESCRIPTION
The digest is not thread safe and concurrent updates
and can end up with deadlock. The stack traces typically
look like:

```
java.lang.Thread.State: RUNNABLE
    at com.tdunning.math.stats.AVLGroupTree.floor(AVLGroupTree.java:186)
    at com.tdunning.math.stats.AVLTreeDigest.add(AVLTreeDigest.java:72)
    at com.tdunning.math.stats.AVLTreeDigest.add(AVLTreeDigest.java:67)
    at com.tdunning.math.stats.AbstractTDigest.add(AbstractTDigest.java:142)
    at com.netflix.spectator.tdigest.TDigestTimer.record(TDigestTimer.java:46)
```

This change will drop samples if another thread has the
lock. We'll see how much we actually encounter dropped
samples in practice and whether it perturbs the value
enough to warrant a more complex solution.