### PR TITLE
support config to query JMX data

### DIFF
--- a/spectator-agent/build.gradle
+++ b/spectator-agent/build.gradle
@@ -9,7 +9,6 @@ dependencies {
   compile project(':spectator-reg-atlas')
   compile 'com.typesafe:config'
   compile 'org.slf4j:slf4j-simple'
-  testCompile 'org.apache.cassandra:cassandra-all:2.1.15'
 }
 
 jar {

--- a/spectator-agent/build.gradle
+++ b/spectator-agent/build.gradle
@@ -9,6 +9,7 @@ dependencies {
   compile project(':spectator-reg-atlas')
   compile 'com.typesafe:config'
   compile 'org.slf4j:slf4j-simple'
+  testCompile 'org.apache.cassandra:cassandra-all:2.1.15'
 }
 
 jar {

--- a/spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java
+++ b/spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java
@@ -45,7 +45,7 @@ public final class Agent {
   }
 
   /** Entry point for the agent. */
-  public static void premain(String arg, Instrumentation instrumentation) {
+  public static void premain(String arg, Instrumentation instrumentation) throws Exception {
     // Setup logging
     Config config = loadConfig(arg);
 
@@ -65,6 +65,13 @@ public final class Agent {
     // Enable JVM data collection
     if (config.getBoolean("collection.jvm")) {
       Jmx.registerStandardMXBeans(registry);
+    }
+
+    // Enable JMX query collection
+    if (config.getBoolean("collection.jmx")) {
+      for (Config cfg : config.getConfigList("jmx.mappings")) {
+        registry.register(new JmxMeter(registry, JmxConfig.from(cfg)));
+      }
     }
 
     // Start collection for the registry

--- a/spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java
+++ b/spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java
@@ -35,11 +35,13 @@ public final class Agent {
   private Agent() {
   }
 
-  private static Config loadConfig(String userResource) {
+  private static Config loadConfig(String userResources) {
     Config config = ConfigFactory.load("agent");
-    if (userResource != null && !"".equals(userResource)) {
-      Config user = ConfigFactory.load(userResource);
-      config = user.withFallback(config);
+    if (userResources != null && !"".equals(userResources)) {
+      for (String userResource : userResources.split("[,\\s]+]")) {
+        Config user = ConfigFactory.load(userResource);
+        config = user.withFallback(config);
+      }
     }
     return config.getConfig("netflix.spectator.agent");
   }

--- a/spectator-agent/src/main/java/com/netflix/spectator/agent/JmxConfig.java
+++ b/spectator-agent/src/main/java/com/netflix/spectator/agent/JmxConfig.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.agent;
+
+import com.typesafe.config.Config;
+
+import javax.management.ObjectName;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Config for fetching data from JMX. A configuration consists of:
+ *
+ * <ul>
+ *   <li><b>query:</b> object name query expression, see {@link ObjectName}.</li>
+ *   <li><b>measurements:</b> list of {@link JmxMeasurementConfig} objects.</li>
+ * </ul>
+ */
+final class JmxConfig {
+
+  /** Create a new instance from the Typesafe Config object. */
+  static JmxConfig from(Config config) {
+    try {
+      ObjectName query = new ObjectName(config.getString("query"));
+      List<JmxMeasurementConfig> ms = new ArrayList<>();
+      for (Config cfg : config.getConfigList("measurements")) {
+        ms.add(JmxMeasurementConfig.from(cfg));
+      }
+      return new JmxConfig(query, ms);
+    } catch (Exception e) {
+      throw new IllegalArgumentException("invalid mapping config", e);
+    }
+  }
+
+  private final ObjectName query;
+  private final List<JmxMeasurementConfig> measurements;
+
+  /** Create a new instance. */
+  JmxConfig(ObjectName query, List<JmxMeasurementConfig> measurements) {
+    this.query = query;
+    this.measurements = measurements;
+  }
+
+  /** Object name query expression. */
+  ObjectName getQuery() {
+    return query;
+  }
+
+  /** Measurements to extract for the query. */
+  List<JmxMeasurementConfig> getMeasurements() {
+    return measurements;
+  }
+}

--- a/spectator-agent/src/main/java/com/netflix/spectator/agent/JmxData.java
+++ b/spectator-agent/src/main/java/com/netflix/spectator/agent/JmxData.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.agent;
+
+import javax.management.Attribute;
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanInfo;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Represents the results from querying data out of JMX.
+ */
+class JmxData {
+
+  /** Get data from JMX using object name query expression. */
+  static List<JmxData> query(String query) throws Exception {
+    return query(new ObjectName(query));
+  }
+
+  /** Get data from JMX using object name query expression. */
+  static List<JmxData> query(ObjectName query) throws Exception {
+    return query(ManagementFactory.getPlatformMBeanServer(), query);
+  }
+
+  /** Get data from JMX using object name query expression. */
+  static List<JmxData> query(MBeanServer server, ObjectName query) throws Exception {
+    List<JmxData> data = new ArrayList<>();
+
+    Set<ObjectName> names = server.queryNames(query, null);
+    for (ObjectName name : names) {
+      MBeanInfo info = server.getMBeanInfo(name);
+      MBeanAttributeInfo[] attrs = info.getAttributes();
+      String[] attrNames = new String[attrs.length];
+      for (int i = 0; i < attrs.length; ++i) {
+        attrNames[i] = attrs[i].getName();
+      }
+
+      Map<String, String> stringAttrs = new HashMap<>(name.getKeyPropertyList());
+      Map<String, Number> numberAttrs = new HashMap<>();
+      for (Attribute attr : server.getAttributes(name, attrNames).asList()) {
+        Object obj = attr.getValue();
+        if (obj instanceof String) {
+          stringAttrs.put(attr.getName(), (String) obj);
+        } else if (obj instanceof Number) {
+          numberAttrs.put(attr.getName(), ((Number) obj).doubleValue());
+        } else if (obj instanceof TimeUnit) {
+          stringAttrs.put(attr.getName(), obj.toString());
+        }
+      }
+
+      data.add(new JmxData(name, stringAttrs, numberAttrs));
+    }
+
+    return data;
+  }
+
+  private final ObjectName name;
+  private final Map<String, String> stringAttrs;
+  private final Map<String, Number> numberAttrs;
+
+  /**
+   * Create a new instance.
+   */
+  JmxData(ObjectName name, Map<String, String> stringAttrs, Map<String, Number> numberAttrs) {
+    this.name = name;
+    this.stringAttrs = stringAttrs;
+    this.numberAttrs = numberAttrs;
+  }
+
+  /** Return the name of the bean. */
+  ObjectName getName() {
+    return name;
+  }
+
+  /** Return attributes with string values. */
+  Map<String, String> getStringAttrs() {
+    return stringAttrs;
+  }
+
+  /** Return attributes with numeric values. */
+  Map<String, Number> getNumberAttrs() {
+    return numberAttrs;
+  }
+
+  @Override public String toString() {
+    StringBuilder buf = new StringBuilder(256);
+    buf.append(name.toString())
+        .append("\n- string attributes\n");
+    for (Map.Entry<String, String> entry : new TreeMap<>(stringAttrs).entrySet()) {
+      buf.append("  - ").append(entry.getKey()).append(" = ").append(entry.getValue()).append('\n');
+    }
+    buf.append("- number attributes\n");
+    for (Map.Entry<String, Number> entry : new TreeMap<>(numberAttrs).entrySet()) {
+      buf.append("  - ").append(entry.getKey()).append(" = ").append(entry.getValue()).append('\n');
+    }
+    return buf.toString();
+  }
+}

--- a/spectator-agent/src/main/java/com/netflix/spectator/agent/JmxMeasurementConfig.java
+++ b/spectator-agent/src/main/java/com/netflix/spectator/agent/JmxMeasurementConfig.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.agent;
+
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.Registry;
+import com.typesafe.config.Config;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+
+/**
+ * Config for extracting a measurment from a JMX bean.
+ *
+ * <ul>
+ *   <li><b>name:</b> name pattern to use, see {@link MappingExpr#substitute(String, Map)}</li>
+ *   <li><b>tags:</b> tags to add on, values can use patterns,
+ *   see {@link MappingExpr#substitute(String, Map)}</li>
+ *   <li><b>value:</b> value expression, see {@link MappingExpr#eval(String, Map)}</li>
+ *   <li><b>counter:</b> is the value a monotonically increasing counter value?</li>
+ * </ul>
+ */
+final class JmxMeasurementConfig {
+
+  /** Create from a Typesafe Config object. */
+  static JmxMeasurementConfig from(Config config) {
+    String name = config.getString("name");
+    Map<String, String> tags = config.getConfigList("tags")
+        .stream()
+        .collect(Collectors.toMap(c -> c.getString("key"), c -> c.getString("value")));
+    String value = config.getString("value");
+    boolean counter = config.hasPath("counter") && config.getBoolean("counter");
+    return new JmxMeasurementConfig(name, tags, value, counter);
+  }
+
+  private final String nameMapping;
+  private final Map<String, String> tagMappings;
+  private final String valueMapping;
+  private final boolean counter;
+
+  private final Map<Id, AtomicLong> previous;
+
+  /** Create a new instance. */
+  JmxMeasurementConfig(
+      String nameMapping,
+      Map<String, String> tagMappings,
+      String valueMapping,
+      boolean counter) {
+    this.nameMapping = nameMapping;
+    this.tagMappings = tagMappings;
+    this.valueMapping = valueMapping;
+    this.counter = counter;
+    this.previous = new ConcurrentHashMap<>();
+  }
+
+  /**
+   * Fill in {@code ms} with measurements extracted from {@code data}.
+   */
+  void measure(Registry registry, JmxData data, List<Measurement> ms) {
+    Map<String, String> tags = tagMappings.entrySet().stream().collect(Collectors.toMap(
+        Map.Entry::getKey,
+        e -> MappingExpr.substitute(e.getValue(), data.getStringAttrs())
+    ));
+    Id id = registry
+        .createId(MappingExpr.substitute(nameMapping, data.getStringAttrs()))
+        .withTags(tags);
+    Double v = MappingExpr.eval(valueMapping, data.getNumberAttrs());
+    if (v != null) {
+      if (counter) {
+        updateCounter(registry, id, v.longValue());
+      } else {
+        ms.add(new Measurement(id, registry.clock().wallTime(), v));
+      }
+    }
+  }
+
+  private void updateCounter(Registry registry, Id id, long v) {
+    AtomicLong prev = previous.computeIfAbsent(id, i -> new AtomicLong(0L));
+    long p = prev.get();
+    if (prev.compareAndSet(p, v) && p != 0) {
+      registry.counter(id).increment(v - p);
+    }
+  }
+}

--- a/spectator-agent/src/main/java/com/netflix/spectator/agent/JmxMeter.java
+++ b/spectator-agent/src/main/java/com/netflix/spectator/agent/JmxMeter.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.agent;
+
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.Meter;
+import com.netflix.spectator.api.Registry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Meter based on a {@link JmxConfig}. */
+final class JmxMeter implements Meter {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(JmxMeter.class);
+
+  private final Registry registry;
+  private final JmxConfig config;
+  private final Id id;
+
+  /** Create a new instance. */
+  JmxMeter(Registry registry, JmxConfig config) {
+    this.registry = registry;
+    this.config = config;
+    this.id = registry.createId(config.getQuery().getCanonicalName());
+  }
+
+  @Override public Id id() {
+    return id;
+  }
+
+  @Override
+  public Iterable<Measurement> measure() {
+    List<Measurement> ms = new ArrayList<>();
+    try {
+      for (JmxData data : JmxData.query(config.getQuery())) {
+        for (JmxMeasurementConfig cfg : config.getMeasurements()) {
+          cfg.measure(registry, data, ms);
+        }
+      }
+    } catch (Exception e) {
+      LOGGER.warn("failed to query jmx data: {}", config.getQuery().getCanonicalName(), e);
+    }
+    return ms;
+  }
+
+  @Override public boolean hasExpired() {
+    return false;
+  }
+}

--- a/spectator-agent/src/main/java/com/netflix/spectator/agent/MappingExpr.java
+++ b/spectator-agent/src/main/java/com/netflix/spectator/agent/MappingExpr.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.agent;
+
+import java.beans.Introspector;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Map;
+import java.util.function.DoubleBinaryOperator;
+
+/**
+ * Helper for handling basic expressions uses as part of the mapping config.
+ */
+final class MappingExpr {
+
+  private MappingExpr() {
+  }
+
+  /**
+   * Substitute named variables in the pattern string with the corresponding
+   * values in the variables map.
+   *
+   * @param pattern
+   *     Pattern string with placeholders, name surounded by curly braces, e.g.:
+   *     {@code {variable name}}.
+   * @param vars
+   *     Map of variable substitutions that are available.
+   * @return
+   *     String with values substituted in. If no matching key is found for a
+   *     placeholder, then it will not be modified and left in place.
+   */
+  static String substitute(String pattern, Map<String, String> vars) {
+    String value = pattern;
+    for (Map.Entry<String, String> entry : vars.entrySet()) {
+      String v = Introspector.decapitalize(entry.getValue());
+      value = value.replace("{" + entry.getKey() + "}", v);
+    }
+    return value;
+  }
+
+  /**
+   * Evaluate a simple stack expression for the value.
+   *
+   * @param expr
+   *     Basic stack expression that supports placeholders, numeric constants,
+   *     and basic binary operations (:add, :sub, :mul, :div).
+   * @param vars
+   *     Map of variable substitutions that are available.
+   * @return
+   *     Double value for the expression. If the expression cannot be evaluated
+   *     properly, then null will be returned.
+   */
+  @SuppressWarnings("PMD")
+  static Double eval(String expr, Map<String, ? extends Number> vars) {
+    Deque<Double> stack = new ArrayDeque<>();
+    String[] parts = expr.split("[,\\s]+");
+    for (String part : parts) {
+      switch (part) {
+        case ":add": binaryOp(stack, (a, b) -> a + b); break;
+        case ":sub": binaryOp(stack, (a, b) -> a - b); break;
+        case ":mul": binaryOp(stack, (a, b) -> a * b); break;
+        case ":div": binaryOp(stack, (a, b) -> a / b); break;
+        default:
+          if (part.startsWith("{") && part.endsWith("}")) {
+            Number v = vars.get(part.substring(1, part.length() - 1));
+            if (v == null) return null;
+            stack.addFirst(v.doubleValue());
+          } else {
+            stack.addFirst(Double.parseDouble(part));
+          }
+          break;
+      }
+    }
+    return stack.removeFirst();
+  }
+
+  private static void binaryOp(Deque<Double> stack, DoubleBinaryOperator op) {
+    double b = stack.removeFirst();
+    double a = stack.removeFirst();
+    stack.addFirst(op.applyAsDouble(a, b));
+  }
+}

--- a/spectator-agent/src/main/resources/agent.conf
+++ b/spectator-agent/src/main/resources/agent.conf
@@ -1,7 +1,7 @@
 
 netflix.spectator.agent {
-
   collection {
+    jmx = true
     jvm = true
     gc = true
   }
@@ -9,5 +9,9 @@ netflix.spectator.agent {
   atlas {
     step = PT1M
     uri = "http://localhost:7101/api/v1/publish"
+  }
+
+  jmx {
+    mappings = []
   }
 }

--- a/spectator-agent/src/main/resources/cassandra.conf
+++ b/spectator-agent/src/main/resources/cassandra.conf
@@ -1,0 +1,1762 @@
+
+// http://wiki.apache.org/cassandra/Metrics
+netflix.spectator.agent.jmx {
+  mappings = ${?netflix.spectator.agent.jmx.mappings} [
+    //
+    // type=Cache
+    //
+    {
+      query = "org.apache.cassandra.metrics:type=Cache,name=Hits,*"
+      measurements = [
+        {
+          name = "cass.cache.hits"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "atlas.dstype"
+              value = "rate"
+            }
+          ]
+          value = "{OneMinuteRate}"
+        }
+      ]
+    },
+    {
+      query = "org.apache.cassandra.metrics:type=Cache,name=Requests,*"
+      measurements = [
+        {
+          name = "cass.cache.requests"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "atlas.dstype"
+              value = "rate"
+            }
+          ]
+          value = "{OneMinuteRate}"
+        }
+      ]
+    },
+    {
+      query = "org.apache.cassandra.metrics:type=Cache,name=Size,*"
+      measurements = [
+        {
+          name = "cass.cache.size"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            }
+          ]
+          value = "{Value}"
+        }
+      ]
+    },
+    {
+      query = "org.apache.cassandra.metrics:type=Cache,name=Capacity,*"
+      measurements = [
+        {
+          name = "cass.cache.capacity"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            }
+          ]
+          value = "{Value}"
+        }
+      ]
+    },
+    {
+      query = "org.apache.cassandra.metrics:type=Cache,name=Entries,*"
+      measurements = [
+        {
+          name = "cass.cache.entries"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            }
+          ]
+          value = "{Value}"
+        }
+      ]
+    },
+
+    //
+    // type=ClientRequest
+    //
+    {
+      query = "org.apache.cassandra.metrics:type=ClientRequest,name=Latency,*"
+      measurements = [
+        {
+          name = "cass.request.latency"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "statistic"
+              value = "count"
+            },
+            {
+              key = "atlas.dstype"
+              value = "rate"
+            }
+          ]
+          value = "{OneMinuteRate}"
+        },
+        {
+          name = "cass.request.latency"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "statistic"
+              value = "max"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Max},1e6,:div"
+        },
+        {
+          name = "cass.request.latency"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "statistic"
+              value = "totalTime"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Mean},1e6,:div,{OneMinuteRate},:mul"
+        },
+        {
+          name = "cass.request.latency"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "statistic"
+              value = "mean"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Mean},1e6,:div"
+        },
+        {
+          name = "cass.request.latency"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "statistic"
+              value = "percentile_50"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{50thPercentile},1e6,:div"
+        },
+        {
+          name = "cass.request.latency"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "statistic"
+              value = "percentile_95"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{95thPercentile},1e6,:div"
+        },
+        {
+          name = "cass.request.latency"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "statistic"
+              value = "percentile_99"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{99thPercentile},1e6,:div"
+        },
+        {
+          name = "cass.request.latency"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "statistic"
+              value = "percentile_99.9"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{999thPercentile},1e6,:div"
+        }
+      ]
+    },
+    {
+      query = "org.apache.cassandra.metrics:type=ClientRequest,name=Timeouts,*"
+      measurements = [
+        {
+          name = "cass.request.timeouts"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "atlas.dstype"
+              value = "rate"
+            }
+          ]
+          value = "{OneMinuteRate}"
+        }
+      ]
+    },
+    {
+      query = "org.apache.cassandra.metrics:type=ClientRequest,name=Unavailables,*"
+      measurements = [
+        {
+          name = "cass.request.unavailables"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "atlas.dstype"
+              value = "rate"
+            }
+          ]
+          value = "{OneMinuteRate}"
+        }
+      ]
+    },
+
+    //
+    // type=ColumnFamily
+    //
+    {
+      query = "org.apache.cassandra.metrics:type=*ColumnFamily,name=*Latency,keyspace=*,*"
+      measurements = [
+        {
+          name = "cass.cf.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "keyspace"
+              value = "{keyspace}"
+            },
+            {
+              key = "familyType"
+              value = "{type}"
+            },
+            {
+              key = "statistic"
+              value = "count"
+            },
+            {
+              key = "atlas.dstype"
+              value = "rate"
+            }
+          ]
+          value = "{OneMinuteRate}"
+        },
+        {
+          name = "cass.cf.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "keyspace"
+              value = "{keyspace}"
+            },
+            {
+              key = "familyType"
+              value = "{type}"
+            },
+            {
+              key = "statistic"
+              value = "max"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Max},1e6,:div"
+        },
+        {
+          name = "cass.cf.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "keyspace"
+              value = "{keyspace}"
+            },
+            {
+              key = "familyType"
+              value = "{type}"
+            },
+            {
+              key = "statistic"
+              value = "totalTime"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Mean},1e6,:div,{OneMinuteRate},:mul"
+        },
+        {
+          name = "cass.cf.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "keyspace"
+              value = "{keyspace}"
+            },
+            {
+              key = "familyType"
+              value = "{type}"
+            },
+            {
+              key = "statistic"
+              value = "mean"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Mean},1e6,:div"
+        },
+        {
+          name = "cass.cf.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "keyspace"
+              value = "{keyspace}"
+            },
+            {
+              key = "familyType"
+              value = "{type}"
+            },
+            {
+              key = "statistic"
+              value = "percentile_50"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{50thPercentile},1e6,:div"
+        },
+        {
+          name = "cass.cf.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "keyspace"
+              value = "{keyspace}"
+            },
+            {
+              key = "familyType"
+              value = "{type}"
+            },
+            {
+              key = "statistic"
+              value = "percentile_95"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{95thPercentile},1e6,:div"
+        },
+        {
+          name = "cass.cf.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "keyspace"
+              value = "{keyspace}"
+            },
+            {
+              key = "familyType"
+              value = "{type}"
+            },
+            {
+              key = "statistic"
+              value = "percentile_99"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{99thPercentile},1e6,:div"
+        },
+        {
+          name = "cass.cf.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "keyspace"
+              value = "{keyspace}"
+            },
+            {
+              key = "familyType"
+              value = "{type}"
+            },
+            {
+              key = "statistic"
+              value = "percentile_99.9"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{999thPercentile},1e6,:div"
+        }
+      ]
+    },
+    {
+      // BloomFilterFalseRatio, RecentBloomFilterFalseRatio, and CompressionRatio
+      query = "org.apache.cassandra.metrics:type=*ColumnFamily,name=*Ratio,keyspace=*,*"
+      measurements = [
+        {
+          name = "cass.cf.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "keyspace"
+              value = "{keyspace}"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Value}"
+        }
+      ]
+    },
+    {
+      // BloomFilterFalsePositives and RecentBloomFilterFalsePositives
+      query = "org.apache.cassandra.metrics:type=*ColumnFamily,name=*Positives,keyspace=*,*"
+      measurements = [
+        {
+          name = "cass.cf.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "keyspace"
+              value = "{keyspace}"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Value}"
+        }
+      ]
+    },
+    {
+      // BloomFilterDiskSpaceUsed
+      query = "org.apache.cassandra.metrics:type=*ColumnFamily,name=BloomFilterDiskSpaceUsed,keyspace=*,*"
+      measurements = [
+        {
+          name = "cass.cf.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "keyspace"
+              value = "{keyspace}"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Value}"
+        }
+      ]
+    },
+    {
+      // LiveDiskSpaceUsed
+      query = "org.apache.cassandra.metrics:type=*ColumnFamily,name=LiveDiskSpaceUsed,keyspace=*,*"
+      measurements = [
+        {
+          name = "cass.cf.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "keyspace"
+              value = "{keyspace}"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Count}"
+        }
+      ]
+    },
+    {
+      // OffHeapSize in bytes
+      query = "org.apache.cassandra.metrics:type=*ColumnFamily,name=*OffHeapMemoryUsed,keyspace=*,*"
+      measurements = [
+        {
+          name = "cass.cf.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "keyspace"
+              value = "{keyspace}"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Value}"
+        }
+      ]
+    },
+    {
+      // OffHeapSize in bytes
+      query = "org.apache.cassandra.metrics:type=*ColumnFamily,name=*LiveDataSize,keyspace=*,*"
+      measurements = [
+        {
+          name = "cass.cf.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "keyspace"
+              value = "{keyspace}"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Value}"
+        }
+      ]
+    },
+    {
+      // {Min,Max,Mean}RowSize
+      query = "org.apache.cassandra.metrics:type=*ColumnFamily,name=*RowSize,keyspace=*,*"
+      measurements = [
+        {
+          name = "cass.cf.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "keyspace"
+              value = "{keyspace}"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Value}"
+        }
+      ]
+    },
+    {
+      // LiveSSTableCount
+      query = "org.apache.cassandra.metrics:type=*ColumnFamily,name=LiveSSTableCount,keyspace=*,*"
+      measurements = [
+        {
+          name = "cass.cf.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "keyspace"
+              value = "{keyspace}"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Value}"
+        }
+      ]
+    },
+    {
+      // MemtableColumnsCount
+      query = "org.apache.cassandra.metrics:type=*ColumnFamily,name=MemtableColumnsCount,keyspace=*,*"
+      measurements = [
+        {
+          name = "cass.cf.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "keyspace"
+              value = "{keyspace}"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Value}"
+        }
+      ]
+    },
+    {
+      // MemtableSwitchCount
+      query = "org.apache.cassandra.metrics:type=*ColumnFamily,name=MemtableSwitchCount,keyspace=*,*"
+      measurements = [
+        {
+          name = "cass.cf.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "keyspace"
+              value = "{keyspace}"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Count}"
+        }
+      ]
+    },
+    {
+      // On/Off HeapSizes
+      query = "org.apache.cassandra.metrics:type=*ColumnFamily,name=*HeapSize,keyspace=*,*"
+      measurements = [
+        {
+          name = "cass.cf.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "keyspace"
+              value = "{keyspace}"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Value}"
+        }
+      ]
+    },
+    {
+      // PendingFlushes
+      query = "org.apache.cassandra.metrics:type=*ColumnFamily,name=PendingFlushes,keyspace=*,*"
+      measurements = [
+        {
+          name = "cass.cf.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "keyspace"
+              value = "{keyspace}"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Count}"
+        }
+      ]
+    },
+    {
+      // PendingCompactions
+      query = "org.apache.cassandra.metrics:type=*ColumnFamily,name=PendingCompactions,keyspace=*,*"
+      measurements = [
+        {
+          name = "cass.cf.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "keyspace"
+              value = "{keyspace}"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Value}"
+        }
+      ]
+    },
+    {
+      // SnapshotsSize
+      query = "org.apache.cassandra.metrics:type=*ColumnFamily,name=SnapshotsSize,keyspace=*,*"
+      measurements = [
+        {
+          name = "cass.cf.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "keyspace"
+              value = "{keyspace}"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Value}"
+        }
+      ]
+    },
+    {
+      // EstimatedRowCount
+      query = "org.apache.cassandra.metrics:type=*ColumnFamily,name=EstimatedRowCount,keyspace=*,*"
+      measurements = [
+        {
+          name = "cass.cf.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "keyspace"
+              value = "{keyspace}"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Value}"
+        }
+      ]
+    },
+    {
+      // SpeculativeRetries
+      query = "org.apache.cassandra.metrics:type=*ColumnFamily,name=SpeculativeRetries,keyspace=*,*"
+      measurements = [
+        {
+          name = "cass.cf.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "keyspace"
+              value = "{keyspace}"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Count}"
+        }
+      ]
+    },
+    {
+      // KeyCacheHitRate
+      query = "org.apache.cassandra.metrics:type=*ColumnFamily,name=KeyCacheHitRate,keyspace=*,*"
+      measurements = [
+        {
+          name = "cass.cf.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "keyspace"
+              value = "{keyspace}"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Value}"
+        }
+      ]
+    },
+    {
+      // RowCache counters
+      query = "org.apache.cassandra.metrics:type=*ColumnFamily,name=RowCache*,keyspace=*,*"
+      measurements = [
+        {
+          name = "cass.cf.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "keyspace"
+              value = "{keyspace}"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Count}"
+        }
+      ]
+    },
+    {
+      // WaitingOnFreeMemtableSapce
+      query = "org.apache.cassandra.metrics:type=*ColumnFamily,name=WaitingOnFreeMemtableSpace,keyspace=*,*"
+      measurements = [
+        {
+          name = "cass.cf.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "keyspace"
+              value = "{keyspace}"
+            },
+            {
+              key = "familyType"
+              value = "{type}"
+            },
+            {
+              key = "statistic"
+              value = "count"
+            },
+            {
+              key = "atlas.dstype"
+              value = "rate"
+            }
+          ]
+          value = "{OneMinuteRate}"
+        },
+        {
+          name = "cass.cf.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "keyspace"
+              value = "{keyspace}"
+            },
+            {
+              key = "familyType"
+              value = "{type}"
+            },
+            {
+              key = "statistic"
+              value = "max"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Max},1e6,:div"
+        },
+        {
+          name = "cass.cf.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "keyspace"
+              value = "{keyspace}"
+            },
+            {
+              key = "familyType"
+              value = "{type}"
+            },
+            {
+              key = "statistic"
+              value = "totalTime"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Mean},1e6,:div,{OneMinuteRate},:mul"
+        },
+        {
+          name = "cass.cf.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "keyspace"
+              value = "{keyspace}"
+            },
+            {
+              key = "familyType"
+              value = "{type}"
+            },
+            {
+              key = "statistic"
+              value = "mean"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Mean},1e6,:div"
+        },
+        {
+          name = "cass.cf.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "keyspace"
+              value = "{keyspace}"
+            },
+            {
+              key = "familyType"
+              value = "{type}"
+            },
+            {
+              key = "statistic"
+              value = "percentile_50"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{50thPercentile},1e6,:div"
+        },
+        {
+          name = "cass.cf.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "keyspace"
+              value = "{keyspace}"
+            },
+            {
+              key = "familyType"
+              value = "{type}"
+            },
+            {
+              key = "statistic"
+              value = "percentile_95"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{95thPercentile},1e6,:div"
+        },
+        {
+          name = "cass.cf.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "keyspace"
+              value = "{keyspace}"
+            },
+            {
+              key = "familyType"
+              value = "{type}"
+            },
+            {
+              key = "statistic"
+              value = "percentile_99"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{99thPercentile},1e6,:div"
+        },
+        {
+          name = "cass.cf.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "keyspace"
+              value = "{keyspace}"
+            },
+            {
+              key = "familyType"
+              value = "{type}"
+            },
+            {
+              key = "statistic"
+              value = "percentile_99.9"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{999thPercentile},1e6,:div"
+        }
+      ]
+    },
+
+    //
+    // type=CommitLog
+    //
+    {
+      query = "org.apache.cassandra.metrics:type=CommitLog,name=Waiting*"
+      measurements = [
+        {
+          name = "cass.commitlog.{name}"
+          tags = [
+            {
+              key = "statistic"
+              value = "count"
+            },
+            {
+              key = "atlas.dstype"
+              value = "rate"
+            }
+          ]
+          value = "{OneMinuteRate}"
+        },
+        {
+          name = "cass.commitlog.{name}"
+          tags = [
+            {
+              key = "statistic"
+              value = "max"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Max},1e6,:div"
+        },
+        {
+          name = "cass.commitlog.{name}"
+          tags = [
+            {
+              key = "statistic"
+              value = "totalTime"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Mean},1e6,:div,{OneMinuteRate},:mul"
+        },
+        {
+          name = "cass.commitlog.{name}"
+          tags = [
+            {
+              key = "statistic"
+              value = "mean"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Mean},1e6,:div"
+        },
+        {
+          name = "cass.commitlog.{name}"
+          tags = [
+            {
+              key = "statistic"
+              value = "percentile_50"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{50thPercentile},1e6,:div"
+        },
+        {
+          name = "cass.commitlog.{name}"
+          tags = [
+            {
+              key = "statistic"
+              value = "percentile_95"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{95thPercentile},1e6,:div"
+        },
+        {
+          name = "cass.commitlog.{name}"
+          tags = [
+            {
+              key = "statistic"
+              value = "percentile_99"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{99thPercentile},1e6,:div"
+        },
+        {
+          name = "cass.commitlog.{name}"
+          tags = [
+            {
+              key = "statistic"
+              value = "percentile_99.9"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{999thPercentile},1e6,:div"
+        }
+      ]
+    },
+    {
+      query = "org.apache.cassandra.metrics:type=CommitLog,name=*Tasks"
+      measurements = [
+        {
+          name = "cass.commitlog.{name}"
+          tags = [
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Value}"
+        }
+      ]
+    },
+    {
+      query = "org.apache.cassandra.metrics:type=CommitLog,name=TotalCommitLogSize"
+      measurements = [
+        {
+          name = "cass.commitlog.{name}"
+          tags = [
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Value}"
+        }
+      ]
+    },
+
+    //
+    // type=Compaction
+    //
+    {
+      query = "org.apache.cassandra.metrics:type=Compaction,name=TotalCompactionsCompleted"
+      measurements = [
+        {
+          name = "cass.compaction.compactionsCompleted"
+          tags = [
+            {
+              key = "atlas.dstype"
+              value = "rate"
+            }
+          ]
+          value = "{OneMinuteRate}"
+        }
+      ]
+    },
+    {
+      query = "org.apache.cassandra.metrics:type=Compaction,name=PendingTasks"
+      measurements = [
+        {
+          name = "cass.compaction.{name}"
+          tags = [
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Value}"
+        }
+      ]
+    },
+    {
+      query = "org.apache.cassandra.metrics:type=Compaction,name=BytesCompacted"
+      measurements = [
+        {
+          name = "cass.compaction.{name}"
+          tags = [
+            {
+              key = "atlas.dstype"
+              value = "rate"
+            }
+          ]
+          value = "{Count}"
+          counter = true
+        }
+      ]
+    },
+
+    //
+    // type=Connection
+    //
+    {
+      query = "org.apache.cassandra.metrics:type=Connection,name=TotalTimeouts"
+      measurements = [
+        {
+          name = "cass.connection.timeouts"
+          tags = [
+            {
+              key = "atlas.dstype"
+              value = "rate"
+            }
+          ]
+          value = "{OneMinuteRate}"
+        }
+      ]
+    },
+
+    //
+    // type=Dropped
+    //
+    {
+      query = "org.apache.cassandra.metrics:type=DroppedMessage,name=Dropped,scope=*"
+      measurements = [
+        {
+          name = "cass.dropped.messages"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "atlas.dstype"
+              value = "rate"
+            }
+          ]
+          value = "{OneMinuteRate}"
+        }
+      ]
+    },
+
+    //
+    // type=Streaming
+    //
+    {
+      query = "org.apache.cassandra.metrics:type=Streaming,name=ActiveOutboundStreams"
+      measurements = [
+        {
+          name = "cass.streaming.{name}"
+          tags = [
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Count}"
+        }
+      ]
+    },
+    {
+      query = "org.apache.cassandra.metrics:type=Streaming,name=TotalOutgoingBytes"
+      measurements = [
+        {
+          name = "cass.streaming.bytes"
+          tags = [
+            {
+              key = "id"
+              value = "out"
+            },
+            {
+              key = "atlas.dstype"
+              value = "rate"
+            }
+          ]
+          value = "{Count}"
+          counter = true
+        }
+      ]
+    },
+    {
+      query = "org.apache.cassandra.metrics:type=Streaming,name=TotalIncomingBytes"
+      measurements = [
+        {
+          name = "cass.streaming.bytes"
+          tags = [
+            {
+              key = "id"
+              value = "in"
+            },
+            {
+              key = "atlas.dstype"
+              value = "rate"
+            }
+          ]
+          value = "{Count}"
+          counter = true
+        }
+      ]
+    },
+
+    //
+    // type=Storage
+    //
+    {
+      query = "org.apache.cassandra.metrics:type=Storage,name=Load"
+      measurements = [
+        {
+          name = "cass.storage.diskSpaceUsed"
+          tags = [
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Count}"
+        }
+      ]
+    },
+    {
+      query = "org.apache.cassandra.metrics:type=Storage,name=TotalHintsInProgress"
+      measurements = [
+        {
+          name = "cass.storage.hintsInProgress"
+          tags = [
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Count}"
+        }
+      ]
+    },
+    {
+      query = "org.apache.cassandra.metrics:type=Storage,name=TotalHints"
+      measurements = [
+        {
+          name = "cass.storage.hints"
+          tags = [
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Count}"
+          counter = true
+        }
+      ]
+    },
+    {
+      query = "org.apache.cassandra.metrics:type=Storage,name=Exceptions"
+      measurements = [
+        {
+          name = "cass.storage.{name}"
+          tags = [
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Count}"
+          counter = true
+        }
+      ]
+    },
+
+    //
+    // type=ThreadPool
+    //
+    {
+      query = "org.apache.cassandra.metrics:type=ThreadPools,name=ActiveTasks,scope=*,path=*"
+      measurements = [
+        {
+          name = "cass.threadpool.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "path"
+              value = "{path}"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Value}"
+        }
+      ]
+    },
+    {
+      query = "org.apache.cassandra.metrics:type=ThreadPools,name=PendingTasks,scope=*,path=*"
+      measurements = [
+        {
+          name = "cass.threadpool.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "path"
+              value = "{path}"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Value}"
+        }
+      ]
+    },
+    {
+      query = "org.apache.cassandra.metrics:type=ThreadPools,name=CompletedTasks,scope=*,path=*"
+      measurements = [
+        {
+          name = "cass.threadpool.completed"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "path"
+              value = "{path}"
+            },
+            {
+              key = "atlas.dstype"
+              value = "rate"
+            }
+          ]
+          value = "{Value}"
+          counter = true
+        }
+      ]
+    },
+    {
+      query = "org.apache.cassandra.metrics:type=ThreadPools,name=CurrentlyBlockedTasks,scope=*,path=*"
+      measurements = [
+        {
+          name = "cass.threadpool.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "path"
+              value = "{path}"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Count}"
+        }
+      ]
+    },
+
+    //
+    // type=CQL
+    //
+    {
+      query = "org.apache.cassandra.metrics:type=CQL,name=RegularStatementsExecuted"
+      measurements = [
+        {
+          name = "cass.threadpool.statementsExecuted"
+          tags = [
+            {
+              key = "id"
+              value = "regular"
+            },
+            {
+              key = "atlas.dstype"
+              value = "rate"
+            }
+          ]
+          value = "{Count}"
+          counter = true
+        }
+      ]
+    },
+    {
+      query = "org.apache.cassandra.metrics:type=CQL,name=PreparedStatementsExecuted"
+      measurements = [
+        {
+          name = "cass.threadpool.statementsExecuted"
+          tags = [
+            {
+              key = "id"
+              value = "prepared"
+            },
+            {
+              key = "atlas.dstype"
+              value = "rate"
+            }
+          ]
+          value = "{Count}"
+          counter = true
+        }
+      ]
+    },
+    {
+      query = "org.apache.cassandra.metrics:type=CQL,name=PreparedStatementsEvicted"
+      measurements = [
+        {
+          name = "cass.threadpool.{name}"
+          tags = [
+            {
+              key = "id"
+              value = "prepared"
+            },
+            {
+              key = "atlas.dstype"
+              value = "rate"
+            }
+          ]
+          value = "{Count}"
+          counter = true
+        }
+      ]
+    },
+    {
+      query = "org.apache.cassandra.metrics:type=CQL,name=PreparedStatementsCount"
+      measurements = [
+        {
+          name = "cass.threadpool.{name}"
+          tags = [
+            {
+              key = "id"
+              value = "prepared"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Value}"
+        }
+      ]
+    },
+
+    //
+    // type=FileCache
+    //
+    {
+      query = "org.apache.cassandra.metrics:type=FileCache,name=Requests"
+      measurements = [
+        {
+          name = "cass.filecache.{name}"
+          tags = [
+            {
+              key = "atlas.dstype"
+              value = "rate"
+            }
+          ]
+          value = "{OneMinuteRate}"
+        }
+      ]
+    },
+    {
+      query = "org.apache.cassandra.metrics:type=FileCache,name=Hits"
+      measurements = [
+        {
+          name = "cass.filecache.{name}"
+          tags = [
+            {
+              key = "atlas.dstype"
+              value = "rate"
+            }
+          ]
+          value = "{OneMinuteRate}"
+        }
+      ]
+    },
+    {
+      query = "org.apache.cassandra.metrics:type=FileCache,name=Size"
+      measurements = [
+        {
+          name = "cass.filecache.{name}"
+          tags = [
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Value}"
+        }
+      ]
+    },
+
+    //
+    // type=ReadRepair
+    //
+    {
+      query = "org.apache.cassandra.metrics:type=ReadRepair,name=*"
+      measurements = [
+        {
+          name = "cass.filecache.{name}"
+          tags = [
+            {
+              key = "atlas.dstype"
+              value = "rate"
+            }
+          ]
+          value = "{OneMinuteRate}"
+        }
+      ]
+    },
+  ]
+}

--- a/spectator-agent/src/test/java/com/netflix/spectator/agent/Json.java
+++ b/spectator-agent/src/test/java/com/netflix/spectator/agent/Json.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.agent;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import javax.management.ObjectName;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Used to read sample files created using {@code jmx-dump}.
+ *
+ * <pre>
+ * $ curl -o jmx-dump.jar -L 'https://bintray.com/r4um/generic/download_file?file_path=jmx-dump-0.4.2-standalone.jar'
+ * $ java -jar jmx-dump.jar --local ${pid} --dump-all
+ * </pre>
+ */
+public class Json {
+
+  private static final ObjectMapper mapper = new ObjectMapper();
+
+  @SuppressWarnings("unchecked")
+  static List<JmxData> load(String resource) {
+    try {
+      List<JmxData> results = new ArrayList<>();
+      ClassLoader cl = Thread.currentThread().getContextClassLoader();
+      try (InputStream in = cl.getResourceAsStream(resource)) {
+        Map<String, Object> data = (Map<String, Object>) mapper.readValue(in, Map.class);
+        for (Map.Entry<String, Object> entry : data.entrySet()) {
+          ObjectName name = new ObjectName(entry.getKey());
+          Map<String, Object> attrs = (Map<String, Object>) entry.getValue();
+          Map<String, String> strings = new HashMap<>(name.getKeyPropertyList());
+          Map<String, Number> numbers = new HashMap<>();
+          for (Map.Entry<String, Object> attr : attrs.entrySet()) {
+            Object obj = attr.getValue();
+            if (obj instanceof Number) {
+              numbers.put(attr.getKey(), (Number) obj);
+            } else if (obj != null) {
+              strings.put(attr.getKey(), obj.toString());
+            }
+          }
+          results.add(new JmxData(name, strings, numbers));
+        }
+      }
+      return results;
+    } catch (Exception e) {
+      throw new IllegalArgumentException("invalid json resource: " + resource, e);
+    }
+  }
+}

--- a/spectator-agent/src/test/java/com/netflix/spectator/agent/MappingExprTest.java
+++ b/spectator-agent/src/test/java/com/netflix/spectator/agent/MappingExprTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.agent;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+@RunWith(JUnit4.class)
+public class MappingExprTest {
+
+  @Test
+  public void substituteEmpty() {
+    Map<String, String> vars = new HashMap<>();
+    String actual = MappingExpr.substitute("", vars);
+    Assert.assertEquals("", actual);
+  }
+
+  @Test
+  public void substituteMissing() {
+    Map<String, String> vars = new HashMap<>();
+    String actual = MappingExpr.substitute("abc{def}", vars);
+    Assert.assertEquals("abc{def}", actual);
+  }
+
+  @Test
+  public void substituteSingle() {
+    Map<String, String> vars = new HashMap<>();
+    vars.put("def", "123");
+    String actual = MappingExpr.substitute("abc{def}", vars);
+    Assert.assertEquals("abc123", actual);
+  }
+
+  @Test
+  public void substituteMultiple() {
+    Map<String, String> vars = new HashMap<>();
+    vars.put("def", "123");
+    String actual = MappingExpr.substitute("abc{def}, {def}", vars);
+    Assert.assertEquals("abc123, 123", actual);
+  }
+
+  @Test
+  public void substituteMultiVar() {
+    Map<String, String> vars = new HashMap<>();
+    vars.put("def", "123");
+    vars.put("ghi", "456");
+    String actual = MappingExpr.substitute("abc{def}, {ghi}, {def}", vars);
+    Assert.assertEquals("abc123, 456, 123", actual);
+  }
+
+  @Test
+  public void substituteDecapitalize() {
+    Map<String, String> vars = new HashMap<>();
+    vars.put("name", "FooBarBaz");
+    String actual = MappingExpr.substitute("abc.def.{name}", vars);
+    Assert.assertEquals("abc.def.fooBarBaz", actual);
+  }
+
+  @Test
+  public void evalMissing() {
+    Map<String, Number> vars = new HashMap<>();
+    Double v = MappingExpr.eval("{foo}", vars);
+    Assert.assertNull(v);
+  }
+
+  @Test
+  public void evalSimple() {
+    Map<String, Number> vars = new HashMap<>();
+    vars.put("foo", 0.0);
+    Double v = MappingExpr.eval("{foo}", vars);
+    Assert.assertEquals(0.0, v, 1e-12);
+  }
+
+  @Test
+  public void evalConstant() {
+    Map<String, Number> vars = new HashMap<>();
+    Double v = MappingExpr.eval("42.0", vars);
+    Assert.assertEquals(42.0, v, 1e-12);
+  }
+
+  @Test
+  public void evalAdd() {
+    Map<String, Number> vars = new HashMap<>();
+    vars.put("foo", 1.0);
+    Double v = MappingExpr.eval("42.0,{foo},:add", vars);
+    Assert.assertEquals(43.0, v, 1e-12);
+  }
+
+  @Test
+  public void evalSub() {
+    Map<String, Number> vars = new HashMap<>();
+    vars.put("foo", 1.0);
+    Double v = MappingExpr.eval("42.0,{foo},:sub", vars);
+    Assert.assertEquals(41.0, v, 1e-12);
+  }
+
+  @Test
+  public void evalMul() {
+    Map<String, Number> vars = new HashMap<>();
+    vars.put("foo", 2.0);
+    Double v = MappingExpr.eval("42.0,{foo},:mul", vars);
+    Assert.assertEquals(84.0, v, 1e-12);
+  }
+
+  @Test
+  public void evalDiv() {
+    Map<String, Number> vars = new HashMap<>();
+    vars.put("foo", 2.0);
+    Double v = MappingExpr.eval("42.0,{foo},:div", vars);
+    Assert.assertEquals(21.0, v, 1e-12);
+  }
+}


### PR DESCRIPTION
Allows the agent to be configured to query arbitrary
JMX data. Sample config is provided for Cassandra.

Test cases are a bit light right now, some of the
were generated using dumps of actual JMX data. These
need to cleaned up and sanitized first. That can
be done later without blocking other experimentation
though.