### PR TITLE
update to nebula 3.5.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,8 +12,8 @@ buildscript {
 }
 
 plugins {
-  id 'nebula.netflixoss' version '3.5.1'
-  id 'me.champeau.gradle.jmh' version '0.3.1'
+  id 'nebula.netflixoss' version '3.5.2'
+  id 'me.champeau.gradle.jmh' version '0.3.0'
 }
 
 // Establish version and status


### PR DESCRIPTION
Updates to nebula 3.5.2 to fix jmh. For more
details see:

nebula-plugins/gradle-netflixoss-project-plugin#32

Note, 0.3.1 of the jmh plugin breaks for a
different reason on both nebular versions. So
pinning back to 0.3.0 for now.