### PR TITLE
initial version of Atlas registry

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,8 +111,8 @@ subprojects {
   tasks.withType(FindBugs) {
     findbugs.toolVersion "3.0.0"
     reports {
-      xml.enabled = true
-      html.enabled = false
+      xml.enabled = false
+      html.enabled = true
     }
   }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,6 +8,7 @@ include 'spectator-api',
         'spectator-ext-placeholders',
         'spectator-ext-sandbox',
         'spectator-ext-spark',
+        'spectator-reg-atlas',
         'spectator-reg-metrics3',
         'spectator-reg-servo',
         'spectator-web-spring'

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/StepDouble.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/StepDouble.java
@@ -28,7 +28,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * <p><b>This class is an internal implementation detail only intended for use within spectator.
  * It is subject to change without notice.</b></p>
  */
-public class StepDouble {
+public class StepDouble implements StepValue {
 
   private final double init;
   private final Clock clock;
@@ -71,6 +71,18 @@ public class StepDouble {
   public double poll() {
     rollCount(clock.wallTime());
     return previous.get();
+  }
+
+  /** Get the value for the last completed interval as a rate per second. */
+  @Override public double pollAsRate() {
+    final double amount = poll();
+    final double period = step / 1000.0;
+    return amount / period;
+  }
+
+  /** Get the timestamp for the end of the last completed interval. */
+  @Override public long timestamp() {
+    return lastInitPos.get() * step;
   }
 
   @Override public String toString() {

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/StepLong.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/StepLong.java
@@ -28,7 +28,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * <p><b>This class is an internal implementation detail only intended for use within spectator.
  * It is subject to change without notice.</b></p>
  */
-public class StepLong {
+public class StepLong implements StepValue {
 
   private final long init;
   private final Clock clock;
@@ -71,6 +71,18 @@ public class StepLong {
   public long poll() {
     rollCount(clock.wallTime());
     return previous.get();
+  }
+
+  /** Get the value for the last completed interval as a rate per second. */
+  @Override public double pollAsRate() {
+    final long amount = poll();
+    final double period = step / 1000.0;
+    return amount / period;
+  }
+
+  /** Get the timestamp for the end of the last completed interval. */
+  @Override public long timestamp() {
+    return lastInitPos.get() * step;
   }
 
   @Override public String toString() {

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/StepValue.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/StepValue.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.impl;
+
+/**
+ * Base for {@link StepLong} and {@link StepDouble}.
+ */
+public interface StepValue {
+
+  /** Get the value for the last completed interval as a rate per second. */
+  double pollAsRate();
+
+  /** Get the timestamp for the end of the last completed interval. */
+  long timestamp();
+}

--- a/spectator-reg-atlas/build.gradle
+++ b/spectator-reg-atlas/build.gradle
@@ -1,0 +1,7 @@
+dependencies {
+  compileApi project(':spectator-api')
+  compile project(':spectator-ext-sandbox')
+  compile 'com.fasterxml.jackson.core:jackson-databind'
+  compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-smile'
+  jmh project(':spectator-api')
+}

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasConfig.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasConfig.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import com.netflix.spectator.api.RegistryConfig;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Configuration for Atlas registry.
+ */
+public interface AtlasConfig extends RegistryConfig {
+
+  /**
+   * Returns the step size (reporting frequency) to use. The default is 1 minute.
+   */
+  default Duration step() {
+    String v = get("atlas.step");
+    return (v == null) ? Duration.ofMinutes(1) : Duration.parse(v);
+  }
+
+  /**
+   * Returns the number of threads to use with the scheduler. The default is
+   * 2 threads.
+   */
+  default int numThreads() {
+    String v = get("atlas.numThreads");
+    return (v == null) ? 2 : Integer.parseInt(v);
+  }
+
+  /**
+   * Returns the URI for the Atlas backend. The default is
+   * {@code http://localhost:7101/api/v1/publish}.
+   */
+  default String uri() {
+    String v = get("atlas.uri");
+    return (v == null) ? "http://localhost:7101/api/v1/publish" : v;
+  }
+
+  /**
+   * Returns the connection timeout for requests to the backend. The default is
+   * 1 second.
+   */
+  default Duration connectTimeout() {
+    String v = get("atlas.connectTimeout");
+    return (v == null) ? Duration.ofSeconds(1) : Duration.parse(v);
+  }
+
+  /**
+   * Returns the read timeout for requests to the backend. The default is
+   * 10 seconds.
+   */
+  default Duration readTimeout() {
+    String v = get("atlas.readTimeout");
+    return (v == null) ? Duration.ofSeconds(10) : Duration.parse(v);
+  }
+
+  /**
+   * Returns the number of measurements per request to use for the backend. If more
+   * measurements are found, then multiple requests will be made. The default is
+   * 10,000.
+   */
+  default int batchSize() {
+    String v = get("atlas.batchSize");
+    return (v == null) ? 10000 : Integer.parseInt(v);
+  }
+
+  /**
+   * Returns the common tags to apply to all metrics reported to Atlas.
+   * The default is an empty map.
+   */
+  default Map<String, String> commonTags() {
+    return Collections.emptyMap();
+  }
+}

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasCounter.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasCounter.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import com.netflix.spectator.api.Clock;
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.impl.StepLong;
+
+import java.util.Collections;
+
+/**
+ * Counter that reports a rate per second to Atlas. Note that {@link #count()} will
+ * report the number events in the last complete interval rather than the total for
+ * the life of the process.
+ */
+class AtlasCounter implements Counter {
+
+  private final Id id;
+  private final StepLong value;
+  private final Id stat;
+
+  /** Create a new instance. */
+  AtlasCounter(Id id, Clock clock, long step) {
+    this.id = id;
+    this.value = new StepLong(0L, clock, step);
+    this.stat = id.withTag(DsType.rate);
+  }
+
+  @Override public Id id() {
+    return id;
+  }
+
+  @Override public boolean hasExpired() {
+    return false;
+  }
+
+  @Override public Iterable<Measurement> measure() {
+    final double rate = value.pollAsRate();
+    final Measurement m = new Measurement(stat, value.timestamp(), rate);
+    return Collections.singletonList(m);
+  }
+
+  @Override public void increment() {
+    value.getCurrent().incrementAndGet();
+  }
+
+  @Override public void increment(long amount) {
+    value.getCurrent().addAndGet(amount);
+  }
+
+  @Override public long count() {
+    return value.poll();
+  }
+}

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasDistributionSummary.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasDistributionSummary.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import com.netflix.spectator.api.Clock;
+import com.netflix.spectator.api.DistributionSummary;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.Statistic;
+import com.netflix.spectator.impl.StepDouble;
+import com.netflix.spectator.impl.StepLong;
+import com.netflix.spectator.impl.StepValue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Distribution summary that reports four measurements to Atlas:
+ *
+ * <ul>
+ *   <li><b>count:</b> counter incremented each time record is called</li>
+ *   <li><b>totalTime:</b> counter incremented by the recorded amount</li>
+ *   <li><b>totalOfSquares:</b> counter incremented by the recorded amount<sup>2</sup></li>
+ *   <li><b>max:</b> maximum recorded amount</li>
+ * </ul>
+ *
+ * <p>Having an explicit {@code totalTime} and {@code count} on the backend
+ * can be used to calculate an accurate average for an arbitrary grouping. The
+ * {@code totalOfSquares} is used for computing a standard deviation.</p>
+ *
+ * <p>Note that the {@link #count()} and {@link #totalAmount()} will report
+ * the values since the last complete interval rather than the total for the
+ * life of the process.</p>
+ */
+class AtlasDistributionSummary implements DistributionSummary {
+
+  private final Id id;
+  private final StepLong count;
+  private final StepLong total;
+  private final StepDouble totalOfSquares;
+  private final StepLong max;
+
+  private final Id[] stats;
+
+  /** Create a new instance. */
+  AtlasDistributionSummary(Id id, Clock clock, long step) {
+    this.id = id;
+    this.count = new StepLong(0L, clock, step);
+    this.total = new StepLong(0L, clock, step);
+    this.totalOfSquares = new StepDouble(0.0, clock, step);
+    this.max = new StepLong(0L, clock, step);
+    this.stats = new Id[] {
+        id.withTags(DsType.rate,  Statistic.count),
+        id.withTags(DsType.rate,  Statistic.totalAmount),
+        id.withTags(DsType.rate,  Statistic.totalOfSquares),
+        id.withTags(DsType.gauge, Statistic.max)
+    };
+  }
+
+  @Override public Id id() {
+    return id;
+  }
+
+  @Override public boolean hasExpired() {
+    return false;
+  }
+
+  @Override public Iterable<Measurement> measure() {
+    List<Measurement> ms = new ArrayList<>(4);
+    ms.add(newMeasurement(stats[0], count));
+    ms.add(newMeasurement(stats[1], total));
+    ms.add(newMeasurement(stats[2], totalOfSquares));
+    ms.add(newMaxMeasurement(stats[3], max));
+    return ms;
+  }
+
+  private Measurement newMeasurement(Id mid, StepValue v) {
+    // poll needs to be called before accessing the timestamp to ensure
+    // the counters have been rotated if there was no activity in the
+    // current interval.
+    double rate = v.pollAsRate();
+    long timestamp = v.timestamp();
+    return new Measurement(mid, timestamp, rate);
+  }
+
+  private Measurement newMaxMeasurement(Id mid, StepLong v) {
+    // poll needs to be called before accessing the timestamp to ensure
+    // the counters have been rotated if there was no activity in the
+    // current interval.
+    double maxValue = v.poll();
+    long timestamp = v.timestamp();
+    return new Measurement(mid, timestamp, maxValue);
+  }
+
+  @Override public void record(long amount) {
+    if (amount > 0) {
+      count.getCurrent().incrementAndGet();
+      total.getCurrent().addAndGet(amount);
+      totalOfSquares.getCurrent().addAndGet((double) amount * amount);
+      updateMax(max.getCurrent(), amount);
+    }
+  }
+
+  private void updateMax(AtomicLong maxValue, long v) {
+    long p = maxValue.get();
+    while (v > p && !maxValue.compareAndSet(p, v)) {
+      p = maxValue.get();
+    }
+  }
+
+  @Override public long count() {
+    return count.poll();
+  }
+
+  @Override public long totalAmount() {
+    return total.poll();
+  }
+}

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.dataformat.smile.SmileFactory;
+import com.netflix.spectator.api.AbstractRegistry;
+import com.netflix.spectator.api.Clock;
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.DistributionSummary;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.Timer;
+import com.netflix.spectator.impl.Scheduler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+/**
+ * Registry for reporting metrics to Atlas.
+ */
+public final class AtlasRegistry extends AbstractRegistry {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(AtlasRegistry.class);
+
+  private final Clock clock;
+  private final Duration step;
+  private final long stepMillis;
+  private final URI uri;
+  private final int connectTimeout;
+  private final int readTimeout;
+  private final int batchSize;
+  private final int numThreads;
+  private final Map<String, String> commonTags;
+
+  private Scheduler scheduler;
+
+  private final ObjectMapper mapper;
+
+  /** Create a new instance. */
+  public AtlasRegistry(Clock clock, AtlasConfig config) {
+    super(new StepClock(clock, config.step().toMillis()), config);
+    this.clock = clock;
+    this.step = config.step();
+    this.stepMillis = step.toMillis();
+    this.uri = URI.create(config.uri());
+    this.connectTimeout = (int) config.connectTimeout().toMillis();
+    this.readTimeout = (int) config.readTimeout().toMillis();
+    this.batchSize = config.batchSize();
+    this.numThreads = config.numThreads();
+    this.commonTags = config.commonTags();
+
+    SimpleModule module = new SimpleModule()
+        .addSerializer(Measurement.class, new MeasurementSerializer());
+    this.mapper = new ObjectMapper(new SmileFactory()).registerModule(module);
+  }
+
+  /**
+   * Start the scheduler to collect metrics data.
+   */
+  public void start() {
+    if (scheduler == null) {
+      Scheduler.Options options = new Scheduler.Options()
+          .withFrequency(Scheduler.Policy.FIXED_RATE_SKIP_IF_LONG, step)
+          .withInitialDelay(Duration.ofMillis(getInitialDelay(stepMillis)))
+          .withStopOnFailure(false);
+
+      scheduler = new Scheduler(this, "atlas-registry", numThreads);
+      scheduler.schedule(options, this::collectData);
+      LOGGER.info("started collecting metrics every {}ms reporting to {}", step, uri);
+    } else {
+      LOGGER.warn("registry already started, ignoring duplicate request");
+    }
+  }
+
+  /**
+   * Avoid collecting right on boundaries to minimize transitions on step longs
+   * during a collection. Randomly distribute across the middle of the step interval.
+   */
+  long getInitialDelay(long stepSize) {
+    long now = clock.wallTime();
+    long stepBoundary = now / stepSize * stepSize;
+
+    // Buffer by 10% of the step interval on either side
+    long offset = stepSize / 10;
+
+    // Check if the current delay is within the acceptable range
+    long delay = now - stepBoundary;
+    if (delay < offset) {
+      return delay + offset;
+    } else if (delay > stepSize - offset) {
+      return stepSize - offset;
+    } else {
+      return delay;
+    }
+  }
+
+  /**
+   * Stop the scheduler reporting Atlas data.
+   */
+  public void stop() {
+    if (scheduler != null) {
+      scheduler.shutdown();
+      scheduler = null;
+      LOGGER.info("stopped collecting metrics every {}ms reporting to {}", step, uri);
+    } else {
+      LOGGER.warn("registry stopped, but was never started");
+    }
+  }
+
+  private void collectData() {
+    try {
+      for (List<Measurement> batch : getBatches()) {
+        PublishPayload p = new PublishPayload(commonTags, batch);
+        new HttpRequest(uri)
+            .withMethod("POST")
+            .withConnectTimeout(connectTimeout)
+            .withReadTimeout(readTimeout)
+            .withSmileContent(mapper.writeValueAsBytes(p))
+            .sendAndLog();
+      }
+    } catch (Exception e) {
+      LOGGER.warn("failed to send metrics", e);
+    }
+  }
+
+  /** Get a list of all measurements from the registry. */
+  List<Measurement> getMeasurements() {
+    return stream()
+        .flatMap(m -> StreamSupport.stream(m.measure().spliterator(), false))
+        .collect(Collectors.toList());
+  }
+
+  /** Get a list of all measurements and break them into batches. */
+  List<List<Measurement>> getBatches() {
+    List<List<Measurement>> batches = new ArrayList<>();
+    List<Measurement> ms = getMeasurements();
+    for (int i = 0; i < ms.size(); i += batchSize) {
+      List<Measurement> batch = ms.subList(i, Math.min(ms.size(), i + batchSize));
+      batches.add(batch);
+    }
+    return batches;
+  }
+
+  @Override protected Counter newCounter(Id id) {
+    return new AtlasCounter(id, clock, stepMillis);
+  }
+
+  @Override protected DistributionSummary newDistributionSummary(Id id) {
+    return new AtlasDistributionSummary(id, clock, stepMillis);
+  }
+
+  @Override protected Timer newTimer(Id id) {
+    return new AtlasTimer(id, clock, stepMillis);
+  }
+}

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasTimer.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasTimer.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import com.netflix.spectator.api.Clock;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.Statistic;
+import com.netflix.spectator.api.Timer;
+import com.netflix.spectator.impl.StepDouble;
+import com.netflix.spectator.impl.StepLong;
+import com.netflix.spectator.impl.StepValue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Timer that reports four measurements to Atlas:
+ *
+ * <ul>
+ *   <li><b>count:</b> counter incremented each time record is called</li>
+ *   <li><b>totalTime:</b> counter incremented by the recorded amount</li>
+ *   <li><b>totalOfSquares:</b> counter incremented by the recorded amount<sup>2</sup></li>
+ *   <li><b>max:</b> maximum recorded amount</li>
+ * </ul>
+ *
+ * <p>Having an explicit {@code totalTime} and {@code count} on the backend
+ * can be used to calculate an accurate average for an arbitrary grouping. The
+ * {@code totalOfSquares} is used for computing a standard deviation.</p>
+ *
+ * <p>Note that the {@link #count()} and {@link #totalTime()} will report
+ * the values since the last complete interval rather than the total for the
+ * life of the process.</p>
+ */
+class AtlasTimer implements Timer {
+
+  private final Id id;
+  private final Clock clock;
+  private final StepLong count;
+  private final StepLong total;
+  private final StepDouble totalOfSquares;
+  private final StepLong max;
+
+  private final Id[] stats;
+
+  /** Create a new instance. */
+  AtlasTimer(Id id, Clock clock, long step) {
+    this.id = id;
+    this.clock = clock;
+    this.count = new StepLong(0L, clock, step);
+    this.total = new StepLong(0L, clock, step);
+    this.totalOfSquares = new StepDouble(0.0, clock, step);
+    this.max = new StepLong(0L, clock, step);
+    this.stats = new Id[] {
+        id.withTags(DsType.rate,  Statistic.count),
+        id.withTags(DsType.rate,  Statistic.totalTime),
+        id.withTags(DsType.rate,  Statistic.totalOfSquares),
+        id.withTags(DsType.gauge, Statistic.max)
+    };
+  }
+
+  @Override public Id id() {
+    return id;
+  }
+
+  @Override public boolean hasExpired() {
+    return false;
+  }
+
+  @Override public Iterable<Measurement> measure() {
+    List<Measurement> ms = new ArrayList<>(4);
+    ms.add(newMeasurement(stats[0], count, 1.0));
+    ms.add(newMeasurement(stats[1], total, 1e-9));
+    ms.add(newMeasurement(stats[2], totalOfSquares, 1e-18));
+    ms.add(newMaxMeasurement(stats[3], max));
+    return ms;
+  }
+
+  private Measurement newMeasurement(Id mid, StepValue v, double f) {
+    // poll needs to be called before accessing the timestamp to ensure
+    // the counters have been rotated if there was no activity in the
+    // current interval.
+    double rate = v.pollAsRate() * f;
+    long timestamp = v.timestamp();
+    return new Measurement(mid, timestamp, rate);
+  }
+
+  private Measurement newMaxMeasurement(Id mid, StepLong v) {
+    // poll needs to be called before accessing the timestamp to ensure
+    // the counters have been rotated if there was no activity in the
+    // current interval.
+    double maxValue = v.poll() / 1e9;
+    long timestamp = v.timestamp();
+    return new Measurement(mid, timestamp, maxValue);
+  }
+
+  @Override public void record(long amount, TimeUnit unit) {
+    if (amount > 0) {
+      final long nanos = unit.toNanos(amount);
+      count.getCurrent().incrementAndGet();
+      total.getCurrent().addAndGet(nanos);
+      totalOfSquares.getCurrent().addAndGet((double) nanos * nanos);
+      updateMax(max.getCurrent(), nanos);
+    }
+  }
+
+  private void updateMax(AtomicLong maxValue, long v) {
+    long p = maxValue.get();
+    while (v > p && !maxValue.compareAndSet(p, v)) {
+      p = maxValue.get();
+    }
+  }
+
+  @Override public <T> T record(Callable<T> f) throws Exception {
+    final long start = clock.monotonicTime();
+    try {
+      return f.call();
+    } finally {
+      record(clock.monotonicTime() - start, TimeUnit.NANOSECONDS);
+    }
+  }
+
+  @Override public void record(Runnable f) {
+    final long start = clock.monotonicTime();
+    try {
+      f.run();
+    } finally {
+      record(clock.monotonicTime() - start, TimeUnit.NANOSECONDS);
+    }
+  }
+
+  @Override public long count() {
+    return count.poll();
+  }
+
+  @Override public long totalTime() {
+    return total.poll();
+  }
+}

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/DsType.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/DsType.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import com.netflix.spectator.api.Tag;
+
+/**
+ * Data source type for Atlas. See the
+ * <a href="https://github.com/Netflix/atlas/wiki/Concepts#normalization">normalization</a>
+ * docs for more information.
+ */
+public enum DsType implements Tag {
+  /** Sampled value that should be used as is without weighting. */
+  gauge,
+
+  /** Rate per second that should use weighted averaging during normalization. */
+  rate;
+
+  @Override public String key() {
+    return "atlas.dstype";
+  }
+
+  @Override public String value() {
+    return name();
+  }
+}

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/HttpRequest.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/HttpRequest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import com.netflix.spectator.sandbox.HttpLogEntry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Helper for sending an HTTP request using {@link HttpURLConnection}.
+ */
+class HttpRequest {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(HttpRequest.class);
+
+  private final URI uri;
+  private final HttpLogEntry entry;
+  private final HttpURLConnection con;
+  private byte[] entity;
+
+  /** Create a new instance for the specified URI. */
+  HttpRequest(URI uri) throws Exception {
+    this.uri = uri;
+    this.entry = new HttpLogEntry()
+        .withRequestUri(uri);
+    this.con = (HttpURLConnection) uri.toURL().openConnection();
+  }
+
+  /** Set the request method (GET, PUT, POST, DELETE). */
+  HttpRequest withMethod(String method) throws Exception {
+    entry.withMethod(method);
+    con.setRequestMethod(method);
+    return this;
+  }
+
+  /**
+   * Add a header to the request. Note the content type will be set automatically
+   * when providing the content payload and should not be set here.
+   */
+  HttpRequest addHeader(String name, String value) {
+    entry.withRequestHeader(name, value);
+    con.addRequestProperty(name, value);
+    return this;
+  }
+
+  /** Set the connection timeout for the request. */
+  HttpRequest withConnectTimeout(int timeout) {
+    con.setConnectTimeout(timeout);
+    return this;
+  }
+
+  /** Set the read timeout for the request. */
+  HttpRequest withReadTimeout(int timeout) {
+    con.setReadTimeout(timeout);
+    return this;
+  }
+
+  /** Set the request body as JSON. */
+  HttpRequest withJsonContent(String content) throws IOException {
+    addHeader("Content-Type", "application/json");
+    entity = content.getBytes(StandardCharsets.UTF_8);
+    return this;
+  }
+
+  /** Set the request body as Smile encoded. */
+  HttpRequest withSmileContent(byte[] content) throws IOException {
+    addHeader("Content-Type", "application/x-jackson-smile");
+    entity = content;
+    return this;
+  }
+
+  /** Send the request and log/update metrics for the results. */
+  void sendAndLog() throws IOException {
+    try {
+      con.setDoInput(true);
+      con.setDoOutput(true);
+      entry.withRequestContentLength(entity.length).mark("start");
+      try (OutputStream out = con.getOutputStream()) {
+        out.write(entity);
+      }
+
+      int status = con.getResponseCode();
+      entry.mark("complete").withStatusCode(status);
+      try (InputStream in = (status >= 400) ? con.getErrorStream() : con.getInputStream()) {
+        byte[] data = readAll(in);
+        entry.withResponseContentLength(data.length);
+        if (LOGGER.isDebugEnabled()) {
+          String payload = new String(data, StandardCharsets.UTF_8);
+          LOGGER.debug("uri {}, status code {}, payload: {}", uri, status, payload);
+        }
+      }
+    } catch (IOException e) {
+      entry.mark("complete").withException(e);
+      LOGGER.warn("request to {} failed", uri, e);
+    } finally {
+      HttpLogEntry.logClientRequest(entry);
+    }
+  }
+
+  @SuppressWarnings("PMD.AssignmentInOperand")
+  private byte[] readAll(InputStream in) throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    byte[] buffer = new byte[4096];
+    int length;
+    while ((length = in.read(buffer)) > 0) {
+      baos.write(buffer, 0, length);
+    }
+    return baos.toByteArray();
+  }
+}

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/MeasurementSerializer.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/MeasurementSerializer.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.Tag;
+
+import java.io.IOException;
+
+/**
+ * Jackson serializer for measurements. Values will be converted to a
+ * valid set as they are written out by replacing invalid characters with
+ * an '_'.
+ */
+class MeasurementSerializer extends JsonSerializer<Measurement> {
+  @Override
+  public void serialize(
+      Measurement value,
+      JsonGenerator gen,
+      SerializerProvider serializers) throws IOException, JsonProcessingException {
+    gen.writeStartObject();
+    gen.writeObjectFieldStart("tags");
+    gen.writeStringField("name", ValidCharacters.toValidCharset(value.id().name()));
+    boolean explicitDsType = false;
+    for (Tag t : value.id().tags()) {
+      if ("atlas.dstype".equals(t.key())) {
+        explicitDsType = true;
+      }
+      final String k = ValidCharacters.toValidCharset(t.key());
+      final String v = ValidCharacters.toValidCharset(t.value());
+      gen.writeStringField(k, v);
+    }
+
+    // If the dstype has not been explicitly set, then the value must be coming in
+    // as a gauge. Go ahead and explicitly mark it as such because the backend will
+    // default to a rate.
+    if (!explicitDsType) {
+      gen.writeStringField("atlas.dstype", "gauge");
+    }
+    gen.writeEndObject();
+    gen.writeNumberField("timestamp", value.timestamp());
+    gen.writeNumberField("value", value.value());
+    gen.writeEndObject();
+  }
+}

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/PublishPayload.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/PublishPayload.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import com.netflix.spectator.api.Measurement;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Wraps a list of measurements with a set of common tags. The common tags are
+ * typically used for things like the application and instance id.
+ */
+class PublishPayload {
+
+  private final Map<String, String> tags;
+  private final List<Measurement> metrics;
+
+  /** Create a new instance. */
+  PublishPayload(Map<String, String> tags, List<Measurement> metrics) {
+    this.tags = tags;
+    this.metrics = metrics;
+  }
+
+  /** Return the common tags. Needs to be public for Jackson bean mapper. */
+  public Map<String, String> getTags() {
+    return tags;
+  }
+
+  /** Return the list of measurements. Needs to be public for Jackson bean mapper. */
+  public List<Measurement> getMetrics() {
+    return metrics;
+  }
+}

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/StepClock.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/StepClock.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import com.netflix.spectator.api.Clock;
+
+/**
+ * Wraps a clock implementation with one that only reports wall times on
+ * exact boundaries of the step. This is used so that measurements sampled
+ * from gauges will all have the same timestamp for a given reporting
+ * interval.
+ */
+class StepClock implements Clock {
+
+  private final Clock impl;
+  private final long step;
+
+  /** Create a new instance. */
+  StepClock(Clock impl, long step) {
+    this.impl = impl;
+    this.step = step;
+  }
+
+  @Override
+  public long wallTime() {
+    return impl.wallTime() / step * step;
+  }
+
+  @Override
+  public long monotonicTime() {
+    return impl.monotonicTime();
+  }
+}

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/ValidCharacters.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/ValidCharacters.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+/**
+ * Utility class to deal with rewriting keys/values to the character set accepted by atlas.
+ */
+public final class ValidCharacters {
+  /** Only allow letters, numbers, underscores, dashes and dots. */
+  private static final boolean[] CHARS_ALLOWED = new boolean[128];
+
+  static {
+    CHARS_ALLOWED['.'] = true;
+    CHARS_ALLOWED['-'] = true;
+    CHARS_ALLOWED['_'] = true;
+    for (char ch = '0'; ch <= '9'; ch++) {
+      CHARS_ALLOWED[ch] = true;
+    }
+    for (char ch = 'A'; ch <= 'Z'; ch++) {
+      CHARS_ALLOWED[ch] = true;
+    }
+    for (char ch = 'a'; ch <= 'z'; ch++) {
+      CHARS_ALLOWED[ch] = true;
+    }
+  }
+
+  private ValidCharacters() {
+  }
+
+  /** Convert a given string to one where all characters are valid. */
+  public static String toValidCharset(String str) {
+    final int n = str.length();
+    final StringBuilder buf = new StringBuilder(n + 1);
+    for (int i = 0; i < n; i++) {
+      final char c = str.charAt(i);
+      if (c < CHARS_ALLOWED.length && CHARS_ALLOWED[c]) {
+        buf.append(c);
+      } else {
+        buf.append('_');
+      }
+    }
+    return buf.toString();
+  }
+}

--- a/spectator-reg-atlas/src/main/resources/META-INF/services/com.netflix.spectator.api.Registry
+++ b/spectator-reg-atlas/src/main/resources/META-INF/services/com.netflix.spectator.api.Registry
@@ -1,0 +1,1 @@
+com.netflix.spectator.atlas.AtlasRegistry

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasCounterTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasCounterTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.ManualClock;
+import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.Registry;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+
+@RunWith(JUnit4.class)
+public class AtlasCounterTest {
+
+  private ManualClock clock = new ManualClock();
+  private Registry registry = new DefaultRegistry();
+  private long step = 10000L;
+  private AtlasCounter counter = new AtlasCounter(registry.createId("test"), clock, step);
+
+  private void checkValue(long expected) {
+    int count = 0;
+    for (Measurement m : counter.measure()) {
+      Assert.assertEquals(counter.id().withTag(DsType.rate), m.id());
+      Assert.assertEquals(expected / 10.0, m.value(), 1e-12);
+      Assert.assertEquals(expected, counter.count());
+      ++count;
+    }
+    Assert.assertEquals(1, count);
+  }
+
+  @Test
+  public void measuredIdHasDsType() {
+    checkValue(0);
+  }
+
+  @Test
+  public void increment() {
+    counter.increment();
+    checkValue(0);
+
+    clock.setWallTime(step + 1);
+    checkValue(1);
+  }
+
+  @Test
+  public void incrementAmount() {
+    counter.increment(42);
+    checkValue(0);
+
+    clock.setWallTime(step + 1);
+    checkValue(42);
+  }
+
+  @Test
+  public void rollForward() {
+    counter.increment(42);
+    clock.setWallTime(step + 1);
+    checkValue(42);
+    clock.setWallTime(step + step + 1);
+    checkValue(0);
+  }
+}

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasDistributionSummaryTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasDistributionSummaryTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.ManualClock;
+import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Utils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+
+@RunWith(JUnit4.class)
+public class AtlasDistributionSummaryTest {
+
+  private ManualClock clock = new ManualClock();
+  private Registry registry = new DefaultRegistry();
+  private long step = 10000L;
+  private AtlasDistributionSummary dist = new AtlasDistributionSummary(registry.createId("test"), clock, step);
+
+  private void checkValue(long count, long amount, long square, long max) {
+    int num = 0;
+    for (Measurement m : dist.measure()) {
+      String stat = Utils.getTagValue(m.id(), "statistic");
+      DsType ds = "max".equals(stat) ? DsType.gauge : DsType.rate;
+      Id expectedId = dist.id().withTag(ds).withTag("statistic", stat);
+      Assert.assertEquals(expectedId, m.id());
+      switch (stat) {
+        case "count":
+          Assert.assertEquals(count / 10.0, m.value(), 1e-12);
+          break;
+        case "totalAmount":
+          Assert.assertEquals(amount / 10.0, m.value(), 1e-12);
+          break;
+        case "totalOfSquares":
+          Assert.assertEquals(square / 10.0, m.value(), 1e-12);
+          break;
+        case "max":
+          Assert.assertEquals(max, m.value(), 1e-12);
+          break;
+        default:
+          throw new IllegalArgumentException("unknown stat: " + stat);
+      }
+      Assert.assertEquals(count, dist.count());
+      Assert.assertEquals(amount, dist.totalAmount());
+      ++num;
+    }
+    Assert.assertEquals(4, num);
+  }
+
+  @Test
+  public void measuredIdHasDsType() {
+    checkValue(0, 0, 0, 0);
+  }
+
+  @Test
+  public void recordOne() {
+    dist.record(1);
+    checkValue(0, 0, 0, 0);
+
+    clock.setWallTime(step + 1);
+    checkValue(1, 1, 1, 1);
+  }
+
+  @Test
+  public void recordTwo() {
+    dist.record(2);
+    checkValue(0, 0, 0, 0);
+
+    clock.setWallTime(step + 1);
+    checkValue(1, 2, 4, 2);
+  }
+
+  @Test
+  public void recordZero() {
+    dist.record(0);
+    clock.setWallTime(step + 1);
+    checkValue(0, 0, 0, 0);
+  }
+
+  @Test
+  public void recordNegativeValue() {
+    dist.record(-2);
+    clock.setWallTime(step + 1);
+    checkValue(0, 0, 0, 0);
+  }
+
+  @Test
+  public void recordSeveralValues() {
+    dist.record(1);
+    dist.record(2);
+    dist.record(3);
+    dist.record(1);
+    clock.setWallTime(step + 1);
+    checkValue(4, 1 + 2 + 3 + 1, 1 + 4 + 9 + 1, 3);
+  }
+
+  @Test
+  public void rollForward() {
+    dist.record(42);
+    clock.setWallTime(step + 1);
+    checkValue(1, 42, 42 * 42, 42);
+    clock.setWallTime(step + step + 1);
+    checkValue(0, 0, 0, 0);
+  }
+}

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasRegistryTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasRegistryTest.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import com.netflix.spectator.api.ManualClock;
+import com.netflix.spectator.api.Measurement;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+
+@RunWith(JUnit4.class)
+public class AtlasRegistryTest {
+
+  private ManualClock clock = new ManualClock();
+  private AtlasRegistry registry = new AtlasRegistry(clock, newConfig());
+
+  private AtlasConfig newConfig() {
+    ConcurrentHashMap<String, String> props = new ConcurrentHashMap<>();
+    props.put("atlas.step", "PT10S");
+    props.put("atlas.batchSize", "3");
+    return props::get;
+  }
+
+  @Test
+  public void measurementsEmpty() {
+    Assert.assertEquals(0, registry.getMeasurements().size());
+  }
+
+  @Test
+  public void measurementsWithCounter() {
+    registry.counter("test").increment();
+    Assert.assertEquals(1, registry.getMeasurements().size());
+  }
+
+  @Test
+  public void measurementsWithTimer() {
+    registry.timer("test").record(42, TimeUnit.NANOSECONDS);
+    Assert.assertEquals(4, registry.getMeasurements().size());
+  }
+
+  @Test
+  public void measurementsWithDistributionSummary() {
+    registry.distributionSummary("test").record(42);
+    Assert.assertEquals(4, registry.getMeasurements().size());
+  }
+
+  @Test
+  public void measurementsWithGauge() {
+    AtomicLong v = registry.gauge("test", new AtomicLong(0L));
+    Assert.assertEquals(1, registry.getMeasurements().size());
+  }
+
+  @Test
+  public void batchesEmpty() {
+    Assert.assertEquals(0, registry.getBatches().size());
+  }
+
+  @Test
+  public void batchesExact() {
+    for (int i = 0; i < 9; ++i) {
+      registry.counter("" + i).increment();
+    }
+    Assert.assertEquals(3, registry.getBatches().size());
+    for (List<Measurement> batch : registry.getBatches()) {
+      Assert.assertEquals(3, batch.size());
+    }
+  }
+
+  @Test
+  public void batchesLastPartial() {
+    for (int i = 0; i < 7; ++i) {
+      registry.counter("" + i).increment();
+    }
+    List<List<Measurement>> batches = registry.getBatches();
+    Assert.assertEquals(3, batches.size());
+    for (int i = 0; i < batches.size(); ++i) {
+      Assert.assertEquals((i < 2) ? 3 : 1, batches.get(i).size());
+    }
+  }
+
+  @Test
+  public void initialDelayTooCloseToStart() {
+    long d = registry.getInitialDelay(10000);
+    Assert.assertEquals(1000, d);
+  }
+
+  @Test
+  public void initialDelayTooCloseToEnd() {
+    clock.setWallTime(19123);
+    long d = registry.getInitialDelay(10000);
+    Assert.assertEquals(9000, d);
+  }
+
+  @Test
+  public void initialDelayOk() {
+    clock.setWallTime(12123);
+    long d = registry.getInitialDelay(10000);
+    Assert.assertEquals(2123, d);
+  }
+}

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasTimerTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasTimerTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.ManualClock;
+import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Utils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.concurrent.TimeUnit;
+
+
+@RunWith(JUnit4.class)
+public class AtlasTimerTest {
+
+  private ManualClock clock = new ManualClock();
+  private Registry registry = new DefaultRegistry();
+  private long step = 10000L;
+  private AtlasTimer dist = new AtlasTimer(registry.createId("test"), clock, step);
+
+  private void checkValue(long count, long amount, double square, long max) {
+    int num = 0;
+    for (Measurement m : dist.measure()) {
+      String stat = Utils.getTagValue(m.id(), "statistic");
+      DsType ds = "max".equals(stat) ? DsType.gauge : DsType.rate;
+      Id expectedId = dist.id().withTag(ds).withTag("statistic", stat);
+      Assert.assertEquals(expectedId, m.id());
+      switch (stat) {
+        case "count":
+          Assert.assertEquals(count / 10.0, m.value(), 1e-12);
+          break;
+        case "totalTime":
+          Assert.assertEquals(amount / 10.0e9, m.value(), 1e-12);
+          break;
+        case "totalOfSquares":
+          Assert.assertEquals(square / 10.0e18, m.value(), 1e-12);
+          break;
+        case "max":
+          Assert.assertEquals(max / 1e9, m.value(), 1e-12);
+          break;
+        default:
+          throw new IllegalArgumentException("unknown stat: " + stat);
+      }
+      Assert.assertEquals(count, dist.count());
+      Assert.assertEquals(amount, dist.totalTime());
+      ++num;
+    }
+    Assert.assertEquals(4, num);
+  }
+
+  @Test
+  public void measuredIdHasDsType() {
+    checkValue(0, 0, 0, 0);
+  }
+
+  @Test
+  public void recordOne() {
+    dist.record(1, TimeUnit.NANOSECONDS);
+    checkValue(0, 0, 0, 0);
+
+    clock.setWallTime(step + 1);
+    checkValue(1, 1, 1, 1);
+  }
+
+  @Test
+  public void recordTwo() {
+    dist.record(2, TimeUnit.NANOSECONDS);
+    checkValue(0, 0, 0, 0);
+
+    clock.setWallTime(step + 1);
+    checkValue(1, 2, 4, 2);
+  }
+
+  @Test
+  public void recordMillis() {
+    dist.record(2, TimeUnit.MILLISECONDS);
+    clock.setWallTime(step + 1);
+    checkValue(1, 2000000L, 4000000000000L, 2000000L);
+  }
+
+  @Test
+  public void recordSquaresOverflow() {
+    long v = (long) (Math.sqrt(Long.MAX_VALUE) / 1e9) + 1;
+    dist.record(v, TimeUnit.SECONDS);
+    clock.setWallTime(step + 1);
+    double square = 1e18 * v * v;
+    checkValue(1, v * 1000000000L, square, v * 1000000000L);
+  }
+
+  @Test
+  public void recordZero() {
+    dist.record(0, TimeUnit.NANOSECONDS);
+    clock.setWallTime(step + 1);
+    checkValue(0, 0, 0, 0);
+  }
+
+  @Test
+  public void recordNegativeValue() {
+    dist.record(-2, TimeUnit.NANOSECONDS);
+    clock.setWallTime(step + 1);
+    checkValue(0, 0, 0, 0);
+  }
+
+  @Test
+  public void recordSeveralValues() {
+    dist.record(1, TimeUnit.NANOSECONDS);
+    dist.record(2, TimeUnit.NANOSECONDS);
+    dist.record(3, TimeUnit.NANOSECONDS);
+    dist.record(1, TimeUnit.NANOSECONDS);
+    clock.setWallTime(step + 1);
+    checkValue(4, 1 + 2 + 3 + 1, 1 + 4 + 9 + 1, 3);
+  }
+
+  @Test
+  public void recordRunnable() {
+    dist.record(() -> clock.setMonotonicTime(clock.monotonicTime() + 2));
+    clock.setWallTime(step + 1);
+    checkValue(1, 2, 4, 2);
+  }
+
+  @Test
+  public void recordCallable() throws Exception {
+    String s = dist.record(() -> {
+      clock.setMonotonicTime(clock.monotonicTime() + 2);
+      return "foo";
+    });
+    Assert.assertEquals("foo", s);
+    clock.setWallTime(step + 1);
+    checkValue(1, 2, 4, 2);
+  }
+
+  @Test
+  public void rollForward() {
+    dist.record(42, TimeUnit.NANOSECONDS);
+    clock.setWallTime(step + 1);
+    checkValue(1, 42, 42 * 42, 42);
+    clock.setWallTime(step + step + 1);
+    checkValue(0, 0, 0, 0);
+  }
+}

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/MeasurementSerializerTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/MeasurementSerializerTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.ManualClock;
+import com.netflix.spectator.api.Measurement;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.Collections;
+
+
+@RunWith(JUnit4.class)
+public class MeasurementSerializerTest {
+
+  private DefaultRegistry registry = new DefaultRegistry();
+  private SimpleModule module = new SimpleModule()
+      .addSerializer(Measurement.class, new MeasurementSerializer());
+  private ObjectMapper mapper = new ObjectMapper().registerModule(module);
+
+  @Test
+  public void encode() throws Exception {
+    Id id = registry.createId("foo", "bar", "baz");
+    Measurement m = new Measurement(id, 42L, 3.0);
+    String json = mapper.writeValueAsString(m);
+    String tags = "{\"name\":\"foo\",\"bar\":\"baz\",\"atlas.dstype\":\"gauge\"}";
+    String expected = "{\"tags\":" + tags + ",\"timestamp\":42,\"value\":3.0}";
+    Assert.assertEquals(expected, json);
+  }
+
+  @Test
+  public void explicitDsType() throws Exception {
+    Id id = registry.createId("foo", "atlas.dstype", "rate");
+    Measurement m = new Measurement(id, 42L, 3.0);
+    String json = mapper.writeValueAsString(m);
+    String tags = "{\"name\":\"foo\",\"atlas.dstype\":\"rate\"}";
+    String expected = "{\"tags\":" + tags + ",\"timestamp\":42,\"value\":3.0}";
+    Assert.assertEquals(expected, json);
+  }
+
+  @Test
+  public void invalidName() throws Exception {
+    Id id = registry.createId("f@%", "bar", "baz");
+    Measurement m = new Measurement(id, 42L, 3.0);
+    String json = mapper.writeValueAsString(m);
+    String tags = "{\"name\":\"f__\",\"bar\":\"baz\",\"atlas.dstype\":\"gauge\"}";
+    String expected = "{\"tags\":" + tags + ",\"timestamp\":42,\"value\":3.0}";
+    Assert.assertEquals(expected, json);
+  }
+
+  @Test
+  public void invalidKey() throws Exception {
+    Id id = registry.createId("foo", "b$$", "baz");
+    Measurement m = new Measurement(id, 42L, 3.0);
+    String json = mapper.writeValueAsString(m);
+    String tags = "{\"name\":\"foo\",\"b__\":\"baz\",\"atlas.dstype\":\"gauge\"}";
+    String expected = "{\"tags\":" + tags + ",\"timestamp\":42,\"value\":3.0}";
+    Assert.assertEquals(expected, json);
+  }
+
+  @Test
+  public void invalidValue() throws Exception {
+    Id id = registry.createId("foo", "bar", "b&*");
+    Measurement m = new Measurement(id, 42L, 3.0);
+    String json = mapper.writeValueAsString(m);
+    String tags = "{\"name\":\"foo\",\"bar\":\"b__\",\"atlas.dstype\":\"gauge\"}";
+    String expected = "{\"tags\":" + tags + ",\"timestamp\":42,\"value\":3.0}";
+    Assert.assertEquals(expected, json);
+  }
+
+  @Test
+  public void publishPayloadEmpty() throws Exception {
+    PublishPayload p = new PublishPayload(Collections.emptyMap(), Collections.emptyList());
+    String json = mapper.writeValueAsString(p);
+    String expected = "{\"tags\":{},\"metrics\":[]}";
+    Assert.assertEquals(expected, json);
+  }
+
+  @Test
+  public void publishPayloadNoCommonTags() throws Exception {
+    Id id = registry.createId("foo");
+    Measurement m = new Measurement(id, 42L, 3.0);
+    PublishPayload p = new PublishPayload(Collections.emptyMap(), Collections.singletonList(m));
+    String json = mapper.writeValueAsString(p);
+    String tags = "{\"name\":\"foo\",\"atlas.dstype\":\"gauge\"}";
+    String mjson = "{\"tags\":" + tags + ",\"timestamp\":42,\"value\":3.0}";
+    String expected = "{\"tags\":{},\"metrics\":[" + mjson + "]}";
+    Assert.assertEquals(expected, json);
+  }
+
+  @Test
+  public void publishPayloadWithCommonTags() throws Exception {
+    Id id = registry.createId("foo");
+    Measurement m = new Measurement(id, 42L, 3.0);
+    PublishPayload p = new PublishPayload(Collections.singletonMap("a", "b"), Collections.singletonList(m));
+    String json = mapper.writeValueAsString(p);
+    String tags = "{\"name\":\"foo\",\"atlas.dstype\":\"gauge\"}";
+    String mjson = "{\"tags\":" + tags + ",\"timestamp\":42,\"value\":3.0}";
+    String expected = "{\"tags\":{\"a\":\"b\"},\"metrics\":[" + mjson + "]}";
+    Assert.assertEquals(expected, json);
+  }
+}

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/StepClockTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/StepClockTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import com.netflix.spectator.api.ManualClock;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+
+@RunWith(JUnit4.class)
+public class StepClockTest {
+
+  @Test
+  public void wallTime() {
+    ManualClock mc = new ManualClock();
+    StepClock sc = new StepClock(mc, 10000);
+
+    mc.setWallTime(5000);
+    Assert.assertEquals(0L, sc.wallTime());
+
+    mc.setWallTime(10000);
+    Assert.assertEquals(10000L, sc.wallTime());
+
+    mc.setWallTime(20212);
+    Assert.assertEquals(20000L, sc.wallTime());
+  }
+
+  @Test
+  public void monotonicTime() {
+    ManualClock mc = new ManualClock();
+    StepClock sc = new StepClock(mc, 10000);
+
+    mc.setMonotonicTime(5000);
+    Assert.assertEquals(5000L, sc.monotonicTime());
+
+    mc.setMonotonicTime(10000);
+    Assert.assertEquals(10000L, sc.monotonicTime());
+
+    mc.setMonotonicTime(20212);
+    Assert.assertEquals(20212L, sc.monotonicTime());
+  }
+}

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/ValidCharactersTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/ValidCharactersTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+
+@RunWith(JUnit4.class)
+public class ValidCharactersTest {
+
+  @Test(expected = NullPointerException.class)
+  public void nullValue() throws Exception {
+    String input = null;
+    ValidCharacters.toValidCharset(input);
+  }
+
+  @Test
+  public void empty() throws Exception {
+    String input = "";
+    String actual = ValidCharacters.toValidCharset(input);
+    Assert.assertEquals("", actual);
+  }
+
+  @Test
+  public void allValid() throws Exception {
+    String input = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-";
+    String actual = ValidCharacters.toValidCharset(input);
+    Assert.assertEquals(input, actual);
+  }
+
+  @Test
+  public void invalidConvertsToUnderscore() throws Exception {
+    String input = "a,b%c^d&e|f{g}h:i;";
+    String actual = ValidCharacters.toValidCharset(input);
+    Assert.assertEquals("a_b_c_d_e_f_g_h_i_", actual);
+  }
+}


### PR DESCRIPTION
An initial version of a registry that talks to Atlas
directly rather doing it via Servo. This allows apps
that do not need all of the legacy compatibility working
to shed many dependencies and simplify the usage.

This is still considered experimental for now and may
have changes to configuration and other settings.