### PR TITLE
add percentile timer and distribution summary

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/histogram/PercentileBuckets.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/histogram/PercentileBuckets.java
@@ -1,0 +1,224 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.api.histogram;
+
+import com.netflix.spectator.impl.Preconditions;
+
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.function.Function;
+
+/**
+ * Bucket values for estimating a percentile from a set of non-negative long values. This class
+ * acts as an immutable array of the buckets along with providing some helper functions.
+ */
+public final class PercentileBuckets {
+
+  private PercentileBuckets() {
+  }
+
+  /** Returns a copy of the bucket values array. */
+  public static long[] asArray() {
+    long[] values = new long[BUCKET_VALUES.length];
+    System.arraycopy(BUCKET_VALUES, 0, values, 0, BUCKET_VALUES.length);
+    return values;
+  }
+
+  /** Map the bucket values to a new array of a different type. */
+  public static <T> T[] map(Class<T> c, Function<Long, T> f) {
+    @SuppressWarnings("unchecked")
+    T[] values = (T[]) Array.newInstance(c, BUCKET_VALUES.length);
+    for (int i = 0; i < BUCKET_VALUES.length; ++i) {
+      values[i] = f.apply(BUCKET_VALUES[i]);
+    }
+    return values;
+  }
+
+  /** Return the value of the bucket at index {@code i}. */
+  public static long get(int i) {
+    return BUCKET_VALUES[i];
+  }
+
+  /** Returns the number of buckets. */
+  public static int length() {
+    return BUCKET_VALUES.length;
+  }
+
+  /**
+   * Returns the value the index of the bucket that should be used for {@code v}. The bucket value
+   * can be retrieved using {@link #get(int)}.
+   */
+  public static int indexOf(long v) {
+    if (v <= 0) {
+      return 0;
+    } else if (v <= 4) {
+      return (int) v;
+    } else {
+      int lz = Long.numberOfLeadingZeros(v);
+      int shift = 64 - lz - 1;
+      long prevPowerOf2 = (v >> shift) << shift;
+      long prevPowerOf4 = prevPowerOf2;
+      if (shift % 2 != 0) {
+        shift--;
+        prevPowerOf4 = prevPowerOf2 >> 1;
+      }
+
+      long base = prevPowerOf4;
+      long delta = base / 3;
+      int offset = (int) ((v - base) / delta);
+      int pos = offset + POWER_OF_4_INDEX[shift / 2];
+      return (pos >= BUCKET_VALUES.length - 1) ? BUCKET_VALUES.length - 1 : pos + 1;
+    }
+  }
+
+  /** Returns the value of the bucket that should be used for {@code v}. */
+  public static long bucket(long v) {
+    return BUCKET_VALUES[indexOf(v)];
+  }
+
+  /**
+   * Compute a set of percentiles based on the counts for the buckets.
+   *
+   * @param counts
+   *     Counts for each of the buckets. The size must be the same as {@link #length()} and the
+   *     positions must correspond to the positions of the bucket values.
+   * @param pcts
+   *     Array with the requested percentile values. The length must be at least 1 and the
+   *     array should be sorted. Each value, {@code v}, should adhere to {@code 0.0 <= v <= 100.0}.
+   * @param results
+   *     The calculated percentile values will be written to the results array. It should have the
+   *     same length as {@code pcts}.
+   */
+  public static void percentiles(long[] counts, double[] pcts, double[] results) {
+    Preconditions.checkArg(counts.length == BUCKET_VALUES.length,
+        "counts is not the same size as buckets array");
+    Preconditions.checkArg(pcts.length > 0, "pct array cannot be empty");
+    Preconditions.checkArg(pcts.length == results.length,
+        "pcts is not the same size as results array");
+
+    long total = 0L;
+    for (int i = 0; i < counts.length; ++i) {
+      total += counts[i];
+    }
+
+    int pctIdx = 0;
+
+    long prev = 0;
+    double prevP = 0.0;
+    long prevB = 0;
+    for (int i = 0; i < BUCKET_VALUES.length; ++i) {
+      long next = prev + counts[i];
+      double nextP = 100.0 * next / total;
+      long nextB = BUCKET_VALUES[i];
+      while (pctIdx < pcts.length && nextP >= pcts[pctIdx]) {
+        double f = (pcts[pctIdx] - prevP) / (nextP - prevP);
+        results[pctIdx] = f * (nextB - prevB) + prevB;
+        ++pctIdx;
+      }
+      if (pctIdx >= pcts.length) break;
+      prev = next;
+      prevP = nextP;
+      prevB = nextB;
+    }
+
+    double nextP = 100.0;
+    long nextB = Long.MAX_VALUE;
+    while (pctIdx < pcts.length) {
+      double f = (pcts[pctIdx] - prevP) / (nextP - prevP);
+      results[pctIdx] = f * (nextB - prevB) + prevB;
+      ++pctIdx;
+    }
+  }
+
+  /**
+   * Compute a percentile based on the counts for the buckets.
+   *
+   * @param counts
+   *     Counts for each of the buckets. The size must be the same as {@link #length()} and the
+   *     positions must correspond to the positions of the bucket values.
+   * @param p
+   *     Percentile to compute, the value should be {@code 0.0 <= p <= 100.0}.
+   * @return
+   *     The calculated percentile value.
+   */
+  public static double percentile(long[] counts, double p) {
+    double[] pcts = new double[] {p};
+    double[] results = new double[1];
+    percentiles(counts, pcts, results);
+    return results[0];
+  }
+
+  // Number of positions of base-2 digits to shift when iterating over the long space.
+  private static final int DIGITS = 2;
+
+  // Bucket values to use, see static block for initialization.
+  private static final long[] BUCKET_VALUES;
+
+  // Keeps track of the positions for even powers of 4 within BUCKET_VALUES. This is used to
+  // quickly compute the offset for a long without traversing the array.
+  private static final int[] POWER_OF_4_INDEX;
+
+  // The set of buckets is generated by using powers of 4 and incrementing by one-third of the
+  // previous power of 4 in between as long as the value is less than the next power of 4 minus
+  // the delta.
+  //
+  // <pre>
+  // Base: 1, 2, 3
+  //
+  // 4 (4^1), delta = 1
+  //     5, 6, 7, ..., 14,
+  //
+  // 16 (4^2), delta = 5
+  //    21, 26, 31, ..., 56,
+  //
+  // 64 (4^3), delta = 21
+  // ...
+  // </pre>
+  static {
+    ArrayList<Integer> powerOf4Index = new ArrayList<>();
+    powerOf4Index.add(0);
+
+    ArrayList<Long> buckets = new ArrayList<>();
+    buckets.add(1L);
+    buckets.add(2L);
+    buckets.add(3L);
+
+    int exp = DIGITS;
+    while (exp < 64) {
+      long current = 1L << exp;
+      long delta = current / 3;
+      long next = (current << DIGITS) - delta;
+
+      powerOf4Index.add(buckets.size());
+      while (current < next) {
+        buckets.add(current);
+        current += delta;
+      }
+      exp += DIGITS;
+    }
+    buckets.add(Long.MAX_VALUE);
+
+    BUCKET_VALUES = new long[buckets.size()];
+    for (int i = 0; i < buckets.size(); ++i) {
+      BUCKET_VALUES[i] = buckets.get(i);
+    }
+
+    POWER_OF_4_INDEX = new int[powerOf4Index.size()];
+    for (int i = 0; i < powerOf4Index.size(); ++i) {
+      POWER_OF_4_INDEX[i] = powerOf4Index.get(i);
+    }
+  }
+}

