### PR TITLE
work-around for null context class loader

### DIFF
--- a/spectator-ext-spark/src/main/java/com/netflix/spectator/spark/SpectatorReporter.java
+++ b/spectator-ext-spark/src/main/java/com/netflix/spectator/spark/SpectatorReporter.java
@@ -56,7 +56,7 @@ public final class SpectatorReporter extends ScheduledReporter {
    */
   public static final class Builder {
     private final MetricRegistry registry;
-    private ExtendedRegistry spectatorRegistry = Spectator.registry();
+    private ExtendedRegistry spectatorRegistry;
     private NameFunction nameFunction = new NameFunction() {
       @Override public Id apply(String name) {
         return spectatorRegistry.createId(name);
@@ -93,6 +93,9 @@ public final class SpectatorReporter extends ScheduledReporter {
 
     /** Create a new instance of the reporter. */
     public SpectatorReporter build() {
+      if (spectatorRegistry == null) {
+        spectatorRegistry = Spectator.registry();
+      }
       return new SpectatorReporter(registry, spectatorRegistry, nameFunction, valueFunction);
     }
   }


### PR DESCRIPTION
In some cases we are seeing:

```
Thread.currentThread().getContextClassLoader() == null
```

For now this workaround will use the classloader of
the local class. In some quick tests this works and
unblocks the teams seeing this problem. We probably
need to find a better solution longer term after we
understand why the context class loader is null.