### PR TITLE
reduce thread contention for registry

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,14 +70,16 @@ subprojects {
     testCompile 'junit:junit'
     testCompile 'nl.jqno.equalsverifier:equalsverifier'
     jmh "org.slf4j:slf4j-simple"
+    jmh "org.openjdk.jmh:jmh-core:1.17"
+    jmh "org.openjdk.jmh:jmh-generator-annprocess:1.17"
   }
 
   jmh {
-    warmupIterations = 2
+    warmupIterations = 10
     iterations = 10
-    fork = 5
+    fork = 1
     profilers = ['stack']
-    include '.*Ids.*'
+    include '.*Counters.*'
   }
 
   jacoco {

--- a/spectator-api/src/jmh/java/com/netflix/spectator/perf/Counters.java
+++ b/spectator-api/src/jmh/java/com/netflix/spectator/perf/Counters.java
@@ -16,7 +16,8 @@
 package com.netflix.spectator.perf;
 
 import com.netflix.spectator.api.Counter;
-import com.netflix.spectator.api.Spectator;
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.Registry;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
@@ -27,63 +28,214 @@ import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
+import java.util.Random;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
 @State(Scope.Thread)
 public class Counters {
 
-  private final Counter cached = Spectator.globalRegistry().counter("cachedIncrement");
+  @State(Scope.Benchmark)
+  public static class Data {
+    Registry registry = new DefaultRegistry();
+    Counter cached = registry.counter("cached");
+    String[] names;
+    String[] newNames;
 
-  @Threads(1)
-  @Benchmark
-  public void cachedIncrement_T1() {
-    cached.increment();
+    public Data() {
+      newNames = new String[100000];
+      for (int i = 0; i < 100000; ++i) {
+        registry.counter(UUID.randomUUID().toString()).increment();
+        newNames[i] = UUID.randomUUID().toString();
+      }
+      names = registry.counters()
+          .map(c -> c.id().name())
+          .collect(Collectors.toList())
+          .toArray(new String[]{});
+    }
+  }
+
+  @State(Scope.Thread)
+  public static class Metrics {
+    private Random random = new Random();
+
+    Counter get(Data data) {
+      // Assumes about 5% of lookups will be for a new or expired counter. This is
+      // mostly just to have some activity that will cause an addition to the map
+      // mixed in with the reads.
+      String name = (random.nextDouble() < 0.05)
+          ? data.newNames[random.nextInt(data.newNames.length)]
+          : data.names[random.nextInt(data.names.length)];
+      return data.registry.counter(name);
+    }
   }
 
   @Threads(1)
   @Benchmark
-  public void lookupIncrement_T1() {
-    Spectator.globalRegistry().counter("lookupIncrement").increment();
+  public void cached_T001(Data data) {
+    data.cached.increment();
+  }
+
+  @Threads(1)
+  @Benchmark
+  public void lookup_T001(Data data) {
+    data.registry.counter("lookup").increment();
+  }
+
+  @Threads(1)
+  @Benchmark
+  public void random_T001(Data data, Metrics metrics) {
+    metrics.get(data).increment();
   }
 
   @Threads(2)
   @Benchmark
-  public void cachedIncrement_T2() {
-    cached.increment();
+  public void cached_T002(Data data) {
+    data.cached.increment();
   }
 
   @Threads(2)
   @Benchmark
-  public void lookupIncrement_T2() {
-    Spectator.globalRegistry().counter("lookupIncrement").increment();
+  public void lookup_T002(Data data) {
+    data.registry.counter("lookup").increment();
+  }
+
+  @Threads(2)
+  @Benchmark
+  public void random_T002(Data data, Metrics metrics) {
+    metrics.get(data).increment();
   }
 
   @Threads(4)
   @Benchmark
-  public void cachedIncrement_T4() {
-    cached.increment();
+  public void cached_T004(Data data) {
+    data.cached.increment();
   }
 
   @Threads(4)
   @Benchmark
-  public void lookupIncrement_T4() {
-    Spectator.globalRegistry().counter("lookupIncrement").increment();
+  public void lookup_T004(Data data) {
+    data.registry.counter("lookup").increment();
+  }
+
+  @Threads(4)
+  @Benchmark
+  public void random_T004(Data data, Metrics metrics) {
+    metrics.get(data).increment();
   }
 
   @Threads(8)
   @Benchmark
-  public void cachedIncrement_T8() {
-    cached.increment();
+  public void cached_T008(Data data) {
+    data.cached.increment();
   }
 
   @Threads(8)
   @Benchmark
-  public void lookupIncrement_T8() {
-    Spectator.globalRegistry().counter("lookupIncrement").increment();
+  public void lookup_T008(Data data) {
+    data.registry.counter("lookup").increment();
+  }
+
+  @Threads(8)
+  @Benchmark
+  public void random_T008(Data data, Metrics metrics) {
+    metrics.get(data).increment();
+  }
+
+  @Threads(16)
+  @Benchmark
+  public void cached_T016(Data data) {
+    data.cached.increment();
+  }
+
+  @Threads(16)
+  @Benchmark
+  public void lookup_T016(Data data) {
+    data.registry.counter("lookup").increment();
+  }
+
+  @Threads(16)
+  @Benchmark
+  public void random_T016(Data data, Metrics metrics) {
+    metrics.get(data).increment();
+  }
+
+  @Threads(32)
+  @Benchmark
+  public void cached_T032(Data data) {
+    data.cached.increment();
+  }
+
+  @Threads(32)
+  @Benchmark
+  public void lookup_T032(Data data) {
+    data.registry.counter("lookup").increment();
+  }
+
+  @Threads(32)
+  @Benchmark
+  public void random_T032(Data data, Metrics metrics) {
+    metrics.get(data).increment();
+  }
+
+  @Threads(64)
+  @Benchmark
+  public void cached_T064(Data data) {
+    data.cached.increment();
+  }
+
+  @Threads(64)
+  @Benchmark
+  public void lookup_T064(Data data) {
+    data.registry.counter("lookup").increment();
+  }
+
+  @Threads(64)
+  @Benchmark
+  public void random_T064(Data data, Metrics metrics) {
+    metrics.get(data).increment();
+  }
+
+  @Threads(128)
+  @Benchmark
+  public void cached_T128(Data data) {
+    data.cached.increment();
+  }
+
+  @Threads(128)
+  @Benchmark
+  public void lookup_T128(Data data) {
+    data.registry.counter("lookup").increment();
+  }
+
+  @Threads(128)
+  @Benchmark
+  public void random_T128(Data data, Metrics metrics) {
+    metrics.get(data).increment();
+  }
+
+  @Threads(256)
+  @Benchmark
+  public void cached_T256(Data data) {
+    data.cached.increment();
+  }
+
+  @Threads(256)
+  @Benchmark
+  public void lookup_T256(Data data) {
+    data.registry.counter("lookup").increment();
+  }
+
+  @Threads(256)
+  @Benchmark
+  public void random_T256(Data data, Metrics metrics) {
+    metrics.get(data).increment();
   }
 
   @TearDown
-  public void check() {
-    final long cv = cached.count();
-    final long lv = Spectator.globalRegistry().counter("lookupIncrement").count();
+  public void check(Data data) {
+    final long cv = data.cached.count();
+    final long lv = data.registry.counter("lookup").count();
     assert cv > 0 || lv > 0 : "counters haven't been incremented";
   }
 


### PR DESCRIPTION
The `AbstractRegistry` base class uses a `ConcurrentHashMap`
for storing the meters. In some use-cases on larger instance
types like m4.16xlarge we are seeing a lot of thread
contention.

Sample profile from the JMH benchmark running on a
m4.16xlarge:

```
Result "lookup_T032":
  5606833.986 ±(99.9%) 630187.261 ops/s [Average]
  (min, avg, max) = (5031460.935, 5606833.986, 6415287.533), stdev = 416829.854
  CI (99.9%): [4976646.724, 6237021.247] (assumes normal distribution)

Secondary result "·stack":
Stack profiler:

....[Thread state distributions]....................................................................
 92.0%         BLOCKED
  6.7%         RUNNABLE
  1.3%         WAITING

....[Thread state: BLOCKED].........................................................................
 92.0% 100.0% java.util.concurrent.ConcurrentHashMap.computeIfAbsent

....[Thread state: RUNNABLE]........................................................................
  6.3%  94.4% java.util.concurrent.ConcurrentHashMap.computeIfAbsent
  0.3%   4.6% com.netflix.spectator.api.AbstractRegistry.counter
  0.0%   0.6% com.netflix.spectator.perf.generated.Counters_lookup_T032_jmhTest.lookup_T032_thrpt_jmhStub
  0.0%   0.1% sun.misc.Unsafe.unpark
  0.0%   0.1% sun.reflect.Reflection.getClassAccessFlags
  0.0%   0.1% java.lang.System.nanoTime
  0.0%   0.1% sun.misc.Unsafe.park
  0.0%   0.1% java.lang.Thread.isInterrupted

....[Thread state: WAITING].........................................................................
  1.3% 100.0% sun.misc.Unsafe.park
```

To avoid the problem, this changes to using a combination
of `get` and `putIfAbsent` rather than `computeIfAbsent`.
The `computeIfAbsent` call has stronger guarantees, but
at the cost of some locking for the more common case where
the key exists. The method used now will potentially create
some transient meters that will get thrown away, but behaves
better when contended.

The tables below show the thread state distributions
before and after this change for a couple of sample use
cases. With this change we no longer see blocked threads.

**Cached**

Counter that is stored in a member variable for quick
access. This was expected to be unchanged and that seems
to be true.

```
          |        before         |         after         |
|=========|=======================|=======================|
| threads |   R   |   W   |   B   |   R   |   W   |   B   |
|---------|-------|-------|-------|-------|-------|-------|
|       1 | 100.0 |   0.0 |   0.0 | 100.0 |   0.0 |   0.0 |
|       2 |  99.4 |   0.6 |   0.0 |  99.4 |   0.6 |   0.0 |
|       4 |  99.3 |   0.7 |   0.0 |  99.3 |   0.7 |   0.0 |
|       8 |  99.0 |   1.0 |   0.0 |  98.9 |   1.1 |   0.0 |
|      16 |  98.9 |   1.1 |   0.0 |  98.9 |   1.1 |   0.0 |
|      32 |  98.4 |   1.6 |   0.0 |  98.2 |   1.8 |   0.0 |
|      64 |  97.5 |   2.5 |   0.0 |  96.3 |   3.7 |   0.0 |
|     128 |  93.7 |   6.3 |   0.0 |  93.8 |   6.3 |   0.0 |
|     256 |  82.5 |  17.5 |   0.0 |  80.4 |  19.6 |   0.0 |
```

**Lookup**

Looking up the same counter each time. This will cause
it to access the same segment of the concurrent map so
should be a worst case for contention on locks.

```
          |        before         |         after         |
|=========|=======================|=======================|
| threads |   R   |   W   |   B   |   R   |   W   |   B   |
|---------|-------|-------|-------|-------|-------|-------|
|       1 | 100.0 |   0.0 |   0.0 | 100.0 |   0.0 |   0.0 |
|       2 |  99.2 |   0.5 |   0.3 |  99.7 |   0.3 |   0.0 |
|       4 |  58.9 |   0.7 |  40.5 |  99.4 |   0.6 |   0.0 |
|       8 |  28.2 |   1.0 |  70.8 |  99.0 |   1.0 |   0.0 |
|      16 |  13.4 |   1.2 |  85.4 |  98.9 |   1.1 |   0.0 |
|      32 |   6.7 |   1.3 |  92.0 |  98.5 |   1.5 |   0.0 |
|      64 |   3.4 |   1.8 |  94.8 |  97.4 |   2.6 |   0.0 |
|     128 |   1.7 |   3.0 |  95.3 |  93.6 |   6.4 |   0.0 |
|     256 |   0.8 |   6.6 |  92.6 |  81.9 |  18.1 |   0.0 |
```

**Random**

Looks up a random counter from the registry. Also triggers
a create for about 5% of the reads. This is thought to be
more representative of a typical app.

```
          |        before         |         after         |
|=========|=======================|=======================|
| threads |   R   |   W   |   B   |   R   |   W   |   B   |
|---------|-------|-------|-------|-------|-------|-------|
|       1 | 100.0 |   0.0 |   0.0 |  99.9 |   0.1 |   0.0 |
|       2 |  99.3 |   0.7 |   0.0 |  99.5 |   0.5 |   0.0 |
|       4 |  99.3 |   0.7 |   0.0 |  99.2 |   0.8 |   0.0 |
|       8 |  99.1 |   0.9 |   0.0 |  99.1 |   0.9 |   0.0 |
|      16 |  98.9 |   1.1 |   0.0 |  98.9 |   1.1 |   0.0 |
|      32 |  98.3 |   1.6 |   0.1 |  98.4 |   1.6 |   0.0 |
|      64 |  96.3 |   2.4 |   1.3 |  97.5 |   2.5 |   0.0 |
|     128 |  54.4 |   7.4 |  38.3 |  93.0 |   7.0 |   0.0 |
|     256 |  31.2 |  14.4 |  54.4 |  78.4 |  21.6 |   0.0 |
```