--- a/spectator-api/src/main/java/com/netflix/spectator/api/histogram/PercentileDistributionSummary.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/histogram/PercentileDistributionSummary.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.api.histogram;
+
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.DistributionSummary;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.Registry;
+
+import java.util.Collections;
+
+/** Timers that get updated based on the bucket for recorded values. */
+public class PercentileDistributionSummary implements DistributionSummary {
+
+  /**
+   * Creates a timer object that manages a set of timers based on the bucket
+   * function supplied. Calling record will be mapped to the record on the appropriate timer.
+   *
+   * @param registry
+   *     Registry to use.
+   * @param id
+   *     Identifier for the metric being registered.
+   * @return
+   *     Timer that manages sub-timers based on the bucket function.
+   */
+  public static PercentileDistributionSummary get(Registry registry, Id id) {
+    return new PercentileDistributionSummary(registry, id);
+  }
+
+  private final Id id;
+  private final DistributionSummary summary;
+  private final Counter[] counters;
+
+  /** Create a new instance. */
+  PercentileDistributionSummary(Registry registry, Id id) {
+    this.id = id;
+    this.summary = registry.distributionSummary(id);
+    this.counters = new Counter[PercentileBuckets.length()];
+    for (int i = 0; i < counters.length; ++i) {
+      Id counterId = id.withTag("percentile", String.format("%4X", i));
+      counters[i] = registry.counter(counterId);
+    }
+  }
+
+  @Override public Id id() {
+    return id;
+  }
+
+  @Override public Iterable<Measurement> measure() {
+    return Collections.emptyList();
+  }
+
+  @Override public boolean hasExpired() {
+    return summary.hasExpired();
+  }
+
+  @Override public void record(long amount) {
+    if (amount >= 0L) {
+      summary.record(amount);
+      counters[PercentileBuckets.indexOf(amount)].increment();
+    }
+  }
+
+  /**
+   * Computes the specified percentile for this timer. The unit will be seconds.
+   *
+   * @param p
+   *     Percentile to compute, value must be {@code 0.0 <= p <= 100.0}.
+   * @return
+   *     An approximation of the {@code p}`th percentile in seconds.
+   */
+  public double percentile(double p) {
+    long[] counts = new long[PercentileBuckets.length()];
+    for (int i = 0; i < counts.length; ++i) {
+      counts[i] = counters[i].count();
+    }
+    return PercentileBuckets.percentile(counts, p);
+  }
+
+  @Override public long count() {
+    return summary.count();
+  }
+
+  @Override public long totalAmount() {
+    return summary.totalAmount();
+  }
+}

