### PR TITLE
use registry for creating the ids in t-digest lib

### DIFF
--- a/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/FileTDigestReader.java
+++ b/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/FileTDigestReader.java
@@ -15,6 +15,8 @@
  */
 package com.netflix.spectator.tdigest;
 
+import com.netflix.spectator.api.Registry;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -24,7 +26,7 @@ import java.io.FileNotFoundException;
  */
 public class FileTDigestReader extends StreamTDigestReader {
   /** Create a new instance. */
-  public FileTDigestReader(File f) throws FileNotFoundException {
-    super(new FileInputStream(f));
+  public FileTDigestReader(Registry registry, File f) throws FileNotFoundException {
+    super(registry, new FileInputStream(f));
   }
 }

--- a/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/FileTDigestWriter.java
+++ b/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/FileTDigestWriter.java
@@ -15,6 +15,8 @@
  */
 package com.netflix.spectator.tdigest;
 
+import com.netflix.spectator.api.Registry;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
@@ -25,7 +27,7 @@ import java.io.FileOutputStream;
 public class FileTDigestWriter extends StreamTDigestWriter {
 
   /** Create a new instance. */
-  public FileTDigestWriter(File file) throws FileNotFoundException {
-    super(new FileOutputStream(file));
+  public FileTDigestWriter(Registry registry, File file) throws FileNotFoundException {
+    super(registry, new FileOutputStream(file));
   }
 }

--- a/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/KinesisTDigestWriter.java
+++ b/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/KinesisTDigestWriter.java
@@ -16,6 +16,7 @@
 package com.netflix.spectator.tdigest;
 
 import com.amazonaws.services.kinesis.AmazonKinesisClient;
+import com.netflix.spectator.api.Registry;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -35,13 +36,15 @@ public class KinesisTDigestWriter extends TDigestWriter {
   /**
    * Create a new instance.
    *
+   * @param registry
+   *     Registry for creating metrics.
    * @param client
    *     Client for sending data to Kinesis.
    * @param stream
    *     Name of the stream to use for writing.
    */
-  public KinesisTDigestWriter(AmazonKinesisClient client, String stream) {
-    super();
+  public KinesisTDigestWriter(Registry registry, AmazonKinesisClient client, String stream) {
+    super(registry);
     this.client = client;
     this.stream = stream;
   }

--- a/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/StreamTDigestWriter.java
+++ b/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/StreamTDigestWriter.java
@@ -15,6 +15,8 @@
  */
 package com.netflix.spectator.tdigest;
 
+import com.netflix.spectator.api.Registry;
+
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -29,13 +31,13 @@ public class StreamTDigestWriter extends TDigestWriter {
   private final byte[] buf = new byte[BUFFER_SIZE];
 
   /** Create a new instance. */
-  public StreamTDigestWriter(OutputStream out) {
-    this(new DataOutputStream(out));
+  public StreamTDigestWriter(Registry registry, OutputStream out) {
+    this(registry, new DataOutputStream(out));
   }
 
   /** Create a new instance. */
-  public StreamTDigestWriter(DataOutputStream out) {
-    super();
+  public StreamTDigestWriter(Registry registry, DataOutputStream out) {
+    super(registry);
     this.out = out;
   }
 

--- a/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestModule.java
+++ b/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestModule.java
@@ -20,6 +20,7 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Inject;
 import com.google.inject.Provides;
 import com.netflix.spectator.api.ExtendedRegistry;
+import com.netflix.spectator.api.Registry;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
@@ -48,10 +49,10 @@ public class TDigestModule extends AbstractModule {
 
   @Provides
   @Singleton
-  private TDigestWriter providesWriter(TDigestConfig config) {
+  private TDigestWriter providesWriter(Registry registry, TDigestConfig config) {
     AmazonKinesisClient client = new AmazonKinesisClient();
     client.setEndpoint(config.getEndpoint());
-    return new KinesisTDigestWriter(client, config.getStream());
+    return new KinesisTDigestWriter(registry, client, config.getStream());
   }
 
   private static class OptionalInjections {

--- a/spectator-reg-tdigest/src/test/java/com/netflix/spectator/tdigest/StepDigestTest.java
+++ b/spectator-reg-tdigest/src/test/java/com/netflix/spectator/tdigest/StepDigestTest.java
@@ -15,7 +15,7 @@
  */
 package com.netflix.spectator.tdigest;
 
-import com.netflix.spectator.api.DefaultId;
+import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.ManualClock;
 import org.junit.Assert;
@@ -24,12 +24,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import java.io.ByteArrayOutputStream;
-
 @RunWith(JUnit4.class)
 public class StepDigestTest {
 
   private final ManualClock clock = new ManualClock();
+  private final Id id = (new DefaultRegistry()).createId("foo");
 
   @Before
   public void init() {
@@ -38,7 +37,6 @@ public class StepDigestTest {
 
   @Test
   public void none() throws Exception {
-    Id id = new DefaultId("foo");
     StepDigest digest = new StepDigest(id, 100.0, clock, 10);
     clock.setWallTime(10);
     Assert.assertEquals(Double.NaN, digest.poll().quantile(0.5), 0.2);
@@ -46,7 +44,6 @@ public class StepDigestTest {
 
   @Test
   public void addOne() throws Exception {
-    Id id = new DefaultId("foo");
     StepDigest digest = new StepDigest(id, 100.0, clock, 10);
     digest.add(1.0);
     clock.setWallTime(10);
@@ -55,7 +52,6 @@ public class StepDigestTest {
 
   @Test
   public void addTwoValues() throws Exception {
-    Id id = new DefaultId("foo");
     StepDigest digest = new StepDigest(id, 100.0, clock, 10);
     digest.add(1.0);
     digest.add(100.0);

--- a/spectator-reg-tdigest/src/test/java/com/netflix/spectator/tdigest/TDigestPluginTest.java
+++ b/spectator-reg-tdigest/src/test/java/com/netflix/spectator/tdigest/TDigestPluginTest.java
@@ -50,7 +50,7 @@ public class TDigestPluginTest {
 
   private Map<Long, List<TDigestMeasurement>> readFromFile(File f) throws IOException {
     Map<Long, List<TDigestMeasurement>> result = new HashMap<>();
-    try (TDigestReader in = new FileTDigestReader(f)) {
+    try (TDigestReader in = new FileTDigestReader(new DefaultRegistry(), f)) {
       List<TDigestMeasurement> ms;
       while (!(ms = in.read()).isEmpty()) {
         for (TDigestMeasurement m : ms) {
@@ -72,7 +72,7 @@ public class TDigestPluginTest {
     f.getParentFile().mkdirs();
     final TDigestConfig config = new TDigestConfig(ConfigFactory.load().getConfig("spectator.tdigest"));
     final TDigestRegistry r = new TDigestRegistry(new DefaultRegistry(clock), config);
-    final TDigestPlugin p = new TDigestPlugin(r, new FileTDigestWriter(f), config);
+    final TDigestPlugin p = new TDigestPlugin(r, new FileTDigestWriter(new DefaultRegistry(), f), config);
 
     // Adding a bunch of tags to test the effect of setting
     // SmileGenerator.Feature.CHECK_SHARED_STRING_VALUES.

--- a/spectator-reg-tdigest/src/test/java/com/netflix/spectator/tdigest/TDigestWriterTest.java
+++ b/spectator-reg-tdigest/src/test/java/com/netflix/spectator/tdigest/TDigestWriterTest.java
@@ -15,10 +15,8 @@
  */
 package com.netflix.spectator.tdigest;
 
-import com.netflix.spectator.api.DefaultId;
 import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.Id;
-import com.netflix.spectator.api.ManualClock;
 import com.netflix.spectator.api.Registry;
 import com.tdunning.math.stats.TDigest;
 import org.junit.Assert;
@@ -37,16 +35,17 @@ import java.util.List;
 public class TDigestWriterTest {
 
   private final Registry registry = new DefaultRegistry();
+  private final Id id = registry.createId("foo");
 
   private ByteArrayOutputStream baos;
   private TDigestWriter writer;
 
   private Id bigId() {
-    Id id = new DefaultId("foo");
+    Id tmp = id;
     for (int i = 0; i < 10000; ++i) {
-      id = id.withTag("" + i, "" + i);
+      tmp = tmp.withTag("" + i, "" + i);
     }
-    return id;
+    return tmp;
   }
 
   @Before
@@ -57,7 +56,6 @@ public class TDigestWriterTest {
 
   @Test
   public void emptyDigest() throws Exception {
-    Id id = new DefaultId("foo");
     TDigestMeasurement m = new TDigestMeasurement(id, 0L, TDigest.createDigest(100.0));
     writer.write(Collections.singletonList(m));
     writer.close();
@@ -71,7 +69,6 @@ public class TDigestWriterTest {
 
   @Test
   public void simpleDigest() throws Exception {
-    Id id = new DefaultId("foo");
     TDigest d = TDigest.createDigest(100.0);
     d.add(1.0);
     TDigestMeasurement m = new TDigestMeasurement(id, 0L, d);
@@ -87,7 +84,6 @@ public class TDigestWriterTest {
 
   @Test
   public void overflow() throws Exception {
-    Id id = new DefaultId("foo");
     TDigestMeasurement m = new TDigestMeasurement(id, 0L, TDigest.createDigest(100.0));
     List<TDigestMeasurement> ms = new ArrayList<>();
     for (int i = 0; i < 50000; ++i) {

--- a/spectator-reg-tdigest/src/test/java/com/netflix/spectator/tdigest/TDigestWriterTest.java
+++ b/spectator-reg-tdigest/src/test/java/com/netflix/spectator/tdigest/TDigestWriterTest.java
@@ -16,8 +16,10 @@
 package com.netflix.spectator.tdigest;
 
 import com.netflix.spectator.api.DefaultId;
+import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.ManualClock;
+import com.netflix.spectator.api.Registry;
 import com.tdunning.math.stats.TDigest;
 import org.junit.Assert;
 import org.junit.Before;
@@ -34,6 +36,8 @@ import java.util.List;
 @RunWith(JUnit4.class)
 public class TDigestWriterTest {
 
+  private final Registry registry = new DefaultRegistry();
+
   private ByteArrayOutputStream baos;
   private TDigestWriter writer;
 
@@ -48,7 +52,7 @@ public class TDigestWriterTest {
   @Before
   public void init() {
     baos = new ByteArrayOutputStream();
-    writer = new StreamTDigestWriter(baos);
+    writer = new StreamTDigestWriter(registry, baos);
   }
 
   @Test
@@ -59,7 +63,7 @@ public class TDigestWriterTest {
     writer.close();
 
     ByteArrayInputStream in = new ByteArrayInputStream(baos.toByteArray());
-    List<List<TDigestMeasurement>> data = StreamTDigestReader.readAll(in);
+    List<List<TDigestMeasurement>> data = StreamTDigestReader.readAll(registry, in);
     Assert.assertEquals(1, data.size());
     Assert.assertEquals(1, data.get(0).size());
     Assert.assertEquals(Double.NaN, data.get(0).get(0).value().quantile(0.5), 0.2);
@@ -75,7 +79,7 @@ public class TDigestWriterTest {
     writer.close();
 
     ByteArrayInputStream in = new ByteArrayInputStream(baos.toByteArray());
-    List<List<TDigestMeasurement>> data = StreamTDigestReader.readAll(in);
+    List<List<TDigestMeasurement>> data = StreamTDigestReader.readAll(registry, in);
     Assert.assertEquals(1, data.size());
     Assert.assertEquals(1, data.get(0).size());
     Assert.assertEquals(1.0, data.get(0).get(0).value().quantile(0.5), 0.2);
@@ -93,7 +97,7 @@ public class TDigestWriterTest {
     writer.close();
 
     ByteArrayInputStream in = new ByteArrayInputStream(baos.toByteArray());
-    List<List<TDigestMeasurement>> data = StreamTDigestReader.readAll(in);
+    List<List<TDigestMeasurement>> data = StreamTDigestReader.readAll(registry, in);
     int count = 0;
     for (List<TDigestMeasurement> vs : data) {
       for (TDigestMeasurement v : vs) {
@@ -111,7 +115,7 @@ public class TDigestWriterTest {
     writer.close();
 
     ByteArrayInputStream in = new ByteArrayInputStream(baos.toByteArray());
-    List<List<TDigestMeasurement>> data = StreamTDigestReader.readAll(in);
+    List<List<TDigestMeasurement>> data = StreamTDigestReader.readAll(registry, in);
     Assert.assertEquals(0, data.size());
   }
 }


### PR DESCRIPTION
Updates the Json utility class to use an injected registry
to create the ids rather than using `DefaultId` directly.

This change does break backwards compatibility of some of
the classes to pass in the registry. However, it is still
experimental and our use of those classes is only via tests
or via a guice module so it will not break common usage.

cc @pstout 