### PR TITLE
nebula.netflixoss 3.1.1 breaks maven sync

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 }
 
 plugins {
-  id 'nebula.netflixoss' version '3.1.1'
+  id 'nebula.netflixoss' version '3.1.2'
   id 'me.champeau.gradle.jmh' version '0.2.0'
 }
 


### PR DESCRIPTION
Updgrade to 3.1.2 to fix maven sync.

NEBULA-283:

I recently updated an oss project to nebula 3.1.1:

https://github.com/Netflix/spectator/pull/219

The release build fails with:

https://travis-ci.org/Netflix/spectator/builds/80925469

> Could not sync 'netflixoss/maven/spectator/0.31.0' to
> Maven Central: HTTP/1.1 400 Bad Request [messages:[Invalid
> POM: /com/netflix/spectator/0.31.0/spectator-0.31.0.pom:
> Project URL missing, SCM URL missing, Developer information
> missing, Dropping existing partial staging repository.],
> status:Validation Failed]

It is getting published to jcenter, but failing to sync with
maven central. I looked at the poms for an individual jar
and don't see any major diffs:

```bash
$ curl -O 'http://jcenter.bintray.com/com/netflix/spectator/spectator-api/0.31.0/spectator-api-0.31.0.pom'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2682  100  2682    0     0   4541      0 --:--:-- --:--:-- --:--:--  4545
$ curl -O 'http://jcenter.bintray.com/com/netflix/spectator/spectator-api/0.30.0/spectator-api-0.30.0.pom'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2687  100  2687    0     0  21033      0 --:--:-- --:--:-- --:--:-- 21157
$ diff spectator-api-0.30.0.pom spectator-api-0.31.0.pom
```

```diff
6c6
<   <version>0.30.0</version>
---
>   <version>0.31.0</version>
21c21
<       <email>talent@netflix.com</email>
---
>       <email>netflixoss@netflix.com</email>
33,34c33,34
<     <nebula_Implementation_Title>com.netflix.spectator#spectator-api;0.30.0</nebula_Implementation_Title>
<     <nebula_Implementation_Version>0.30.0</nebula_Implementation_Version>
---
>     <nebula_Implementation_Title>com.netflix.spectator#spectator-api;0.31.0</nebula_Implementation_Title>
>     <nebula_Implementation_Version>0.31.0</nebula_Implementation_Version>
38,41c38,41
<     <nebula_Build_Date>2015-08-26_04:53:29</nebula_Build_Date>
<     <nebula_Gradle_Version>2.2.1</nebula_Gradle_Version>
<     <nebula_Module_Owner>talent@netflix.com</nebula_Module_Owner>
<     <nebula_Module_Email>talent@netflix.com</nebula_Module_Email>
---
>     <nebula_Build_Date>2015-09-17_22:44:28</nebula_Build_Date>
>     <nebula_Gradle_Version>2.6</nebula_Gradle_Version>
>     <nebula_Module_Owner>netflixoss@netflix.com</nebula_Module_Owner>
>     <nebula_Module_Email>netflixoss@netflix.com</nebula_Module_Email>
43,45c43,46
<     <nebula_Module_Origin>git://github.com/Netflix/spectator.git</nebula_Module_Origin>
<     <nebula_Change>615f3d3</nebula_Change>
<     <nebula_Build_Host>testing-worker-linux-docker-50d7b8b9-3192-linux-5.prod.travis-ci.org</nebula_Build_Host>
---
>     <nebula_Module_Origin>https://github.com/Netflix/spectator.git</nebula_Module_Origin>
>     <nebula_Change>2ca03c6</nebula_Change>
>     <nebula_Branch>2ca03c6e7625656ef9477124fb762fac9053e935</nebula_Branch>
>     <nebula_Build_Host>testing-worker-linux-docker-8671366f-3208-linux-3</nebula_Build_Host>
53a55
>   <url>https://github.com/Netflix/spectator</url>
55,56c57
<     <url>scm:git://github.com/Netflix/spectator.git</url>
<     <connection>scm:git://github.com/Netflix/spectator.git</connection>
---
>     <url>https://github.com/Netflix/spectator.git</url>
58d58
<   <url>https://github.com/Netflix/spectator</url>
```

However, I noticed that it is now creating a spurious root pom that
wasn't being created before:

http://jcenter.bintray.com/com/netflix/spectator/0.31.0/

I think that is what is causing the sync to fail.