### PR TITLE
fix name mapping for metrics3 registry

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/DefaultId.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/DefaultId.java
@@ -87,13 +87,17 @@ final class DefaultId implements Id {
    *     New identifier after applying the rollup.
    */
   DefaultId rollup(Set<String> keys, boolean keep) {
-    Map<String, String> ts = new TreeMap<>();
-    for (Tag t : tags) {
-      if (keys.contains(t.key()) == keep && !ts.containsKey(t.key())) {
-        ts.put(t.key(), t.value());
+    if (tags == TagList.EMPTY) {
+      return this;
+    } else {
+      Map<String, String> ts = new TreeMap<>();
+      for (Tag t : tags) {
+        if (keys.contains(t.key()) == keep && !ts.containsKey(t.key())) {
+          ts.put(t.key(), t.value());
+        }
       }
+      return new DefaultId(name, TagList.create(ts));
     }
-    return new DefaultId(name, TagList.create(ts));
   }
 
   @Override public boolean equals(Object obj) {

--- a/spectator-api/src/test/java/com/netflix/spectator/api/DefaultIdTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/DefaultIdTest.java
@@ -87,6 +87,12 @@ public class DefaultIdTest {
   }
 
   @Test
+  public void testRollupJustName() {
+    DefaultId id = new DefaultId("foo");
+    Assert.assertSame(id, id.normalize());
+  }
+
+  @Test
   public void testRollupDeduping() {
     Set<String> keys = new HashSet<>();
     keys.add("k1");

--- a/spectator-reg-metrics3/src/main/java/com/netflix/spectator/metrics3/MetricsRegistry.java
+++ b/spectator-reg-metrics3/src/main/java/com/netflix/spectator/metrics3/MetricsRegistry.java
@@ -34,10 +34,11 @@ public class MetricsRegistry extends AbstractRegistry {
   }
 
   private String toMetricName(Id id) {
+    Id normalized = Utils.normalize(id);
     StringBuilder buf = new StringBuilder();
-    buf.append(id.name());
-    for (Tag t : id.tags()) {
-      buf.append(t.key()).append("-").append(t.value());
+    buf.append(normalized.name());
+    for (Tag t : normalized.tags()) {
+      buf.append('.').append(t.key()).append('-').append(t.value());
     }
     return buf.toString();
   }

--- a/spectator-reg-metrics3/src/test/java/com/netflix/spectator/metrics3/MetricsRegistryTest.java
+++ b/spectator-reg-metrics3/src/test/java/com/netflix/spectator/metrics3/MetricsRegistryTest.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.metrics3;
+
+import com.codahale.metrics.MetricRegistry;
+import com.netflix.spectator.api.ManualClock;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@RunWith(JUnit4.class)
+public class MetricsRegistryTest {
+
+  private final ManualClock clock = new ManualClock();
+
+  @Test
+  public void metricName() {
+    MetricRegistry codaRegistry = new MetricRegistry();
+    MetricsRegistry r = new MetricsRegistry(clock, codaRegistry);
+    r.counter("foo", "id", "bar", "a", "b", "a", "c").increment();
+    Assert.assertTrue(codaRegistry.getMeters().containsKey("foo.id-bar.a-c"));
+  }
+
+  @Test
+  public void counter() {
+    MetricRegistry codaRegistry = new MetricRegistry();
+    MetricsRegistry r = new MetricsRegistry(clock, codaRegistry);
+    r.counter("foo").increment();
+    Assert.assertEquals(1, codaRegistry.getMeters().get("foo").getCount());
+    r.counter("foo").increment(15);
+    Assert.assertEquals(16, codaRegistry.getMeters().get("foo").getCount());
+  }
+
+  @Test
+  public void timer() {
+    MetricRegistry codaRegistry = new MetricRegistry();
+    MetricsRegistry r = new MetricsRegistry(clock, codaRegistry);
+    r.timer("foo").record(1, TimeUnit.MILLISECONDS);
+    Assert.assertEquals(1, codaRegistry.getTimers().get("foo").getCount());
+  }
+
+  @Test
+  public void distributionSummary() {
+    MetricRegistry codaRegistry = new MetricRegistry();
+    MetricsRegistry r = new MetricsRegistry(clock, codaRegistry);
+    r.distributionSummary("foo").record(1);
+    Assert.assertEquals(1, codaRegistry.getHistograms().get("foo").getCount());
+  }
+
+  @Ignore
+  public void gauge() {
+    MetricRegistry codaRegistry = new MetricRegistry();
+    MetricsRegistry r = new MetricsRegistry(clock, codaRegistry);
+    AtomicInteger num = r.gauge("foo", new AtomicInteger(42));
+    Assert.assertEquals(42.0, (Double) codaRegistry.getGauges().get("foo").getValue(), 1e-12);
+  }
+}


### PR DESCRIPTION
The `.` was not getting added between tags when
creating the names leading to:

```
server.requestCountagent-safaristatus-400method-GET
```

rather than the expected:

```
server.requestCount.agent-safari.status-400.method-GET
```

Also fixes a NPE if normalize is called on an Id with
an empty tag list. A test case was added for gauges
that are not currently getting mapped properly, but it
is ignored until that problem is fixed in a later commit.