### PR TITLE
add module for unit tests with digest registry

### DIFF
--- a/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestTestModule.java
+++ b/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestTestModule.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.tdigest;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Inject;
+import com.google.inject.Provides;
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.Registry;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+import javax.inject.Singleton;
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * Guice module to configure the plugin.
+ */
+public final class TDigestTestModule extends AbstractModule {
+
+  /** Create a new instance of the test module. */
+  public static TDigestTestModule create() {
+    return new TDigestTestModule(null);
+  }
+
+  /** Create a new instance of the test module that writes to a file. */
+  static TDigestTestModule file(File output) {
+    return new TDigestTestModule(output);
+  }
+
+  private final File output;
+
+  private TDigestTestModule(File output) {
+    super();
+    this.output = output;
+  }
+
+  @Override protected void configure() {
+    bind(TDigestPlugin.class).asEagerSingleton();
+  }
+
+  @Provides
+  @Singleton
+  private TDigestConfig providesDigestConfig() {
+    Config cfg = ConfigFactory.parseResources("test.conf");
+    return new TDigestConfig(cfg.getConfig("spectator.tdigest"));
+  }
+
+  @Provides
+  @Singleton
+  private TDigestRegistry providesRegistry(OptionalInjections opts, TDigestConfig config) {
+    return new TDigestRegistry(opts.getRegistry(), config);
+  }
+
+  @Provides
+  @Singleton
+  private TDigestWriter providesWriter(OptionalInjections opts, TDigestConfig config) throws Exception {
+    if (output != null) {
+      return new FileTDigestWriter(opts.getRegistry(), config, output);
+    } else {
+      return new TDigestWriter(opts.getRegistry(), config) {
+        @Override
+        void write(ByteBuffer buffer) throws IOException {
+        }
+      };
+    }
+  }
+
+  private static class OptionalInjections {
+    @Inject(optional = true)
+    private Registry registry;
+
+    Registry getRegistry() {
+      if (registry == null) {
+        registry = new DefaultRegistry();
+      }
+      return registry;
+    }
+  }
+}

--- a/spectator-reg-tdigest/src/main/resources/test.conf
+++ b/spectator-reg-tdigest/src/main/resources/test.conf
@@ -1,0 +1,25 @@
+
+spectator.tdigest {
+
+  // Compression factor to use constructing digests
+  compression-factor = 100.0
+
+  kinesis {
+    // Kinesis endpoint to use. Assumes EC2_REGION environment variable will be set
+    endpoint = "kinesis.us-east-1.amazonaws.com"
+
+    // Name of the kinesis stream
+    stream = "spectator-tdigest"
+  }
+
+  // How frequently data will be collected and sent to the backend
+  polling-frequency = 60s
+
+  // Common tags to add when pushing
+  tags = [
+    {
+      key = "test-key"
+      value = "test-value"
+    }
+  ]
+}

--- a/spectator-reg-tdigest/src/test/java/com/netflix/spectator/tdigest/TDigestTimerTest.java
+++ b/spectator-reg-tdigest/src/test/java/com/netflix/spectator/tdigest/TDigestTimerTest.java
@@ -15,8 +15,12 @@
  */
 package com.netflix.spectator.tdigest;
 
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
 import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.ManualClock;
+import com.netflix.spectator.api.Registry;
 import com.typesafe.config.ConfigFactory;
 import org.junit.Assert;
 import org.junit.Before;
@@ -33,8 +37,16 @@ public class TDigestTimerTest {
   private final ManualClock clock = new ManualClock();
 
   private TDigestTimer newTimer(String name) {
-    final TDigestConfig config = new TDigestConfig(ConfigFactory.load().getConfig("spectator.tdigest"));
-    final TDigestRegistry r = new TDigestRegistry(new DefaultRegistry(clock), config);
+    final Injector injector = Guice.createInjector(
+        TDigestTestModule.create(),
+        new AbstractModule() {
+          @Override
+          protected void configure() {
+            bind(Registry.class).toInstance(new DefaultRegistry(clock));
+          }
+        }
+    );
+    final TDigestRegistry r = injector.getInstance(TDigestRegistry.class);
     return (TDigestTimer) r.timer(r.createId(name));
   }
 

--- a/spectator-reg-tdigest/src/test/java/com/netflix/spectator/tdigest/TDigestWriterTest.java
+++ b/spectator-reg-tdigest/src/test/java/com/netflix/spectator/tdigest/TDigestWriterTest.java
@@ -65,7 +65,8 @@ public class TDigestWriterTest {
 
   @Before
   public void init() {
-    final TDigestConfig config = new TDigestConfig(ConfigFactory.load().getConfig("spectator.tdigest"));
+    final TDigestConfig config = new TDigestConfig(
+        ConfigFactory.parseResources("test.conf").getConfig("spectator.tdigest"));
     baos = new ByteArrayOutputStream();
     writer = new StreamTDigestWriter(registry, config, baos);
   }

--- a/spectator-reg-tdigest/src/test/java/com/netflix/spectator/tdigest/TestModuleTest.java
+++ b/spectator-reg-tdigest/src/test/java/com/netflix/spectator/tdigest/TestModuleTest.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.tdigest;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.netflix.spectator.api.Timer;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import javax.inject.Inject;
+import java.util.concurrent.TimeUnit;
+
+@RunWith(JUnit4.class)
+public class TestModuleTest {
+
+  @Test
+  public void writeData() throws Exception {
+    Injector injector = Guice.createInjector(TDigestTestModule.create());
+    injector.getInstance(Foo.class).doSomething();
+
+    final TDigestRegistry r = injector.getInstance(TDigestRegistry.class);
+    Assert.assertEquals(1, r.timer("foo").count());
+    Assert.assertEquals(42, r.timer("foo").totalTime());
+  }
+
+  private static class Foo {
+    private final Timer t;
+
+    @Inject
+    Foo(TDigestRegistry registry) {
+      t = registry.timer("foo");
+    }
+
+    void doSomething() {
+      t.record(42, TimeUnit.NANOSECONDS);
+    }
+  }
+
+}

--- a/spectator-reg-tdigest/src/test/resources/reference.conf
+++ b/spectator-reg-tdigest/src/test/resources/reference.conf
@@ -1,9 +1,0 @@
-
-// To make region resolve for test cases
-NETFLIX_APP = "local"
-NETFLIX_CLUSTER = "local-dev"
-NETFLIX_AUTO_SCALE_GROUP = "local-dev-v001"
-EC2_AMI_ID = "ami-12345"
-EC2_INSTANCE_TYPE = "r3.xlarge"
-EC2_REGION = "us-east-1"
-EC2_AVAILABILITY_ZONE = "us-east-1c"


### PR DESCRIPTION
Helper module to make it easier to unit test. Usage:

```java
  @Test
  public void testSomething() {
    Injector injector = Guice.createInjector(TDigestTestModule.create());
    injector.getInstance(Foo.class).doSomething();

    final TDigestRegistry r = injector.getInstance(TDigestRegistry.class);
    Assert.assertEquals(1, r.timer("foo").count());
  }

  private static class Foo {
    private final Timer t;

    @Inject
    Foo(TDigestRegistry registry) {
      t = registry.timer("foo");
    }

    void doSomething() {
      t.record(42, TimeUnit.NANOSECONDS);
    }
  }
```