### PR TITLE
fix CCE for reading gauges via ServoRegistry

### DIFF
--- a/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoGauge.java
+++ b/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoGauge.java
@@ -16,6 +16,7 @@
 package com.netflix.spectator.servo;
 
 import com.netflix.servo.monitor.AbstractMonitor;
+import com.netflix.servo.monitor.Monitor;
 import com.netflix.servo.monitor.MonitorConfig;
 import com.netflix.servo.monitor.NumericMonitor;
 import com.netflix.spectator.api.Clock;
@@ -24,13 +25,14 @@ import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Measurement;
 import com.netflix.spectator.impl.AtomicDouble;
 
+import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Reports a constant value passed into the constructor.
  */
 final class ServoGauge<T extends Number> extends AbstractMonitor<Double>
-    implements Gauge, NumericMonitor<Double> {
+    implements Gauge, ServoMeter, NumericMonitor<Double> {
 
   private final Clock clock;
   private final AtomicDouble value;
@@ -70,5 +72,9 @@ final class ServoGauge<T extends Number> extends AbstractMonitor<Double>
 
   @Override public Double getValue(int pollerIndex) {
     return value();
+  }
+
+  @Override public void addMonitors(List<Monitor<?>> monitors) {
+    monitors.add(this);
   }
 }

--- a/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoRegistry.java
+++ b/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoRegistry.java
@@ -120,7 +120,7 @@ public class ServoRegistry extends AbstractRegistry implements CompositeMonitor<
   @Override public List<Monitor<?>> getMonitors() {
     List<Monitor<?>> monitors = new ArrayList<>();
     for (Meter meter : this) {
-      if (!meter.hasExpired()) {
+      if (!meter.hasExpired() && meter instanceof ServoMeter) {
         ((ServoMeter) meter).addMonitors(monitors);
       }
     }

--- a/spectator-reg-servo/src/test/java/com/netflix/spectator/servo/ServoGaugeTest.java
+++ b/spectator-reg-servo/src/test/java/com/netflix/spectator/servo/ServoGaugeTest.java
@@ -51,6 +51,16 @@ public class ServoGaugeTest {
   }
 
   @Test
+  public void testGet() {
+    final ServoRegistry r = new ServoRegistry(clock);
+    Gauge g = r.gauge(r.createId("foo"));
+    g.set(1.0);
+
+    Assert.assertEquals(1, r.getMonitors().size());
+    Assert.assertEquals(1.0, (Double) r.getMonitors().get(0).getValue(0), 1e-12);
+  }
+
+  @Test
   public void expiration() {
     final long initTime = TimeUnit.MINUTES.toMillis(30);
     final long fifteenMinutes = TimeUnit.MINUTES.toMillis(15);


### PR DESCRIPTION
The internal `ServoGauge` did not implement the
`ServoMeter` interface. This has been fixed and
test case added.

```
java.lang.ClassCastException: com.netflix.spectator.servo.ServoGauge cannot be cast to com.netflix.spectator.servo.ServoMeter
        at com.netflix.spectator.servo.ServoRegistry.getMonitors(ServoRegistry.java:124) ~[spectator-reg-servo-0.46.0.jar:0.46.0]
```