### PR TITLE
fix NPE with CompositeMeter.hasExpired

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/CompositeMeter.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/CompositeMeter.java
@@ -49,7 +49,7 @@ class CompositeMeter implements Meter {
   @Override public boolean hasExpired() {
     for (Registry r : registries) {
       Meter m = r.get(id);
-      if (!m.hasExpired()) return false;
+      if (m != null && !m.hasExpired()) return false;
     }
     return true;
   }

--- a/spectator-api/src/test/java/com/netflix/spectator/api/CompositeRegistryTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/CompositeRegistryTest.java
@@ -238,6 +238,18 @@ public class CompositeRegistryTest {
   }
 
   @Test
+  public void testHasExpired() {
+    CompositeRegistry r = new CompositeRegistry(clock);
+
+    Counter c1 = r.counter("id1");
+    Assert.assertTrue(c1.hasExpired());
+
+    Registry r1 = new DefaultRegistry(clock);
+    r.add(r1);
+    Assert.assertTrue(c1.hasExpired());
+  }
+
+  @Test
   public void testAddGauges() {
     CompositeRegistry r = new CompositeRegistry(clock);
 

--- a/spectator-api/src/test/java/com/netflix/spectator/api/CompositeRegistryTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/CompositeRegistryTest.java
@@ -247,6 +247,9 @@ public class CompositeRegistryTest {
     Registry r1 = new DefaultRegistry(clock);
     r.add(r1);
     Assert.assertTrue(c1.hasExpired());
+
+    c1.increment();
+    Assert.assertFalse(c1.hasExpired());
   }
 
   @Test


### PR DESCRIPTION
If an id is missing from one of the registries it was
throwing:

```
java.lang.NullPointerException
	at com.netflix.spectator.api.CompositeMeter.hasExpired(CompositeMeter.java:52)
	at com.netflix.spectator.api.CompositeRegistryTest.testHasExpired(CompositeRegistryTest.java:249)
```

@pstout this should fix the NPE bug you found.