### PR TITLE
fix bucket labels

### DIFF
--- a/spectator-ext-sandbox/src/main/java/com/netflix/spectator/sandbox/BucketFunctions.java
+++ b/spectator-ext-sandbox/src/main/java/com/netflix/spectator/sandbox/BucketFunctions.java
@@ -24,18 +24,24 @@ import java.util.concurrent.TimeUnit;
  */
 public final class BucketFunctions {
 
-  private static final List<ValueFormatter> FORMATTERS = new ArrayList<>();
+  /**
+   * Predefined formatters used to create the bucket labels.
+   */
+  static final List<ValueFormatter> FORMATTERS = new ArrayList<>();
 
   static {
     FORMATTERS.add(fmt(TimeUnit.NANOSECONDS.toNanos(10),     1, "ns",  TimeUnit.NANOSECONDS));
     FORMATTERS.add(fmt(TimeUnit.NANOSECONDS.toNanos(100),    2, "ns",  TimeUnit.NANOSECONDS));
     FORMATTERS.add(fmt(TimeUnit.MICROSECONDS.toNanos(1),     3, "ns",  TimeUnit.NANOSECONDS));
+    FORMATTERS.add(fmt(TimeUnit.MICROSECONDS.toNanos(8),     4, "ns",  TimeUnit.NANOSECONDS));
     FORMATTERS.add(fmt(TimeUnit.MICROSECONDS.toNanos(10),    1, "us",  TimeUnit.MICROSECONDS));
     FORMATTERS.add(fmt(TimeUnit.MICROSECONDS.toNanos(100),   2, "us",  TimeUnit.MICROSECONDS));
     FORMATTERS.add(fmt(TimeUnit.MILLISECONDS.toNanos(1),     3, "us",  TimeUnit.MICROSECONDS));
+    FORMATTERS.add(fmt(TimeUnit.MILLISECONDS.toNanos(8),     4, "us",  TimeUnit.MICROSECONDS));
     FORMATTERS.add(fmt(TimeUnit.MILLISECONDS.toNanos(10),    1, "ms",  TimeUnit.MILLISECONDS));
     FORMATTERS.add(fmt(TimeUnit.MILLISECONDS.toNanos(100),   2, "ms",  TimeUnit.MILLISECONDS));
     FORMATTERS.add(fmt(TimeUnit.SECONDS.toNanos(1),          3, "ms",  TimeUnit.MILLISECONDS));
+    FORMATTERS.add(fmt(TimeUnit.SECONDS.toNanos(8),          4, "ms",  TimeUnit.MILLISECONDS));
     FORMATTERS.add(fmt(TimeUnit.SECONDS.toNanos(10),         1, "s",   TimeUnit.SECONDS));
     FORMATTERS.add(fmt(TimeUnit.SECONDS.toNanos(100),        2, "s",   TimeUnit.SECONDS));
     FORMATTERS.add(fmt(TimeUnit.MINUTES.toNanos(8),          3, "s",   TimeUnit.SECONDS));
@@ -50,7 +56,7 @@ public final class BucketFunctions {
     FORMATTERS.add(fmt(TimeUnit.DAYS.toNanos(1000),          3, "d",   TimeUnit.DAYS));
     FORMATTERS.add(fmt(TimeUnit.DAYS.toNanos(10000),         4, "d",   TimeUnit.DAYS));
     FORMATTERS.add(fmt(TimeUnit.DAYS.toNanos(100000),        5, "d",   TimeUnit.DAYS));
-    FORMATTERS.add(fmt(TimeUnit.DAYS.toNanos(1000000),       6, "d",   TimeUnit.DAYS));
+    FORMATTERS.add(fmt(Long.MAX_VALUE,                       6, "d",   TimeUnit.DAYS));
     // TimeUnit.NANOSECONDS.toDays(java.lang.Long.MAX_VALUE) == 106751
   }
 
@@ -73,24 +79,26 @@ public final class BucketFunctions {
   private static BucketFunction timeBiasZero(String ltZero, String gtMax, long max, TimeUnit unit) {
     final long nanos = unit.toNanos(max);
     final ValueFormatter f = getFormatter(nanos);
+    final long v = f.unit().convert(max, unit);
     List<Bucket> buckets = new ArrayList<>();
     buckets.add(new Bucket(ltZero, 0L));
-    buckets.add(new Bucket(f.apply(nanos / 8), nanos / 8));
-    buckets.add(new Bucket(f.apply(nanos / 4), nanos / 4));
-    buckets.add(new Bucket(f.apply(nanos / 2), nanos / 2));
-    buckets.add(new Bucket(f.apply(nanos), nanos));
+    buckets.add(f.newBucket(v / 8));
+    buckets.add(f.newBucket(v / 4));
+    buckets.add(f.newBucket(v / 2));
+    buckets.add(f.newBucket(v));
     return new ListBucketFunction(buckets, gtMax);
   }
 
   private static BucketFunction timeBiasMax(String ltZero, String gtMax, long max, TimeUnit unit) {
     final long nanos = unit.toNanos(max);
     final ValueFormatter f = getFormatter(nanos);
+    final long v = f.unit().convert(max, unit);
     List<Bucket> buckets = new ArrayList<>();
     buckets.add(new Bucket(ltZero, 0L));
-    buckets.add(new Bucket(f.apply(nanos - nanos / 2), nanos - nanos / 2));
-    buckets.add(new Bucket(f.apply(nanos - nanos / 4), nanos - nanos / 4));
-    buckets.add(new Bucket(f.apply(nanos - nanos / 8), nanos - nanos / 8));
-    buckets.add(new Bucket(f.apply(nanos), nanos));
+    buckets.add(f.newBucket(v - v / 2));
+    buckets.add(f.newBucket(v - v / 4));
+    buckets.add(f.newBucket(v - v / 8));
+    buckets.add(f.newBucket(v));
     return new ListBucketFunction(buckets, gtMax);
   }
 
@@ -174,19 +182,51 @@ public final class BucketFunctions {
     return timeBiasMax("negative_latency", "slow", max, unit);
   }
 
-  private static class ValueFormatter {
+  /**
+   * Format a value as a bucket label.
+   */
+  static class ValueFormatter {
     private final long max;
     private final String fmt;
     private final TimeUnit unit;
 
+    /**
+     * Create a new instance.
+     *
+     * @param max
+     *     Maximum value intended to be passed into the apply method. Max value is in nanoseconds.
+     * @param width
+     *     Number of digits to use for the numeric part of the label.
+     * @param suffix
+     *     Unit suffix appended to the label.
+     * @param unit
+     *     Unit for the value in the label.
+     */
     ValueFormatter(long max, int width, String suffix, TimeUnit unit) {
       this.max = max;
       this.fmt = "%0" + width + "d" + suffix;
       this.unit = unit;
     }
 
+    /** Return the max value intended for this formatter. */
+    long max() {
+      return max;
+    }
+
+    /** Return the unit for the formatter. */
+    TimeUnit unit() {
+      return unit;
+    }
+
+    /** Convert the value {@code v} into a bucket label string. */
     String apply(long v) {
       return String.format(fmt, unit.convert(v, TimeUnit.NANOSECONDS));
+    }
+
+    /** Return a new bucket for the specified value. */
+    Bucket newBucket(long v) {
+      final long nanos = unit.toNanos(v);
+      return new Bucket(apply(nanos), nanos);
     }
   }
 
@@ -224,6 +264,10 @@ public final class BucketFunctions {
 
     long upperBoundary() {
       return upperBoundary;
+    }
+
+    @Override public String toString() {
+      return String.format("Bucket(%s,%d)", name, upperBoundary);
     }
   }
 }

--- a/spectator-ext-sandbox/src/test/java/com/netflix/spectator/sandbox/BucketFunctionsTest.java
+++ b/spectator-ext-sandbox/src/test/java/com/netflix/spectator/sandbox/BucketFunctionsTest.java
@@ -20,6 +20,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 @RunWith(JUnit4.class)
@@ -31,7 +33,7 @@ public class BucketFunctionsTest {
     Assert.assertEquals("future", f.apply(TimeUnit.SECONDS.toNanos(-1)));
     Assert.assertEquals("07s", f.apply(TimeUnit.SECONDS.toNanos(1)));
     Assert.assertEquals("07s", f.apply(TimeUnit.SECONDS.toNanos(6)));
-    Assert.assertEquals("07s", f.apply(TimeUnit.SECONDS.toNanos(7)));
+    Assert.assertEquals("15s", f.apply(TimeUnit.SECONDS.toNanos(7)));
     Assert.assertEquals("15s", f.apply(TimeUnit.SECONDS.toNanos(10)));
     Assert.assertEquals("30s", f.apply(TimeUnit.SECONDS.toNanos(20)));
     Assert.assertEquals("60s", f.apply(TimeUnit.SECONDS.toNanos(30)));
@@ -51,7 +53,7 @@ public class BucketFunctionsTest {
     Assert.assertEquals("30s", f.apply(TimeUnit.SECONDS.toNanos(20)));
     Assert.assertEquals("45s", f.apply(TimeUnit.SECONDS.toNanos(30)));
     Assert.assertEquals("45s", f.apply(TimeUnit.SECONDS.toNanos(42)));
-    Assert.assertEquals("52s", f.apply(TimeUnit.SECONDS.toNanos(48)));
+    Assert.assertEquals("53s", f.apply(TimeUnit.SECONDS.toNanos(48)));
     Assert.assertEquals("60s", f.apply(TimeUnit.SECONDS.toNanos(59)));
     Assert.assertEquals("old", f.apply(TimeUnit.SECONDS.toNanos(60)));
     Assert.assertEquals("old", f.apply(TimeUnit.SECONDS.toNanos(61)));
@@ -76,9 +78,50 @@ public class BucketFunctionsTest {
     Assert.assertEquals("050ms", f.apply(TimeUnit.MILLISECONDS.toNanos(13)));
     Assert.assertEquals("050ms", f.apply(TimeUnit.MILLISECONDS.toNanos(25)));
     Assert.assertEquals("075ms", f.apply(TimeUnit.MILLISECONDS.toNanos(74)));
-    Assert.assertEquals("087ms", f.apply(TimeUnit.MILLISECONDS.toNanos(75)));
+    Assert.assertEquals("088ms", f.apply(TimeUnit.MILLISECONDS.toNanos(75)));
     Assert.assertEquals("100ms", f.apply(TimeUnit.MILLISECONDS.toNanos(99)));
     Assert.assertEquals("slow", f.apply(TimeUnit.MILLISECONDS.toNanos(101)));
+  }
+
+  @Test
+  public void latency3s() {
+    BucketFunction f = BucketFunctions.latency(3, TimeUnit.SECONDS);
+    Assert.assertEquals("negative_latency", f.apply(TimeUnit.MILLISECONDS.toNanos(-1)));
+    Assert.assertEquals("0375ms", f.apply(TimeUnit.MILLISECONDS.toNanos(25)));
+    Assert.assertEquals("0750ms", f.apply(TimeUnit.MILLISECONDS.toNanos(740)));
+    Assert.assertEquals("1500ms", f.apply(TimeUnit.MILLISECONDS.toNanos(1000)));
+    Assert.assertEquals("3000ms", f.apply(TimeUnit.MILLISECONDS.toNanos(1567)));
+    Assert.assertEquals("slow", f.apply(TimeUnit.MILLISECONDS.toNanos(3001)));
+  }
+
+  @Test
+  public void latencyRange() {
+    for (BucketFunctions.ValueFormatter fmt : BucketFunctions.FORMATTERS) {
+      final long max = fmt.max();
+      BucketFunction f = BucketFunctions.latency(max, TimeUnit.NANOSECONDS);
+      Set<String> keys = new HashSet<>();
+      final long step = (max > 37) ? max / 37 : 1;
+      for (long j = 0L; max - j > step; j += step) {
+        keys.add(f.apply(j));
+      }
+      keys.add(f.apply(max));
+      Assert.assertEquals(5, keys.size());
+    }
+  }
+
+  @Test
+  public void latencyBiasSlowRange() {
+    for (BucketFunctions.ValueFormatter fmt : BucketFunctions.FORMATTERS) {
+      final long max = fmt.max();
+      BucketFunction f = BucketFunctions.latencyBiasSlow(max, TimeUnit.NANOSECONDS);
+      Set<String> keys = new HashSet<>();
+      final long step = (max > 37) ? max / 37 : 1;
+      for (long j = 0L; max - j >= step; j += step) {
+        keys.add(f.apply(j));
+      }
+      keys.add(f.apply(max));
+      Assert.assertEquals(5, keys.size());
+    }
   }
 
 }


### PR DESCRIPTION
For some values, e.g., `latency(3, TimeUnit.SECONDS)`, the
unit was wrong so we would get labels 0s, 1s, and 3s. The
values should have been 0375ms, 0750ms, 1500ms, and 3000ms.
This change fixes those ranges and adds a test case to
ensure we are getting the proper number of buckets across
the default formatters.