### PR TITLE
try using trusty build environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: java
 jdk:
 - oraclejdk8
-sudo: false
+sudo: required
+dist: trusty
 install: "./installViaTravis.sh"
 script: "./buildViaTravis.sh"
 env:


### PR DESCRIPTION
For more context see:

https://docs.travis-ci.com/user/trusty-ci-environment/

Per https://github.com/Netflix/AWSObjectMapper/pull/17
it results in longer startup time, but
more stable builds overall.