### PR TITLE
use compile scope for deps in public api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ allprojects {
 
 subprojects {
   apply plugin: 'nebula.netflixoss'
+  apply plugin: 'nebula.compile-api'
   apply plugin: 'java'
   apply plugin: 'build-dashboard'
   apply plugin: 'jacoco'

--- a/spectator-ext-aws/build.gradle
+++ b/spectator-ext-aws/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-  compile project(":spectator-api")
-  compile "com.amazonaws:aws-java-sdk-core"
+  compileApi project(":spectator-api")
+  compileApi "com.amazonaws:aws-java-sdk-core"
   testCompile "com.amazonaws:aws-java-sdk-cloudwatch"
 }

--- a/spectator-ext-gc/build.gradle
+++ b/spectator-ext-gc/build.gradle
@@ -1,3 +1,3 @@
 dependencies {
-  compile project(':spectator-api')
+  compileApi project(':spectator-api')
 }

--- a/spectator-ext-jvm/build.gradle
+++ b/spectator-ext-jvm/build.gradle
@@ -1,3 +1,3 @@
 dependencies {
-  compile project(':spectator-api')
+  compileApi project(':spectator-api')
 }

--- a/spectator-ext-log4j2/build.gradle
+++ b/spectator-ext-log4j2/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-  compile project(':spectator-api')
-  compile "org.apache.logging.log4j:log4j-api"
-  compile "org.apache.logging.log4j:log4j-core"
+  compileApi project(':spectator-api')
+  compileApi "org.apache.logging.log4j:log4j-api"
+  compileApi "org.apache.logging.log4j:log4j-core"
 }

--- a/spectator-ext-sandbox/build.gradle
+++ b/spectator-ext-sandbox/build.gradle
@@ -1,3 +1,3 @@
 dependencies {
-  compile project(':spectator-api')
+  compileApi project(':spectator-api')
 }

--- a/spectator-reg-metrics3/build.gradle
+++ b/spectator-reg-metrics3/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-  compile project(':spectator-api')
-  compile 'io.dropwizard.metrics:metrics-core:3.1.2'
+  compileApi project(':spectator-api')
+  compileApi 'io.dropwizard.metrics:metrics-core:3.1.2'
   jmh project(':spectator-api')
 }

--- a/spectator-reg-servo/build.gradle
+++ b/spectator-reg-servo/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-  compile project(':spectator-api')
-  compile 'com.netflix.servo:servo-core'
+  compileApi project(':spectator-api')
+  compileApi 'com.netflix.servo:servo-core'
   jmh project(':spectator-api')
 }


### PR DESCRIPTION
Gradle by default will publish these to the POM
using runtime scope. This changes dependencies
that are exposed via public APIs to get placed
in the compile scope of the POM.

Verified using:

```
$ ./gradlew spectator-reg-metrics3:generatePomFileForNebulaPublication
$ diff before spectator-reg-metrics3/build/publications/nebula/pom-default.xml
```

Diff:

```diff
18c18
<       <scope>runtime</scope>
---
>       <scope>compile</scope>
24c24
<       <scope>runtime</scope>
---
>       <scope>compile</scope>
50c50
<     <nebula_Build_Date>2016-09-01_05:33:46</nebula_Build_Date>
---
>     <nebula_Build_Date>2016-09-01_05:39:17</nebula_Build_Date>
```