### PR TITLE
fix deprecation warnings

### DIFF
--- a/spectator-ext-log4j2/src/test/java/com/netflix/spectator/log4j/SpectatorAppenderTest.java
+++ b/spectator-ext-log4j2/src/test/java/com/netflix/spectator/log4j/SpectatorAppenderTest.java
@@ -40,7 +40,14 @@ public class SpectatorAppenderTest {
   private LogEvent newEvent(Level level, Throwable t, boolean includeSource) {
     final String cname = SpectatorAppenderTest.class.getName();
     final StackTraceElement e = (t == null || !includeSource) ? null : t.getStackTrace()[0];
-    return new Log4jLogEvent(cname, null, cname, level, null, t, null, null, null, e, 0);
+    return new Log4jLogEvent.Builder()
+        .setLoggerName(cname)
+        .setLoggerFqcn(cname)
+        .setLevel(level)
+        .setThrown(t)
+        .setSource(e)
+        .setTimeMillis(0L)
+        .build();
   }
 
   @Before

--- a/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/DoubleCounter.java
+++ b/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/DoubleCounter.java
@@ -15,7 +15,6 @@
  */
 package com.netflix.spectator.servo;
 
-import com.google.common.base.Objects;
 import com.netflix.servo.annotations.DataSourceType;
 import com.netflix.servo.monitor.AbstractMonitor;
 import com.netflix.servo.monitor.MonitorConfig;
@@ -80,9 +79,6 @@ class DoubleCounter extends AbstractMonitor<Number> implements NumericMonitor<Nu
   }
 
   @Override public String toString() {
-    return Objects.toStringHelper(this)
-        .add("config", config)
-        .add("count", getValue())
-        .toString();
+    return "DoubleCounter(config=" + config + ",count=" + getValue() + ")";
   }
 }


### PR DESCRIPTION
Fixes two deprecation warnings:

1. Use of to string helper in guava for DoubleCounter
2. Switch to using builder for log4j event test case