### PR TITLE
update pattern for executor stats

### DIFF
--- a/spectator-ext-spark/src/main/resources/reference.conf
+++ b/spectator-ext-spark/src/main/resources/reference.conf
@@ -32,6 +32,16 @@ spectator.spark {
       }
     },
 
+    // core/src/main/scala/org/apache/spark/executor/ExecutorSource.scala
+    {
+      pattern = "^(.+)\\.(executor)\\.(.+?)(_MB|_ms)?$"
+      name = 3
+      tags = {
+        "role" = 2
+        "appId" = 1
+      }
+    },
+
     // core/src/main/scala/org/apache/spark/scheduler/DAGSchedulerSource.scala
     // core/src/main/scala/org/apache/spark/storage/BlockManagerSource.scala
     {

--- a/spectator-ext-spark/src/test/java/com/netflix/spectator/spark/SparkNameFunctionTest.java
+++ b/spectator-ext-spark/src/test/java/com/netflix/spectator/spark/SparkNameFunctionTest.java
@@ -43,6 +43,24 @@ public class SparkNameFunctionTest {
   }
 
   @Test
+  public void executorName2() {
+    final String name = "20150626-185518-1776258826-5050-2845-S1.executor.filesystem.file.largeRead_ops";
+    final Id expected = new DefaultId("spark.filesystem.file.largeRead_ops")
+        .withTag("role", "executor")
+        .withTag("appId", "20150626-185518-1776258826-5050-2845-S1");
+    assertEquals(expected, f.apply(name));
+  }
+
+  @Test
+  public void executorName3() {
+    final String name = "12345.1.3.executor.filesystem.file.largeRead_ops";
+    final Id expected = new DefaultId("spark.filesystem.file.largeRead_ops")
+        .withTag("role", "executor")
+        .withTag("appId", "12345.1.3");
+    assertEquals(expected, f.apply(name));
+  }
+
+  @Test
   public void driverName() {
     final String name = "app-20150309231421-0000.driver.BlockManager.disk.diskSpaceUsed_MB";
     final Id expected = new DefaultId("spark.disk.diskSpaceUsed")


### PR DESCRIPTION
In some cases there is not an explicit appid.executorid. prefix.