### PR TITLE
add bucket helpers for quantities other than time

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/histogram/BucketFunctions.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/histogram/BucketFunctions.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.LongFunction;
+import java.util.function.LongUnaryOperator;
 
 /**
  * Helpers for creating bucketing functions.
@@ -26,83 +27,141 @@ import java.util.function.LongFunction;
 public final class BucketFunctions {
 
   /**
-   * Predefined formatters used to create the bucket labels.
+   * Predefined time formatters used to create the bucket labels.
    */
-  static final List<ValueFormatter> FORMATTERS = new ArrayList<>();
+  static final List<ValueFormatter> TIME_FORMATTERS = new ArrayList<>();
+
+  /**
+   * Predefined binary formatters used to create bucket labels. For more information see
+   * <a href="https://en.wikipedia.org/wiki/Binary_prefix">binary prefixes wiki</a>.
+   */
+  static final List<ValueFormatter> BINARY_FORMATTERS = new ArrayList<>();
+
+  /**
+   * Predefined decimal formatters used to created bucket labels. For more informations see
+   * <a href="https://en.wikipedia.org/wiki/Metric_prefix">metric prefixes wiki</a>.
+   */
+  static final List<ValueFormatter> DECIMAL_FORMATTERS = new ArrayList<>();
 
   static {
-    FORMATTERS.add(fmt(TimeUnit.NANOSECONDS.toNanos(10),     1, "ns",  TimeUnit.NANOSECONDS));
-    FORMATTERS.add(fmt(TimeUnit.NANOSECONDS.toNanos(100),    2, "ns",  TimeUnit.NANOSECONDS));
-    FORMATTERS.add(fmt(TimeUnit.MICROSECONDS.toNanos(1),     3, "ns",  TimeUnit.NANOSECONDS));
-    FORMATTERS.add(fmt(TimeUnit.MICROSECONDS.toNanos(8),     4, "ns",  TimeUnit.NANOSECONDS));
-    FORMATTERS.add(fmt(TimeUnit.MICROSECONDS.toNanos(10),    1, "us",  TimeUnit.MICROSECONDS));
-    FORMATTERS.add(fmt(TimeUnit.MICROSECONDS.toNanos(100),   2, "us",  TimeUnit.MICROSECONDS));
-    FORMATTERS.add(fmt(TimeUnit.MILLISECONDS.toNanos(1),     3, "us",  TimeUnit.MICROSECONDS));
-    FORMATTERS.add(fmt(TimeUnit.MILLISECONDS.toNanos(8),     4, "us",  TimeUnit.MICROSECONDS));
-    FORMATTERS.add(fmt(TimeUnit.MILLISECONDS.toNanos(10),    1, "ms",  TimeUnit.MILLISECONDS));
-    FORMATTERS.add(fmt(TimeUnit.MILLISECONDS.toNanos(100),   2, "ms",  TimeUnit.MILLISECONDS));
-    FORMATTERS.add(fmt(TimeUnit.SECONDS.toNanos(1),          3, "ms",  TimeUnit.MILLISECONDS));
-    FORMATTERS.add(fmt(TimeUnit.SECONDS.toNanos(8),          4, "ms",  TimeUnit.MILLISECONDS));
-    FORMATTERS.add(fmt(TimeUnit.SECONDS.toNanos(10),         1, "s",   TimeUnit.SECONDS));
-    FORMATTERS.add(fmt(TimeUnit.SECONDS.toNanos(100),        2, "s",   TimeUnit.SECONDS));
-    FORMATTERS.add(fmt(TimeUnit.MINUTES.toNanos(8),          3, "s",   TimeUnit.SECONDS));
-    FORMATTERS.add(fmt(TimeUnit.MINUTES.toNanos(10),         1, "min", TimeUnit.MINUTES));
-    FORMATTERS.add(fmt(TimeUnit.MINUTES.toNanos(100),        2, "min", TimeUnit.MINUTES));
-    FORMATTERS.add(fmt(TimeUnit.HOURS.toNanos(8),            3, "min", TimeUnit.MINUTES));
-    FORMATTERS.add(fmt(TimeUnit.HOURS.toNanos(10),           1, "h",   TimeUnit.HOURS));
-    FORMATTERS.add(fmt(TimeUnit.HOURS.toNanos(100),          2, "h",   TimeUnit.HOURS));
-    FORMATTERS.add(fmt(TimeUnit.DAYS.toNanos(8),             1, "h",   TimeUnit.HOURS));
-    FORMATTERS.add(fmt(TimeUnit.DAYS.toNanos(10),            1, "d",   TimeUnit.DAYS));
-    FORMATTERS.add(fmt(TimeUnit.DAYS.toNanos(100),           2, "d",   TimeUnit.DAYS));
-    FORMATTERS.add(fmt(TimeUnit.DAYS.toNanos(1000),          3, "d",   TimeUnit.DAYS));
-    FORMATTERS.add(fmt(TimeUnit.DAYS.toNanos(10000),         4, "d",   TimeUnit.DAYS));
-    FORMATTERS.add(fmt(TimeUnit.DAYS.toNanos(100000),        5, "d",   TimeUnit.DAYS));
-    FORMATTERS.add(fmt(Long.MAX_VALUE,                       6, "d",   TimeUnit.DAYS));
+    TIME_FORMATTERS.add(fmt(TimeUnit.NANOSECONDS.toNanos(10),     1, "ns",  TimeUnit.NANOSECONDS));
+    TIME_FORMATTERS.add(fmt(TimeUnit.NANOSECONDS.toNanos(100),    2, "ns",  TimeUnit.NANOSECONDS));
+    TIME_FORMATTERS.add(fmt(TimeUnit.MICROSECONDS.toNanos(1),     3, "ns",  TimeUnit.NANOSECONDS));
+    TIME_FORMATTERS.add(fmt(TimeUnit.MICROSECONDS.toNanos(8),     4, "ns",  TimeUnit.NANOSECONDS));
+    TIME_FORMATTERS.add(fmt(TimeUnit.MICROSECONDS.toNanos(10),    1, "us",  TimeUnit.MICROSECONDS));
+    TIME_FORMATTERS.add(fmt(TimeUnit.MICROSECONDS.toNanos(100),   2, "us",  TimeUnit.MICROSECONDS));
+    TIME_FORMATTERS.add(fmt(TimeUnit.MILLISECONDS.toNanos(1),     3, "us",  TimeUnit.MICROSECONDS));
+    TIME_FORMATTERS.add(fmt(TimeUnit.MILLISECONDS.toNanos(8),     4, "us",  TimeUnit.MICROSECONDS));
+    TIME_FORMATTERS.add(fmt(TimeUnit.MILLISECONDS.toNanos(10),    1, "ms",  TimeUnit.MILLISECONDS));
+    TIME_FORMATTERS.add(fmt(TimeUnit.MILLISECONDS.toNanos(100),   2, "ms",  TimeUnit.MILLISECONDS));
+    TIME_FORMATTERS.add(fmt(TimeUnit.SECONDS.toNanos(1),          3, "ms",  TimeUnit.MILLISECONDS));
+    TIME_FORMATTERS.add(fmt(TimeUnit.SECONDS.toNanos(8),          4, "ms",  TimeUnit.MILLISECONDS));
+    TIME_FORMATTERS.add(fmt(TimeUnit.SECONDS.toNanos(10),         1, "s",   TimeUnit.SECONDS));
+    TIME_FORMATTERS.add(fmt(TimeUnit.SECONDS.toNanos(100),        2, "s",   TimeUnit.SECONDS));
+    TIME_FORMATTERS.add(fmt(TimeUnit.MINUTES.toNanos(8),          3, "s",   TimeUnit.SECONDS));
+    TIME_FORMATTERS.add(fmt(TimeUnit.MINUTES.toNanos(10),         1, "min", TimeUnit.MINUTES));
+    TIME_FORMATTERS.add(fmt(TimeUnit.MINUTES.toNanos(100),        2, "min", TimeUnit.MINUTES));
+    TIME_FORMATTERS.add(fmt(TimeUnit.HOURS.toNanos(8),            3, "min", TimeUnit.MINUTES));
+    TIME_FORMATTERS.add(fmt(TimeUnit.HOURS.toNanos(10),           1, "h",   TimeUnit.HOURS));
+    TIME_FORMATTERS.add(fmt(TimeUnit.HOURS.toNanos(100),          2, "h",   TimeUnit.HOURS));
+    TIME_FORMATTERS.add(fmt(TimeUnit.DAYS.toNanos(8),             1, "h",   TimeUnit.HOURS));
+    TIME_FORMATTERS.add(fmt(TimeUnit.DAYS.toNanos(10),            1, "d",   TimeUnit.DAYS));
+    TIME_FORMATTERS.add(fmt(TimeUnit.DAYS.toNanos(100),           2, "d",   TimeUnit.DAYS));
+    TIME_FORMATTERS.add(fmt(TimeUnit.DAYS.toNanos(1000),          3, "d",   TimeUnit.DAYS));
+    TIME_FORMATTERS.add(fmt(TimeUnit.DAYS.toNanos(10000),         4, "d",   TimeUnit.DAYS));
+    TIME_FORMATTERS.add(fmt(TimeUnit.DAYS.toNanos(100000),        5, "d",   TimeUnit.DAYS));
+    TIME_FORMATTERS.add(fmt(Long.MAX_VALUE,                       6, "d",   TimeUnit.DAYS));
     // TimeUnit.NANOSECONDS.toDays(java.lang.Long.MAX_VALUE) == 106751
+
+    final String[] binaryUnits = {"B", "KiB", "MiB", "GiB", "TiB", "PiB"};
+    for (int i = 0; i < binaryUnits.length; ++i) {
+      BINARY_FORMATTERS.add(bin(10,    i, 1, "_" + binaryUnits[i]));
+      BINARY_FORMATTERS.add(bin(100,   i, 2, "_" + binaryUnits[i]));
+      BINARY_FORMATTERS.add(bin(1000,  i, 3, "_" + binaryUnits[i]));
+      BINARY_FORMATTERS.add(bin(10000, i, 4, "_" + binaryUnits[i]));
+    }
+    BINARY_FORMATTERS.add(new ValueFormatter(Long.MAX_VALUE, 4, "_PiB", v -> v >> 50));
+
+    final String[] decimalUnits = {"", "_k", "_M", "_G", "_T", "_P"};
+    for (int i = 0; i < decimalUnits.length; ++i) {
+      final int pow = i * 3;
+      DECIMAL_FORMATTERS.add(dec(10,   pow, 1, decimalUnits[i]));
+      DECIMAL_FORMATTERS.add(dec(100,  pow, 2, decimalUnits[i]));
+      DECIMAL_FORMATTERS.add(dec(1000, pow, 3, decimalUnits[i]));
+    }
+    DECIMAL_FORMATTERS.add(new ValueFormatter(Long.MAX_VALUE, 1, "_E", v -> v / pow10(1, 18)));
   }
 
   private static ValueFormatter fmt(long max, int width, String suffix, TimeUnit unit) {
-    return new ValueFormatter(max, width, suffix, unit);
+    return new ValueFormatter(max, width, suffix, v -> unit.convert(v, TimeUnit.NANOSECONDS));
+  }
+
+  private static ValueFormatter bin(long max, int pow, int width, String suffix) {
+    final int shift = pow * 10;
+    final long maxBytes = (shift == 0) ? max : max << shift;
+    return new ValueFormatter(maxBytes, width, suffix, v -> v >> shift);
+  }
+
+  private static ValueFormatter dec(long max, int pow, int width, String suffix) {
+    final long factor = pow10(1, pow);
+    final long maxBytes = max * factor;
+    return new ValueFormatter(maxBytes, width, suffix, v -> v / factor);
+  }
+
+  private static long pow10(long a, int b) {
+    long r = a;
+    for (int i = 0; i < b; ++i) {
+      r *= 10;
+    }
+    return r;
   }
 
   private BucketFunctions() {
   }
 
