### PR TITLE
archaius-2.0.0-rc.8

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,8 @@
-version_archaius=2.0.0-rc.7
+version_archaius1=0.6.6
+version_archaius=2.0.0-rc.8
 version_aws=1.9.23
 version_iep=0.1.13.1
 version_jackson=2.5.2
 version_log4j=2.2
 version_ribbon=2.0.0
-version_slf4j=1.7.10
+version_slf4j=1.7.12

--- a/spectator-nflx-plugin/build.gradle
+++ b/spectator-nflx-plugin/build.gradle
@@ -6,8 +6,7 @@ dependencies {
   compile project(':spectator-reg-servo')
   compile "com.fasterxml.jackson.core:jackson-databind:$version_jackson"
   compile "com.google.inject:guice:3.0"
-  compile "com.netflix.archaius:archaius-core:$version_archaius"
-  compile "com.netflix.archaius:archaius-legacy:$version_archaius"
+  compile "com.netflix.archaius:archaius-core:$version_archaius1"
   compile "com.netflix.eureka:eureka-client:1.1.147"
   compile "com.netflix.iep-shadow:iepshadow-iep-rxhttp:$version_iep"
   testCompile "com.netflix.governator:governator:1.3.3"

--- a/spectator-reg-tdigest/build.gradle
+++ b/spectator-reg-tdigest/build.gradle
@@ -2,8 +2,8 @@ dependencies {
   compile project(':spectator-api')
   compile project(':spectator-nflx-plugin')
   compile "com.amazonaws:aws-java-sdk-kinesis:$version_aws"
-  compile "com.netflix.archaius:archaius-core:$version_archaius"
-  compile "com.netflix.archaius:archaius-guice:$version_archaius"
+  compile "com.netflix.archaius:archaius2-core:$version_archaius"
+  compile "com.netflix.archaius:archaius2-guice:$version_archaius"
   compile "com.fasterxml.jackson.core:jackson-core:$version_jackson"
   compile "com.fasterxml.jackson.dataformat:jackson-dataformat-smile:$version_jackson"
   // Older version


### PR DESCRIPTION
Upgrade to latest rc and update spectator-nflx-plugin
dependency so it is on the more stable 0.6.6 version.

The 2.x version will only get used for the experimental
tdigest registry right now.