### PR TITLE
delay reporting until there is activity

### DIFF
--- a/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoCounter.java
+++ b/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoCounter.java
@@ -38,7 +38,7 @@ class ServoCounter implements Counter, ServoMeter {
     this.clock = clock;
     this.impl = impl;
     this.count = new AtomicLong(0L);
-    this.lastUpdated = new AtomicLong(clock.wallTime());
+    this.lastUpdated = new AtomicLong(0L);
   }
 
   @Override public void addMonitors(List<Monitor<?>> monitors) {

--- a/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoDistributionSummary.java
+++ b/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoDistributionSummary.java
@@ -59,7 +59,7 @@ class ServoDistributionSummary implements DistributionSummary, ServoMeter {
         r.toMonitorConfig(id.withTag(Statistic.totalOfSquares)));
     servoMax = new MaxGauge(r.toMonitorConfig(id.withTag(Statistic.max)));
 
-    lastUpdated = new AtomicLong(clock.wallTime());
+    lastUpdated = new AtomicLong(0L);
   }
 
   @Override public void addMonitors(List<Monitor<?>> monitors) {

--- a/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoTimer.java
+++ b/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoTimer.java
@@ -66,7 +66,7 @@ class ServoTimer extends AbstractTimer implements ServoMeter {
     // Constructor that takes a clock param is not public
     servoMax = new MaxGauge(r.toMonitorConfig(id.withTag(Statistic.max)));
 
-    lastUpdated = new AtomicLong(clock.wallTime());
+    lastUpdated = new AtomicLong(0L);
   }
 
   @Override public void addMonitors(List<Monitor<?>> monitors) {

--- a/spectator-reg-servo/src/test/java/com/netflix/spectator/servo/ServoCounterTest.java
+++ b/spectator-reg-servo/src/test/java/com/netflix/spectator/servo/ServoCounterTest.java
@@ -52,18 +52,22 @@ public class ServoCounterTest {
 
   @Test
   public void expiration() {
-    // Not expired on init
-    clock.setWallTime(0L);
+    final long initTime = TimeUnit.MINUTES.toMillis(30);
+    final long fifteenMinutes = TimeUnit.MINUTES.toMillis(15);
+
+    // Expired on init, wait for activity to mark as active
+    clock.setWallTime(initTime);
     Counter c = newCounter("foo");
-    Assert.assertTrue(!c.hasExpired());
+    Assert.assertTrue(c.hasExpired());
     c.increment(42);
-
-    // Expires with inactivity, total count in memory is maintained
-    clock.setWallTime(TimeUnit.MINUTES.toMillis(15));
     Assert.assertTrue(!c.hasExpired());
 
     // Expires with inactivity, total count in memory is maintained
-    clock.setWallTime(TimeUnit.MINUTES.toMillis(15) + 1);
+    clock.setWallTime(initTime + fifteenMinutes);
+    Assert.assertTrue(!c.hasExpired());
+
+    // Expires with inactivity, total count in memory is maintained
+    clock.setWallTime(initTime + fifteenMinutes + 1);
     Assert.assertEquals(c.count(), 42);
     Assert.assertTrue(c.hasExpired());
 

--- a/spectator-reg-servo/src/test/java/com/netflix/spectator/servo/ServoTimerTest.java
+++ b/spectator-reg-servo/src/test/java/com/netflix/spectator/servo/ServoTimerTest.java
@@ -222,13 +222,18 @@ public class ServoTimerTest {
 
   @Test
   public void expiration() {
-    // Not expired on init
-    clock.setWallTime(0L);
+    final long initTime = TimeUnit.MINUTES.toMillis(30);
+    final long fifteenMinutes = TimeUnit.MINUTES.toMillis(15);
+
+    // Expired on init, wait for activity to mark as active
+    clock.setWallTime(initTime);
     Timer t = newTimer("foo");
+    Assert.assertTrue(t.hasExpired());
+    t.record(1, TimeUnit.SECONDS);
     Assert.assertTrue(!t.hasExpired());
 
     // Expires with inactivity
-    clock.setWallTime(TimeUnit.MINUTES.toMillis(16));
+    clock.setWallTime(initTime + fifteenMinutes + 1);
     Assert.assertTrue(t.hasExpired());
 
     // Activity brings it back


### PR DESCRIPTION
For the servo registry delay marking the counter, timer, or
distribution summary as active until there is some activity
such as a call to increment on the counter. This is mainly
for use-cases that cache the meter instance to avoid the
lookup cost, but may not get used for quite a while.