### PR TITLE
update gc logger to report using power of 1024

### DIFF
--- a/spectator-ext-gc/src/main/java/com/netflix/spectator/gc/GcEvent.java
+++ b/spectator-ext-gc/src/main/java/com/netflix/spectator/gc/GcEvent.java
@@ -26,6 +26,10 @@ import java.util.Date;
  */
 public class GcEvent {
 
+  private static final long ONE_KIBIBYTE = 1 << 10;
+  private static final long ONE_MEBIBYTE = 1 << 20;
+  private static final long ONE_GIBIBYTE = 1 << 30;
+
   private final String name;
   private final GarbageCollectionNotificationInfo info;
   private final GcType type;
@@ -73,19 +77,19 @@ public class GcEvent {
 
   @Override
   public String toString() {
-    GcInfo gcInfo = info.getGcInfo();
-    long totalBefore = HelperFunctions.getTotalUsage(gcInfo.getMemoryUsageBeforeGc());
-    long totalAfter = HelperFunctions.getTotalUsage(gcInfo.getMemoryUsageAfterGc());
-    long max = HelperFunctions.getTotalMaxUsage(gcInfo.getMemoryUsageAfterGc());
+    final GcInfo gcInfo = info.getGcInfo();
+    final long totalBefore = HelperFunctions.getTotalUsage(gcInfo.getMemoryUsageBeforeGc());
+    final long totalAfter = HelperFunctions.getTotalUsage(gcInfo.getMemoryUsageAfterGc());
+    final long max = HelperFunctions.getTotalMaxUsage(gcInfo.getMemoryUsageAfterGc());
 
-    String unit = "K";
-    double cnv = 1000.0;
-    if (max > 1000000000L) {
-      unit = "G";
-      cnv = 1e9;
-    } else if (max > 1000000L) {
-      unit = "M";
-      cnv = 1e6;
+    String unit = "KiB";
+    double cnv = ONE_KIBIBYTE;
+    if (max > ONE_GIBIBYTE) {
+      unit = "GiB";
+      cnv = ONE_GIBIBYTE;
+    } else if (max > ONE_MEBIBYTE) {
+      unit = "MiB";
+      cnv = ONE_MEBIBYTE;
     }
 
     String change = String.format(

--- a/spectator-ext-gc/src/test/java/com/netflix/spectator/gc/GcEventTest.java
+++ b/spectator-ext-gc/src/test/java/com/netflix/spectator/gc/GcEventTest.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.gc;
+
+import com.sun.management.GarbageCollectionNotificationInfo;
+import com.sun.management.GcInfo;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+
+@RunWith(JUnit4.class)
+public class GcEventTest {
+
+  @Test
+  public void toStringSizes() {
+    // Try to ensure that at least one GC event has occurred
+    System.gc();
+
+    // Loop through and get a GcInfo
+    for (GarbageCollectorMXBean mbean : ManagementFactory.getGarbageCollectorMXBeans()) {
+      GcInfo gcInfo = ((com.sun.management.GarbageCollectorMXBean) mbean).getLastGcInfo();
+      if (gcInfo != null) {
+        GarbageCollectionNotificationInfo info = new GarbageCollectionNotificationInfo(
+            mbean.getName(),
+            "Action",
+            "Allocation Failure",
+            gcInfo);
+        GcEvent event = new GcEvent(info, 0L);
+
+        final String eventStr = event.toString();
+        Assert.assertTrue(eventStr.contains("cause=[Allocation Failure]"));
+
+        // TODO: need to find a better way to create a fake GcInfo object for tests
+        final long max = HelperFunctions.getTotalMaxUsage(gcInfo.getMemoryUsageAfterGc());
+        if (max > (1L << 30)) {
+          Assert.assertTrue(eventStr.contains("GiB"));
+        } else if (max > (1L << 20)) {
+          Assert.assertTrue(eventStr.contains("MiB"));
+        } else {
+          Assert.assertTrue(eventStr.contains("KiB"));
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The arguments to java for setting the heap sizes using
a power of 1024. This change updates the logger to report
using a power of 1024 instead of power of 1000 to match
the jvm behavior. To try and minimize confusion labels
use KiB, MiB, and GiB to make it explicit in the output.