### PR TITLE
indicate type as prefix on idx value

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/histogram/PercentileDistributionSummary.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/histogram/PercentileDistributionSummary.java
@@ -53,7 +53,7 @@ public class PercentileDistributionSummary implements DistributionSummary {
     this.summary = registry.distributionSummary(id);
     this.counters = new Counter[PercentileBuckets.length()];
     for (int i = 0; i < counters.length; ++i) {
-      Id counterId = id.withTag("percentile", String.format("%04X", i));
+      Id counterId = id.withTag("percentile", String.format("D%04X", i));
       counters[i] = registry.counter(counterId);
     }
   }

--- a/spectator-api/src/main/java/com/netflix/spectator/api/histogram/PercentileTimer.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/histogram/PercentileTimer.java
@@ -58,7 +58,7 @@ public final class PercentileTimer implements Timer {
     this.timer = registry.timer(id);
     this.counters = new Counter[PercentileBuckets.length()];
     for (int i = 0; i < counters.length; ++i) {
-      Id counterId = id.withTag("percentile", String.format("%04X", i));
+      Id counterId = id.withTag("percentile", String.format("T%04X", i));
       counters[i] = registry.counter(counterId);
     }
   }


### PR DESCRIPTION
Timers are mapped to nanoseconds before computing the
bucket. This allows better precision without needing
to support floating point. For display it is often
preferred to use base units, like seconds. In any
case, it is useful to distinguish whether the value
was reported for a timer or a distribution summary. The
index value stored for the `percentile` key is now
prefixed with a `T` for timers and `D` for distribution
summaries.