### PR TITLE
MetricCollector for the AWS SDK

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,7 @@
 include 'spectator-api',
         'spectator-nflx',
         'spectator-nflx-plugin',
+        'spectator-ext-aws',
         'spectator-ext-gc',
         'spectator-ext-jvm',
         'spectator-ext-log4j2',

--- a/spectator-ext-aws/README.md
+++ b/spectator-ext-aws/README.md
@@ -1,0 +1,73 @@
+# spectator-ext-aws
+Use Spectator as the Metrics backend for AWS SDK Request Metrics.
+
+# Usage
+The spectator-ext-aws module can be plugged into the SDK globally using:
+
+`````java
+SpectatorMetricsCollector collector = new SpectatorMetricsCollector(Spectator.globalRegistry());
+AwsSdkMetrics.setMetricCollector(collector);
+`````
+
+A specific AWS SDK Client can be instrumented using:
+
+`````java
+SpectatorRequestMetricCollector requestMetricCollector = new SpectatorRequestMetricCollector(Spectator.globalRegistry());
+AmazonEC2 client = new AmazonEC2Client(credentialsProvider, clientConfiguration, requestMetricCollector);
+`````
+
+Alternatively a single request can be instrumented using:
+`````java
+SpectatorRequestMetricCollector requestMetricCollector = new SpectatorRequestMetricCollector(Spectator.globalRegistry());
+DescribeInstancesRequest awsRequest = new DescribeInstancesRequest().withRequestMetricCollector(requestMetricCollector());
+`````
+
+Any combination of the above three techniques will work, and the most specific (instance > client > SDK) `RequestMetricCollector`
+is used. This could potentially allow capturing some subset of metrics into an alternative Registry.
+
+# Metrics
+
+Each metric is tagged with:
+
+tag             | description
+----------------|------------
+serviceName     | the name of the AWS service
+serviceEndpoint | the endpoint used for the request
+statusCode      | the HTTP status code returned
+error           | whether there was an error
+requestType     | the type of request that was made (e.g. `DescribeInstancesRequest`)
+
+Additionally, an error request is tagged with
+
+tag             | description
+----------------|------------
+aWSErrorCode    | the aws specific error code
+exception       | the exception type that occurred (e.g. `IOException`)
+
+If a tag value is not available, `UNKNOWN` is used. 
+
+The following request metrics are captured as counters:
+
+metric name                      | SDK metric
+---------------------------------|-----------
+aws.request.bytesProcessed       | AWSRequestMetrics.Field.BytesProcessed,
+aws.request.httpClientRetryCount | AWSRequestMetrics.Field.HttpClientRetryCount,
+aws.request.requestCount         | AWSRequestMetrics.Field.RequestCount
+
+The following request metrics are captured as timers:
+
+metric name                               | SDK metric
+------------------------------------------|-----------
+aws.request.clientExecuteTime             | Field.ClientExecuteTime,
+aws.request.credentialsRequestTime        | Field.CredentialsRequestTime,
+aws.request.httpClientReceiveResponseTime | Field.HttpClientReceiveResponseTime,
+aws.request.httpClientSendRequestTime     | Field.HttpClientSendRequestTime,
+aws.request.HttpRequestTime               | Field.HttpRequestTime,
+aws.request.RequestMarshallTime           | Field.RequestMarshallTime,
+aws.request.RequestSigningTime            | Field.RequestSigningTime,
+aws.request.responseProcessingTime        | Field.ResponseProcessingTime,
+aws.request.retryPauseTime                | Field.RetryPauseTime
+
+Any throttling exception that occurs is tracked in a timer `aws.request.throttling` with the same
+set of tags as the other metrics, and one additional tag `throttleException` containing the exception
+that caused the throttling to occur.

--- a/spectator-ext-aws/build.gradle
+++ b/spectator-ext-aws/build.gradle
@@ -1,0 +1,4 @@
+dependencies {
+  compile project(":spectator-api")
+  compile "com.amazonaws:aws-java-sdk-core:$version_aws"
+}

--- a/spectator-ext-aws/src/main/java/com/netflix/spectator/aws/SpectatorMetricsCollector.java
+++ b/spectator-ext-aws/src/main/java/com/netflix/spectator/aws/SpectatorMetricsCollector.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spectator.aws;
+
+import com.amazonaws.metrics.MetricCollector;
+import com.amazonaws.metrics.RequestMetricCollector;
+import com.amazonaws.metrics.ServiceMetricCollector;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Spectator;
+import com.netflix.spectator.impl.Preconditions;
+
+/**
+ * A MetricCollector that captures SDK metrics.
+ */
+public class SpectatorMetricsCollector extends MetricCollector {
+    private final RequestMetricCollector requestMetricCollector;
+
+    /**
+     * Constructs a new instance.
+     */
+    public SpectatorMetricsCollector(Registry registry) {
+        super();
+        Preconditions.checkNotNull(registry, "registry");
+
+        this.requestMetricCollector = new SpectatorRequestMetricCollector(registry);
+    }
+
+    @Override public boolean start() {
+        return true;
+    }
+
+    @Override public boolean stop() {
+        return true;
+    }
+
+    @Override public boolean isEnabled() {
+        return Spectator.config().getBoolean("spectator.ext.aws.enabled", true);
+    }
+
+    @Override public RequestMetricCollector getRequestMetricCollector() {
+        return requestMetricCollector;
+    }
+
+    @Override public ServiceMetricCollector getServiceMetricCollector() {
+        return ServiceMetricCollector.NONE;
+    }
+}