--- a/spectator-api/src/main/java/com/netflix/spectator/api/histogram/PercentileTimer.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/histogram/PercentileTimer.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.api.histogram;
+
+import com.netflix.spectator.api.Clock;
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Timer;
+
+import java.util.Collections;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+/** Timers that get updated based on the bucket for recorded values. */
+public final class PercentileTimer implements Timer {
+
+  /**
+   * Creates a timer object that manages a set of timers based on the bucket
+   * function supplied. Calling record will be mapped to the record on the appropriate timer.
+   *
+   * @param registry
+   *     Registry to use.
+   * @param id
+   *     Identifier for the metric being registered.
+   * @return
+   *     Timer that manages sub-timers based on the bucket function.
+   */
+  public static PercentileTimer get(Registry registry, Id id) {
+    return new PercentileTimer(registry, id);
+  }
+
+  private final Registry registry;
+  private final Id id;
+  private final Timer timer;
+  private final Counter[] counters;
+
+  /** Create a new instance. */
+  PercentileTimer(Registry registry, Id id) {
+    this.registry = registry;
+    this.id = id;
+    this.timer = registry.timer(id);
+    this.counters = new Counter[PercentileBuckets.length()];
+    for (int i = 0; i < counters.length; ++i) {
+      Id counterId = id.withTag("percentile", String.format("%4X", i));
+      counters[i] = registry.counter(counterId);
+    }
+  }
+
+  @Override public Id id() {
+    return id;
+  }
+
+  @Override public Iterable<Measurement> measure() {
+    return Collections.emptyList();
+  }
+
+  @Override public boolean hasExpired() {
+    return timer.hasExpired();
+  }
+
+  @Override public void record(long amount, TimeUnit unit) {
+    final long nanos = unit.toNanos(amount);
+    timer.record(amount, unit);
+    counters[PercentileBuckets.indexOf(nanos)].increment();
+  }
+
+  @Override public <T> T record(Callable<T> rf) throws Exception {
+    final Clock clock = registry.clock();
+    final long s = clock.monotonicTime();
+    try {
+      return rf.call();
+    } finally {
+      final long e = clock.monotonicTime();
+      record(e - s, TimeUnit.NANOSECONDS);
+    }
+  }
+
+  @Override public void record(Runnable rf) {
+    final Clock clock = registry.clock();
+    final long s = clock.monotonicTime();
+    try {
+      rf.run();
+    } finally {
+      final long e = clock.monotonicTime();
+      record(e - s, TimeUnit.NANOSECONDS);
+    }
+  }
+
+  /**
+   * Computes the specified percentile for this timer. The unit will be seconds.
+   *
+   * @param p
+   *     Percentile to compute, value must be {@code 0.0 <= p <= 100.0}.
+   * @return
+   *     An approximation of the {@code p}`th percentile in seconds.
+   */
+  public double percentile(double p) {
+    long[] counts = new long[PercentileBuckets.length()];
+    for (int i = 0; i < counts.length; ++i) {
+      counts[i] = counters[i].count();
+    }
+    double v = PercentileBuckets.percentile(counts, p);
+    return v / 1e9;
+  }
+
+  @Override public long count() {
+    return timer.count();
+  }
+
+  @Override public long totalTime() {
+    return timer.totalTime();
+  }
+}

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/Preconditions.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/Preconditions.java
@@ -38,6 +38,15 @@ public final class Preconditions {
   /**
    * Ensures the truth of an expression involving the state of the calling instance.
    */
+  public static void checkArg(boolean expression, String errMsg) {
+    if (!expression) {
+      throw new IllegalArgumentException(errMsg);
+    }
+  }
+
+  /**
+   * Ensures the truth of an expression involving the state of the calling instance.
+   */
   public static void checkState(boolean expression, String errMsg) {
     if (!expression) {
       throw new IllegalStateException(errMsg);

--- a/spectator-api/src/test/java/com/netflix/spectator/api/histogram/PercentileBucketsTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/histogram/PercentileBucketsTest.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.api.histogram;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.Random;
+
+@RunWith(JUnit4.class)
+public class PercentileBucketsTest {
+
+  @Test
+  public void indexOf() {
+    Assert.assertEquals(0, PercentileBuckets.indexOf(-1));
+    Assert.assertEquals(0, PercentileBuckets.indexOf(0));
+    Assert.assertEquals(1, PercentileBuckets.indexOf(1));
+    Assert.assertEquals(2, PercentileBuckets.indexOf(2));
+    Assert.assertEquals(3, PercentileBuckets.indexOf(3));
+    Assert.assertEquals(4, PercentileBuckets.indexOf(4));
+
+    Assert.assertEquals(25, PercentileBuckets.indexOf(87));
+
+    Assert.assertEquals(PercentileBuckets.length() - 1, PercentileBuckets.indexOf(Long.MAX_VALUE));
+  }
+
+  @Test
+  public void indexOfSanityCheck() {
+    Random r = new Random(42);
+    for (int i = 0; i < 10000; ++i) {
+      long v = r.nextLong();
+      if (v < 0) {
+        Assert.assertEquals(0, PercentileBuckets.indexOf(v));
+      } else {
+        long b = PercentileBuckets.get(PercentileBuckets.indexOf(v));
+        Assert.assertTrue(String.format("%d > %d", v, b), v <= b);
+      }
+    }
+  }
+
+  @Test
+  public void bucketSanityCheck() {
+    Random r = new Random(42);
+    for (int i = 0; i < 10000; ++i) {
+      long v = r.nextLong();
+      if (v < 0) {
+        Assert.assertEquals(1, PercentileBuckets.bucket(v));
+      } else {
+        long b = PercentileBuckets.bucket(v);
+        Assert.assertTrue(String.format("%d > %d", v, b), v <= b);
+      }
+    }
+  }
+
+  @Test
+  public void asArray() {
+    long[] values = PercentileBuckets.asArray();
+    Assert.assertEquals(PercentileBuckets.length(), values.length);
+    for (int i = 0; i < values.length; ++i) {
+      Assert.assertEquals(PercentileBuckets.get(i), values[i]);
+    }
+  }
+
+  @Test
+  public void asArrayIsCopy() {
+    long[] values = PercentileBuckets.asArray();
+    values[0] = 42;
+    Assert.assertEquals(1, PercentileBuckets.get(0));
+  }
+
+  @Test
+  public void map() {
+    String[] values = PercentileBuckets.map(String.class, v -> String.format("%016X", v));
+    Assert.assertEquals(PercentileBuckets.length(), values.length);
+    for (int i = 0; i < values.length; ++i) {
+      Assert.assertEquals(PercentileBuckets.get(i), Long.parseLong(values[i], 16));
+    }
+  }
+
+  @Test
+  public void percentiles() {
+    long[] counts = new long[PercentileBuckets.length()];
+    for (int i = 0; i < 100_000; ++i) {
+      ++counts[PercentileBuckets.indexOf(i)];
+    }
+
+    double[] pcts = new double[] {0.0, 25.0, 50.0, 75.0, 90.0, 95.0, 98.0, 99.0, 99.5, 100.0};
+    double[] results = new double[pcts.length];
+
+    PercentileBuckets.percentiles(counts, pcts, results);
+
+    double[] expected = new double[] {0.0, 25e3, 50e3, 75e3, 90e3, 95e3, 98e3, 99e3, 99.5e3, 100e3};
+    double threshold = 0.1 * 100_000; // quick check, should be within 10% of total
+    Assert.assertArrayEquals(expected, results, threshold);
+
+    // Further check each value is within 10% of actual percentile
+    for (int i = 0 ; i < results.length; ++i) {
+      threshold = 0.1 * expected[i];
+      Assert.assertEquals(expected[i], results[i], threshold);
+    }
+  }
+
+  @Test
+  public void percentile() {
+    long[] counts = new long[PercentileBuckets.length()];
+    for (int i = 0; i < 100_000; ++i) {
+      ++counts[PercentileBuckets.indexOf(i)];
+    }
+
+    double[] pcts = new double[] {0.0, 25.0, 50.0, 75.0, 90.0, 95.0, 98.0, 99.0, 99.5, 100.0};
+    for (int i = 0 ; i < pcts.length; ++i) {
+      double expected = pcts[i] * 1e3;
+      double threshold = 0.1 * expected;
+      Assert.assertEquals(expected, PercentileBuckets.percentile(counts, pcts[i]), threshold);
+    }
+  }
+}

--- a/spectator-api/src/test/java/com/netflix/spectator/api/histogram/PercentileDistributionSummaryTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/histogram/PercentileDistributionSummaryTest.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.api.histogram;
+
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.Registry;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class PercentileDistributionSummaryTest {
+
+  @Test
+  public void percentile() {
+    Registry r = new DefaultRegistry();
+    PercentileDistributionSummary t = PercentileDistributionSummary.get(r, r.createId("test"));
+    for (int i = 0; i < 100_000; ++i) {
+      t.record(i);
+    }
+
+    for (int i = 0; i <= 100; ++i) {
+      double expected = i * 1e3;
+      double threshold = 0.15 * expected;
+      Assert.assertEquals(expected, t.percentile(i), threshold);
+    }
+  }
+
+}

--- a/spectator-api/src/test/java/com/netflix/spectator/api/histogram/PercentileTimerTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/histogram/PercentileTimerTest.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.api.histogram;
+
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.Registry;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.concurrent.TimeUnit;
+
+@RunWith(JUnit4.class)
+public class PercentileTimerTest {
+
+  @Test
+  public void percentile() {
+    Registry r = new DefaultRegistry();
+    PercentileTimer t = PercentileTimer.get(r, r.createId("test"));
+    for (int i = 0; i < 100_000; ++i) {
+      t.record(i, TimeUnit.MILLISECONDS);
+    }
+
+    for (int i = 0; i <= 100; ++i) {
+      double expected = (double) i;
+      double threshold = 0.15 * expected;
+      Assert.assertEquals(expected, t.percentile(i), threshold);
+    }
+  }
+
+}

--- a/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestRegistry.java
+++ b/spectator-reg-tdigest/src/main/java/com/netflix/spectator/tdigest/TDigestRegistry.java
@@ -17,6 +17,8 @@ package com.netflix.spectator.tdigest;
 
 import com.netflix.spectator.api.*;
 import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.histogram.PercentileDistributionSummary;
+import com.netflix.spectator.api.histogram.PercentileTimer;
 
 import javax.inject.Inject;
 import java.util.concurrent.TimeUnit;
@@ -41,11 +43,13 @@ public class TDigestRegistry extends AbstractRegistry {
   }
 
   @Override protected TDigestDistributionSummary newDistributionSummary(Id id) {
-    return new TDigestDistributionSummary(newDigest(id), underlying.distributionSummary(id));
+    DistributionSummary summary = PercentileDistributionSummary.get(underlying, id);
+    return new TDigestDistributionSummary(newDigest(id), summary);
   }
 
   @Override protected TDigestTimer newTimer(Id id) {
-    return new TDigestTimer(newDigest(id), underlying.timer(id));
+    Timer timer = PercentileTimer.get(underlying, id);
+    return new TDigestTimer(newDigest(id), timer);
   }
 
   private StepDigest newDigest(Id id) {


### PR DESCRIPTION
This is an alternative to using digests to get an approximate
percentile value that works well with slicing and dicing. For
this approach we are using a fixed set of buckets that partition
the range of long values so it can be used with most sets of
non-negative long values.

The error for an estimate is usually within a few percent of
the actual percentile for the real data sets tried, but there
are some exceptions. Compared with using t-Digests it is far
more performant and usually more compact. That comes at a
cost of being less accurate and more restrictive on inputs.

Docs will be updated after the cheaper bucket options are
moved from sandbox to stable. We do need to be careful with
the overhead and encourage users to be diligent about the
usage of percentiles and the overhead compared to options
such as a normal timer or bucket timer. A rule of thumb
is that a percentile timer will be ~ 300x more expensive in
terms of metrics volume than a normal timer.