### PR TITLE
move Throwables to impl package

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/AbstractRegistry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/AbstractRegistry.java
@@ -15,6 +15,9 @@
  */
 package com.netflix.spectator.api;
 
+import com.netflix.spectator.impl.Config;
+import com.netflix.spectator.impl.Throwables;
+
 import java.util.Iterator;
 import java.util.concurrent.ConcurrentHashMap;
 

--- a/spectator-api/src/main/java/com/netflix/spectator/api/RegistryMeter.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/RegistryMeter.java
@@ -15,6 +15,8 @@
  */
 package com.netflix.spectator.api;
 
+import com.netflix.spectator.impl.Throwables;
+
 import java.util.ArrayList;
 import java.util.List;
 

--- a/spectator-api/src/main/java/com/netflix/spectator/api/Utils.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/Utils.java
@@ -16,6 +16,7 @@
 package com.netflix.spectator.api;
 
 import com.netflix.spectator.impl.Preconditions;
+import com.netflix.spectator.impl.Throwables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/AtomicDouble.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/AtomicDouble.java
@@ -19,6 +19,9 @@ import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Wrapper around AtomicLong to make working with double values easier.
+ *
+ * <p><b>Please notice that this should be considered an internal implementation detail, and
+ * it is subject to change without notice.</b></p>
  */
 public class AtomicDouble extends Number {
 

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/AtomicDouble.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/AtomicDouble.java
@@ -20,8 +20,8 @@ import java.util.concurrent.atomic.AtomicLong;
 /**
  * Wrapper around AtomicLong to make working with double values easier.
  *
- * <p><b>Please notice that this should be considered an internal implementation detail, and
- * it is subject to change without notice.</b></p>
+ * <p><b>This class is an internal implementation detail only intended for use within spectator.
+ * It is subject to change without notice.</b></p>
  */
 public class AtomicDouble extends Number {
 

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/Config.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/Config.java
@@ -18,8 +18,8 @@ package com.netflix.spectator.impl;
 /**
  * Helper methods for accessing configuration settings.
  *
- * <p><b>Please notice that this should be considered an internal implementation detail, and
- * it is subject to change without notice.</b></p>
+ * <p><b>This class is an internal implementation detail only intended for use within spectator.
+ * It is subject to change without notice.</b></p>
  */
 public final class Config {
 

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/Config.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/Config.java
@@ -13,10 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.spectator.api;
+package com.netflix.spectator.impl;
 
-/** Helper methods for accessing configuration settings. */
-final class Config {
+/**
+ * Helper methods for accessing configuration settings.
+ *
+ * <p><b>Please notice that this should be considered an internal implementation detail, and
+ * it is subject to change without notice.</b></p>
+ */
+public final class Config {
 
   private static final String PREFIX = "spectator.api.";
 
@@ -33,20 +38,21 @@ final class Config {
   }
 
   /** Should an exception be thrown for warnings? */
-  static boolean propagateWarnings() {
+  public static boolean propagateWarnings() {
     return Boolean.valueOf(get(PREFIX + "propagateWarnings", "false"));
   }
 
   /**
-   * For classes based on {@link AbstractRegistry} this setting is used to determine the maximum
-   * number of registered meters permitted. This limit is used to help protect the system from a
-   * memory leak if there is a bug or irresponsible usage of registering meters.
+   * For classes based on {@link com.netflix.spectator.api.AbstractRegistry} this setting is used
+   * to determine the maximum number of registered meters permitted. This limit is used to help
+   * protect the system from a memory leak if there is a bug or irresponsible usage of registering
+   * meters.
    *
    * @return
    *     Maximum number of distinct meters that can be registered at a given time. The default is
    *     {@link java.lang.Integer#MAX_VALUE}.
    */
-  static int maxNumberOfMeters() {
+  public static int maxNumberOfMeters() {
     final String v = get(PREFIX + "maxNumberOfMeters");
     return (v == null) ? Integer.MAX_VALUE : Integer.parseInt(v);
   }

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/Preconditions.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/Preconditions.java
@@ -19,8 +19,8 @@ package com.netflix.spectator.impl;
  * Internal convenience methods that help a method or constructor check whether it was invoked
  * correctly.
  *
- * <p><b>Please notice that this should be considered an internal implementation detail, and
- * it is subject to change without notice.</b></p>
+ * <p><b>This class is an internal implementation detail only intended for use within spectator.
+ * It is subject to change without notice.</b></p>
  */
 public final class Preconditions {
   private Preconditions() {

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/Preconditions.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/Preconditions.java
@@ -17,8 +17,10 @@ package com.netflix.spectator.impl;
 
 /**
  * Internal convenience methods that help a method or constructor check whether it was invoked
- * correctly. Please notice that this should be considered an internal implementation detail, and
- * it is subject to change without notice.
+ * correctly.
+ *
+ * <p><b>Please notice that this should be considered an internal implementation detail, and
+ * it is subject to change without notice.</b></p>
  */
 public final class Preconditions {
   private Preconditions() {

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/StepDouble.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/StepDouble.java
@@ -25,8 +25,8 @@ import java.util.concurrent.atomic.AtomicLong;
  * being updated and the other is the value from the previous interval and is only available for
  * polling.
  *
- * <p><b>Please notice that this should be considered an internal implementation detail, and
- * it is subject to change without notice.</b></p>
+ * <p><b>This class is an internal implementation detail only intended for use within spectator.
+ * It is subject to change without notice.</b></p>
  */
 public class StepDouble {
 

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/StepDouble.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/StepDouble.java
@@ -24,6 +24,9 @@ import java.util.concurrent.atomic.AtomicLong;
  * The current implementation keeps an array of with two items where one is the current value
  * being updated and the other is the value from the previous interval and is only available for
  * polling.
+ *
+ * <p><b>Please notice that this should be considered an internal implementation detail, and
+ * it is subject to change without notice.</b></p>
  */
 public class StepDouble {
 

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/StepLong.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/StepLong.java
@@ -24,6 +24,9 @@ import java.util.concurrent.atomic.AtomicLong;
  * The current implementation keeps an array of with two items where one is the current value
  * being updated and the other is the value from the previous interval and is only available for
  * polling.
+ *
+ * <p><b>Please notice that this should be considered an internal implementation detail, and
+ * it is subject to change without notice.</b></p>
  */
 public class StepLong {
 

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/StepLong.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/StepLong.java
@@ -25,8 +25,8 @@ import java.util.concurrent.atomic.AtomicLong;
  * being updated and the other is the value from the previous interval and is only available for
  * polling.
  *
- * <p><b>Please notice that this should be considered an internal implementation detail, and
- * it is subject to change without notice.</b></p>
+ * <p><b>This class is an internal implementation detail only intended for use within spectator.
+ * It is subject to change without notice.</b></p>
  */
 public class StepLong {
 

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/Throwables.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/Throwables.java
@@ -13,13 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.spectator.api;
+package com.netflix.spectator.impl;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Helper functions for working with exceptions. */
-final class Throwables {
+/**
+ * Helper functions for working with exceptions.
+ *
+ * <p><b>Please notice that this should be considered an internal implementation detail, and
+ * it is subject to change without notice.</b></p>
+ */
+public final class Throwables {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(Throwables.class);
 
@@ -30,7 +35,7 @@ final class Throwables {
    * @param t
    *     Exception to log and optionally propagate.
    */
-  static void propagate(Throwable t) {
+  public static void propagate(Throwable t) {
     propagate(t.getMessage(), t);
   }
 
@@ -43,7 +48,7 @@ final class Throwables {
    * @param t
    *     Exception to log and optionally propagate.
    */
-  static void propagate(String msg, Throwable t) {
+  public static void propagate(String msg, Throwable t) {
     LOGGER.warn(msg, t);
     if (Config.propagateWarnings()) {
       if (t instanceof RuntimeException) {

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/Throwables.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/Throwables.java
@@ -21,8 +21,8 @@ import org.slf4j.LoggerFactory;
 /**
  * Helper functions for working with exceptions.
  *
- * <p><b>Please notice that this should be considered an internal implementation detail, and
- * it is subject to change without notice.</b></p>
+ * <p><b>This class is an internal implementation detail only intended for use within spectator.
+ * It is subject to change without notice.</b></p>
  */
 public final class Throwables {
 

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/package-info.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/package-info.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Classes in this package are only intended for use internally within spectator. They may change
+ * at any time and without notice.
+ */
+package com.netflix.spectator.impl;

--- a/spectator-api/src/test/java/com/netflix/spectator/impl/ThrowablesTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/ThrowablesTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.spectator.api;
+package com.netflix.spectator.impl;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;


### PR DESCRIPTION
In some cases it would be useful in other spectator sub-projects
to keep the behavior consistent (for example #269). Also adds
comments to make sure it is clear these should not be used
outside of spectator itself.