### PR TITLE
test of disabling findbugs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ subprojects {
   apply plugin: 'build-dashboard'
   apply plugin: 'jacoco'
   apply plugin: 'checkstyle'
-  apply plugin: 'findbugs'
+  //apply plugin: 'findbugs'
   apply plugin: 'pmd'
 
   repositories {
@@ -81,7 +81,7 @@ subprojects {
     exclude '**/tdunning/**'
   }
   
-  findbugs {
+  /*findbugs {
     excludeFilter = rootProject.file('codequality/findbugs-exclude.xml')
     ignoreFailures = false
     sourceSets = [sourceSets.main]
@@ -92,7 +92,7 @@ subprojects {
       xml.enabled = false
       html.enabled = true
     }
-  }
+  }*/
 
   pmd {
     ignoreFailures = false


### PR DESCRIPTION
FindBugs seems to be roughly half the overall build time
when running locally. Just checking what happens to travis
build times with it disabled.