### PR TITLE
read in common tags from agent config

### DIFF
--- a/spectator-agent/src/main/resources/agent.conf
+++ b/spectator-agent/src/main/resources/agent.conf
@@ -9,6 +9,8 @@ netflix.spectator.agent {
   atlas {
     step = PT1M
     uri = "http://localhost:7101/api/v1/publish"
+
+    tags = []
   }
 
   jmx {


### PR DESCRIPTION
Overrides the common tags method so the tags can
be specified as part of the agent configuration.