### PR TITLE
add counters to track number of samples dropped

### DIFF
--- a/spectator-reg-tdigest/src/jmh/java/com/netflix/spectator/tdigest/Record.java
+++ b/spectator-reg-tdigest/src/jmh/java/com/netflix/spectator/tdigest/Record.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.tdigest;
+
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Timer;
+import com.typesafe.config.ConfigFactory;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@State(Scope.Benchmark)
+public class Record {
+
+  private final long[] values = new long[1000000];
+
+  private final Registry registry = new DefaultRegistry();
+  private final TDigestConfig config = new TDigestConfig(ConfigFactory.parseString("polling-frequency = 60s"));
+  private final Registry digestRegistry = new TDigestRegistry(registry, config);
+
+  private final Timer defaultTimer = registry.timer("jmh");
+  private final Timer digestTimer = digestRegistry.timer("jmh");
+
+  private AtomicInteger pos = new AtomicInteger();
+
+  @Setup(Level.Iteration)
+  public void setup() {
+    Random random = new Random();
+    for (int i = 0; i < values.length; ++i) {
+      values[i] = random.nextLong();
+    }
+  }
+
+  @Threads(1)
+  @Benchmark
+  public void defaultRecord_T1(Blackhole bh) {
+    int i = pos.getAndIncrement() % values.length;
+    defaultTimer.record(values[i], TimeUnit.SECONDS);
+    bh.consume(defaultTimer.totalTime());
+  }
+
+  @Threads(2)
+  @Benchmark
+  public void defaultRecord_T2(Blackhole bh) {
+    int i = pos.getAndIncrement() % values.length;
+    defaultTimer.record(values[i], TimeUnit.SECONDS);
+    bh.consume(defaultTimer.totalTime());
+  }
+
+  @Threads(4)
+  @Benchmark
+  public void defaultRecord_T4(Blackhole bh) {
+    int i = pos.getAndIncrement() % values.length;
+    defaultTimer.record(values[i], TimeUnit.SECONDS);
+    bh.consume(defaultTimer.totalTime());
+  }
+
+  @Threads(8)
+  @Benchmark
+  public void defaultRecord_T8(Blackhole bh) {
+    int i = pos.getAndIncrement() % values.length;
+    defaultTimer.record(values[i], TimeUnit.SECONDS);
+    bh.consume(defaultTimer.totalTime());
+  }
+
+  @Threads(1)
+  @Benchmark
+  public void digestRecord_T1(Blackhole bh) {
+    int i = pos.getAndIncrement() % values.length;
+    digestTimer.record(values[i], TimeUnit.SECONDS);
+    bh.consume(digestTimer.totalTime());
+  }
+
+  @Threads(2)
+  @Benchmark
+  public void digestRecord_T2(Blackhole bh) {
+    int i = pos.getAndIncrement() % values.length;
+    digestTimer.record(values[i], TimeUnit.SECONDS);
+    bh.consume(digestTimer.totalTime());
+  }
+
+  @Threads(4)
+  @Benchmark
+  public void digestRecord_T4(Blackhole bh) {
+    int i = pos.getAndIncrement() % values.length;
+    digestTimer.record(values[i], TimeUnit.SECONDS);
+    bh.consume(digestTimer.totalTime());
+  }
+
+  @Threads(8)
+  @Benchmark
+  public void digestRecord_T8(Blackhole bh) {
+    int i = pos.getAndIncrement() % values.length;
+    digestTimer.record(values[i], TimeUnit.SECONDS);
+    bh.consume(digestTimer.totalTime());
+  }
+
+  @TearDown
+  public void tearDown() {
+    long recorded = registry.counter("spectator.tdigest.samples", "id", "recorded").count();
+    long dropped = registry.counter("spectator.tdigest.samples", "id", "dropped").count();
+    double percent = 100.0 * dropped / (dropped + recorded);
+    System.out.printf("recorded: %d, dropped: %d, percent-dropped: %.2f%%%n", recorded, dropped, percent);
+  }
+
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .include(".*")
+        .forks(1)
+        .build();
+    new Runner(opt).run();
+  }
+}

--- a/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestRegistry.java
+++ b/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestRegistry.java
@@ -50,6 +50,6 @@ public class TDigestRegistry extends AbstractRegistry {
 
   private StepDigest newDigest(Id id) {
     final long step = config.getPollingFrequency(TimeUnit.MILLISECONDS);
-    return new StepDigest(id, 100.0, clock(), step);
+    return new StepDigest(underlying, id, 100.0, step);
   }
 }

--- a/spectator-reg-tdigest/src/test/java/com/netflix/spectator/tdigest/StepDigestTest.java
+++ b/spectator-reg-tdigest/src/test/java/com/netflix/spectator/tdigest/StepDigestTest.java
@@ -18,6 +18,7 @@ package com.netflix.spectator.tdigest;
 import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.ManualClock;
+import com.netflix.spectator.api.Registry;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -28,7 +29,8 @@ import org.junit.runners.JUnit4;
 public class StepDigestTest {
 
   private final ManualClock clock = new ManualClock();
-  private final Id id = (new DefaultRegistry()).createId("foo");
+  private final Registry registry = new DefaultRegistry(clock);
+  private final Id id = registry.createId("foo");
 
   @Before
   public void init() {
@@ -37,14 +39,14 @@ public class StepDigestTest {
 
   @Test
   public void none() throws Exception {
-    StepDigest digest = new StepDigest(id, 100.0, clock, 10);
+    StepDigest digest = new StepDigest(registry, id, 100.0, 10);
     clock.setWallTime(10);
     Assert.assertEquals(Double.NaN, digest.poll().quantile(0.5), 0.2);
   }
 
   @Test
   public void addOne() throws Exception {
-    StepDigest digest = new StepDigest(id, 100.0, clock, 10);
+    StepDigest digest = new StepDigest(registry, id, 100.0, 10);
     digest.add(1.0);
     clock.setWallTime(10);
     Assert.assertEquals(1.0, digest.poll().quantile(0.5), 0.2);
@@ -52,7 +54,7 @@ public class StepDigestTest {
 
   @Test
   public void addTwoValues() throws Exception {
-    StepDigest digest = new StepDigest(id, 100.0, clock, 10);
+    StepDigest digest = new StepDigest(registry, id, 100.0, 10);
     digest.add(1.0);
     digest.add(100.0);
     clock.setWallTime(10);


### PR DESCRIPTION
The digest timer will drop samples if another thread already
has the lock. For artificial benchmarks of the timer
we see a high loss rate as threads that do not perform an update
will take a shorter amount of time. In practice, the timer update
is usually small compared to the code being measured.