### PR TITLE
remove archaius2 dependency

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,7 @@
 version_archaius1=0.7.0
 version_archaius=2.0.0-rc.18
 version_aws=1.9.39
+version_config=1.2.1
 version_eureka=1.1.156
 version_governator=1.7.5
 version_guice=4.0

--- a/spectator-ext-spark/build.gradle
+++ b/spectator-ext-spark/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 dependencies {
   compile project(':spectator-api')
-  compile 'com.typesafe:config:1.2.1'
+  compile "com.typesafe:config:$version_config"
   compile 'io.dropwizard.metrics:metrics-core:3.1.2'
   compile 'org.apache.spark:spark-core_2.10:1.3.1'
 }

--- a/spectator-reg-tdigest/build.gradle
+++ b/spectator-reg-tdigest/build.gradle
@@ -3,10 +3,9 @@ dependencies {
   compile project(':spectator-nflx-plugin')
   compile "com.amazonaws:aws-java-sdk-kinesis:$version_aws"
   compile "com.google.inject:guice:$version_guice"
-  compile "com.netflix.archaius:archaius2-core:$version_archaius"
-  compile "com.netflix.archaius:archaius2-guice:$version_archaius"
   compile "com.fasterxml.jackson.core:jackson-core:$version_jackson"
   compile "com.fasterxml.jackson.dataformat:jackson-dataformat-smile:$version_jackson"
+  compile "com.typesafe:config:$version_config"
   // Older version
   //compile 'com.tdunning:t-digest:3.0'
 }

--- a/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestConfig.java
+++ b/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestConfig.java
@@ -15,23 +15,36 @@
  */
 package com.netflix.spectator.tdigest;
 
-import com.netflix.archaius.annotations.Configuration;
-import com.netflix.archaius.annotations.DefaultValue;
+import com.typesafe.config.Config;
+
+import java.util.concurrent.TimeUnit;
 
 /**
  * Configuration settings for the digest plugin.
  */
-@Configuration(prefix = "spectator.tdigest.kinesis")
-public interface TDigestConfig {
+public final class TDigestConfig {
+
+  private final Config cfg;
+
+  /**
+   * Create a new instance based on the {@link Config} object.
+   */
+  public TDigestConfig(Config cfg) {
+    this.cfg = cfg;
+  }
+
   /** Kinesis endpoint to use. */
-  @DefaultValue("kinesis.${EC2_REGION}.amazonaws.com")
-  String getEndpoint();
+  public String getEndpoint() {
+    return cfg.getString("kinesis.endpoint");
+  }
 
   /** Name of the kinesis stream where the data should be written. */
-  @DefaultValue("spectator-tdigest")
-  String getStream();
+  public String getStream() {
+    return cfg.getString("kinesis.stream");
+  }
 
   /** Polling frequency for digest data. */
-  @DefaultValue("60")
-  long getPollingFrequency();
+  public long getPollingFrequency(TimeUnit unit) {
+    return cfg.getDuration("polling-frequency", unit);
+  }
 }

--- a/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestPlugin.java
+++ b/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestPlugin.java
@@ -75,7 +75,8 @@ class TDigestPlugin {
       }
     };
 
-    executor.scheduleAtFixedRate(task, 0L, config.getPollingFrequency(), TimeUnit.SECONDS);
+    final long freq = config.getPollingFrequency(TimeUnit.SECONDS);
+    executor.scheduleAtFixedRate(task, 0L, freq, TimeUnit.SECONDS);
   }
 
   /**

--- a/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestRegistry.java
+++ b/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestRegistry.java
@@ -49,7 +49,7 @@ public class TDigestRegistry extends AbstractRegistry {
   }
 
   private StepDigest newDigest(Id id) {
-    final long step = TimeUnit.SECONDS.toMillis(config.getPollingFrequency());
+    final long step = config.getPollingFrequency(TimeUnit.MILLISECONDS);
     return new StepDigest(id, 100.0, clock(), step);
   }
 }

--- a/spectator-reg-tdigest/src/main/resources/reference.conf
+++ b/spectator-reg-tdigest/src/main/resources/reference.conf
@@ -1,0 +1,14 @@
+
+spectator.tdigest {
+
+  kinesis {
+    // Kinesis endpoint to use. Assumes EC2_REGION environment variable will be set
+    endpoint = "kinesis."${EC2_REGION}".amazonaws.com"
+
+    // Name of the kinesis stream
+    stream = "spectator-tdigest"
+  }
+
+  // How frequently data will be collected and sent to the backend
+  polling-frequency = 60s
+}

--- a/spectator-reg-tdigest/src/test/java/com/netflix/spectator/tdigest/TDigestPluginTest.java
+++ b/spectator-reg-tdigest/src/test/java/com/netflix/spectator/tdigest/TDigestPluginTest.java
@@ -21,6 +21,7 @@ import com.netflix.spectator.api.ManualClock;
 import com.netflix.spectator.api.Registry;
 import com.tdunning.math.stats.TDigest;
 import com.tdunning.math.stats.TreeDigest;
+import com.typesafe.config.ConfigFactory;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -69,19 +70,7 @@ public class TDigestPluginTest {
   public void writeData() throws Exception {
     final File f = new File("build/TDigestPlugin_writeData.out");
     f.getParentFile().mkdirs();
-    final TDigestConfig config = new TDigestConfig() {
-      @Override public String getEndpoint() {
-        return "";
-      }
-
-      @Override public String getStream() {
-        return "";
-      }
-
-      @Override public long getPollingFrequency() {
-        return 60L;
-      }
-    };
+    final TDigestConfig config = new TDigestConfig(ConfigFactory.load().getConfig("spectator.tdigest"));
     final TDigestRegistry r = new TDigestRegistry(new DefaultRegistry(clock), config);
     final TDigestPlugin p = new TDigestPlugin(r, new FileTDigestWriter(f), config);
 

--- a/spectator-reg-tdigest/src/test/java/com/netflix/spectator/tdigest/TDigestTimerTest.java
+++ b/spectator-reg-tdigest/src/test/java/com/netflix/spectator/tdigest/TDigestTimerTest.java
@@ -17,6 +17,7 @@ package com.netflix.spectator.tdigest;
 
 import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.ManualClock;
+import com.typesafe.config.ConfigFactory;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -32,19 +33,7 @@ public class TDigestTimerTest {
   private final ManualClock clock = new ManualClock();
 
   private TDigestTimer newTimer(String name) {
-    final TDigestConfig config = new TDigestConfig() {
-      @Override public String getEndpoint() {
-        return null;
-      }
-
-      @Override public String getStream() {
-        return null;
-      }
-
-      @Override public long getPollingFrequency() {
-        return 60L;
-      }
-    };
+    final TDigestConfig config = new TDigestConfig(ConfigFactory.load().getConfig("spectator.tdigest"));
     final TDigestRegistry r = new TDigestRegistry(new DefaultRegistry(clock), config);
     return (TDigestTimer) r.timer(r.createId(name));
   }

--- a/spectator-reg-tdigest/src/test/resources/reference.conf
+++ b/spectator-reg-tdigest/src/test/resources/reference.conf
@@ -1,0 +1,3 @@
+
+// To make region resolve for test cases
+EC2_REGION = "us-east-1"


### PR DESCRIPTION
Will revisit when final version with stable api is released. For now I want to avoid others getting one of the RC versions as a transitive from spectator.