### PR TITLE
add support for Atlas query and data expressions

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/DataExpr.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/DataExpr.java
@@ -1,0 +1,571 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import com.netflix.spectator.impl.Preconditions;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+/**
+ * Data expressions for defining how to aggregate values. For more information see:
+ *
+ * https://github.com/Netflix/atlas/wiki/Reference-data
+ */
+interface DataExpr {
+
+  /** Query for selecting the input measurements that should be aggregated. */
+  Query query();
+
+  /**
+   * Get an aggregator that can be incrementally fed values. See {@link #eval(Iterable)} if
+   * you already have the completed list of values.
+   *
+   * @param tags
+   *     The set of tags for the final aggregate.
+   * @return
+   *     Aggregator for this data expression.
+   */
+  Aggregator aggregator(Map<String, String> tags);
+
+  /**
+   * Get an aggregator using the default set of tags for the final result. The tags will
+   * be extracted based on the exact matches for the underlying query.
+   */
+  default Aggregator aggregator() {
+    return aggregator(query().exactTags());
+  }
+
+  /**
+   * Evaluate the data expression over the input.
+   *
+   * @param input
+   *     Set of data values. The data will get filtered based on the query, that does
+   *     not need to be done in advance.
+   * @return
+   *     Aggregated data values.
+   */
+  default Iterable<TagsValuePair> eval(Iterable<TagsValuePair> input) {
+    Aggregator aggr = aggregator();
+    for (TagsValuePair p : input) {
+      aggr.update(p);
+    }
+    return aggr.result();
+  }
+
+  /** Helper for incrementally computing an aggregate of a set of tag values. */
+  interface Aggregator {
+    /** Update the aggregate with the provided value. */
+    void update(TagsValuePair p);
+
+    /** Returns the aggregated data values. */
+    Iterable<TagsValuePair> result();
+  }
+
+  /**
+   * Includes all datapoints that match the query expression. See also:
+   * https://github.com/Netflix/atlas/wiki/data-all
+   */
+  final class All implements DataExpr {
+
+    private final Query query;
+
+    /** Create a new instance. */
+    All(Query query) {
+      this.query = query;
+    }
+
+    @Override public Query query() {
+      return query;
+    }
+
+    @Override public Aggregator aggregator(Map<String, String> ignored) {
+      return new Aggregator() {
+        private List<TagsValuePair> pairs = new ArrayList<>();
+
+        @Override public void update(TagsValuePair p) {
+          Map<String, String> tags = p.tags();
+          if (query.matches(tags)) {
+            pairs.add(new TagsValuePair(tags, p.value()));
+          }
+        }
+
+        @Override public Iterable<TagsValuePair> result() {
+          return pairs;
+        }
+      };
+    }
+
+    @Override public Aggregator aggregator() {
+      return aggregator(null);
+    }
+
+    @Override public String toString() {
+      return query.toString() + ",:all";
+    }
+
+    @Override public boolean equals(Object obj) {
+      if (this == obj) return true;
+      if (obj == null || !(obj instanceof All)) return false;
+      All other = (All) obj;
+      return query.equals(other.query);
+    }
+
+    @Override public int hashCode() {
+      int result = query.hashCode();
+      result = 31 * result + ":all".hashCode();
+      return result;
+    }
+  }
+
+  /** Base type for simple aggregate functions. */
+  interface AggregateFunction extends DataExpr {
+  }
+
+  /**
+   * Aggregates all datapoints that match the query to a single datapoint that is the
+   * sum of the input values. See also: https://github.com/Netflix/atlas/wiki/data-sum
+   */
+  final class Sum implements AggregateFunction {
+
+    private final Query query;
+
+    /** Create a new instance. */
+    Sum(Query query) {
+      this.query = query;
+    }
+
+    @Override public Query query() {
+      return query;
+    }
+
+    @Override public Aggregator aggregator(Map<String, String> tags) {
+      return new Aggregator() {
+        private double aggr = 0.0;
+        private int count = 0;
+
+        @Override public void update(TagsValuePair p) {
+          if (query.matches(p.tags())) {
+            aggr += p.value();
+            ++count;
+          }
+        }
+
+        @Override public Iterable<TagsValuePair> result() {
+          return (count > 0)
+              ? Collections.singletonList(new TagsValuePair(tags, aggr))
+              : Collections.emptyList();
+        }
+      };
+    }
+
+    @Override public String toString() {
+      return query.toString() + ",:sum";
+    }
+
+    @Override public boolean equals(Object obj) {
+      if (this == obj) return true;
+      if (obj == null || !(obj instanceof Sum)) return false;
+      Sum other = (Sum) obj;
+      return query.equals(other.query);
+    }
+
+    @Override public int hashCode() {
+      int result = query.hashCode();
+      result = 31 * result + ":sum".hashCode();
+      return result;
+    }
+  }
+
+  /**
+   * Aggregates all datapoints that match the query to a single datapoint that is the
+   * minimum of the input values. See also: https://github.com/Netflix/atlas/wiki/data-min
+   */
+  final class Min implements AggregateFunction {
+
+    private final Query query;
+
+    /** Create a new instance. */
+    Min(Query query) {
+      this.query = query;
+    }
+
+    @Override public Query query() {
+      return query;
+    }
+
+    @Override public Aggregator aggregator(Map<String, String> tags) {
+      return new Aggregator() {
+        private double aggr = Double.MAX_VALUE;
+        private int count = 0;
+
+        @Override public void update(TagsValuePair p) {
+          if (query.matches(p.tags()) && p.value() < aggr) {
+            aggr = p.value();
+            ++count;
+          }
+        }
+
+        @Override public Iterable<TagsValuePair> result() {
+          return (count > 0)
+              ? Collections.singletonList(new TagsValuePair(tags, aggr))
+              : Collections.emptyList();
+        }
+      };
+    }
+
+    @Override public String toString() {
+      return query.toString() + ",:min";
+    }
+
+    @Override public boolean equals(Object obj) {
+      if (this == obj) return true;
+      if (obj == null || !(obj instanceof Min)) return false;
+      Min other = (Min) obj;
+      return query.equals(other.query);
+    }
+
+    @Override public int hashCode() {
+      int result = query.hashCode();
+      result = 31 * result + ":min".hashCode();
+      return result;
+    }
+  }
+
+  /**
+   * Aggregates all datapoints that match the query to a single datapoint that is the
+   * maximum of the input values. See also: https://github.com/Netflix/atlas/wiki/data-max
+   */
+  final class Max implements AggregateFunction {
+
+    private final Query query;
+
+    /** Create a new instance. */
+    Max(Query query) {
+      this.query = query;
+    }
+
+    @Override public Query query() {
+      return query;
+    }
+
+    @Override public Aggregator aggregator(Map<String, String> tags) {
+      return new Aggregator() {
+        private double aggr = -Double.MAX_VALUE;
+        private int count = 0;
+
+        @Override public void update(TagsValuePair p) {
+          if (query.matches(p.tags()) && p.value() > aggr) {
+            aggr = p.value();
+            ++count;
+          }
+        }
+
+        @Override public Iterable<TagsValuePair> result() {
+          return (count > 0)
+              ? Collections.singletonList(new TagsValuePair(tags, aggr))
+              : Collections.emptyList();
+        }
+      };
+    }
+
+    @Override public String toString() {
+      return query.toString() + ",:max";
+    }
+
+    @Override public boolean equals(Object obj) {
+      if (this == obj) return true;
+      if (obj == null || !(obj instanceof Max)) return false;
+      Max other = (Max) obj;
+      return query.equals(other.query);
+    }
+
+    @Override public int hashCode() {
+      int result = query.hashCode();
+      result = 31 * result + ":max".hashCode();
+      return result;
+    }
+  }
+
+  /**
+   * Aggregates all datapoints that match the query to a single datapoint that is the
+   * number of input values. See also: https://github.com/Netflix/atlas/wiki/data-count
+   */
+  final class Count implements AggregateFunction {
+
+    private final Query query;
+
+    /** Create a new instance. */
+    Count(Query query) {
+      this.query = query;
+    }
+
+    @Override public Query query() {
+      return query;
+    }
+
+    @Override public Aggregator aggregator(Map<String, String> tags) {
+      return new Aggregator() {
+        private int aggr = 0;
+
+        @Override public void update(TagsValuePair p) {
+          if (query.matches(p.tags())) {
+            ++aggr;
+          }
+        }
+
+        @Override public Iterable<TagsValuePair> result() {
+          return (aggr > 0)
+              ? Collections.singletonList(new TagsValuePair(tags, aggr))
+              : Collections.emptyList();
+        }
+      };
+    }
+
+    @Override public String toString() {
+      return query.toString() + ",:count";
+    }
+
+    @Override public boolean equals(Object obj) {
+      if (this == obj) return true;
+      if (obj == null || !(obj instanceof Count)) return false;
+      Count other = (Count) obj;
+      return query.equals(other.query);
+    }
+
+    @Override public int hashCode() {
+      int result = query.hashCode();
+      result = 31 * result + ":count".hashCode();
+      return result;
+    }
+  }
+
+  /**
+   * Compute a set of time series matching the query and grouped by the specified keys.
+   * See also: https://github.com/Netflix/atlas/wiki/data-by
+   */
+  final class GroupBy implements DataExpr {
+
+    private final AggregateFunction af;
+    private final List<String> keys;
+
+    /** Create a new instance. */
+    GroupBy(AggregateFunction af, List<String> keys) {
+      Preconditions.checkArg(!keys.isEmpty(), "key list for group by cannot be empty");
+      this.af = af;
+      this.keys = keys;
+    }
+
+    private Map<String, String> keyTags(Map<String, String> tags) {
+      Map<String, String> result = new HashMap<>();
+      for (String k : keys) {
+        String v = tags.get(k);
+        if (v == null) {
+          return null;
+        }
+        result.put(k, v);
+      }
+      return result;
+    }
+
+    @Override public Query query() {
+      return af.query();
+    }
+
+    @Override public Aggregator aggregator(Map<String, String> queryTags) {
+      return new Aggregator() {
+        private Map<Map<String, String>, Aggregator> aggrs = new HashMap<>();
+
+        @Override public void update(TagsValuePair p) {
+          Map<String, String> tags = p.tags();
+          if (af.query().matches(tags)) {
+            Map<String, String> k = keyTags(tags);
+            if (k != null) {
+              k.putAll(queryTags);
+              aggrs.computeIfAbsent(k, af::aggregator).update(p);
+            }
+          }
+        }
+
+        @Override public Iterable<TagsValuePair> result() {
+          return aggrs.values().stream()
+              .flatMap(a -> StreamSupport.stream(a.result().spliterator(), false))
+              .collect(Collectors.toList());
+        }
+      };
+    }
+
+    @Override public String toString() {
+      final String keyList = keys.stream().collect(Collectors.joining(","));
+      return af.toString() + ",(," + keyList + ",),:by";
+    }
+
+    @Override public boolean equals(Object obj) {
+      if (this == obj) return true;
+      if (obj == null || !(obj instanceof GroupBy)) return false;
+      GroupBy other = (GroupBy) obj;
+      return af.equals(other.af) && keys.equals(other.keys);
+    }
+
+    @Override public int hashCode() {
+      int result = af.hashCode();
+      result = 31 * result + keys.hashCode();
+      result = 31 * result + ":by".hashCode();
+      return result;
+    }
+  }
+
+  /**
+   * Rollup inputs by dropping the specified keys. This is typically used with
+   * a rollup config to reduce the amount of data going out. If a whitelist
+   * of keys is needed, then see {@link KeepRollup}.
+   */
+  final class DropRollup implements DataExpr {
+
+    private final AggregateFunction af;
+    private final List<String> keys;
+
+    /** Create a new instance. */
+    DropRollup(AggregateFunction af, List<String> keys) {
+      Preconditions.checkArg(!keys.contains("name"), "name is required and cannot be dropped");
+      this.af = af;
+      this.keys = keys;
+    }
+
+    @Override public Query query() {
+      return af.query();
+    }
+
+    @Override public Aggregator aggregator(Map<String, String> ignored) {
+      return new Aggregator() {
+        private Map<Map<String, String>, Aggregator> aggrs = new HashMap<>();
+
+        @Override public void update(TagsValuePair p) {
+          Map<String, String> tags = new HashMap<>(p.tags());
+          if (af.query().matches(tags)) {
+            for (String k : keys) {
+              tags.remove(k);
+            }
+            aggrs.computeIfAbsent(tags, af::aggregator).update(p);
+          }
+        }
+
+        @Override public Iterable<TagsValuePair> result() {
+          return aggrs.values().stream()
+              .flatMap(a -> StreamSupport.stream(a.result().spliterator(), false))
+              .collect(Collectors.toList());
+        }
+      };
+    }
+
+    @Override public Aggregator aggregator() {
+      return aggregator(null);
+    }
+
+    @Override public String toString() {
+      final String keyList = keys.stream().collect(Collectors.joining(","));
+      return af.toString() + ",(," + keyList + ",),:rollup-drop";
+    }
+
+    @Override public boolean equals(Object obj) {
+      if (this == obj) return true;
+      if (obj == null || !(obj instanceof DropRollup)) return false;
+      DropRollup other = (DropRollup) obj;
+      return af.equals(other.af) && keys.equals(other.keys);
+    }
+
+    @Override public int hashCode() {
+      int result = af.hashCode();
+      result = 31 * result + keys.hashCode();
+      result = 31 * result + ":by".hashCode();
+      return result;
+    }
+  }
+
+  /**
+   * Rollup inputs by only keeping the specified keys. This is typically used with
+   * a rollup config to reduce the amount of data going out. If a blacklist of
+   * keys is needed, then see {@link DropRollup}.
+   */
+  final class KeepRollup implements DataExpr {
+
+    private final AggregateFunction af;
+    private final Set<String> keys;
+
+    /** Create a new instance. */
+    KeepRollup(AggregateFunction af, List<String> keys) {
+      this.af = af;
+      this.keys = new HashSet<>(keys);
+      this.keys.add("name");
+    }
+
+    @Override public Query query() {
+      return af.query();
+    }
+
+    @Override public Aggregator aggregator(Map<String, String> ignored) {
+      return new Aggregator() {
+        private Map<Map<String, String>, Aggregator> aggrs = new HashMap<>();
+
+        @Override public void update(TagsValuePair p) {
+          Map<String, String> tags = p.tags();
+          if (af.query().matches(tags)) {
+            Map<String, String> newTags = tags.entrySet().stream()
+                .filter(e -> keys.contains(e.getKey()))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+            aggrs.computeIfAbsent(newTags, af::aggregator).update(p);
+          }
+        }
+
+        @Override public Iterable<TagsValuePair> result() {
+          return aggrs.values().stream()
+              .flatMap(a -> StreamSupport.stream(a.result().spliterator(), false))
+              .collect(Collectors.toList());
+        }
+      };
+    }
+
+    @Override public Aggregator aggregator() {
+      return aggregator(null);
+    }
+
+    @Override public String toString() {
+      final String keyList = keys.stream().collect(Collectors.joining(","));
+      return af.toString() + ",(," + keyList + ",),:rollup-keep";
+    }
+
+    @Override public boolean equals(Object obj) {
+      if (this == obj) return true;
+      if (obj == null || !(obj instanceof KeepRollup)) return false;
+      KeepRollup other = (KeepRollup) obj;
+      return af.equals(other.af) && keys.equals(other.keys);
+    }
+
+    @Override public int hashCode() {
+      int result = af.hashCode();
+      result = 31 * result + keys.hashCode();
+      result = 31 * result + ":by".hashCode();
+      return result;
+    }
+  }
+}

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/Parser.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/Parser.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.TreeSet;
+import java.util.regex.Pattern;
+
+/**
+ * Parses an Atlas data or query expression.
+ */
+final class Parser {
+
+  private Parser() {
+  }
+
+  /**
+   * Parse an <a href="https://github.com/Netflix/atlas/wiki/Reference-data">Atlas data
+   * expression</a>.
+   */
+  static DataExpr parseDataExpr(String expr) {
+    return (DataExpr) parse(expr);
+  }
+
+  /**
+   * Parse an <a href="https://github.com/Netflix/atlas/wiki/Reference-query">Atlas query
+   * expression</a>.
+   */
+  static Query parseQuery(String expr) {
+    return (Query) parse(expr);
+  }
+
+  @SuppressWarnings({"unchecked", "PMD"})
+  private static Object parse(String expr) {
+    DataExpr.AggregateFunction af;
+    Query q, q1, q2;
+    String k, v;
+    List<String> vs = null;
+    String[] parts = expr.split(",");
+    Deque<Object> stack = new ArrayDeque<>(parts.length);
+    for (String p : parts) {
+      String token = p.trim();
+      if (token.isEmpty()) {
+        continue;
+      }
+      if (vs != null && !")".equals(token)) {
+        vs.add(token);
+        continue;
+      }
+      switch (token) {
+        case "(":
+          vs = new ArrayList<>();
+          break;
+        case ")":
+          stack.push(vs);
+          vs = null;
+          break;
+        case ":true":
+          stack.push(Query.TRUE);
+          break;
+        case ":false":
+          stack.push(Query.FALSE);
+          break;
+        case ":and":
+          q2 = (Query) stack.pop();
+          q1 = (Query) stack.pop();
+          stack.push(new Query.And(q1, q2));
+          break;
+        case ":or":
+          q2 = (Query) stack.pop();
+          q1 = (Query) stack.pop();
+          stack.push(new Query.Or(q1, q2));
+          break;
+        case ":not":
+          q = (Query) stack.pop();
+          stack.push(new Query.Not(q));
+          break;
+        case ":has":
+          k = (String) stack.pop();
+          stack.push(new Query.Has(k));
+          break;
+        case ":eq":
+          v = (String) stack.pop();
+          k = (String) stack.pop();
+          stack.push(new Query.Equal(k, v));
+          break;
+        case ":in":
+          vs = (List<String>) stack.pop();
+          k = (String) stack.pop();
+          stack.push(new Query.In(k, new TreeSet<>(vs)));
+          break;
+        case ":lt":
+          v = (String) stack.pop();
+          k = (String) stack.pop();
+          stack.push(new Query.LessThan(k, v));
+          break;
+        case ":le":
+          v = (String) stack.pop();
+          k = (String) stack.pop();
+          stack.push(new Query.LessThanEqual(k, v));
+          break;
+        case ":gt":
+          v = (String) stack.pop();
+          k = (String) stack.pop();
+          stack.push(new Query.GreaterThan(k, v));
+          break;
+        case ":ge":
+          v = (String) stack.pop();
+          k = (String) stack.pop();
+          stack.push(new Query.GreaterThanEqual(k, v));
+          break;
+        case ":re":
+          v = (String) stack.pop();
+          k = (String) stack.pop();
+          stack.push(new Query.Regex(k, v));
+          break;
+        case ":reic":
+          v = (String) stack.pop();
+          k = (String) stack.pop();
+          stack.push(new Query.Regex(k, v, Pattern.CASE_INSENSITIVE, ":reic"));
+          break;
+        case ":all":
+          q = (Query) stack.pop();
+          stack.push(new DataExpr.All(q));
+          break;
+        case ":sum":
+          q = (Query) stack.pop();
+          stack.push(new DataExpr.Sum(q));
+          break;
+        case ":min":
+          q = (Query) stack.pop();
+          stack.push(new DataExpr.Min(q));
+          break;
+        case ":max":
+          q = (Query) stack.pop();
+          stack.push(new DataExpr.Max(q));
+          break;
+        case ":count":
+          q = (Query) stack.pop();
+          stack.push(new DataExpr.Count(q));
+          break;
+        case ":by":
+          vs = (List<String>) stack.pop();
+          af = (DataExpr.AggregateFunction) stack.pop();
+          stack.push(new DataExpr.GroupBy(af, vs));
+          break;
+        case ":rollup-drop":
+          vs = (List<String>) stack.pop();
+          af = (DataExpr.AggregateFunction) stack.pop();
+          stack.push(new DataExpr.DropRollup(af, vs));
+          break;
+        case ":rollup-keep":
+          vs = (List<String>) stack.pop();
+          af = (DataExpr.AggregateFunction) stack.pop();
+          stack.push(new DataExpr.KeepRollup(af, vs));
+          break;
+        default:
+          if (token.startsWith(":")) {
+            throw new IllegalArgumentException("unknown word '" + token + "'");
+          }
+          stack.push(token);
+          break;
+      }
+    }
+    Object obj = stack.pop();
+    if (!stack.isEmpty()) {
+      throw new IllegalArgumentException("too many items remaining on stack: " + stack);
+    }
+    return obj;
+  }
+}

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/Query.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/Query.java
@@ -1,0 +1,529 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Tag;
+import com.netflix.spectator.impl.Preconditions;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Query for matching based on tags. For more information see:
+ *
+ * https://github.com/Netflix/atlas/wiki/Stack-Language#query
+ */
+interface Query {
+
+  /** Convert {@code id} to a map. */
+  static Map<String, String> toMap(Id id) {
+    Map<String, String> tags = new HashMap<>();
+    for (Tag t : id.tags()) {
+      tags.put(t.key(), t.value());
+    }
+    tags.put("name", id.name());
+    return tags;
+  }
+
+  /**
+   * Check to see if this query matches a set of tags. Common tags or changes to fix
+   * invalid characters should be performed prior to checking for a match.
+   *
+   * @param tags
+   *     Tags to use when checking for a match.
+   * @return
+   *     True if the query expression matches the tag map.
+   */
+  boolean matches(Map<String, String> tags);
+
+  /**
+   * Check to see if this query matches an id. Equivalent to calling {@link #matches(Map)}
+   * with the result of {@link #toMap(Id)}.
+   *
+   * @param id
+   *     Id to use when checking for a match.
+   * @return
+   *     True if the query expression matches the id.
+   */
+  default boolean matches(Id id) {
+    return matches(toMap(id));
+  }
+
+  /**
+   * Extract the tags from the query that have an exact match for a given value. That
+   * is are specified using an {@link Equal} clause.
+   *
+   * @return
+   *     Tags that are exactly matched as part of the query.
+   */
+  default Map<String, String> exactTags() {
+    return Collections.emptyMap();
+  }
+
+  /** Returns a new query: {@code this AND q}. */
+  default Query and(Query q) {
+    return new And(this, q);
+  }
+
+  /** Returns a new query: {@code this OR q}. */
+  default Query or(Query q) {
+    return new Or(this, q);
+  }
+
+  /** Returns an inverted version of this query. */
+  default Query not() {
+    return new Not(this);
+  }
+
+  /** Query that always matches. */
+  Query TRUE = new Query() {
+    @Override public boolean matches(Map<String, String> tags) {
+      return true;
+    }
+
+    @Override public String toString() {
+      return ":true";
+    }
+  };
+
+  /** Query that never matches. */
+  Query FALSE = new Query() {
+    @Override public boolean matches(Map<String, String> tags) {
+      return false;
+    }
+
+    @Override public String toString() {
+      return ":false";
+    }
+  };
+
+  /** Query that matches if both sub-queries match. */
+  final class And implements Query {
+    private final Query q1;
+    private final Query q2;
+
+    /** Create a new instance. */
+    And(Query q1, Query q2) {
+      this.q1 = Preconditions.checkNotNull(q1, "q1");
+      this.q2 = Preconditions.checkNotNull(q2, "q2");
+    }
+
+    @Override public boolean matches(Map<String, String> tags) {
+      return q1.matches(tags) && q2.matches(tags);
+    }
+
+    @Override public Map<String, String> exactTags() {
+      Map<String, String> tags = new HashMap<>();
+      tags.putAll(q1.exactTags());
+      tags.putAll(q2.exactTags());
+      return tags;
+    }
+
+    @Override public String toString() {
+      return q1 + "," + q2 + ",:and";
+    }
+
+    @Override public boolean equals(Object obj) {
+      if (this == obj) return true;
+      if (obj == null || !(obj instanceof And)) return false;
+      And other = (And) obj;
+      return q1.equals(other.q1) && q2.equals(other.q2);
+    }
+
+    @Override public int hashCode() {
+      int result = q1.hashCode();
+      result = 31 * result + q2.hashCode();
+      return result;
+    }
+  }
+
+  /** Query that matches if either sub-queries match. */
+  final class Or implements Query {
+    private final Query q1;
+    private final Query q2;
+
+    /** Create a new instance. */
+    Or(Query q1, Query q2) {
+      this.q1 = Preconditions.checkNotNull(q1, "q1");
+      this.q2 = Preconditions.checkNotNull(q2, "q2");
+    }
+
+    @Override public boolean matches(Map<String, String> tags) {
+      return q1.matches(tags) || q2.matches(tags);
+    }
+
+    @Override public String toString() {
+      return q1 + "," + q2 + ",:or";
+    }
+
+    @Override public boolean equals(Object obj) {
+      if (this == obj) return true;
+      if (obj == null || !(obj instanceof Or)) return false;
+      Or other = (Or) obj;
+      return q1.equals(other.q1) && q2.equals(other.q2);
+    }
+
+    @Override public int hashCode() {
+      int result = q1.hashCode();
+      result = 31 * result + q2.hashCode();
+      return result;
+    }
+  }
+
+  /** Query that matches if the sub-query does not match. */
+  final class Not implements Query {
+    private final Query q;
+
+    /** Create a new instance. */
+    Not(Query q) {
+      this.q = Preconditions.checkNotNull(q, "q");
+    }
+
+    @Override public boolean matches(Map<String, String> tags) {
+      return !q.matches(tags);
+    }
+
+    @Override public String toString() {
+      return q + ",:not";
+    }
+
+    @Override public boolean equals(Object obj) {
+      if (this == obj) return true;
+      if (obj == null || !(obj instanceof Not)) return false;
+      Not other = (Not) obj;
+      return q.equals(other.q);
+    }
+
+    @Override public int hashCode() {
+      return q.hashCode();
+    }
+  }
+
+  /** Query that matches if the tag map contains a specified key. */
+  final class Has implements Query {
+    private final String k;
+
+    /** Create a new instance. */
+    Has(String k) {
+      this.k = Preconditions.checkNotNull(k, "k");
+    }
+
+    @Override public boolean matches(Map<String, String> tags) {
+      return tags.containsKey(k);
+    }
+
+    @Override public String toString() {
+      return k + ",:has";
+    }
+
+    @Override public boolean equals(Object obj) {
+      if (this == obj) return true;
+      if (obj == null || !(obj instanceof Has)) return false;
+      Has other = (Has) obj;
+      return k.equals(other.k);
+    }
+
+    @Override public int hashCode() {
+      return k.hashCode();
+    }
+  }
+
+  /** Query that matches if the tag map contains key {@code k} with value {@code v}. */
+  final class Equal implements Query {
+    private final String k;
+    private final String v;
+
+    /** Create a new instance. */
+    Equal(String k, String v) {
+      this.k = Preconditions.checkNotNull(k, "k");
+      this.v = Preconditions.checkNotNull(v, "v");
+    }
+
+    @Override public boolean matches(Map<String, String> tags) {
+      return v.equals(tags.get(k));
+    }
+
+    @Override public Map<String, String> exactTags() {
+      Map<String, String> tags = new HashMap<>();
+      tags.put(k, v);
+      return tags;
+    }
+
+    @Override public String toString() {
+      return k + "," + v + ",:eq";
+    }
+
+    @Override public boolean equals(Object obj) {
+      if (this == obj) return true;
+      if (obj == null || !(obj instanceof Equal)) return false;
+      Equal other = (Equal) obj;
+      return k.equals(other.k) && v.equals(other.v);
+    }
+
+    @Override public int hashCode() {
+      int result = k.hashCode();
+      result = 31 * result + v.hashCode();
+      return result;
+    }
+  }
+
+  /**
+   * Query that matches if the tag map contains key {@code k} with a value in the set
+   * {@code vs}.
+   */
+  final class In implements Query {
+    private final String k;
+    private final Set<String> vs;
+
+    /** Create a new instance. */
+    In(String k, Set<String> vs) {
+      Preconditions.checkArg(!vs.isEmpty(), "list of values for :in cannot be empty");
+      this.k = Preconditions.checkNotNull(k, "k");
+      this.vs = Preconditions.checkNotNull(vs, "vs");
+    }
+
+    @Override public boolean matches(Map<String, String> tags) {
+      String s = tags.get(k);
+      return s != null && vs.contains(tags.get(k));
+    }
+
+    @Override public String toString() {
+      String values = vs.stream().collect(Collectors.joining(","));
+      return k + ",(," + values + ",),:in";
+    }
+
+    @Override public boolean equals(Object obj) {
+      if (this == obj) return true;
+      if (obj == null || !(obj instanceof In)) return false;
+      In other = (In) obj;
+      return k.equals(other.k) && vs.equals(other.vs);
+    }
+
+    @Override public int hashCode() {
+      int result = k.hashCode();
+      result = 31 * result + vs.hashCode();
+      return result;
+    }
+  }
+
+  /**
+   * Query that matches if the tag map contains key {@code k} with a value that is lexically
+   * less than {@code v}.
+   */
+  final class LessThan implements Query {
+    private final String k;
+    private final String v;
+
+    /** Create a new instance. */
+    LessThan(String k, String v) {
+      this.k = Preconditions.checkNotNull(k, "k");
+      this.v = Preconditions.checkNotNull(v, "v");
+    }
+
+    @Override public boolean matches(Map<String, String> tags) {
+      String s = tags.get(k);
+      return s != null && s.compareTo(v) < 0;
+    }
+
+    @Override public String toString() {
+      return k + "," + v + ",:lt";
+    }
+
+    @Override public boolean equals(Object obj) {
+      if (this == obj) return true;
+      if (obj == null || !(obj instanceof LessThan)) return false;
+      LessThan other = (LessThan) obj;
+      return k.equals(other.k) && v.equals(other.v);
+    }
+
+    @Override public int hashCode() {
+      int result = k.hashCode();
+      result = 31 * result + v.hashCode();
+      return result;
+    }
+  }
+
+  /**
+   * Query that matches if the tag map contains key {@code k} with a value that is lexically
+   * less than or equal to {@code v}.
+   */
+  final class LessThanEqual implements Query {
+    private final String k;
+    private final String v;
+
+    /** Create a new instance. */
+    LessThanEqual(String k, String v) {
+      this.k = Preconditions.checkNotNull(k, "k");
+      this.v = Preconditions.checkNotNull(v, "v");
+    }
+
+    @Override public boolean matches(Map<String, String> tags) {
+      String s = tags.get(k);
+      return s != null && s.compareTo(v) <= 0;
+    }
+
+    @Override public String toString() {
+      return k + "," + v + ",:le";
+    }
+
+    @Override public boolean equals(Object obj) {
+      if (this == obj) return true;
+      if (obj == null || !(obj instanceof LessThanEqual)) return false;
+      LessThanEqual other = (LessThanEqual) obj;
+      return k.equals(other.k) && v.equals(other.v);
+    }
+
+    @Override public int hashCode() {
+      int result = k.hashCode();
+      result = 31 * result + v.hashCode();
+      return result;
+    }
+  }
+
+  /**
+   * Query that matches if the tag map contains key {@code k} with a value that is lexically
+   * greater than {@code v}.
+   */
+  final class GreaterThan implements Query {
+    private final String k;
+    private final String v;
+
+    /** Create a new instance. */
+    GreaterThan(String k, String v) {
+      this.k = Preconditions.checkNotNull(k, "k");
+      this.v = Preconditions.checkNotNull(v, "v");
+    }
+
+    @Override public boolean matches(Map<String, String> tags) {
+      String s = tags.get(k);
+      return s != null && s.compareTo(v) > 0;
+    }
+
+    @Override public String toString() {
+      return k + "," + v + ",:gt";
+    }
+
+    @Override public boolean equals(Object obj) {
+      if (this == obj) return true;
+      if (obj == null || !(obj instanceof GreaterThan)) return false;
+      GreaterThan other = (GreaterThan) obj;
+      return k.equals(other.k) && v.equals(other.v);
+    }
+
+    @Override public int hashCode() {
+      int result = k.hashCode();
+      result = 31 * result + v.hashCode();
+      return result;
+    }
+  }
+
+  /**
+   * Query that matches if the tag map contains key {@code k} with a value that is lexically
+   * greater than or equal to {@code v}.
+   */
+  final class GreaterThanEqual implements Query {
+    private final String k;
+    private final String v;
+
+    /** Create a new instance. */
+    GreaterThanEqual(String k, String v) {
+      this.k = Preconditions.checkNotNull(k, "k");
+      this.v = Preconditions.checkNotNull(v, "v");
+    }
+
+    @Override public boolean matches(Map<String, String> tags) {
+      String s = tags.get(k);
+      return s != null && s.compareTo(v) >= 0;
+    }
+
+    @Override public String toString() {
+      return k + "," + v + ",:ge";
+    }
+
+    @Override public boolean equals(Object obj) {
+      if (this == obj) return true;
+      if (obj == null || !(obj instanceof GreaterThanEqual)) return false;
+      GreaterThanEqual other = (GreaterThanEqual) obj;
+      return k.equals(other.k) && v.equals(other.v);
+    }
+
+    @Override public int hashCode() {
+      int result = k.hashCode();
+      result = 31 * result + v.hashCode();
+      return result;
+    }
+  }
+
+  /**
+   * Query that matches if the tag map contains key {@code k} with a value that matches the
+   * regex in {@code v}. The expression will be automatically anchored to the start to encourage
+   * prefix matches.
+   *
+   * <p><b>Warning:</b> regular expressions are often expensive and can add a lot of overhead.
+   * Use them sparingly.</p>
+   */
+  final class Regex implements Query {
+    private final String k;
+    private final String v;
+    private final Pattern pattern;
+    private final String name;
+
+    /** Create a new instance. */
+    Regex(String k, String v) {
+      this(k, v, 0, ":re");
+    }
+
+    /** Create a new instance. */
+    Regex(String k, String v, int flags, String name) {
+      this.k = Preconditions.checkNotNull(k, "k");
+      this.v = Preconditions.checkNotNull(v, "v");
+      this.pattern = Pattern.compile("^" + v, flags);
+      this.name = Preconditions.checkNotNull(name, "name");
+    }
+
+    @Override public boolean matches(Map<String, String> tags) {
+      String s = tags.get(k);
+      return s != null && pattern.matcher(s).find();
+    }
+
+    @Override public String toString() {
+      return k + "," + v + "," + name;
+    }
+
+    @Override public boolean equals(Object obj) {
+      if (this == obj) return true;
+      if (obj == null || !(obj instanceof Regex)) return false;
+      Regex other = (Regex) obj;
+      return k.equals(other.k)
+          && v.equals(other.v)
+          && pattern.flags() == other.pattern.flags()
+          && name.equals(other.name);
+    }
+
+    @Override public int hashCode() {
+      int result = k.hashCode();
+      result = 31 * result + v.hashCode();
+      result = 31 * result + pattern.flags();
+      result = 31 * result + name.hashCode();
+      return result;
+    }
+  }
+}

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/TagsValuePair.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/TagsValuePair.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.Tag;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Pair consisting of a set of tags and a double value.
+ */
+class TagsValuePair {
+
+  /** Create a pair from a measurement. */
+  static TagsValuePair from(Measurement m) {
+    return new TagsValuePair(convert(m.id()), m.value());
+  }
+
+  /**
+   * Create a pair from a measurement.
+   *
+   * @param commonTags
+   *     Common tags that will get added in after computing the tag map from the
+   *     measurement. These will override any values with the same key already in
+   *     the map.
+   * @param m
+   *     The input measurement used for the based tags and the value.
+   * @return
+   *     Pair based on the common tags and measurement.
+   */
+  static TagsValuePair from(Map<String, String> commonTags, Measurement m) {
+    Map<String, String> tags = convert(m.id());
+    tags.putAll(commonTags);
+    return new TagsValuePair(tags, m.value());
+  }
+
+  private static Map<String, String> convert(Id id) {
+    Map<String, String> tags = new HashMap<>();
+
+    for (Tag t : id.tags()) {
+      String k = ValidCharacters.toValidCharset(t.key());
+      String v = ValidCharacters.toValidCharset(t.value());
+      tags.put(k, v);
+    }
+
+    String name = ValidCharacters.toValidCharset(id.name());
+    tags.put("name", name);
+
+    return tags;
+  }
+
+  private final Map<String, String> tags;
+  private final double value;
+
+  /** Create a new instance. */
+  TagsValuePair(Map<String, String> tags, double value) {
+    this.tags = Collections.unmodifiableMap(tags);
+    this.value = value;
+  }
+
+  /** Return the tags from the pair. */
+  Map<String, String> tags() {
+    return tags;
+  }
+
+  /** Return the value from the pair. */
+  double value() {
+    return value;
+  }
+
+  @Override public String toString() {
+    return "TagsValuePair(" + tags + "," + value + ")";
+  }
+
+  @Override public boolean equals(Object obj) {
+    if (this == obj) return true;
+    if (obj == null || !(obj instanceof TagsValuePair)) return false;
+    TagsValuePair other = (TagsValuePair) obj;
+    return tags.equals(other.tags) && Double.compare(value, other.value) == 0;
+  }
+
+  @Override public int hashCode() {
+    int result = tags.hashCode();
+    result = 31 * result + Double.hashCode(value);
+    return result;
+  }
+}

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/DataExprTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/DataExprTest.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.Registry;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+
+@RunWith(JUnit4.class)
+public class DataExprTest {
+
+  private final Registry registry = new DefaultRegistry();
+
+  private DataExpr parse(String expr) {
+    DataExpr de = Parser.parseDataExpr(expr);
+    Assert.assertEquals(expr, de.toString());
+    return de;
+  }
+
+  private List<TagsValuePair> data(String name, double... vs) {
+    List<Measurement> ms = new ArrayList<>();
+    for (int i = 0; i < vs.length; ++i) {
+      String pos = String.format("%03d", i);
+      String value = String.format("%f", vs[i]);
+      ms.add(new Measurement(registry.createId(name, "i", pos, "v", value), 0L, vs[i]));
+    }
+    return ms.stream().map(TagsValuePair::from).collect(Collectors.toList());
+  }
+
+  @Test
+  public void sumEmpty() {
+    DataExpr expr = parse(":true,:sum");
+    Assert.assertFalse(expr.eval(Collections.emptyList()).iterator().hasNext());
+  }
+
+  @Test
+  public void minEmpty() {
+    DataExpr expr = parse(":true,:min");
+    Assert.assertFalse(expr.eval(Collections.emptyList()).iterator().hasNext());
+  }
+
+  @Test
+  public void maxEmpty() {
+    DataExpr expr = parse(":true,:max");
+    Assert.assertFalse(expr.eval(Collections.emptyList()).iterator().hasNext());
+  }
+
+  @Test
+  public void countEmpty() {
+    DataExpr expr = parse(":true,:count");
+    Assert.assertFalse(expr.eval(Collections.emptyList()).iterator().hasNext());
+  }
+
+  private void aggrData(String aggr, double expected) {
+    DataExpr expr = parse("name,foo,:eq," + aggr);
+    List<TagsValuePair> ms = data("foo", 1.0, 2.0, 3.0, 1.0);
+    ms.addAll(data("bar", 42.0));
+
+    Map<String, String> expectedTags = new HashMap<>();
+    expectedTags.put("name", "foo");
+
+    Iterable<TagsValuePair> vs = expr.eval(ms);
+    int count = 0;
+    for (TagsValuePair v : vs) {
+      ++count;
+      Assert.assertEquals(expectedTags, v.tags());
+      Assert.assertEquals(expected, v.value(), 1e-12);
+    }
+    Assert.assertEquals(1, count);
+  }
+
+  @Test
+  public void sumData() {
+    aggrData(":sum", 7.0);
+  }
+
+  @Test
+  public void minData() {
+    aggrData(":min", 1.0);
+  }
+
+  @Test
+  public void maxData() {
+    aggrData(":max", 3.0);
+  }
+
+  @Test
+  public void countData() {
+    aggrData(":count", 4.0);
+  }
+
+  @Test
+  public void groupByNameData() {
+    aggrData(":sum,(,name,),:by", 7.0);
+  }
+
+  private void groupingData(String aggr) {
+    DataExpr expr = parse("name,foo,:eq,:sum," + aggr);
+    List<TagsValuePair> ms = data("foo", 1.0, 2.0, 3.0, 1.0);
+    ms.addAll(data("bar", 42.0));
+
+    Iterable<TagsValuePair> vs = expr.eval(ms);
+    int count = 0;
+    for (TagsValuePair v : vs) {
+      ++count;
+      Assert.assertEquals(2, v.tags().size());
+      Assert.assertEquals("foo", v.tags().get("name"));
+      double tv = Double.parseDouble(v.tags().get("v"));
+      Assert.assertEquals((tv < 2.0) ? 2.0 : tv, v.value(), 1e-12);
+    }
+    Assert.assertEquals(3, count);
+  }
+
+  @Test
+  public void groupByValueData() {
+    groupingData("(,v,),:by");
+  }
+
+  @Test
+  public void groupByUnknownData() {
+    DataExpr expr = parse("name,foo,:eq,:sum,(,a,v,),:by");
+    List<TagsValuePair> ms = data("foo", 1.0, 2.0, 3.0, 1.0);
+    ms.addAll(data("bar", 42.0));
+
+    Iterable<TagsValuePair> vs = expr.eval(ms);
+    Assert.assertFalse(vs.iterator().hasNext());
+  }
+
+  @Test
+  public void rollupKeepData() {
+    groupingData("(,v,name,),:rollup-keep");
+  }
+
+  @Test
+  public void rollupKeepUnknownData() {
+    groupingData("(,a,v,name,),:rollup-keep");
+  }
+
+  @Test
+  public void rollupDropData() {
+    groupingData("(,i,),:rollup-drop");
+  }
+
+  @Test
+  public void allData() {
+    DataExpr expr = parse("name,foo,:eq,:all");
+    List<TagsValuePair> ms = data("foo", 1.0, 2.0, 3.0, 1.0);
+    ms.addAll(data("bar", 42.0));
+
+    Iterable<TagsValuePair> vs = expr.eval(ms);
+    Assert.assertEquals(4, StreamSupport.stream(vs.spliterator(), false).count());
+  }
+
+  @Test
+  public void notData() {
+    DataExpr expr = parse("name,foo,:eq,:not,:all");
+    List<TagsValuePair> ms = data("foo", 1.0, 2.0, 3.0, 1.0);
+    ms.addAll(data("bar", 42.0));
+
+    Iterable<TagsValuePair> vs = expr.eval(ms);
+    Assert.assertEquals(1, StreamSupport.stream(vs.spliterator(), false).count());
+  }
+
+  @Test
+  public void allEqualsContract() {
+    EqualsVerifier
+        .forClass(DataExpr.All.class)
+        .suppress(Warning.NULL_FIELDS)
+        .verify();
+  }
+
+  @Test
+  public void sumEqualsContract() {
+    EqualsVerifier
+        .forClass(DataExpr.Sum.class)
+        .suppress(Warning.NULL_FIELDS)
+        .verify();
+  }
+
+  @Test
+  public void minEqualsContract() {
+    EqualsVerifier
+        .forClass(DataExpr.Min.class)
+        .suppress(Warning.NULL_FIELDS)
+        .verify();
+  }
+
+  @Test
+  public void maxEqualsContract() {
+    EqualsVerifier
+        .forClass(DataExpr.Max.class)
+        .suppress(Warning.NULL_FIELDS)
+        .verify();
+  }
+
+  @Test
+  public void countEqualsContract() {
+    EqualsVerifier
+        .forClass(DataExpr.Count.class)
+        .suppress(Warning.NULL_FIELDS)
+        .verify();
+  }
+
+  @Test
+  public void byEqualsContract() {
+    EqualsVerifier
+        .forClass(DataExpr.GroupBy.class)
+        .suppress(Warning.NULL_FIELDS)
+        .verify();
+  }
+
+  @Test
+  public void dropEqualsContract() {
+    EqualsVerifier
+        .forClass(DataExpr.DropRollup.class)
+        .suppress(Warning.NULL_FIELDS)
+        .verify();
+  }
+
+  @Test
+  public void keepEqualsContract() {
+    EqualsVerifier
+        .forClass(DataExpr.KeepRollup.class)
+        .suppress(Warning.NULL_FIELDS)
+        .verify();
+  }
+}

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/QueryTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/QueryTest.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.Registry;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+
+@RunWith(JUnit4.class)
+public class QueryTest {
+
+  private final Registry registry = new DefaultRegistry();
+
+  private Query parse(String expr) {
+    Query q1 = Parser.parseQuery(expr);
+    Query q2 = Parser.parseQuery(expr);
+    Assert.assertEquals(q1, q2);
+    Assert.assertEquals(expr, q1.toString());
+    return q1;
+  }
+
+  @Test
+  public void trueQuery() {
+    Query q = parse(":true");
+    Assert.assertTrue(q.matches(registry.createId("foo")));
+  }
+
+  @Test
+  public void falseQuery() {
+    Query q = parse(":false");
+    Assert.assertFalse(q.matches(registry.createId("foo")));
+  }
+
+  @Test
+  public void eqQuery() {
+    Query q = parse("name,foo,:eq");
+    Assert.assertTrue(q.matches(registry.createId("foo")));
+    Assert.assertFalse(q.matches(registry.createId("bar")));
+  }
+
+  @Test
+  public void eqEqualsContract() {
+    EqualsVerifier
+        .forClass(Query.Equal.class)
+        .suppress(Warning.NULL_FIELDS)
+        .verify();
+  }
+
+  @Test
+  public void hasQuery() {
+    Query q = parse("bar,:has");
+    Assert.assertFalse(q.matches(registry.createId("bar")));
+    Assert.assertTrue(q.matches(registry.createId("foo", "bar", "baz")));
+    Assert.assertFalse(q.matches(registry.createId("foo", "baz", "baz")));
+  }
+
+  @Test
+  public void hasEqualsContract() {
+    EqualsVerifier
+        .forClass(Query.Has.class)
+        .suppress(Warning.NULL_FIELDS)
+        .verify();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void inQueryEmpty() {
+    parse("name,(,),:in");
+  }
+
+  @Test
+  public void inQuery() {
+    Query q = parse("name,(,bar,foo,),:in");
+    Assert.assertTrue(q.matches(registry.createId("foo")));
+    Assert.assertTrue(q.matches(registry.createId("bar")));
+    Assert.assertFalse(q.matches(registry.createId("baz")));
+  }
+
+  @Test
+  public void inEqualsContract() {
+    EqualsVerifier
+        .forClass(Query.In.class)
+        .suppress(Warning.NULL_FIELDS)
+        .verify();
+  }
+
+  @Test
+  public void ltQuery() {
+    Query q = parse("name,foo,:lt");
+    Assert.assertFalse(q.matches(registry.createId("foo")));
+    Assert.assertTrue(q.matches(registry.createId("faa")));
+    Assert.assertFalse(q.matches(registry.createId("fzz")));
+  }
+
+  @Test
+  public void ltEqualsContract() {
+    EqualsVerifier
+        .forClass(Query.LessThan.class)
+        .suppress(Warning.NULL_FIELDS)
+        .verify();
+  }
+
+  @Test
+  public void leQuery() {
+    Query q = parse("name,foo,:le");
+    Assert.assertTrue(q.matches(registry.createId("foo")));
+    Assert.assertTrue(q.matches(registry.createId("faa")));
+    Assert.assertFalse(q.matches(registry.createId("fzz")));
+  }
+
+  @Test
+  public void leEqualsContract() {
+    EqualsVerifier
+        .forClass(Query.LessThanEqual.class)
+        .suppress(Warning.NULL_FIELDS)
+        .verify();
+  }
+
+  @Test
+  public void gtQuery() {
+    Query q = parse("name,foo,:gt");
+    Assert.assertFalse(q.matches(registry.createId("foo")));
+    Assert.assertFalse(q.matches(registry.createId("faa")));
+    Assert.assertTrue(q.matches(registry.createId("fzz")));
+  }
+
+  @Test
+  public void gtEqualsContract() {
+    EqualsVerifier
+        .forClass(Query.GreaterThan.class)
+        .suppress(Warning.NULL_FIELDS)
+        .verify();
+  }
+
+  @Test
+  public void geQuery() {
+    Query q = parse("name,foo,:ge");
+    Assert.assertTrue(q.matches(registry.createId("foo")));
+    Assert.assertFalse(q.matches(registry.createId("faa")));
+    Assert.assertTrue(q.matches(registry.createId("fzz")));
+  }
+
+  @Test
+  public void geEqualsContract() {
+    EqualsVerifier
+        .forClass(Query.GreaterThanEqual.class)
+        .suppress(Warning.NULL_FIELDS)
+        .verify();
+  }
+
+  @Test
+  public void reQuery() {
+    Query q = parse("name,foo,:re");
+    Assert.assertTrue(q.matches(registry.createId("foo")));
+    Assert.assertFalse(q.matches(registry.createId("abcfoo")));
+    Assert.assertTrue(q.matches(registry.createId("foobar")));
+  }
+
+  @Test
+  public void reicQuery() {
+    Query q = parse("name,foO,:reic");
+    Assert.assertTrue(q.matches(registry.createId("fOo")));
+    Assert.assertFalse(q.matches(registry.createId("abcFoo")));
+    Assert.assertTrue(q.matches(registry.createId("Foobar")));
+  }
+
+  @Test
+  public void reEqualsContract() {
+    EqualsVerifier
+        .forClass(Query.Regex.class)
+        .suppress(Warning.NULL_FIELDS)
+        .verify();
+  }
+
+  @Test
+  public void andQuery() {
+    Query q = parse("name,foo,:eq,bar,baz,:eq,:and");
+    Assert.assertFalse(q.matches(registry.createId("foo")));
+    Assert.assertFalse(q.matches(registry.createId("bar")));
+    Assert.assertTrue(q.matches(registry.createId("foo", "bar", "baz")));
+    Assert.assertFalse(q.matches(registry.createId("bar", "bar", "baz")));
+    Assert.assertFalse(q.matches(registry.createId("foo", "bar", "def")));
+    Assert.assertFalse(q.matches(registry.createId("foo", "abc", "def")));
+  }
+
+  @Test
+  public void andEqualsContract() {
+    EqualsVerifier
+        .forClass(Query.And.class)
+        .suppress(Warning.NULL_FIELDS)
+        .verify();
+  }
+
+  @Test
+  public void orQuery() {
+    Query q = parse("name,foo,:eq,bar,baz,:eq,:or");
+    Assert.assertTrue(q.matches(registry.createId("foo")));
+    Assert.assertFalse(q.matches(registry.createId("bar")));
+    Assert.assertTrue(q.matches(registry.createId("foo", "bar", "baz")));
+    Assert.assertTrue(q.matches(registry.createId("bar", "bar", "baz")));
+    Assert.assertTrue(q.matches(registry.createId("foo", "bar", "def")));
+    Assert.assertTrue(q.matches(registry.createId("foo", "abc", "def")));
+  }
+
+  @Test
+  public void orEqualsContract() {
+    EqualsVerifier
+        .forClass(Query.Or.class)
+        .suppress(Warning.NULL_FIELDS)
+        .verify();
+  }
+
+  @Test
+  public void notQuery() {
+    Query q = parse("name,foo,:eq,:not");
+    Assert.assertFalse(q.matches(registry.createId("foo")));
+    Assert.assertTrue(q.matches(registry.createId("bar")));
+  }
+
+  @Test
+  public void notEqualsContract() {
+    EqualsVerifier
+        .forClass(Query.Not.class)
+        .suppress(Warning.NULL_FIELDS)
+        .verify();
+  }
+}


### PR DESCRIPTION
Adds support for basic Atlas expressions to be used with
local filtering and aggregation. For some later work with
streaming data off this will form a minimal basis that can
be done locally on each node to reduce the volume going
out to only what is needed.

For example, assume we have a metric `requestsPerSecond`
that has dimensions for `status` with cardinality around 4,
`endpoint` with cardinality 20, and `country` with a
cardinality of about 250. So the overall number of values
is around `4 * 20 * 250 = 20,000`. If we want to stream
a query like:

```
name,requestsPerSecond,:eq,:sum
```

This will allow a local aggregation on the node to reduce
it to a single value rather than sending all 20k and doing
all reduction server side. This is similar to map and combiner
steps of a Hadoop style job.