### PR TITLE
improve totalTime estimate for cass latencies

### DIFF
--- a/spectator-agent/src/main/resources/cassandra.conf
+++ b/spectator-agent/src/main/resources/cassandra.conf
@@ -144,28 +144,13 @@ netflix.spectator.agent.jmx {
             },
             {
               key = "atlas.dstype"
-              value = "gauge"
+              value = "rate"
             }
           ]
-          value = "{Mean},1e6,:div,{OneMinuteRate},:mul"
-        },
-        {
-          name = "cass.request.latency"
-          tags = [
-            {
-              key = "scope"
-              value = "{scope}"
-            },
-            {
-              key = "statistic"
-              value = "mean"
-            },
-            {
-              key = "atlas.dstype"
-              value = "gauge"
-            }
-          ]
-          value = "{Mean},1e6,:div"
+          // 50th percentile is used instead of mean because prior to metrics3 the mean
+          // is for the life of the timer rather than for the last snapshot of the
+          // reservoir
+          value = "{50thPercentile},1e6,:div,{OneMinuteRate},:mul"
         },
         {
           name = "cass.request.latency"
@@ -359,36 +344,13 @@ netflix.spectator.agent.jmx {
             },
             {
               key = "atlas.dstype"
-              value = "gauge"
+              value = "rate"
             }
           ]
-          value = "{Mean},1e6,:div,{OneMinuteRate},:mul"
-        },
-        {
-          name = "cass.cf.{name}"
-          tags = [
-            {
-              key = "scope"
-              value = "{scope}"
-            },
-            {
-              key = "keyspace"
-              value = "{keyspace}"
-            },
-            {
-              key = "familyType"
-              value = "{type}"
-            },
-            {
-              key = "statistic"
-              value = "mean"
-            },
-            {
-              key = "atlas.dstype"
-              value = "gauge"
-            }
-          ]
-          value = "{Mean},1e6,:div"
+          // 50th percentile is used instead of mean because prior to metrics3 the mean
+          // is for the life of the timer rather than for the last snapshot of the
+          // reservoir
+          value = "{50thPercentile},1e6,:div,{OneMinuteRate},:mul"
         },
         {
           name = "cass.cf.{name}"
@@ -1007,36 +969,13 @@ netflix.spectator.agent.jmx {
             },
             {
               key = "atlas.dstype"
-              value = "gauge"
+              value = "rate"
             }
           ]
-          value = "{Mean},1e6,:div,{OneMinuteRate},:mul"
-        },
-        {
-          name = "cass.cf.{name}"
-          tags = [
-            {
-              key = "scope"
-              value = "{scope}"
-            },
-            {
-              key = "keyspace"
-              value = "{keyspace}"
-            },
-            {
-              key = "familyType"
-              value = "{type}"
-            },
-            {
-              key = "statistic"
-              value = "mean"
-            },
-            {
-              key = "atlas.dstype"
-              value = "gauge"
-            }
-          ]
-          value = "{Mean},1e6,:div"
+          // 50th percentile is used instead of mean because prior to metrics3 the mean
+          // is for the life of the timer rather than for the last snapshot of the
+          // reservoir
+          value = "{50thPercentile},1e6,:div,{OneMinuteRate},:mul"
         },
         {
           name = "cass.cf.{name}"
@@ -1188,24 +1127,13 @@ netflix.spectator.agent.jmx {
             },
             {
               key = "atlas.dstype"
-              value = "gauge"
+              value = "rate"
             }
           ]
-          value = "{Mean},1e6,:div,{OneMinuteRate},:mul"
-        },
-        {
-          name = "cass.commitlog.{name}"
-          tags = [
-            {
-              key = "statistic"
-              value = "mean"
-            },
-            {
-              key = "atlas.dstype"
-              value = "gauge"
-            }
-          ]
-          value = "{Mean},1e6,:div"
+          // 50th percentile is used instead of mean because prior to metrics3 the mean
+          // is for the life of the timer rather than for the last snapshot of the
+          // reservoir
+          value = "{50thPercentile},1e6,:div,{OneMinuteRate},:mul"
         },
         {
           name = "cass.commitlog.{name}"


### PR DESCRIPTION
For cassandra 2.x the metrics 2.2 library is used. When
extracting latencies for sending to Atlas, the `totalTime`
was being estimated by using the `Mean` value reported via
jmx. However, the `Mean` in metrics 2.2 does not come from
the snapshot used for the percentiles, but is since the timer
was created. This means that it isn't very reflective of
recent behavior. Metrics 3 changes that so that the `Mean`
is useful and is used with cassandra 3.x.

For now since we need to work with cassandra 2.x, the config
for `totalTime` uses the `50thPercentile` reported in jmx to
get the estimate.