-  private static ValueFormatter getFormatter(long max) {
-    for (ValueFormatter f : FORMATTERS) {
+  private static ValueFormatter getFormatter(List<ValueFormatter> fmts, long max) {
+    for (ValueFormatter f : fmts) {
       if (max < f.max) {
         return f;
       }
     }
-    return new ValueFormatter(max, ("" + max).length(), "ns", TimeUnit.NANOSECONDS);
+    return fmts.get(fmts.size() - 1);
+  }
+
+  private static LongFunction<String> biasZero(
+      String ltZero, String gtMax, long max, ValueFormatter f) {
+    List<Bucket> buckets = new ArrayList<>();
+    buckets.add(new Bucket(ltZero, 0L));
+    buckets.add(f.newBucket(max / 8));
+    buckets.add(f.newBucket(max / 4));
+    buckets.add(f.newBucket(max / 2));
+    buckets.add(f.newBucket(max));
+    return new ListBucketFunction(buckets, gtMax);
   }
 
   private static LongFunction<String> timeBiasZero(
       String ltZero, String gtMax, long max, TimeUnit unit) {
-    final long nanos = unit.toNanos(max);
-    final ValueFormatter f = getFormatter(nanos);
-    final long v = f.unit().convert(max, unit);
+    final long v = unit.toNanos(max);
+    final ValueFormatter f = getFormatter(TIME_FORMATTERS, v);
+    return biasZero(ltZero, gtMax, v, f);
+  }
+
+  private static LongFunction<String> biasMax(
+      String ltZero, String gtMax, long max, ValueFormatter f) {
     List<Bucket> buckets = new ArrayList<>();
     buckets.add(new Bucket(ltZero, 0L));
-    buckets.add(f.newBucket(v / 8));
-    buckets.add(f.newBucket(v / 4));
-    buckets.add(f.newBucket(v / 2));
-    buckets.add(f.newBucket(v));
+    buckets.add(f.newBucket(max - max / 2));
+    buckets.add(f.newBucket(max - max / 4));
+    buckets.add(f.newBucket(max - max / 8));
+    buckets.add(f.newBucket(max));
     return new ListBucketFunction(buckets, gtMax);
   }
 
   private static LongFunction<String> timeBiasMax(
       String ltZero, String gtMax, long max, TimeUnit unit) {
-    final long nanos = unit.toNanos(max);
-    final ValueFormatter f = getFormatter(nanos);
-    final long v = f.unit().convert(max, unit);
-    List<Bucket> buckets = new ArrayList<>();
-    buckets.add(new Bucket(ltZero, 0L));
-    buckets.add(f.newBucket(v - v / 2));
-    buckets.add(f.newBucket(v - v / 4));
-    buckets.add(f.newBucket(v - v / 8));
-    buckets.add(f.newBucket(v));
-    return new ListBucketFunction(buckets, gtMax);
+    final long v = unit.toNanos(max);
+    final ValueFormatter f = getFormatter(TIME_FORMATTERS, v);
+    return biasMax(ltZero, gtMax, v, f);
   }
 
   /**
@@ -188,12 +247,47 @@ public final class BucketFunctions {
   }
 
   /**
+   * Returns a function that maps size values in bytes to a set of buckets. The buckets will
+   * use <a href="https://en.wikipedia.org/wiki/Binary_prefix">binary prefixes</a> representing
+   * powers of 1024. If you want powers of 1000, then see {@link #decimal(long)}.
+   *
+   * @param max
+   *     Maximum expected size of data being recorded. Values greater than this amount will be
+   *     mapped to a "large" bucket.
+   * @return
+   *     Function mapping size values to string labels. The labels for buckets will sort
+   *     so they can be used with a simple group by.
+   */
+  public static LongFunction<String> bytes(long max) {
+    ValueFormatter f = getFormatter(BINARY_FORMATTERS, max);
+    return biasZero("negative", "large", max, f);
+  }
+
+  /**
+   * Returns a function that maps size values to a set of buckets. The buckets will
+   * use <a href="https://en.wikipedia.org/wiki/Metric_prefix">decimal prefixes</a> representing
+   * powers of 1000. If you are measuring quantities in bytes and want powers of 1024, then see
+   * {@link #bytes(long)}.
+   *
+   * @param max
+   *     Maximum expected size of data being recorded. Values greater than this amount will be
+   *     mapped to a "large" bucket.
+   * @return
+   *     Function mapping size values to string labels. The labels for buckets will sort
+   *     so they can be used with a simple group by.
+   */
+  public static LongFunction<String> decimal(long max) {
+    ValueFormatter f = getFormatter(DECIMAL_FORMATTERS, max);
+    return biasZero("negative", "large", max, f);
+  }
+
+  /**
    * Format a value as a bucket label.
    */
   static class ValueFormatter {
     private final long max;
     private final String fmt;
-    private final TimeUnit unit;
+    private final LongUnaryOperator cnv;
 
     /**
      * Create a new instance.
@@ -204,13 +298,13 @@ public final class BucketFunctions {
      *     Number of digits to use for the numeric part of the label.
      * @param suffix
      *     Unit suffix appended to the label.
-     * @param unit
-     *     Unit for the value in the label.
+     * @param cnv
+     *     Value conversion function. Converts the input value to the right units for the label.
      */
-    ValueFormatter(long max, int width, String suffix, TimeUnit unit) {
+    ValueFormatter(long max, int width, String suffix, LongUnaryOperator cnv) {
       this.max = max;
       this.fmt = "%0" + width + "d" + suffix;
-      this.unit = unit;
+      this.cnv = cnv;
     }
 
     /** Return the max value intended for this formatter. */
@@ -218,20 +312,19 @@ public final class BucketFunctions {
       return max;
     }
 
-    /** Return the unit for the formatter. */
-    TimeUnit unit() {
-      return unit;
+    /** Apply conversion function to value. */
+    long convert(long v) {
+      return cnv.applyAsLong(v);
     }
 
     /** Convert the value {@code v} into a bucket label string. */
     String apply(long v) {
-      return String.format(fmt, unit.convert(v, TimeUnit.NANOSECONDS));
+      return String.format(fmt, cnv.applyAsLong(v));
     }
 
     /** Return a new bucket for the specified value. */
     Bucket newBucket(long v) {
-      final long nanos = unit.toNanos(v);
-      return new Bucket(apply(nanos), nanos);
+      return new Bucket(apply(v), v);
     }
   }
 
@@ -246,8 +339,8 @@ public final class BucketFunctions {
 
     @Override public String apply(long amount) {
       for (Bucket b : buckets) {
-        if (amount < b.upperBoundary) {
-          return b.name();
+        if (amount <= b.upperBoundary) {
+          return b.name;
         }
       }
       return fallback;
@@ -261,14 +354,6 @@ public final class BucketFunctions {
     Bucket(String name, long upperBoundary) {
       this.name = name;
       this.upperBoundary = upperBoundary;
-    }
-
-    String name() {
-      return name;
-    }
-
-    long upperBoundary() {
-      return upperBoundary;
     }
 
     @Override public String toString() {

--- a/spectator-api/src/test/java/com/netflix/spectator/api/histogram/BucketFunctionsTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/histogram/BucketFunctionsTest.java
@@ -34,12 +34,14 @@ public class BucketFunctionsTest {
     Assert.assertEquals("future", f.apply(TimeUnit.SECONDS.toNanos(-1)));
     Assert.assertEquals("07s", f.apply(TimeUnit.SECONDS.toNanos(1)));
     Assert.assertEquals("07s", f.apply(TimeUnit.SECONDS.toNanos(6)));
-    Assert.assertEquals("15s", f.apply(TimeUnit.SECONDS.toNanos(7)));
+    Assert.assertEquals("07s", f.apply(TimeUnit.SECONDS.toNanos(7)));
+    Assert.assertEquals("15s", f.apply(TimeUnit.SECONDS.toNanos(8)));
     Assert.assertEquals("15s", f.apply(TimeUnit.SECONDS.toNanos(10)));
     Assert.assertEquals("30s", f.apply(TimeUnit.SECONDS.toNanos(20)));
-    Assert.assertEquals("60s", f.apply(TimeUnit.SECONDS.toNanos(30)));
+    Assert.assertEquals("30s", f.apply(TimeUnit.SECONDS.toNanos(30)));
+    Assert.assertEquals("60s", f.apply(TimeUnit.SECONDS.toNanos(31)));
     Assert.assertEquals("60s", f.apply(TimeUnit.SECONDS.toNanos(42)));
-    Assert.assertEquals("old", f.apply(TimeUnit.SECONDS.toNanos(60)));
+    Assert.assertEquals("60s", f.apply(TimeUnit.SECONDS.toNanos(60)));
     Assert.assertEquals("old", f.apply(TimeUnit.SECONDS.toNanos(61)));
   }
 
@@ -52,11 +54,11 @@ public class BucketFunctionsTest {
     Assert.assertEquals("30s", f.apply(TimeUnit.SECONDS.toNanos(7)));
     Assert.assertEquals("30s", f.apply(TimeUnit.SECONDS.toNanos(10)));
     Assert.assertEquals("30s", f.apply(TimeUnit.SECONDS.toNanos(20)));
-    Assert.assertEquals("45s", f.apply(TimeUnit.SECONDS.toNanos(30)));
+    Assert.assertEquals("30s", f.apply(TimeUnit.SECONDS.toNanos(30)));
     Assert.assertEquals("45s", f.apply(TimeUnit.SECONDS.toNanos(42)));
-    Assert.assertEquals("53s", f.apply(TimeUnit.SECONDS.toNanos(48)));
+    Assert.assertEquals("52s", f.apply(TimeUnit.SECONDS.toNanos(48)));
     Assert.assertEquals("60s", f.apply(TimeUnit.SECONDS.toNanos(59)));
-    Assert.assertEquals("old", f.apply(TimeUnit.SECONDS.toNanos(60)));
+    Assert.assertEquals("60s", f.apply(TimeUnit.SECONDS.toNanos(60)));
     Assert.assertEquals("old", f.apply(TimeUnit.SECONDS.toNanos(61)));
   }
 
@@ -66,7 +68,7 @@ public class BucketFunctionsTest {
     Assert.assertEquals("negative_latency", f.apply(TimeUnit.MILLISECONDS.toNanos(-1)));
     Assert.assertEquals("012ms", f.apply(TimeUnit.MILLISECONDS.toNanos(1)));
     Assert.assertEquals("025ms", f.apply(TimeUnit.MILLISECONDS.toNanos(13)));
-    Assert.assertEquals("050ms", f.apply(TimeUnit.MILLISECONDS.toNanos(25)));
+    Assert.assertEquals("025ms", f.apply(TimeUnit.MILLISECONDS.toNanos(25)));
     Assert.assertEquals("100ms", f.apply(TimeUnit.MILLISECONDS.toNanos(99)));
     Assert.assertEquals("slow", f.apply(TimeUnit.MILLISECONDS.toNanos(101)));
   }
@@ -79,7 +81,8 @@ public class BucketFunctionsTest {
     Assert.assertEquals("050ms", f.apply(TimeUnit.MILLISECONDS.toNanos(13)));
     Assert.assertEquals("050ms", f.apply(TimeUnit.MILLISECONDS.toNanos(25)));
     Assert.assertEquals("075ms", f.apply(TimeUnit.MILLISECONDS.toNanos(74)));
-    Assert.assertEquals("088ms", f.apply(TimeUnit.MILLISECONDS.toNanos(75)));
+    Assert.assertEquals("075ms", f.apply(TimeUnit.MILLISECONDS.toNanos(75)));
+    Assert.assertEquals("087ms", f.apply(TimeUnit.MILLISECONDS.toNanos(76)));
     Assert.assertEquals("100ms", f.apply(TimeUnit.MILLISECONDS.toNanos(99)));
     Assert.assertEquals("slow", f.apply(TimeUnit.MILLISECONDS.toNanos(101)));
   }
@@ -97,7 +100,7 @@ public class BucketFunctionsTest {
 
   @Test
   public void latencyRange() {
-    for (BucketFunctions.ValueFormatter fmt : BucketFunctions.FORMATTERS) {
+    for (BucketFunctions.ValueFormatter fmt : BucketFunctions.TIME_FORMATTERS) {
       final long max = fmt.max();
       LongFunction<String> f = BucketFunctions.latency(max, TimeUnit.NANOSECONDS);
       Set<String> keys = new HashSet<>();
@@ -112,7 +115,7 @@ public class BucketFunctionsTest {
 
   @Test
   public void latencyBiasSlowRange() {
-    for (BucketFunctions.ValueFormatter fmt : BucketFunctions.FORMATTERS) {
+    for (BucketFunctions.ValueFormatter fmt : BucketFunctions.TIME_FORMATTERS) {
       final long max = fmt.max();
       LongFunction<String> f = BucketFunctions.latencyBiasSlow(max, TimeUnit.NANOSECONDS);
       Set<String> keys = new HashSet<>();
@@ -123,6 +126,56 @@ public class BucketFunctionsTest {
       keys.add(f.apply(max));
       Assert.assertEquals(5, keys.size());
     }
+  }
+
+  @Test
+  public void bytes1K() {
+    LongFunction<String> f = BucketFunctions.bytes(1024);
+    Assert.assertEquals("negative", f.apply(-1L));
+    Assert.assertEquals("0256_B", f.apply(212));
+    Assert.assertEquals("0512_B", f.apply(512));
+    Assert.assertEquals("1024_B", f.apply(761));
+    Assert.assertEquals("large", f.apply(20001));
+  }
+
+  @Test
+  public void bytes20K() {
+    LongFunction<String> f = BucketFunctions.bytes(20000);
+    Assert.assertEquals("negative", f.apply(-1L));
+    Assert.assertEquals("02_KiB", f.apply(761));
+    Assert.assertEquals("04_KiB", f.apply(4567));
+    Assert.assertEquals("19_KiB", f.apply(15761));
+    Assert.assertEquals("large", f.apply(20001));
+  }
+
+  @Test
+  public void bytesMaxValue() {
+    LongFunction<String> f = BucketFunctions.bytes(Long.MAX_VALUE);
+    Assert.assertEquals("negative", f.apply(-1L));
+    Assert.assertEquals("1023_PiB", f.apply(761));
+    Assert.assertEquals("2047_PiB", f.apply(Long.MAX_VALUE / 4));
+    Assert.assertEquals("4095_PiB", f.apply(Long.MAX_VALUE / 2));
+    Assert.assertEquals("8191_PiB", f.apply(Long.MAX_VALUE));
+  }
+
+  @Test
+  public void decimal20K() {
+    LongFunction<String> f = BucketFunctions.decimal(20000);
+    Assert.assertEquals("negative", f.apply(-1L));
+    Assert.assertEquals("02_k", f.apply(761));
+    Assert.assertEquals("05_k", f.apply(4567));
+    Assert.assertEquals("20_k", f.apply(15761));
+    Assert.assertEquals("large", f.apply(20001));
+  }
+
+  @Test
+  public void decimalMaxValue() {
+    LongFunction<String> f = BucketFunctions.decimal(Long.MAX_VALUE);
+    Assert.assertEquals("negative", f.apply(-1L));
+    Assert.assertEquals("1_E", f.apply(761));
+    Assert.assertEquals("2_E", f.apply(Long.MAX_VALUE / 4));
+    Assert.assertEquals("4_E", f.apply(Long.MAX_VALUE / 2));
+    Assert.assertEquals("9_E", f.apply(Long.MAX_VALUE));
   }
 
 }

--- a/spectator-ext-sandbox/src/test/java/com/netflix/spectator/sandbox/BucketFunctionsTest.java
+++ b/spectator-ext-sandbox/src/test/java/com/netflix/spectator/sandbox/BucketFunctionsTest.java
@@ -31,12 +31,12 @@ public class BucketFunctionsTest {
     Assert.assertEquals("future", f.apply(TimeUnit.SECONDS.toNanos(-1)));
     Assert.assertEquals("07s", f.apply(TimeUnit.SECONDS.toNanos(1)));
     Assert.assertEquals("07s", f.apply(TimeUnit.SECONDS.toNanos(6)));
-    Assert.assertEquals("15s", f.apply(TimeUnit.SECONDS.toNanos(7)));
+    Assert.assertEquals("07s", f.apply(TimeUnit.SECONDS.toNanos(7)));
     Assert.assertEquals("15s", f.apply(TimeUnit.SECONDS.toNanos(10)));
     Assert.assertEquals("30s", f.apply(TimeUnit.SECONDS.toNanos(20)));
-    Assert.assertEquals("60s", f.apply(TimeUnit.SECONDS.toNanos(30)));
+    Assert.assertEquals("30s", f.apply(TimeUnit.SECONDS.toNanos(30)));
     Assert.assertEquals("60s", f.apply(TimeUnit.SECONDS.toNanos(42)));
-    Assert.assertEquals("old", f.apply(TimeUnit.SECONDS.toNanos(60)));
+    Assert.assertEquals("60s", f.apply(TimeUnit.SECONDS.toNanos(60)));
     Assert.assertEquals("old", f.apply(TimeUnit.SECONDS.toNanos(61)));
   }
 
@@ -49,11 +49,11 @@ public class BucketFunctionsTest {
     Assert.assertEquals("30s", f.apply(TimeUnit.SECONDS.toNanos(7)));
     Assert.assertEquals("30s", f.apply(TimeUnit.SECONDS.toNanos(10)));
     Assert.assertEquals("30s", f.apply(TimeUnit.SECONDS.toNanos(20)));
-    Assert.assertEquals("45s", f.apply(TimeUnit.SECONDS.toNanos(30)));
+    Assert.assertEquals("30s", f.apply(TimeUnit.SECONDS.toNanos(30)));
     Assert.assertEquals("45s", f.apply(TimeUnit.SECONDS.toNanos(42)));
-    Assert.assertEquals("53s", f.apply(TimeUnit.SECONDS.toNanos(48)));
+    Assert.assertEquals("52s", f.apply(TimeUnit.SECONDS.toNanos(48)));
     Assert.assertEquals("60s", f.apply(TimeUnit.SECONDS.toNanos(59)));
-    Assert.assertEquals("old", f.apply(TimeUnit.SECONDS.toNanos(60)));
+    Assert.assertEquals("60s", f.apply(TimeUnit.SECONDS.toNanos(60)));
     Assert.assertEquals("old", f.apply(TimeUnit.SECONDS.toNanos(61)));
   }
 
@@ -63,7 +63,7 @@ public class BucketFunctionsTest {
     Assert.assertEquals("negative_latency", f.apply(TimeUnit.MILLISECONDS.toNanos(-1)));
     Assert.assertEquals("012ms", f.apply(TimeUnit.MILLISECONDS.toNanos(1)));
     Assert.assertEquals("025ms", f.apply(TimeUnit.MILLISECONDS.toNanos(13)));
-    Assert.assertEquals("050ms", f.apply(TimeUnit.MILLISECONDS.toNanos(25)));
+    Assert.assertEquals("025ms", f.apply(TimeUnit.MILLISECONDS.toNanos(25)));
     Assert.assertEquals("100ms", f.apply(TimeUnit.MILLISECONDS.toNanos(99)));
     Assert.assertEquals("slow", f.apply(TimeUnit.MILLISECONDS.toNanos(101)));
   }
@@ -76,7 +76,7 @@ public class BucketFunctionsTest {
     Assert.assertEquals("050ms", f.apply(TimeUnit.MILLISECONDS.toNanos(13)));
     Assert.assertEquals("050ms", f.apply(TimeUnit.MILLISECONDS.toNanos(25)));
     Assert.assertEquals("075ms", f.apply(TimeUnit.MILLISECONDS.toNanos(74)));
-    Assert.assertEquals("088ms", f.apply(TimeUnit.MILLISECONDS.toNanos(75)));
+    Assert.assertEquals("075ms", f.apply(TimeUnit.MILLISECONDS.toNanos(75)));
     Assert.assertEquals("100ms", f.apply(TimeUnit.MILLISECONDS.toNanos(99)));
     Assert.assertEquals("slow", f.apply(TimeUnit.MILLISECONDS.toNanos(101)));
   }


### PR DESCRIPTION
Update BucketFunctions so it provides helpers for working with
quantities other than time. The most commonly requested has been
bytes which will automatically generate labels using powers of
1024. There is also a helper for other arbitrary quantities that
uses the decimal metric prefixes.