--- a/spectator-ext-aws/src/main/java/com/netflix/spectator/aws/SpectatorRequestMetricCollector.java
+++ b/spectator-ext-aws/src/main/java/com/netflix/spectator/aws/SpectatorRequestMetricCollector.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.aws;
+
+import com.amazonaws.Request;
+import com.amazonaws.Response;
+import com.amazonaws.metrics.RequestMetricCollector;
+import com.amazonaws.util.AWSRequestMetrics;
+import com.amazonaws.util.AWSRequestMetrics.Field;
+import com.amazonaws.util.TimingInfo;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.impl.Preconditions;
+
+import java.beans.Introspector;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+/**
+ * A {@link RequestMetricCollector} that captures request level metrics for AWS clients.
+ */
+public class SpectatorRequestMetricCollector extends RequestMetricCollector {
+
+  private static final Field[] TIMERS = {
+      Field.ClientExecuteTime,
+      Field.CredentialsRequestTime,
+      Field.HttpClientReceiveResponseTime,
+      Field.HttpClientSendRequestTime,
+      Field.HttpRequestTime,
+      Field.RequestMarshallTime,
+      Field.RequestSigningTime,
+      Field.ResponseProcessingTime,
+      Field.RetryPauseTime
+  };
+
+  private static final Field[] COUNTERS = {
+      Field.BytesProcessed,
+      Field.HttpClientRetryCount,
+      Field.RequestCount
+  };
+
+  private static final TagField[] TAGS = {
+      new TagField(Field.ServiceEndpoint),
+      new TagField(Field.ServiceName),
+      new TagField(Field.StatusCode)
+  };
+
+  private static final TagField[] ERRORS = {
+      new TagField(Field.AWSErrorCode),
+      new TagField(Field.Exception, e -> e.getClass().getSimpleName())
+  };
+
+  private final Registry registry;
+
+  /**
+   * Constructs a new instance.
+   */
+  public SpectatorRequestMetricCollector(Registry registry) {
+    super();
+    this.registry = Preconditions.checkNotNull(registry, "registry");
+  }
+
+  @Override
+  public void collectMetrics(Request<?> request, Response<?> response) {
+    final AWSRequestMetrics metrics = request.getAWSRequestMetrics();
+    if (metrics.isEnabled()) {
+      final Map<String, String> baseTags = getBaseTags(request);
+      final TimingInfo timing = metrics.getTimingInfo();
+
+      for (Field counter : COUNTERS) {
+        Optional.ofNullable(timing.getCounter(counter.name()))
+            .filter(v -> v.longValue() > 0)
+            .ifPresent(v -> registry.counter(metricId(counter, baseTags)).increment(v.longValue()));
+      }
+
+      for (Field timer : TIMERS) {
+        Optional.ofNullable(timing.getLastSubMeasurement(timer.name()))
+            .filter(TimingInfo::isEndTimeKnown)
+            .ifPresent(t -> registry.timer(metricId(timer, baseTags))
+                .record(t.getEndTimeNano() - t.getStartTimeNano(), TimeUnit.NANOSECONDS));
+      }
+
+      notEmpty(metrics.getProperty(Field.ThrottleException)).ifPresent(throttleExceptions -> {
+        final Id throttling = metricId("throttling", baseTags);
+        throttleExceptions.forEach(ex ->
+            registry.counter(throttling.withTag("throttleException", ex.getClass().getSimpleName()))
+                .increment());
+      });
+    }
+  }
+
+  private Id metricId(Field metric, Map<String, String> tags) {
+    return metricId(metric.name(), tags);
+  }
+
+  private Id metricId(String metric, Map<String, String> tags) {
+    return registry.createId(idName(metric), tags);
+  }
+
+  private Map<String, String> getBaseTags(Request<?> request) {
+    final AWSRequestMetrics metrics = request.getAWSRequestMetrics();
+    final Map<String, String> baseTags = new HashMap<>();
+    for (TagField tag : TAGS) {
+      baseTags.put(tag.getName(), tag.getValue(metrics).orElse("UNKNOWN"));
+    }
+    baseTags.put("requestType", request.getOriginalRequest().getClass().getSimpleName());
+    final boolean error = isError(metrics);
+    if (error) {
+      for (TagField tag : ERRORS) {
+        baseTags.put(tag.getName(), tag.getValue(metrics).orElse("UNKNOWN"));
+      }
+    }
+    baseTags.put("error", Boolean.toString(error));
+    return Collections.unmodifiableMap(baseTags);
+  }
+
+  /**
+   * Produces the name of a metric from the name of the SDK measurement.
+   *
+   * @param name
+   *     Name of the SDK measurement, usually from the enum
+   *     {@link com.amazonaws.util.AWSRequestMetrics.Field}.
+   * @return
+   *     Name to use in the metric id.
+   */
+  //VisibleForTesting
+  static String idName(String name) {
+    return "aws.request." + Introspector.decapitalize(name);
+  }
+
+  private static Optional<List<Object>> notEmpty(List<Object> properties) {
+    return Optional.ofNullable(properties).filter(v -> !v.isEmpty());
+  }
+
+  private static <R> Optional<R> firstValue(List<Object> properties, Function<Object, R> transform) {
+    return notEmpty(properties).map(v -> transform.apply(v.get(0)));
+  }
+
+  private static boolean isError(AWSRequestMetrics metrics) {
+    for (TagField err : ERRORS) {
+      if (err.getValue(metrics).isPresent()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static class TagField {
+    private final Field field;
+    private final String name;
+    private final Function<Object, String> tagExtractor;
+
+    public TagField(Field field) {
+      this(field, Object::toString);
+    }
+
+    public TagField(Field field, Function<Object, String> tagExtractor) {
+      this.field = field;
+      this.tagExtractor = tagExtractor;
+      this.name = Introspector.decapitalize(field.name());
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public Optional<String> getValue(AWSRequestMetrics metrics) {
+      return firstValue(metrics.getProperty(field), tagExtractor);
+    }
+  }
+}

--- a/spectator-ext-aws/src/test/java/com/netflix/spectator/aws/SpectatorRequestMetricCollectorTest.java
+++ b/spectator-ext-aws/src/test/java/com/netflix/spectator/aws/SpectatorRequestMetricCollectorTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spectator.aws;
+
+import com.amazonaws.DefaultRequest;
+import com.amazonaws.Request;
+import com.amazonaws.Response;
+import com.amazonaws.http.HttpResponse;
+import com.amazonaws.util.AWSRequestMetrics;
+import com.amazonaws.util.AWSRequestMetricsFullSupport;
+import com.amazonaws.util.TimingInfo;
+import com.netflix.spectator.api.*;
+import org.apache.http.client.methods.HttpPost;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.Assert.*;
+
+public class SpectatorRequestMetricCollectorTest {
+
+    Registry registry;
+    SpectatorRequestMetricCollector collector;
+
+    @Before
+    public void setUp() {
+        registry = new DefaultRegistry();
+        collector = new SpectatorRequestMetricCollector(registry);
+    }
+
+    @Test
+    public void testMetricCollection() {
+        //setup
+        AWSRequestMetrics metrics = new AWSRequestMetricsFullSupport();
+        String counterName = "BytesProcessed";
+        String timerName = "ClientExecuteTime";
+        metrics.setCounter(counterName, 12345);
+        metrics.getTimingInfo().addSubMeasurement(timerName, TimingInfo.unmodifiableTimingInfo(100000L, 200000L));
+
+        Request<?> req = new DefaultRequest("foo");
+        req.setAWSRequestMetrics(metrics);
+        req.setEndpoint(URI.create("http://foo"));
+
+        HttpResponse hr = new HttpResponse(req, new HttpPost("http://foo"));
+        hr.setStatusCode(200);
+        Response<?> resp = new Response<>(null, new HttpResponse(req, new HttpPost("http://foo")));
+
+        //when
+        collector.collectMetrics(req, resp);
+
+        //then
+        List<Meter> allMetrics = new ArrayList<>();
+        registry.iterator().forEachRemaining(allMetrics::add);
+
+        assertEquals(2, allMetrics.size());
+        Optional<Timer> expectedTimer = allMetrics
+                .stream()
+                .filter(m -> m instanceof Timer && m.id().name().equals(SpectatorRequestMetricCollector.idName(timerName)))
+                .map(m -> (Timer) m)
+                .findFirst();
+        assertTrue(expectedTimer.isPresent());
+        Timer timer = expectedTimer.get();
+        assertEquals(1, timer.count());
+        assertEquals(100000, timer.totalTime());
+
+        Optional<Counter> expectedCounter = allMetrics
+                .stream()
+                .filter(m -> m.id().name().equals(SpectatorRequestMetricCollector.idName(counterName)))
+                .map(m -> (Counter) m)
+                .findFirst();
+        assertTrue(expectedCounter.isPresent());
+        assertEquals(12345L, expectedCounter.get().count());
+    }
+}


### PR DESCRIPTION
Extension that allows spectator to capture data about
AWS requests being made using the SDK.

Currently this is only capturing request metrics since
it gives us the most context. For now the throughput data
from the ServiceMetricCollector is ignored.