### PR TITLE
remove initializeUsingServiceLoader

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/Config.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/Config.java
@@ -20,9 +20,6 @@ final class Config {
 
   private static final String PREFIX = "spectator.api.";
 
-  /** Value for registry class to explicitly indicate the service loader should be used. */
-  static final String SERVICE_LOADER = "service-loader";
-
   private Config() {
   }
 

--- a/spectator-api/src/main/java/com/netflix/spectator/api/Config.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/Config.java
@@ -44,11 +44,6 @@ final class Config {
     return Boolean.valueOf(get(PREFIX + "propagateWarnings", "false"));
   }
 
-  /** Class implementing the {@link Registry} interface that should be loaded. */
-  static String registryClass() {
-    return get(PREFIX + "registryClass", SERVICE_LOADER);
-  }
-
   /**
    * For classes based on {@link AbstractRegistry} this setting is used to determine the maximum
    * number of registered meters permitted. This limit is used to help protect the system from a

--- a/spectator-api/src/main/java/com/netflix/spectator/api/RegistryMeter.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/RegistryMeter.java
@@ -21,7 +21,7 @@ import java.util.List;
 
 /**
  * Wraps a registry as a meter that can be added to another registry. This is currently used to
- * manage the gauges for the composite registry. Since there is no activity gauges should get
+ * manage the gauges for the composite registry. Since there is no activity, gauges should get
  * polled and must get tracked as a group and added to each sub-registry.
  */
 class RegistryMeter implements Meter {

--- a/spectator-api/src/test/java/com/netflix/spectator/api/ThrowablesTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/ThrowablesTest.java
@@ -15,16 +15,22 @@
  */
 package com.netflix.spectator.api;
 
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
-public class SpectatorTest {
+public class ThrowablesTest {
+
   @Test
-  public void testRegistry() {
-    Assert.assertNotNull(Spectator.registry());
+  public void propagateWarningsFalse() {
+    System.setProperty("spectator.api.propagateWarnings", "false");
+    Throwables.propagate("foo", new RuntimeException("test"));
   }
 
+  @Test(expected = RuntimeException.class)
+  public void propagateWarningsTrue() {
+    System.setProperty("spectator.api.propagateWarnings", "true");
+    Throwables.propagate("foo", new RuntimeException("test"));
+  }
 }


### PR DESCRIPTION
This method was deprecated a while back and depotsearch
shows no internal usage remaining.