### PR TITLE
remove tags with empty values

### DIFF
--- a/spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java
+++ b/spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java
@@ -99,7 +99,12 @@ public final class Agent {
     @Override public Map<String, String> commonTags() {
       Map<String, String> tags = new HashMap<>();
       for (Config cfg : config.getConfigList("atlas.tags")) {
-        tags.put(cfg.getString("key"), cfg.getString("value"));
+        // These are often populated by environment variables that can sometimes be empty
+        // rather than not set when missing. Empty strings are not allowed by Atlas.
+        String value = cfg.getString("value");
+        if (!value.isEmpty()) {
+          tags.put(cfg.getString("key"), cfg.getString("value"));
+        }
       }
       return tags;
     }

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
@@ -88,7 +88,7 @@ public final class AtlasRegistry extends AbstractRegistry {
 
       scheduler = new Scheduler(this, "atlas-registry", numThreads);
       scheduler.schedule(options, this::collectData);
-      LOGGER.info("started collecting metrics every {}ms reporting to {}", step, uri);
+      LOGGER.info("started collecting metrics every {} reporting to {}", step, uri);
     } else {
       LOGGER.warn("registry already started, ignoring duplicate request");
     }

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
@@ -34,6 +34,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -69,7 +70,7 @@ public final class AtlasRegistry extends AbstractRegistry {
     this.readTimeout = (int) config.readTimeout().toMillis();
     this.batchSize = config.batchSize();
     this.numThreads = config.numThreads();
-    this.commonTags = config.commonTags();
+    this.commonTags = new TreeMap<>(config.commonTags());
 
     SimpleModule module = new SimpleModule()
         .addSerializer(Measurement.class, new MeasurementSerializer());
@@ -89,6 +90,7 @@ public final class AtlasRegistry extends AbstractRegistry {
       scheduler = new Scheduler(this, "atlas-registry", numThreads);
       scheduler.schedule(options, this::collectData);
       LOGGER.info("started collecting metrics every {} reporting to {}", step, uri);
+      LOGGER.info("common tags: {}", commonTags);
     } else {
       LOGGER.warn("registry already started, ignoring duplicate request");
     }


### PR DESCRIPTION
Atlas does not allow empty values. For the common tags
where the value often comes from an environment variable
empty values are sometimes used instead of not having
the environment variable. Unfortunately that breaks the
fallback logic in typesafe config. So the agent will now
filter out the empty values.