### PR TITLE
revert governator to 1.7.6-rc1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,11 +1,11 @@
 release.scope=patch
 
-version_archaius1=0.7.0
-version_archaius=2.0.0-rc.18
-version_aws=1.10.2
-version_config=1.2.1
-version_eureka=1.1.158
-version_governator=1.7.5
+version_archaius1=0.7.2
+version_archaius=2.0.0-rc.28
+version_aws=1.10.10
+version_config=1.3.0
+version_eureka=1.2.0
+version_governator=1.7.6-rc.1
 version_guice=4.0
 version_iep=0.1.25.7
 version_jackson=2.5.3


### PR DESCRIPTION
There is some problem with versions above that and loading
the AutoBindSingleton modules.

Conflicts:
	gradle.properties