### PR TITLE
add helpers for working with Streams

### DIFF
--- a/codequality/pmd.xml
+++ b/codequality/pmd.xml
@@ -37,6 +37,7 @@
     <exclude name="DuplicateImports"/>
     <exclude name="EmptyMethodInAbstractClassShouldBeAbstract"/>
     <exclude name="ExcessiveImports"/>
+    <exclude name="ExcessivePublicCount"/>
     <exclude name="FieldDeclarationsShouldBeAtStartOfClass"/>
     <exclude name="ForLoopsMustUseBraces"/>
     <exclude name="GodClass"/>

--- a/spectator-api/src/main/java/com/netflix/spectator/api/Functions.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/Functions.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.spectator.api;
 
+import com.netflix.spectator.impl.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,6 +23,7 @@ import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Predicate;
 import java.util.function.ToDoubleFunction;
 
 
@@ -107,5 +109,23 @@ public final class Functions {
         return Double.NaN;
       }
     };
+  }
+
+  /**
+   * Returns a predicate that matches if the {code}id.name(){code} value for the input meter
+   * is equal to {code}name{code}. Example of usage:
+   *
+   * <pre>
+   * long numberOfMatches = registry.stream().filter(Functions.nameEquals("foo")).count();
+   * </pre>
+   *
+   * @param name
+   *     The name to use for finding matching meter instances. Cannot be null.
+   * @return
+   *     A predicate function that can be used to filter a stream.
+   */
+  public static Predicate<Meter> nameEquals(String name) {
+    Preconditions.checkNotNull(name, "name");
+    return m -> name.equals(m.id().name());
   }
 }

--- a/spectator-api/src/main/java/com/netflix/spectator/api/Registry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/Registry.java
@@ -20,6 +20,8 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.function.ToDoubleFunction;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 /**
  * Registry to manage a set of meters.
@@ -616,5 +618,67 @@ public interface Registry extends Iterable<Meter> {
    */
   default void methodValue(String name, Object obj, String method) {
     methodValue(createId(name), obj, method);
+  }
+
+  /** Returns a stream of all registered meters. */
+  default Stream<Meter> stream() {
+    return StreamSupport.stream(spliterator(), false);
+  }
+
+  /**
+   * Returns a stream of all registered counters. This operation is mainly used for testing as
+   * a convenient way to get an aggregated value. For example, to generate a summary of all
+   * counters with name "foo":
+   *
+   * <pre>
+   * LongSummaryStatistics summary = r.counters()
+   *   .filter(Functions.nameEquals("foo"))
+   *   .collect(Collectors.summarizingLong(Counter::count));
+   * </pre>
+   */
+  default Stream<Counter> counters() {
+    return stream().filter(m -> m instanceof Counter).map(m -> (Counter) m);
+  }
+
+  /**
+   * Returns a stream of all registered distribution summaries. This operation is mainly used for
+   * testing as a convenient way to get an aggregated value. For example, to generate a summary of
+   * the counts and total amounts for all distribution summaries with name "foo":
+   *
+   * <pre>
+   * LongSummaryStatistics countSummary = r.distributionSummaries()
+   *   .filter(Functions.nameEquals("foo"))
+   *   .collect(Collectors.summarizingLong(DistributionSummary::count));
+   *
+   * LongSummaryStatistics totalSummary = r.distributionSummaries()
+   *   .filter(Functions.nameEquals("foo"))
+   *   .collect(Collectors.summarizingLong(DistributionSummary::totalAmount));
+   *
+   * double avgAmount = (double) totalSummary.getSum() / countSummary.getSum();
+   * </pre>
+   */
+  default Stream<DistributionSummary> distributionSummaries() {
+    return stream().filter(m -> m instanceof DistributionSummary).map(m -> (DistributionSummary) m);
+  }
+
+  /**
+   * Returns a stream of all registered timers. This operation is mainly used for testing as a
+   * convenient way to get an aggregated value. For example, to generate a summary of
+   * the counts and total amounts for all timers with name "foo":
+   *
+   * <pre>
+   * LongSummaryStatistics countSummary = r.timers()
+   *   .filter(Functions.nameEquals("foo"))
+   *   .collect(Collectors.summarizingLong(Timer::count));
+   *
+   * LongSummaryStatistics totalSummary = r.timers()
+   *   .filter(Functions.nameEquals("foo"))
+   *   .collect(Collectors.summarizingLong(Timer::totalTime));
+   *
+   * double avgTime = (double) totalSummary.getSum() / countSummary.getSum();
+   * </pre>
+   */
+  default Stream<Timer> timers() {
+    return stream().filter(m -> m instanceof Timer).map(m -> (Timer) m);
   }
 }


### PR DESCRIPTION
For test cases it is sometimes useful to check aggregated
values rather than individual counters. The most common
example is looking at the overall number of increments for
a counter with a given name. The recommendation was to use
streams, but that can get a bit cumbersome:

```java
long sum = StreamSupport.stream(registry.spliterator(), false)
    .filter(m -> m instanceof Counter)        // Convert to counters
    .map(m -> (Counter) m)
    .filter(c -> "foo".equals(c.id().name())) // Restrict by name
    .mapToLong(Counter::count)                // Get value
    .reduce(0L, Long::sum)                    // Compute sum
```

This change adds some helpers to make this sort of use-case
a bit easier:

```java
long sum = registry.counters()
    .filter(Functions.nameEquals("foo"))      // Restrict by name
    .mapToLong(Counter::count)                // Get value
    .reduce(0L, Long::sum)                    // Compute sum
```

There are also some examples in the unit tests and comments
for the stream methods on Registry.