### PR TITLE
pull common tags from the spark env

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/TagList.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/TagList.java
@@ -126,7 +126,7 @@ final class TagList implements Iterable<Tag>, Tag {
    *     New tag list with a copy of the data.
    */
   static TagList create(Iterable<Tag> tags) {
-    if (tags instanceof TagList) {
+    if (tags == EMPTY || tags instanceof TagList) {
       return (TagList) tags;
     } else {
       TagList head = EMPTY;

--- a/spectator-ext-spark/build.gradle
+++ b/spectator-ext-spark/build.gradle
@@ -4,6 +4,8 @@ plugins {
 
 dependencies {
   compile project(':spectator-api')
+  compile project(':spectator-ext-gc')
+  compile project(':spectator-ext-jvm')
   compile "com.eclipsesource.minimal-json:minimal-json:0.9.2"
   compile "com.typesafe:config:$version_config"
   compile 'io.dropwizard.metrics:metrics-core:3.1.2'
@@ -18,6 +20,8 @@ shadowJar {
   // The dependencies not listed here should come from the spark distribution
   dependencies {
     include project(':spectator-api')
+    include project(':spectator-ext-gc')
+    include project(':spectator-ext-jvm')
     include dependency("com.eclipsesource.minimal-json:minimal-json:0.9.2")
     include dependency("com.typesafe:config:$version_config")
   }

--- a/spectator-ext-spark/src/main/resources/reference.conf
+++ b/spectator-ext-spark/src/main/resources/reference.conf
@@ -27,8 +27,8 @@ spectator.spark {
       name = 4
       tags = {
         "role" = 3
-        "appId" = 1
-        "executorId" = 2
+        //"appId" = 1
+        //"executorId" = 2
       }
     },
 
@@ -38,7 +38,7 @@ spectator.spark {
       name = 3
       tags = {
         "role" = 2
-        "appId" = 1
+        //"appId" = 1
       }
     },
 
@@ -49,7 +49,7 @@ spectator.spark {
       name = 4
       tags = {
         "role" = 2
-        "appId" = 1
+        //"appId" = 1
         "source" = 3
       }
     },
@@ -64,8 +64,8 @@ spectator.spark {
       tags = {
         "role" = 2
         "source" = 4
-        "appId" = 1
-        "appName" = 3
+        //"appId" = 1
+        //"appName" = 3
       }
     },
 
@@ -76,8 +76,8 @@ spectator.spark {
       tags = {
         "role" = 2
         "source" = 4
-        "appId" = 1
-        "appName" = 3
+        //"appId" = 1
+        //"appName" = 3
       }
     },
 

--- a/spectator-ext-spark/src/test/java/com/netflix/spectator/spark/SparkNameFunctionTest.java
+++ b/spectator-ext-spark/src/test/java/com/netflix/spectator/spark/SparkNameFunctionTest.java
@@ -36,9 +36,9 @@ public class SparkNameFunctionTest {
   public void executorName() {
     final String name = "app-20150309231421-0000.0.executor.filesystem.file.largeRead_ops";
     final Id expected = new DefaultId("spark.filesystem.file.largeRead_ops")
-        .withTag("role", "executor")
-        .withTag("appId", "app-20150309231421-0000")
-        .withTag("executorId", "0");
+        .withTag("role", "executor");
+        //.withTag("appId", "app-20150309231421-0000")
+        //.withTag("executorId", "0");
     assertEquals(expected, f.apply(name));
   }
 
@@ -46,8 +46,8 @@ public class SparkNameFunctionTest {
   public void executorName2() {
     final String name = "20150626-185518-1776258826-5050-2845-S1.executor.filesystem.file.largeRead_ops";
     final Id expected = new DefaultId("spark.filesystem.file.largeRead_ops")
-        .withTag("role", "executor")
-        .withTag("appId", "20150626-185518-1776258826-5050-2845-S1");
+        .withTag("role", "executor");
+        //.withTag("appId", "20150626-185518-1776258826-5050-2845-S1");
     assertEquals(expected, f.apply(name));
   }
 
@@ -55,8 +55,8 @@ public class SparkNameFunctionTest {
   public void executorName3() {
     final String name = "12345.1.3.executor.filesystem.file.largeRead_ops";
     final Id expected = new DefaultId("spark.filesystem.file.largeRead_ops")
-        .withTag("role", "executor")
-        .withTag("appId", "12345.1.3");
+        .withTag("role", "executor");
+        //.withTag("appId", "12345.1.3");
     assertEquals(expected, f.apply(name));
   }
 
@@ -65,8 +65,8 @@ public class SparkNameFunctionTest {
     final String name = "app-20150309231421-0000.driver.BlockManager.disk.diskSpaceUsed_MB";
     final Id expected = new DefaultId("spark.disk.diskSpaceUsed")
         .withTag("role", "driver")
-        .withTag("source", "BlockManager")
-        .withTag("appId", "app-20150309231421-0000");
+        .withTag("source", "BlockManager");
+        //.withTag("appId", "app-20150309231421-0000");
     assertEquals(expected, f.apply(name));
   }
 
@@ -75,8 +75,8 @@ public class SparkNameFunctionTest {
     final String name = "app-20150309231421-0000.driver.DAGScheduler.job.activeJobs";
     final Id expected = new DefaultId("spark.job.activeJobs")
         .withTag("role", "driver")
-        .withTag("source", "DAGScheduler")
-        .withTag("appId", "app-20150309231421-0000");
+        .withTag("source", "DAGScheduler");
+        //.withTag("appId", "app-20150309231421-0000");
     assertEquals(expected, f.apply(name));
   }
 
@@ -85,8 +85,8 @@ public class SparkNameFunctionTest {
     final String name = "local-1429219722964.<driver>.DAGScheduler.job.activeJobs";
     final Id expected = new DefaultId("spark.job.activeJobs")
         .withTag("role", "driver")
-        .withTag("source", "DAGScheduler")
-        .withTag("appId", "local-1429219722964");
+        .withTag("source", "DAGScheduler");
+        //.withTag("appId", "local-1429219722964");
     assertEquals(expected, f.apply(name));
   }
 
@@ -95,9 +95,9 @@ public class SparkNameFunctionTest {
     final String name = "app-20150527224111-0014.<driver>.SubscriptionEnded.StreamingMetrics.streaming.receivers";
     final Id expected = new DefaultId("spark.streaming.receivers")
         .withTag("role", "driver")
-        .withTag("source", "StreamingMetrics")
-        .withTag("appId", "app-20150527224111-0014")
-        .withTag("appName", "SubscriptionEnded");
+        .withTag("source", "StreamingMetrics");
+        //.withTag("appId", "app-20150527224111-0014")
+        //.withTag("appName", "SubscriptionEnded");
     assertEquals(expected, f.apply(name));
   }
 
@@ -106,9 +106,9 @@ public class SparkNameFunctionTest {
     final String name = "app-20150527224111-0014.<driver>.SubscriptionEnded.StreamingMetrics.streaming.totalCompletedBatches";
     final Id expected = new DefaultId("spark.streaming.totalCompletedBatches")
         .withTag("role", "driver")
-        .withTag("source", "StreamingMetrics")
-        .withTag("appId", "app-20150527224111-0014")
-        .withTag("appName", "SubscriptionEnded");
+        .withTag("source", "StreamingMetrics");
+        //.withTag("appId", "app-20150527224111-0014")
+        //.withTag("appName", "SubscriptionEnded");
     assertEquals(expected, f.apply(name));
   }
 
@@ -117,9 +117,9 @@ public class SparkNameFunctionTest {
     final String name = "app-20150527224111-0014.<driver>.SubscriptionEnded.StreamingMetrics.streaming.lastReceivedBatch_submissionDelay";
     final Id expected = new DefaultId("spark.streaming.lastReceivedBatch_submissionDelay")
         .withTag("role", "driver")
-        .withTag("source", "StreamingMetrics")
-        .withTag("appId", "app-20150527224111-0014")
-        .withTag("appName", "SubscriptionEnded");
+        .withTag("source", "StreamingMetrics");
+        //.withTag("appId", "app-20150527224111-0014")
+        //.withTag("appName", "SubscriptionEnded");
     assertEquals(expected, f.apply(name));
   }
 


### PR DESCRIPTION
Switch to using the SparkEnv to access the config for obtaining the common tags. Will cleanup some of the name mappings after more thorough testing. Enable the jvm and gc stats.