### PR TITLE
catch throwable for reporting thread

### DIFF
--- a/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestPlugin.java
+++ b/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestPlugin.java
@@ -57,6 +57,7 @@ class TDigestPlugin {
    * writer. The thread names will start with {@code TDigestPlugin}.
    */
   @PostConstruct
+  @SuppressWarnings("PMD.AvoidCatchingThrowable")
   public void init() {
     executor = Executors.newSingleThreadScheduledExecutor(r -> new Thread(r, "TDigestPlugin"));
 

--- a/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestPlugin.java
+++ b/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestPlugin.java
@@ -28,7 +28,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
 /**

--- a/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestPlugin.java
+++ b/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestPlugin.java
@@ -59,19 +59,13 @@ class TDigestPlugin {
    */
   @PostConstruct
   public void init() {
-    executor = Executors.newSingleThreadScheduledExecutor(new ThreadFactory() {
-        @Override public Thread newThread(Runnable r) {
-          return new Thread(r, "TDigestPlugin");
-        }
-      });
+    executor = Executors.newSingleThreadScheduledExecutor(r -> new Thread(r, "TDigestPlugin"));
 
-    Runnable task = new Runnable() {
-      @Override public void run() {
-        try {
-          writeData();
-        } catch (Exception e) {
-          LOGGER.error("failed to publish percentile data", e);
-        }
+    Runnable task = () -> {
+      try {
+        writeData();
+      } catch (Throwable t) {
+        LOGGER.error("failed to publish percentile data", t);
       }
     };
 


### PR DESCRIPTION
Generally we want to avoid this, but in this case it should
give us better logging in the case an Error is thrown instead
of an Exception.