### PR TITLE
Make TagList public to use public static constructors

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/TagList.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/TagList.java
@@ -25,7 +25,7 @@ import java.util.NoSuchElementException;
  * A tag list implemented as a singly linked list. Doesn't automatically dedup keys but supports
  * a cheap prepend at the call site to allow for inexpensive dynamic ids.
  */
-final class TagList implements Iterable<Tag>, Tag {
+public final class TagList implements Iterable<Tag>, Tag {
 
   private final String key;
   private final String value;


### PR DESCRIPTION
It would be very useful if TagList was public so I could use the public static constructors to build a Tag.