### PR TITLE
rename to SpectatorMetricCollector

### DIFF
--- a/spectator-ext-aws/src/main/java/com/netflix/spectator/aws/SpectatorMetricCollector.java
+++ b/spectator-ext-aws/src/main/java/com/netflix/spectator/aws/SpectatorMetricCollector.java
@@ -26,13 +26,13 @@ import com.netflix.spectator.impl.Preconditions;
 /**
  * A MetricCollector that captures SDK metrics.
  */
-public class SpectatorMetricsCollector extends MetricCollector {
+public class SpectatorMetricCollector extends MetricCollector {
     private final RequestMetricCollector requestMetricCollector;
 
     /**
      * Constructs a new instance.
      */
-    public SpectatorMetricsCollector(Registry registry) {
+    public SpectatorMetricCollector(Registry registry) {
         super();
         Preconditions.checkNotNull(registry, "registry");
 


### PR DESCRIPTION
There is occasional confusion caused because the name
doesn't match the name for the base class in the AWS
SDK. Since there isn't much use yet, it is probably a
good time to rename to match and avoid more confusion
in the future.