### PR TITLE
initial version of integration with lwc api

### DIFF
--- a/spectator-api/src/test/java/com/netflix/spectator/api/DefaultTimerTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/DefaultTimerTest.java
@@ -117,6 +117,16 @@ public class DefaultTimerTest {
     Assert.assertEquals(t.totalTime(), 400L);
   }
 
+  private int square(int v) {
+    return v * v;
+  }
+
+  @Test
+  public void testCallable() throws Exception {
+    Timer t = new DefaultTimer(clock, NoopId.INSTANCE);
+    int v2 = t.record(() -> square(42));
+  }
+
   @Test
   public void testMeasure() {
     Timer t = new DefaultTimer(clock, new DefaultId("foo"));

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasConfig.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasConfig.java
@@ -35,6 +35,14 @@ public interface AtlasConfig extends RegistryConfig {
   }
 
   /**
+   * Returns true if publishing to Atlas is enabled. Default is true.
+   */
+  default boolean enabled() {
+    String v = get("atlas.enabled");
+    return (v == null) ? true : Boolean.valueOf(v);
+  }
+
+  /**
    * Returns the number of threads to use with the scheduler. The default is
    * 2 threads.
    */
@@ -50,6 +58,38 @@ public interface AtlasConfig extends RegistryConfig {
   default String uri() {
     String v = get("atlas.uri");
     return (v == null) ? "http://localhost:7101/api/v1/publish" : v;
+  }
+
+  /**
+   * Returns true if streaming to Atlas LWC is enabled. Default is false.
+   */
+  default boolean lwcEnabled() {
+    String v = get("atlas.lwc.enabled");
+    return (v == null) ? false : Boolean.valueOf(v);
+  }
+
+  /** Returns the frequency for refreshing config settings from the LWC service. */
+  default Duration configRefreshFrequency() {
+    String v = get("atlas.configRefreshFrequency");
+    return (v == null) ? Duration.ofSeconds(10) : Duration.parse(v);
+  }
+
+  /**
+   * Returns the URI for the Atlas LWC endpoint to retrieve current subscriptions.
+   * The default is {@code http://localhost:7101/lwc/api/v1/expressions/local-dev}.
+   */
+  default String configUri() {
+    String v = get("atlas.config-uri");
+    return (v == null) ? "http://localhost:7101/lwc/api/v1/expressions/local-dev" : v;
+  }
+
+  /**
+   * Returns the URI for the Atlas LWC endpoint to evaluate the data for a suscription.
+   * The default is {@code http://localhost:7101/lwc/api/v1/evaluate}.
+   */
+  default String evalUri() {
+    String v = get("atlas.eval-uri");
+    return (v == null) ? "http://localhost:7101/lwc/api/v1/evaluate" : v;
   }
 
   /**

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/EvalPayload.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/EvalPayload.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Wraps a list of measurements with a set of common tags. The common tags are
+ * typically used for things like the application and instance id.
+ */
+class EvalPayload {
+
+  private final long timestamp;
+  private final List<Metric> metrics;
+
+  /** Create a new instance. */
+  EvalPayload(long timestamp, List<Metric> metrics) {
+    this.timestamp = timestamp;
+    this.metrics = metrics;
+  }
+
+  /** Return the timestamp for metrics in this payload. */
+  public long getTimestamp() {
+    return timestamp;
+  }
+
+  /** Return the metric values for the data for this payload. */
+  public List<Metric> getMetrics() {
+    return metrics;
+  }
+
+  /** Metric value. */
+  static class Metric {
+    private final String id;
+    private final Map<String, String> tags;
+    private final double value;
+
+    /** Create a new instance. */
+    Metric(String id, Map<String, String> tags, double value) {
+      this.id = id;
+      this.tags = tags;
+      this.value = value;
+    }
+
+    /** Id for the expression that this data corresponds with. */
+    public String getId() {
+      return id;
+    }
+
+    /** Tags for identifying the metric. */
+    public Map<String, String> getTags() {
+      return tags;
+    }
+
+    /** Value for the metric. */
+    public double getValue() {
+      return value;
+    }
+  }
+}

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/Subscription.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/Subscription.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+/**
+ * Model object for an individual subscription coming from LWC.
+ */
+class Subscription {
+
+  private String id;
+  private String expression;
+  private long frequency;
+
+  /** Create a new instance. */
+  Subscription() {
+    // Will get filled in with set methods
+  }
+
+  /** Id for a subscription.  */
+  public String getId() {
+    return id;
+  }
+
+  /** Set the subscription id. */
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  /** Expression for the subscription. */
+  public String getExpression() {
+    return expression;
+  }
+
+  /** Set the expression for the subscription. */
+  public void setExpression(String expression) {
+    this.expression = expression;
+  }
+
+  /** Requested frequency to send data for the subscription. */
+  public long getFrequency() {
+    return frequency;
+  }
+
+  /** Set the requested frequency to send data for the subscription. */
+  public void setFrequency(long frequency) {
+    this.frequency = frequency;
+  }
+
+  @Override public String toString() {
+    return "Subscription(" + id + ",[" + expression + "]," + frequency + ")";
+  }
+}

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/Subscriptions.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/Subscriptions.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import java.util.List;
+
+/**
+ * Model object for subscriptions payload coming from LWC service.
+ */
+class Subscriptions {
+
+  private List<Subscription> expressions;
+
+  /** Create a new instance. */
+  Subscriptions() {
+    // Will get filled in with set methods
+  }
+
+  /** Returns the subscriptions with validated expressions. */
+  List<Subscription> validated() {
+    return expressions;
+  }
+
+  /** Return the available subscriptions. */
+  public List<Subscription> getExpressions() {
+    return expressions;
+  }
+
+  /** Set the available subscriptions. */
+  public void setExpressions(List<Subscription> expressions) {
+    this.expressions = expressions;
+  }
+}

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasRegistryTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasRegistryTest.java
@@ -117,4 +117,5 @@ public class AtlasRegistryTest {
     long d = registry.getInitialDelay(10000);
     Assert.assertEquals(2123, d);
   }
+
 }


### PR DESCRIPTION
Still needs a lot of work, but is a minimal base version
that will send data at the same frequency as publishing
to Atlas.

For more details on the server side see:
https://github.com/Netflix/atlas/pull/459.

Future iteration needed for refactoring to honor frequency
in the subscription, performance tuning, etc.