### PR TITLE
fix "Could not create ZIP" for shadowJar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,11 @@ buildscript {
   dependencies {
     classpath 'com.github.ben-manes:gradle-versions-plugin:0.12.0'
     classpath 'com.netflix.nebula:nebula-dependency-recommender:3.6.3'
+
+    // This is a workaround for getting the shadow plugin to work correctly
+    // for some sub-projects. For more details see:
+    // https://github.com/johnrengelman/shadow/issues/188
+    classpath 'org.apache.ant:ant:1.9.7'
   }
 }
 


### PR DESCRIPTION
If an older version of ant is in the root classpath, then
it can cause problems for using the shadow plugin in a
sub project. Specifically the build fails with:

```
FAILURE: Build failed with an exception.
* What went wrong:
Execution failed for task ':spectator-ext-spark:shadowJar'.
> Could not create ZIP '/home/travis/build/Netflix/spectator/spectator-ext-spark/build/libs/spectator-ext-spark-0.41.0-SNAPSHOT-shadow.jar'
* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.
BUILD FAILED
```

The specific failure is:

```
Caused by: groovy.lang.MissingMethodException: No signature of method: org.apache.tools.zip.ZipOutputStream.setUseZip64() is applicable for argument types: (org.apache.tools.zip.Zip64Mode) values: [Never]
        at com.github.jengelman.gradle.plugins.shadow.internal.DefaultZipCompressor.createArchiveOutputStream(DefaultZipCompressor.groovy:36)
        ... 83 more
```

The work around is to explicitly request a newer version
of ant in the root classpath for the build.