### PR TITLE
Softened spring dependencies

### DIFF
--- a/spectator-web-spring/build.gradle
+++ b/spectator-web-spring/build.gradle
@@ -17,7 +17,9 @@
 dependencies {
   compile project(':spectator-api')
 
-  compile 'org.springframework.boot:spring-boot-starter-actuator:1.2.8.RELEASE'
-  compile 'org.springframework.boot:spring-boot-starter-data-rest:1.2.8.RELEASE'
-  compile 'com.fasterxml.jackson.core:jackson-databind:2.5.3'
+  compileOnly 'org.springframework.boot:spring-boot-starter-actuator:1.2.8.RELEASE'
+  compileOnly 'org.springframework.data:spring-data-rest-webmvc:2.2.4.RELEASE'
+
+  testCompile 'org.springframework.boot:spring-boot-starter-actuator:1.2.8.RELEASE'
+
 }


### PR DESCRIPTION
Fewer dependencies, but still requires spring auto configure so that the
endpoint bean can be disabled by default.

Uses compileOnly to require application using this module to supply concrete
versions.

@cfieber, @ttomsu
This is intended to complement the PR I'm sending to kork. It works for me, but is it correct?