### PR TITLE
fix types to make lambdas work better

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/DoubleFunction.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/DoubleFunction.java
@@ -15,15 +15,15 @@
  */
 package com.netflix.spectator.api;
 
+import java.util.function.ToDoubleFunction;
+
 /**
  * Function to extract a double value from an object.
  */
-public abstract class DoubleFunction implements ValueFunction {
+public abstract class DoubleFunction<T extends Number> implements ToDoubleFunction<T> {
 
-  @Override public double apply(Object obj) {
-    return (obj instanceof Number)
-      ? apply(((Number) obj).doubleValue())
-      : Double.NaN;
+  @Override public double applyAsDouble(T n) {
+    return apply(n.doubleValue());
   }
 
   /**
@@ -34,5 +34,5 @@ public abstract class DoubleFunction implements ValueFunction {
    * @return
    *     Result of applying this function to `v`.
    */
-  public abstract double apply(double v);
+  abstract double apply(double v);
 }

--- a/spectator-api/src/main/java/com/netflix/spectator/api/Functions.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/Functions.java
@@ -21,6 +21,7 @@ import org.slf4j.LoggerFactory;
 import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.Map;
+import java.util.function.ToDoubleFunction;
 
 
 /**
@@ -37,29 +38,27 @@ public final class Functions {
    * Identity function that just returns the passed in value if it implements the
    * {@link java.lang.Number} interface.
    */
-  public static final DoubleFunction IDENTITY = new DoubleFunction() {
-    public double apply(double v) {
+  public static final DoubleFunction<? extends Number> IDENTITY = new DoubleFunction<Number>() {
+    @Override double apply(double v) {
       return v;
     }
   };
 
   /**
    * Returns the size of the collection.
+   *
+   * @deprecated Use {@code Collection::size} instead.
    */
-  public static final ValueFunction COLLECTION_SIZE = new ValueFunction() {
-    public double apply(Object obj) {
-      return (obj instanceof Collection) ? ((Collection) obj).size() : Double.NaN;
-    }
-  };
+  @Deprecated
+  public static final ValueFunction<Collection<?>> COLLECTION_SIZE = Collection::size;
 
   /**
    * Returns the size of the map.
+   *
+   * @deprecated Use {@code Map::size} instead.
    */
-  public static final ValueFunction MAP_SIZE = new ValueFunction() {
-    public double apply(Object obj) {
-      return (obj instanceof Map) ? ((Map) obj).size() : Double.NaN;
-    }
-  };
+  @Deprecated
+  public static final ValueFunction<Map<?, ?>> MAP_SIZE = Map::size;
 
   /**
    * Age function based on the system clock. See {@link #age(Clock)} for more details.
@@ -96,17 +95,15 @@ public final class Functions {
    * @return
    *     Value returned by the method or NaN if an exception is thrown.
    */
-  public static ValueFunction invokeMethod(final Method method) {
+  public static ToDoubleFunction invokeMethod(final Method method) {
     method.setAccessible(true);
-    return new ValueFunction() {
-      public double apply(Object obj) {
-        try {
-          final Number n = (Number) method.invoke(obj);
-          return n.doubleValue();
-        } catch (Exception e) {
-          LOGGER.warn("exception from method registered as a gauge [" + method + "]", e);
-          return Double.NaN;
-        }
+    return (obj) -> {
+      try {
+        final Number n = (Number) method.invoke(obj);
+        return n.doubleValue();
+      } catch (Exception e) {
+        LOGGER.warn("exception from method registered as a gauge [" + method + "]", e);
+        return Double.NaN;
       }
     };
   }

--- a/spectator-api/src/main/java/com/netflix/spectator/api/ObjectGauge.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/ObjectGauge.java
@@ -16,13 +16,14 @@
 package com.netflix.spectator.api;
 
 import java.util.Collections;
+import java.util.function.ToDoubleFunction;
 
 /**
  * Gauge that is defined by executing a {@link ValueFunction} on an object.
  */
 class ObjectGauge extends AbstractMeter<Object> implements Gauge {
 
-  private final ValueFunction f;
+  private final ToDoubleFunction f;
 
   /**
    * Create a gauge that samples the provided number for the value.
@@ -37,7 +38,7 @@ class ObjectGauge extends AbstractMeter<Object> implements Gauge {
    *     Function that is applied on the value for the number. The operation {@code f.apply(obj)}
    *     should be thread-safe.
    */
-  ObjectGauge(Clock clock, Id id, Object obj, ValueFunction f) {
+  ObjectGauge(Clock clock, Id id, Object obj, ToDoubleFunction f) {
     super(clock, id, obj);
     this.f = f;
   }
@@ -48,6 +49,6 @@ class ObjectGauge extends AbstractMeter<Object> implements Gauge {
 
   @Override public double value() {
     final Object obj = ref.get();
-    return (obj == null) ? Double.NaN : f.apply(obj);
+    return (obj == null) ? Double.NaN : f.applyAsDouble(obj);
   }
 }

--- a/spectator-api/src/main/java/com/netflix/spectator/api/Registry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/Registry.java
@@ -19,6 +19,7 @@ import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.function.ToDoubleFunction;
 
 /**
  * Registry to manage a set of meters.
@@ -327,7 +328,7 @@ public interface Registry extends Iterable<Meter> {
    *     statement.
    */
   default <T extends Number> T gauge(Id id, T number) {
-    return gauge(id, number, Functions.IDENTITY);
+    return (T) gauge(id, number, (ToDoubleFunction<T>) Functions.IDENTITY);
   }
 
   /**
@@ -379,14 +380,14 @@ public interface Registry extends Iterable<Meter> {
    *     The number that was passed in so the registration can be done as part of an assignment
    *     statement.
    */
-  default <T> T gauge(Id id, T obj, ValueFunction f) {
+  default <T> T gauge(Id id, T obj, ToDoubleFunction<T> f) {
     register(new ObjectGauge(clock(), id, obj, f));
     return obj;
   }
 
   /**
    * Register a gauge that reports the value of the object. See
-   * {@link #gauge(Id, Object, ValueFunction)}.
+   * {@link #gauge(Id, Object, ToDoubleFunction)}.
    *
    * @param name
    *     Name of the metric being registered.
@@ -398,7 +399,7 @@ public interface Registry extends Iterable<Meter> {
    *     The number that was passed in so the registration can be done as part of an assignment
    *     statement.
    */
-  default <T> T gauge(String name, T obj, ValueFunction f) {
+  default <T> T gauge(String name, T obj, ToDoubleFunction<T> f) {
     return gauge(createId(name), obj, f);
   }
 
@@ -418,7 +419,7 @@ public interface Registry extends Iterable<Meter> {
    *     statement.
    */
   default <T extends Collection<?>> T collectionSize(Id id, T collection) {
-    return gauge(id, collection, Functions.COLLECTION_SIZE);
+    return gauge(id, collection, Collection::size);
   }
 
   /**
@@ -456,7 +457,7 @@ public interface Registry extends Iterable<Meter> {
    *     statement.
    */
   default <T extends Map<?, ?>> T mapSize(Id id, T collection) {
-    return gauge(id, collection, Functions.MAP_SIZE);
+    return gauge(id, collection, Map::size);
   }
 
   /**

--- a/spectator-api/src/main/java/com/netflix/spectator/api/ValueFunction.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/ValueFunction.java
@@ -15,10 +15,15 @@
  */
 package com.netflix.spectator.api;
 
+import java.util.function.ToDoubleFunction;
+
 /**
  * Function to extract a double value from an object.
+ *
+ * @deprecated Use {@link ToDoubleFunction} instead.
  */
-public interface ValueFunction {
+@Deprecated
+public interface ValueFunction<T> extends ToDoubleFunction<T> {
   /**
    * Returns a double value based on the object {@code ref}.
    *
@@ -27,5 +32,9 @@ public interface ValueFunction {
    * @return
    *     Double value based on the object.
    */
-  double apply(Object ref);
+  double apply(T ref);
+
+  @Override default double applyAsDouble(T ref) {
+    return apply(ref);
+  }
 }

--- a/spectator-api/src/test/java/com/netflix/spectator/api/FunctionsTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/FunctionsTest.java
@@ -20,6 +20,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import java.util.function.ToDoubleFunction;
+
 @RunWith(JUnit4.class)
 public class FunctionsTest {
 
@@ -39,8 +41,8 @@ public class FunctionsTest {
 
   @Test
   public void invokeMethodByte() throws Exception {
-    final ValueFunction f = Functions.invokeMethod(Utils.getMethod(getClass(), "byteMethod"));
-    Assert.assertEquals(f.apply(this), 1.0, 1e-12);
+    final ToDoubleFunction f = Functions.invokeMethod(Utils.getMethod(getClass(), "byteMethod"));
+    Assert.assertEquals(f.applyAsDouble(this), 1.0, 1e-12);
   }
 
   private short shortMethod() {
@@ -49,8 +51,8 @@ public class FunctionsTest {
 
   @Test
   public void invokeMethodShort() throws Exception  {
-    final ValueFunction f = Functions.invokeMethod(Utils.getMethod(getClass(), "shortMethod"));
-    Assert.assertEquals(f.apply(this), 2.0, 1e-12);
+    final ToDoubleFunction f = Functions.invokeMethod(Utils.getMethod(getClass(), "shortMethod"));
+    Assert.assertEquals(f.applyAsDouble(this), 2.0, 1e-12);
   }
 
   private int intMethod() {
@@ -59,8 +61,8 @@ public class FunctionsTest {
 
   @Test
   public void invokeMethodInt() throws Exception  {
-    final ValueFunction f = Functions.invokeMethod(Utils.getMethod(getClass(), "intMethod"));
-    Assert.assertEquals(f.apply(this), 3.0, 1e-12);
+    final ToDoubleFunction f = Functions.invokeMethod(Utils.getMethod(getClass(), "intMethod"));
+    Assert.assertEquals(f.applyAsDouble(this), 3.0, 1e-12);
   }
 
   private long longMethod() {
@@ -69,8 +71,8 @@ public class FunctionsTest {
 
   @Test
   public void invokeMethodLong() throws Exception  {
-    final ValueFunction f = Functions.invokeMethod(Utils.getMethod(getClass(), "longMethod"));
-    Assert.assertEquals(f.apply(this), 4.0, 1e-12);
+    final ToDoubleFunction f = Functions.invokeMethod(Utils.getMethod(getClass(), "longMethod"));
+    Assert.assertEquals(f.applyAsDouble(this), 4.0, 1e-12);
   }
 
   private Long wrapperLongMethod() {
@@ -79,9 +81,9 @@ public class FunctionsTest {
 
   @Test
   public void invokeMethodWrapperLong() throws Exception  {
-    final ValueFunction f = Functions.invokeMethod(
+    final ToDoubleFunction f = Functions.invokeMethod(
         Utils.getMethod(getClass(), "wrapperLongMethod"));
-    Assert.assertEquals(f.apply(this), 5.0, 1e-12);
+    Assert.assertEquals(f.applyAsDouble(this), 5.0, 1e-12);
   }
 
   private Long throwsMethod() {
@@ -90,8 +92,8 @@ public class FunctionsTest {
 
   @Test
   public void invokeBadMethod() throws Exception  {
-    final ValueFunction f = Functions.invokeMethod(Utils.getMethod(getClass(), "throwsMethod"));
-    Assert.assertEquals(f.apply(this), Double.NaN, 1e-12);
+    final ToDoubleFunction f = Functions.invokeMethod(Utils.getMethod(getClass(), "throwsMethod"));
+    Assert.assertEquals(f.applyAsDouble(this), Double.NaN, 1e-12);
   }
 
   @Test(expected = NoSuchMethodException.class)
@@ -101,20 +103,20 @@ public class FunctionsTest {
 
   @Test
   public void invokeOnSubclass() throws Exception  {
-    final ValueFunction f = Functions.invokeMethod(Utils.getMethod(B.class, "two"));
-    Assert.assertEquals(f.apply(new B()), 2.0, 1e-12);
+    final ToDoubleFunction f = Functions.invokeMethod(Utils.getMethod(B.class, "two"));
+    Assert.assertEquals(f.applyAsDouble(new B()), 2.0, 1e-12);
   }
 
   @Test
   public void invokeOneA() throws Exception  {
-    final ValueFunction f = Functions.invokeMethod(Utils.getMethod(A.class, "one"));
-    Assert.assertEquals(f.apply(new A()), 1.0, 1e-12);
+    final ToDoubleFunction f = Functions.invokeMethod(Utils.getMethod(A.class, "one"));
+    Assert.assertEquals(f.applyAsDouble(new A()), 1.0, 1e-12);
   }
 
   @Test
   public void invokeOneB() throws Exception  {
-    final ValueFunction f = Functions.invokeMethod(Utils.getMethod(B.class, "one"));
-    Assert.assertEquals(f.apply(new B()), -1.0, 1e-12);
+    final ToDoubleFunction f = Functions.invokeMethod(Utils.getMethod(B.class, "one"));
+    Assert.assertEquals(f.applyAsDouble(new B()), -1.0, 1e-12);
   }
 
   private static class A {


### PR DESCRIPTION
Fixes the typing on `ValueFunction` so that a cast isn't
needed when using lambdas. Also deprecates `ValueFunction`
in favor of `ToDoubleFunction` that comes with the jdk.