### PR TITLE
add agent that can be hooked to jvm

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,5 @@
 include 'spectator-api',
+        'spectator-agent',
         'spectator-nflx',
         'spectator-nflx-plugin',
         'spectator-ext-aws',

--- a/spectator-agent/build.gradle
+++ b/spectator-agent/build.gradle
@@ -1,0 +1,36 @@
+plugins {
+  id 'com.github.johnrengelman.shadow' version '1.2.3'
+}
+
+dependencies {
+  compile project(':spectator-api')
+  compile project(':spectator-ext-gc')
+  compile project(':spectator-ext-jvm')
+  compile project(':spectator-reg-atlas')
+  compile 'com.typesafe:config'
+  compile 'org.slf4j:slf4j-simple'
+}
+
+jar {
+  manifest {
+    attributes 'Premain-Class': 'spectator-agent.spectator.agent.Agent'
+  }
+}
+
+shadowJar {
+  classifier = 'shadow'
+  configurations = [project.configurations.runtime]
+  relocate('com.netflix.spectator',    'spectator-agent.spectator')
+  relocate('com.fasterxml',            'spectator-agent.json')
+  relocate('com.typesafe.config',      'spectator-agent.config')
+  relocate('org.slf4j',                'spectator-agent.slf4j')
+}
+
+publishing {
+  publications {
+    nebula(MavenPublication) {
+      artifact shadowJar
+    }
+  }
+}
+

--- a/spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java
+++ b/spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.agent;
+
+import com.netflix.spectator.api.Clock;
+import com.netflix.spectator.api.Spectator;
+import com.netflix.spectator.atlas.AtlasConfig;
+import com.netflix.spectator.atlas.AtlasRegistry;
+import com.netflix.spectator.gc.GcLogger;
+import com.netflix.spectator.jvm.Jmx;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+import java.lang.instrument.Instrumentation;
+
+/**
+ * Agent that can be added to JVM to get basic stats about GC, memory, and optionally
+ * JMX.
+ */
+public final class Agent {
+
+  private Agent() {
+  }
+
+  private static Config loadConfig(String userResource) {
+    Config config = ConfigFactory.load("agent");
+    if (userResource != null && !"".equals(userResource)) {
+      Config user = ConfigFactory.load(userResource);
+      config = user.withFallback(config);
+    }
+    return config.getConfig("netflix.spectator.agent");
+  }
+
+  /** Entry point for the agent. */
+  public static void premain(String arg, Instrumentation instrumentation) {
+    // Setup logging
+    Config config = loadConfig(arg);
+
+    // Setup Registry
+    AtlasConfig atlasConfig = k -> config.hasPath(k) ? config.getString(k) : null;
+    AtlasRegistry registry = new AtlasRegistry(Clock.SYSTEM, atlasConfig);
+
+    // Add to global registry for http stats and GC logger
+    Spectator.globalRegistry().add(registry);
+
+    // Enable GC logger
+    GcLogger gcLogger = new GcLogger();
+    if (config.getBoolean("collection.gc")) {
+      gcLogger.start(null);
+    }
+
+    // Enable JVM data collection
+    if (config.getBoolean("collection.jvm")) {
+      Jmx.registerStandardMXBeans(registry);
+    }
+
+    // Start collection for the registry
+    registry.start();
+
+    // Shutdown registry
+    Runtime.getRuntime().addShutdownHook(new Thread(registry::stop, "spectator-agent-shutdown"));
+  }
+}

--- a/spectator-agent/src/main/resources/agent.conf
+++ b/spectator-agent/src/main/resources/agent.conf
@@ -1,0 +1,13 @@
+
+netflix.spectator.agent {
+
+  collection {
+    jvm = true
+    gc = true
+  }
+
+  atlas {
+    step = PT1M
+    uri = "http://localhost:7101/api/v1/publish"
+  }
+}

--- a/spectator-agent/src/main/resources/simplelogger.properties
+++ b/spectator-agent/src/main/resources/simplelogger.properties
@@ -1,0 +1,5 @@
+
+spectator-agent.slf4j.simpleLogger.logFile=System.out
+spectator-agent.slf4j.simpleLogger.defaultLogLevel=warn
+spectator-agent.slf4j.simpleLogger.showDateTime=true
+spectator-agent.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd'T'HH:mm:ss


### PR DESCRIPTION
Adds a simple agent that can be used to start collecting
basic metrics about the JVM and GC behavior without changing
the code.

Usage:

```
java -javaagent:spectator-agent-shadow.jar=custom-config Main
```

The `custom-config` is optional and can be used to change
settings. See the `agent.conf` for available settings.