### PR TITLE
rename accessors to getXXX

### DIFF
--- a/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestConfig.java
+++ b/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestConfig.java
@@ -25,13 +25,13 @@ import com.netflix.archaius.annotations.DefaultValue;
 public interface TDigestConfig {
   /** Kinesis endpoint to use. */
   @DefaultValue("kinesis.${EC2_REGION}.amazonaws.com")
-  String endpoint();
+  String getEndpoint();
 
   /** Name of the kinesis stream where the data should be written. */
   @DefaultValue("spectator-tdigest")
-  String stream();
+  String getStream();
 
   /** Polling frequency for digest data. */
   @DefaultValue("60")
-  long pollingFrequency();
+  long getPollingFrequency();
 }

--- a/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestModule.java
+++ b/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestModule.java
@@ -43,7 +43,7 @@ public class TDigestModule extends AbstractModule {
   @Singleton
   private TDigestWriter providesWriter(TDigestConfig config) {
     AmazonKinesisClient client = new AmazonKinesisClient();
-    client.setEndpoint(config.endpoint());
-    return new KinesisTDigestWriter(client, config.stream());
+    client.setEndpoint(config.getEndpoint());
+    return new KinesisTDigestWriter(client, config.getStream());
   }
 }

--- a/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestPlugin.java
+++ b/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestPlugin.java
@@ -75,7 +75,7 @@ class TDigestPlugin {
       }
     };
 
-    executor.scheduleAtFixedRate(task, 0L, config.pollingFrequency(), TimeUnit.SECONDS);
+    executor.scheduleAtFixedRate(task, 0L, config.getPollingFrequency(), TimeUnit.SECONDS);
   }
 
   /**

--- a/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestRegistry.java
+++ b/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestRegistry.java
@@ -49,7 +49,7 @@ public class TDigestRegistry extends AbstractRegistry {
   }
 
   private StepDigest newDigest(Id id) {
-    final long step = TimeUnit.SECONDS.toMillis(config.pollingFrequency());
+    final long step = TimeUnit.SECONDS.toMillis(config.getPollingFrequency());
     return new StepDigest(id, 100.0, clock(), step);
   }
 }

--- a/spectator-reg-tdigest/src/test/java/com/netflix/spectator/tdigest/TDigestPluginTest.java
+++ b/spectator-reg-tdigest/src/test/java/com/netflix/spectator/tdigest/TDigestPluginTest.java
@@ -70,15 +70,15 @@ public class TDigestPluginTest {
     final File f = new File("build/TDigestPlugin_writeData.out");
     f.getParentFile().mkdirs();
     final TDigestConfig config = new TDigestConfig() {
-      @Override public String endpoint() {
+      @Override public String getEndpoint() {
         return "";
       }
 
-      @Override public String stream() {
+      @Override public String getStream() {
         return "";
       }
 
-      @Override public long pollingFrequency() {
+      @Override public long getPollingFrequency() {
         return 60L;
       }
     };

--- a/spectator-reg-tdigest/src/test/java/com/netflix/spectator/tdigest/TDigestTimerTest.java
+++ b/spectator-reg-tdigest/src/test/java/com/netflix/spectator/tdigest/TDigestTimerTest.java
@@ -33,15 +33,15 @@ public class TDigestTimerTest {
 
   private TDigestTimer newTimer(String name) {
     final TDigestConfig config = new TDigestConfig() {
-      @Override public String endpoint() {
+      @Override public String getEndpoint() {
         return null;
       }
 
-      @Override public String stream() {
+      @Override public String getStream() {
         return null;
       }
 
-      @Override public long pollingFrequency() {
+      @Override public long getPollingFrequency() {
         return 60L;
       }
     };


### PR DESCRIPTION
At some point the archaius2 logic changed to require
this and with the latest RC's we get a NPE:

```
Caused by: java.lang.NullPointerException
	at com.netflix.archaius.ProxyFactory$1.invoke(ProxyFactory.java:87) ~[archaius2-core-2.0.0-rc.18.jar:2.0.0-rc.18]
	at com.netflix.spectator.tdigest.$Proxy61.endpoint(Unknown Source) ~[?:0.27.0-SNAPSHOT]
	at com.netflix.spectator.tdigest.TDigestModule.providesWriter(TDigestModule.java:46) ~[spectator-reg-tdigest-0.27.0-SNAPSHOT.jar:0.27.0-SNAPSHOT]
```