### PR TITLE
add explicit client name to request logging

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/HttpRequest.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/HttpRequest.java
@@ -43,7 +43,8 @@ class HttpRequest {
   HttpRequest(URI uri) throws Exception {
     this.uri = uri;
     this.entry = new HttpLogEntry()
-        .withRequestUri(uri);
+        .withRequestUri(uri)
+        .withClientName("spectator-reg-atlas");
     this.con = (HttpURLConnection) uri.toURL().openConnection();
   }
 


### PR DESCRIPTION
Updates the Atlas registry to explicitly set the client
name to make debugging easier.