### PR TITLE
avoid overloaded methods with different SAM types

### DIFF
--- a/docs/intro/clock.md
+++ b/docs/intro/clock.md
@@ -72,7 +72,7 @@ ManualClock clock = new ManualClock();
 Registry registry = new DefaultRegistry(clock);
 
 Timer timer = registry.timer("test");
-timer.record(() -> {
+timer.run(() -> {
   doSomething();
   clock.setMonotonicTime(42L);
 });

--- a/docs/intro/servo-comparison.md
+++ b/docs/intro/servo-comparison.md
@@ -308,7 +308,7 @@ public class Foo {
   }
 
   public void doSomething() {
-    t.record(() -> {
+    t.run(() -> {
       ...
     });
   }

--- a/docs/intro/timer.md
+++ b/docs/intro/timer.md
@@ -53,7 +53,7 @@ Then wrap the call you need to measure, preferably using a lambda:
 
 ```java
   public Response handle(Request request) {
-    return requestLatency.record(() -> handleImpl(request));
+    return requestLatency.call(() -> handleImpl(request));
   }
 ```
 
@@ -128,6 +128,6 @@ simplify the common case:
 
 ```java
   private void refresh() {
-    metadataRefresh.record(this::refreshImpl);
+    metadataRefresh.run(this::refreshImpl);
   }
 ```

--- a/spectator-api/src/main/java/com/netflix/spectator/api/AbstractTimer.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/AbstractTimer.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 Netflix, Inc.
+/*
+ * Copyright 2014-2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,6 @@
  */
 package com.netflix.spectator.api;
 
-import java.util.concurrent.Callable;
-import java.util.concurrent.TimeUnit;
-
-
 /**
  * Base class to simplify implementing a {@link Timer}.
  */
@@ -32,23 +28,7 @@ public abstract class AbstractTimer implements Timer {
     this.clock = clock;
   }
 
-  @Override public <T> T record(Callable<T> f) throws Exception {
-    final long s = clock.monotonicTime();
-    try {
-      return f.call();
-    } finally {
-      final long e = clock.monotonicTime();
-      record(e - s, TimeUnit.NANOSECONDS);
-    }
-  }
-
-  @Override public void record(Runnable f) {
-    final long s = clock.monotonicTime();
-    try {
-      f.run();
-    } finally {
-      final long e = clock.monotonicTime();
-      record(e - s, TimeUnit.NANOSECONDS);
-    }
+  @Override public Clock clock() {
+    return clock;
   }
 }

--- a/spectator-api/src/main/java/com/netflix/spectator/api/CompositeTimer.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/CompositeTimer.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 Netflix, Inc.
+/*
+ * Copyright 2014-2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package com.netflix.spectator.api;
 
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 /** Timer implementation for the composite registry. */
@@ -31,29 +30,13 @@ final class CompositeTimer extends CompositeMeter implements Timer {
     this.clock = clock;
   }
 
+  @Override public Clock clock() {
+    return clock;
+  }
+
   @Override public void record(long amount, TimeUnit unit) {
     for (Registry r : registries) {
       r.timer(id).record(amount, unit);
-    }
-  }
-
-  @Override public <T> T record(Callable<T> f) throws Exception {
-    final long s = clock.monotonicTime();
-    try {
-      return f.call();
-    } finally {
-      final long e = clock.monotonicTime();
-      record(e - s, TimeUnit.NANOSECONDS);
-    }
-  }
-
-  @Override public void record(Runnable f) {
-    final long s = clock.monotonicTime();
-    try {
-      f.run();
-    } finally {
-      final long e = clock.monotonicTime();
-      record(e - s, TimeUnit.NANOSECONDS);
     }
   }
 

--- a/spectator-api/src/main/java/com/netflix/spectator/api/DefaultTimer.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/DefaultTimer.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 Netflix, Inc.
+/*
+ * Copyright 2014-2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spectator-api/src/main/java/com/netflix/spectator/api/NoopTimer.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/NoopTimer.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 Netflix, Inc.
+/*
+ * Copyright 2014-2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,11 +39,11 @@ enum NoopTimer implements Timer {
     return Collections.emptyList();
   }
 
-  @Override public <T> T record(Callable<T> f) throws Exception {
+  @Override public <T> T call(Callable<T> f) throws Exception {
     return f.call();
   }
 
-  @Override public void record(Runnable f) {
+  @Override public void run(Runnable f) {
     f.run();
   }
 

--- a/spectator-api/src/main/java/com/netflix/spectator/api/histogram/BucketTimer.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/histogram/BucketTimer.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 Netflix, Inc.
+/*
+ * Copyright 2014-2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Timer;
 
 import java.util.Collections;
-import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.LongFunction;
 
@@ -69,31 +68,13 @@ public final class BucketTimer implements Timer {
     return false;
   }
 
+  @Override public Clock clock() {
+    return registry.clock();
+  }
+
   @Override public void record(long amount, TimeUnit unit) {
     final long nanos = unit.toNanos(amount);
     timer(f.apply(nanos)).record(amount, unit);
-  }
-
-  @Override public <T> T record(Callable<T> rf) throws Exception {
-    final Clock clock = registry.clock();
-    final long s = clock.monotonicTime();
-    try {
-      return rf.call();
-    } finally {
-      final long e = clock.monotonicTime();
-      record(e - s, TimeUnit.NANOSECONDS);
-    }
-  }
-
-  @Override public void record(Runnable rf) {
-    final Clock clock = registry.clock();
-    final long s = clock.monotonicTime();
-    try {
-      rf.run();
-    } finally {
-      final long e = clock.monotonicTime();
-      record(e - s, TimeUnit.NANOSECONDS);
-    }
   }
 
   /** Return the timer for a given bucket. */

--- a/spectator-api/src/main/java/com/netflix/spectator/api/histogram/PercentileTimer.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/histogram/PercentileTimer.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 Netflix, Inc.
+/*
+ * Copyright 2014-2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@ import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Timer;
 
 import java.util.Collections;
-import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -75,32 +74,14 @@ public final class PercentileTimer implements Timer {
     return timer.hasExpired();
   }
 
+  @Override public Clock clock() {
+    return registry.clock();
+  }
+
   @Override public void record(long amount, TimeUnit unit) {
     final long nanos = unit.toNanos(amount);
     timer.record(amount, unit);
     counters[PercentileBuckets.indexOf(nanos)].increment();
-  }
-
-  @Override public <T> T record(Callable<T> rf) throws Exception {
-    final Clock clock = registry.clock();
-    final long s = clock.monotonicTime();
-    try {
-      return rf.call();
-    } finally {
-      final long e = clock.monotonicTime();
-      record(e - s, TimeUnit.NANOSECONDS);
-    }
-  }
-
-  @Override public void record(Runnable rf) {
-    final Clock clock = registry.clock();
-    final long s = clock.monotonicTime();
-    try {
-      rf.run();
-    } finally {
-      final long e = clock.monotonicTime();
-      record(e - s, TimeUnit.NANOSECONDS);
-    }
   }
 
   /**

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/Scheduler.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/Scheduler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -400,7 +400,7 @@ public class Scheduler {
             final long delay = clock.wallTime() - task.getNextExecutionTime();
             taskExecutionDelay.record(delay, TimeUnit.MILLISECONDS);
 
-            taskExecutionTime.record(() -> task.runAndReschedule(queue, skipped));
+            taskExecutionTime.run(() -> task.runAndReschedule(queue, skipped));
           } catch (InterruptedException e) {
             LOGGER.debug("task interrupted", e);
             break;

--- a/spectator-api/src/test/java/com/netflix/spectator/api/CompositeTimerTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/CompositeTimerTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 Netflix, Inc.
+/*
+ * Copyright 2014-2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -90,7 +90,7 @@ public class CompositeTimerTest {
   public void testRecordCallable() throws Exception {
     Timer t = newTimer();
     clock.setMonotonicTime(100L);
-    int v = t.record(() -> {
+    int v = t.call(() -> {
       clock.setMonotonicTime(500L);
       return 42;
     });
@@ -105,7 +105,7 @@ public class CompositeTimerTest {
     clock.setMonotonicTime(100L);
     boolean seen = false;
     try {
-      t.record((Callable<Integer>) () -> {
+      t.call((Callable<Integer>) () -> {
         clock.setMonotonicTime(500L);
         throw new RuntimeException("foo");
       });
@@ -121,7 +121,7 @@ public class CompositeTimerTest {
   public void testRecordRunnable() throws Exception {
     Timer t = newTimer();
     clock.setMonotonicTime(100L);
-    t.record(() -> clock.setMonotonicTime(500L));
+    t.run(() -> clock.setMonotonicTime(500L));
     assertCountEquals(t, 1L);
     assertTotalEquals(t, 400L);
   }
@@ -132,7 +132,7 @@ public class CompositeTimerTest {
     clock.setMonotonicTime(100L);
     boolean seen = false;
     try {
-      t.record((Runnable) () -> {
+      t.run(() -> {
         clock.setMonotonicTime(500L);
         throw new RuntimeException("foo");
       });

--- a/spectator-api/src/test/java/com/netflix/spectator/api/DefaultTimerTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/DefaultTimerTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 Netflix, Inc.
+/*
+ * Copyright 2014-2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,7 +63,7 @@ public class DefaultTimerTest {
   public void testRecordCallable() throws Exception {
     Timer t = new DefaultTimer(clock, NoopId.INSTANCE);
     clock.setMonotonicTime(100L);
-    int v = t.record(() -> {
+    int v = t.call(() -> {
       clock.setMonotonicTime(500L);
       return 42;
     });
@@ -78,7 +78,7 @@ public class DefaultTimerTest {
     clock.setMonotonicTime(100L);
     boolean seen = false;
     try {
-      t.record(() -> {
+      t.call(() -> {
         clock.setMonotonicTime(500L);
         throw new Exception("foo");
       });
@@ -94,7 +94,7 @@ public class DefaultTimerTest {
   public void testRecordRunnable() throws Exception {
     Timer t = new DefaultTimer(clock, NoopId.INSTANCE);
     clock.setMonotonicTime(100L);
-    t.record(() -> clock.setMonotonicTime(500L));
+    t.run(() -> clock.setMonotonicTime(500L));
     Assert.assertEquals(t.count(), 1L);
     Assert.assertEquals(t.totalTime(), 400L);
   }
@@ -105,7 +105,7 @@ public class DefaultTimerTest {
     clock.setMonotonicTime(100L);
     boolean seen = false;
     try {
-      t.record(() -> {
+      t.run(() -> {
         clock.setMonotonicTime(500L);
         throw new RuntimeException("foo");
       });

--- a/spectator-api/src/test/java/com/netflix/spectator/api/NoopTimerTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/NoopTimerTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 Netflix, Inc.
+/*
+ * Copyright 2014-2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ public class NoopTimerTest {
     NoopTimer t = NoopTimer.INSTANCE;
     boolean seen = false;
     try {
-      t.record(() -> {
+      t.call(() -> {
         throw new Exception("foo");
       });
     } catch (Exception e) {
@@ -58,7 +58,7 @@ public class NoopTimerTest {
     NoopTimer t = NoopTimer.INSTANCE;
     AtomicBoolean run = new AtomicBoolean();
 
-    t.record(() -> run.set(true));
+    t.run(() -> run.set(true));
     Assert.assertTrue(run.get());
   }
 

--- a/spectator-api/src/test/java/com/netflix/spectator/api/SpectatorTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/SpectatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 Netflix, Inc.
+/*
+ * Copyright 2014-2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spectator-ext-placeholders/src/main/java/com/netflix/spectator/placeholders/DefaultPlaceholderTimer.java
+++ b/spectator-ext-placeholders/src/main/java/com/netflix/spectator/placeholders/DefaultPlaceholderTimer.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 Netflix, Inc.
+/*
+ * Copyright 2014-2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,10 @@
  */
 package com.netflix.spectator.placeholders;
 
+import com.netflix.spectator.api.Clock;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Timer;
 
-import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -27,29 +27,30 @@ import java.util.concurrent.TimeUnit;
  * interface methods are called.
  */
 class DefaultPlaceholderTimer extends AbstractDefaultPlaceholderMeter<Timer> implements Timer {
+
+  private final Clock clock;
+
   /**
    * Constructs a new timer with the specified dynamic id.
    *
-   * @param id the dynamic (template) id for generating the individual timers
-   * @param registry the registry to use to instantiate the individual timers
+   * @param id
+   *     The template id for generating the individual timers.
+   * @param registry
+   *     The registry to use to instantiate the individual timers.
    */
   DefaultPlaceholderTimer(PlaceholderId id, Registry registry) {
     super(id, registry::timer);
+    this.clock = registry.clock();
+  }
+
+  @Override
+  public Clock clock() {
+    return clock;
   }
 
   @Override
   public void record(long amount, TimeUnit unit) {
     resolveToCurrentMeter().record(amount, unit);
-  }
-
-  @Override
-  public <T> T record(Callable<T> f) throws Exception {
-    return resolveToCurrentMeter().record(f);
-  }
-
-  @Override
-  public void record(Runnable f) {
-    resolveToCurrentMeter().record(f);
   }
 
   @Override

--- a/spectator-ext-placeholders/src/test/java/com/netflix/spectator/placeholders/DefaultPlaceholderTimerTest.java
+++ b/spectator-ext-placeholders/src/test/java/com/netflix/spectator/placeholders/DefaultPlaceholderTimerTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 Netflix, Inc.
+/*
+ * Copyright 2014-2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,7 +84,7 @@ public class DefaultPlaceholderTimerTest {
     int expected = 42;
     Timer timer = factory.timer(factory.createId("testRecordCallable"));
     clock.setMonotonicTime(100L);
-    int actual = timer.record(() -> {
+    int actual = timer.call(() -> {
       clock.setMonotonicTime(500L);
       return expected;
     });
@@ -99,7 +99,7 @@ public class DefaultPlaceholderTimerTest {
     clock.setMonotonicTime(100L);
     boolean seen = false;
     try {
-      timer.record(() -> {
+      timer.call(() -> {
         clock.setMonotonicTime(500L);
         throw new Exception("foo");
       });
@@ -115,7 +115,7 @@ public class DefaultPlaceholderTimerTest {
   public void testRecordRunnable() throws Exception {
     Timer timer = factory.timer(factory.createId("testRecordRunnable"));
     clock.setMonotonicTime(100L);
-    timer.record(() -> clock.setMonotonicTime(500L));
+    timer.run(() -> clock.setMonotonicTime(500L));
     Assert.assertEquals(1L, timer.count());
     Assert.assertEquals(timer.totalTime(), 400L);
   }
@@ -124,10 +124,10 @@ public class DefaultPlaceholderTimerTest {
   public void testRecordRunnableException() throws Exception {
     Timer timer = factory.timer(factory.createId("testRecordRunnableException"));
     clock.setMonotonicTime(100L);
-    Exception expectedExc = new RuntimeException("foo");
+    RuntimeException expectedExc = new RuntimeException("foo");
     Exception actualExc = null;
     try {
-      timer.record(() -> {
+      timer.run(() -> {
         clock.setMonotonicTime(500L);
         throw expectedExc;
       });

--- a/spectator-ext-spark/src/main/java/com/netflix/spectator/spark/SidecarTimer.java
+++ b/spectator-ext-spark/src/main/java/com/netflix/spectator/spark/SidecarTimer.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 Netflix, Inc.
+/*
+ * Copyright 2014-2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ import com.netflix.spectator.api.Timer;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Callable;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
@@ -47,27 +46,13 @@ class SidecarTimer implements Timer {
     return id;
   }
 
+  @Override public Clock clock() {
+    return clock;
+  }
+
   @Override public void record(long amount, TimeUnit unit) {
     Measurement m = new Measurement(id, clock.wallTime(), unit.toMillis(amount));
     values.offer(m);
-  }
-
-  @Override public <T> T record(Callable<T> f) throws Exception {
-    final long start = clock.monotonicTime();
-    try {
-      return f.call();
-    } finally {
-      record(clock.monotonicTime() - start, TimeUnit.NANOSECONDS);
-    }
-  }
-
-  @Override public void record(Runnable f) {
-    final long start = clock.monotonicTime();
-    try {
-      f.run();
-    } finally {
-      record(clock.monotonicTime() - start, TimeUnit.NANOSECONDS);
-    }
   }
 
   @Override public long count() {

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasTimer.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasTimer.java
@@ -15,18 +15,17 @@
  */
 package com.netflix.spectator.atlas;
 
+import com.netflix.spectator.api.AbstractTimer;
 import com.netflix.spectator.api.Clock;
 import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Measurement;
 import com.netflix.spectator.api.Statistic;
-import com.netflix.spectator.api.Timer;
 import com.netflix.spectator.impl.StepDouble;
 import com.netflix.spectator.impl.StepLong;
 import com.netflix.spectator.impl.StepValue;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -48,10 +47,9 @@ import java.util.concurrent.atomic.AtomicLong;
  * the values since the last complete interval rather than the total for the
  * life of the process.</p>
  */
-class AtlasTimer implements Timer {
+class AtlasTimer extends AbstractTimer {
 
   private final Id id;
-  private final Clock clock;
   private final StepLong count;
   private final StepLong total;
   private final StepDouble totalOfSquares;
@@ -61,8 +59,8 @@ class AtlasTimer implements Timer {
 
   /** Create a new instance. */
   AtlasTimer(Id id, Clock clock, long step) {
+    super(clock);
     this.id = id;
-    this.clock = clock;
     this.count = new StepLong(0L, clock, step);
     this.total = new StepLong(0L, clock, step);
     this.totalOfSquares = new StepDouble(0.0, clock, step);
@@ -124,24 +122,6 @@ class AtlasTimer implements Timer {
     long p = maxValue.get();
     while (v > p && !maxValue.compareAndSet(p, v)) {
       p = maxValue.get();
-    }
-  }
-
-  @Override public <T> T record(Callable<T> f) throws Exception {
-    final long start = clock.monotonicTime();
-    try {
-      return f.call();
-    } finally {
-      record(clock.monotonicTime() - start, TimeUnit.NANOSECONDS);
-    }
-  }
-
-  @Override public void record(Runnable f) {
-    final long start = clock.monotonicTime();
-    try {
-      f.run();
-    } finally {
-      record(clock.monotonicTime() - start, TimeUnit.NANOSECONDS);
     }
   }
 

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasTimerTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasTimerTest.java
@@ -132,14 +132,14 @@ public class AtlasTimerTest {
 
   @Test
   public void recordRunnable() {
-    dist.record(() -> clock.setMonotonicTime(clock.monotonicTime() + 2));
+    dist.run(() -> clock.setMonotonicTime(clock.monotonicTime() + 2));
     clock.setWallTime(step + 1);
     checkValue(1, 2, 4, 2);
   }
 
   @Test
   public void recordCallable() throws Exception {
-    String s = dist.record(() -> {
+    String s = dist.call(() -> {
       clock.setMonotonicTime(clock.monotonicTime() + 2);
       return "foo";
     });

--- a/spectator-reg-servo/src/test/java/com/netflix/spectator/servo/ServoTimerTest.java
+++ b/spectator-reg-servo/src/test/java/com/netflix/spectator/servo/ServoTimerTest.java
@@ -82,7 +82,7 @@ public class ServoTimerTest {
   public void testRecordCallable() throws Exception {
     Timer t = newTimer("foo");
     clock.setMonotonicTime(100L);
-    int v = t.record(() -> {
+    int v = t.call(() -> {
       clock.setMonotonicTime(500L);
       return 42;
     });
@@ -97,7 +97,7 @@ public class ServoTimerTest {
     clock.setMonotonicTime(100L);
     boolean seen = false;
     try {
-      t.record((Callable<Integer>) () -> {
+      t.call((Callable<Integer>) () -> {
         clock.setMonotonicTime(500L);
         throw new RuntimeException("foo");
       });
@@ -113,7 +113,7 @@ public class ServoTimerTest {
   public void testRecordRunnable() throws Exception {
     Timer t = newTimer("foo");
     clock.setMonotonicTime(100L);
-    t.record(() -> clock.setMonotonicTime(500L));
+    t.run(() -> clock.setMonotonicTime(500L));
     Assert.assertEquals(t.count(), 1L);
     Assert.assertEquals(t.totalTime(), 400L);
   }
@@ -124,7 +124,7 @@ public class ServoTimerTest {
     clock.setMonotonicTime(100L);
     boolean seen = false;
     try {
-      t.record((Runnable) () -> {
+      t.run((Runnable) () -> {
         clock.setMonotonicTime(500L);
         throw new RuntimeException("foo");
       });


### PR DESCRIPTION
Deprecates the `record(Runnable)` and `record(Callable)`
on timers and replaces them with `run(Runnable)` and
`call(Callable)` respectively. This avoids issues with
ambiuous overloaded definitions such as:

```
scala> t.call { () => foo }
bar

scala> t.run { () => foo }
bar

scala> t.record { () => foo }
<console>:17: error: ambiguous reference to overloaded definition,
both method record in trait Timer of type (x$1: Runnable)Unit
and  method record in trait Timer of type [T](x$1: java.util.concurrent.Callable[T])T
match argument types (() => Unit)
       t.record { () => foo }
```