### PR TITLE
archaius-2.0.0-rc.9

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,7 @@
 version_archaius1=0.6.6
-version_archaius=2.0.0-rc.8
+version_archaius=2.0.0-rc.9
 version_aws=1.9.23
 version_iep=0.1.16.4
 version_jackson=2.5.2
 version_log4j=2.2
-version_ribbon=2.0.0
 version_slf4j=1.7.12


### PR DESCRIPTION
rc.9 changed quite a few of the APIs. In particular
the `AppConfig` class was removed. Spectator is only
using archaius2 for the T-Digest registry and no
code changes were needed.