### PR TITLE
switch to wrap the main registry

### DIFF
--- a/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/StepDigest.java
+++ b/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/StepDigest.java
@@ -84,6 +84,16 @@ class StepDigest {
     }
   }
 
+  /** Return the id for the digest. */
+  Id id() {
+    return id;
+  }
+
+  /** Return the clock for the digest. */
+  Clock clock() {
+    return clock;
+  }
+
   /** Return the previous digest. */
   TDigest previous() {
     roll(clock.wallTime());

--- a/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestConfig.java
+++ b/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestConfig.java
@@ -22,7 +22,7 @@ import com.netflix.archaius.annotations.DefaultValue;
  * Configuration settings for the digest plugin.
  */
 @Configuration(prefix = "spectator.tdigest.kinesis")
-public interface TDigestConfig {
+interface TDigestConfig {
   /** Kinesis endpoint to use. */
   @DefaultValue("kinesis.${EC2_REGION}.amazonaws.com")
   String endpoint();
@@ -30,4 +30,8 @@ public interface TDigestConfig {
   /** Name of the kinesis stream where the data should be written. */
   @DefaultValue("spectator-tdigest")
   String stream();
+
+  /** Polling frequency for digest data. */
+  @DefaultValue("60")
+  long pollingFrequency();
 }

--- a/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestMeter.java
+++ b/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestMeter.java
@@ -20,7 +20,7 @@ import com.netflix.spectator.api.Meter;
 /**
  * Meter type for collecting a digest measurment.
  */
-public interface TDigestMeter extends Meter {
+interface TDigestMeter extends Meter {
   /** Returns the measurement for the last completed interval. */
   TDigestMeasurement measureDigest();
 }

--- a/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestModule.java
+++ b/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestModule.java
@@ -21,6 +21,8 @@ import com.google.inject.Provides;
 import com.netflix.archaius.guice.ArchaiusModule;
 import com.netflix.spectator.api.ExtendedRegistry;
 
+import javax.inject.Singleton;
+
 /**
  * Guice module to configure the plugin.
  */
@@ -31,11 +33,15 @@ public class TDigestModule extends AbstractModule {
     bind(TDigestPlugin.class).asEagerSingleton();
   }
 
-  @Provides private TDigestRegistry providesRegistry(ExtendedRegistry registry) {
-    return registry.underlying(TDigestRegistry.class);
+  @Provides
+  @Singleton
+  private TDigestRegistry providesRegistry(ExtendedRegistry registry, TDigestConfig config) {
+    return new TDigestRegistry(registry, config);
   }
 
-  @Provides private TDigestWriter providesWriter(TDigestConfig config) {
+  @Provides
+  @Singleton
+  private TDigestWriter providesWriter(TDigestConfig config) {
     AmazonKinesisClient client = new AmazonKinesisClient();
     client.setEndpoint(config.endpoint());
     return new KinesisTDigestWriter(client, config.stream());

--- a/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestPlugin.java
+++ b/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestPlugin.java
@@ -35,20 +35,22 @@ import java.util.concurrent.TimeUnit;
  * Plugin for managing the collection of digest measurements.
  */
 @Singleton
-public class TDigestPlugin {
+class TDigestPlugin {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(TDigestPlugin.class);
 
   private final TDigestRegistry registry;
   private final TDigestWriter writer;
+  private final TDigestConfig config;
 
   private ScheduledExecutorService executor;
 
   /** Create a new instance. */
   @Inject
-  public TDigestPlugin(TDigestRegistry registry, TDigestWriter writer) {
+  public TDigestPlugin(TDigestRegistry registry, TDigestWriter writer, TDigestConfig config) {
     this.registry = registry;
     this.writer = writer;
+    this.config = config;
   }
 
   /**
@@ -73,7 +75,7 @@ public class TDigestPlugin {
       }
     };
 
-    executor.scheduleWithFixedDelay(task, 0L, 40L, TimeUnit.SECONDS);
+    executor.scheduleAtFixedRate(task, 0L, config.pollingFrequency(), TimeUnit.SECONDS);
   }
 
   /**

--- a/spectator-reg-tdigest/src/test/java/com/netflix/spectator/tdigest/TDigestPluginTest.java
+++ b/spectator-reg-tdigest/src/test/java/com/netflix/spectator/tdigest/TDigestPluginTest.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.spectator.tdigest;
 
+import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.ManualClock;
 import com.netflix.spectator.api.Registry;
@@ -68,8 +69,21 @@ public class TDigestPluginTest {
   public void writeData() throws Exception {
     final File f = new File("build/TDigestPlugin_writeData.out");
     f.getParentFile().mkdirs();
-    final TDigestRegistry r = new TDigestRegistry(clock);
-    final TDigestPlugin p = new TDigestPlugin(r, new FileTDigestWriter(f));
+    final TDigestConfig config = new TDigestConfig() {
+      @Override public String endpoint() {
+        return "";
+      }
+
+      @Override public String stream() {
+        return "";
+      }
+
+      @Override public long pollingFrequency() {
+        return 60L;
+      }
+    };
+    final TDigestRegistry r = new TDigestRegistry(new DefaultRegistry(clock), config);
+    final TDigestPlugin p = new TDigestPlugin(r, new FileTDigestWriter(f), config);
 
     // Adding a bunch of tags to test the effect of setting
     // SmileGenerator.Feature.CHECK_SHARED_STRING_VALUES.

--- a/spectator-reg-tdigest/src/test/java/com/netflix/spectator/tdigest/TDigestTimerTest.java
+++ b/spectator-reg-tdigest/src/test/java/com/netflix/spectator/tdigest/TDigestTimerTest.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.spectator.tdigest;
 
+import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.ManualClock;
 import org.junit.Assert;
 import org.junit.Before;
@@ -31,7 +32,20 @@ public class TDigestTimerTest {
   private final ManualClock clock = new ManualClock();
 
   private TDigestTimer newTimer(String name) {
-    final TDigestRegistry r = new TDigestRegistry(clock);
+    final TDigestConfig config = new TDigestConfig() {
+      @Override public String endpoint() {
+        return null;
+      }
+
+      @Override public String stream() {
+        return null;
+      }
+
+      @Override public long pollingFrequency() {
+        return 60L;
+      }
+    };
+    final TDigestRegistry r = new TDigestRegistry(new DefaultRegistry(clock), config);
     return (TDigestTimer) r.timer(r.createId(name));
   }
 


### PR DESCRIPTION
Before the TDigestRegistry would get included via
the service loader as part of the composite. While
convenient for testing that causes everything to
use the digest timers which is potentially expensive
on the client and server.

With this change the expectation is that for use
cases that need it the TDigestRegistry will be
injected directly. The old behavior can be simulated
by mapping the main Registry binding to TDigestRegistry.