### PR TITLE
Make the TagList.create methods publicly accessible.

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/TagList.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/TagList.java
@@ -25,7 +25,7 @@ import java.util.NoSuchElementException;
  * A tag list implemented as a singly linked list. Doesn't automatically dedup keys but supports
  * a cheap prepend at the call site to allow for inexpensive dynamic ids.
  */
-final class TagList implements Iterable<Tag>, Tag {
+public final class TagList implements Iterable<Tag>, Tag {
 
   private final String key;
   private final String value;
@@ -125,7 +125,7 @@ final class TagList implements Iterable<Tag>, Tag {
    * @return
    *     New tag list with a copy of the data.
    */
-  static TagList create(Iterable<Tag> tags) {
+  public static TagList create(Iterable<Tag> tags) {
     if (tags instanceof TagList) {
       return (TagList) tags;
     } else {
@@ -145,7 +145,7 @@ final class TagList implements Iterable<Tag>, Tag {
    * @return
    *     New tag list with a copy of the data.
    */
-  static TagList create(Map<String, String> tags) {
+  public static TagList create(Map<String, String> tags) {
     TagList head = EMPTY;
     for (Map.Entry<String, String> t : tags.entrySet()) {
       head = new TagList(t.getKey(), t.getValue(), head);


### PR DESCRIPTION
It would useful to be able to use the static create methods in TagList.