### PR TITLE
Extend visibility of MeasurementSerializer and PublishPayload

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/MeasurementSerializer.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/MeasurementSerializer.java
@@ -29,7 +29,7 @@ import java.io.IOException;
  * valid set as they are written out by replacing invalid characters with
  * an '_'.
  */
-class MeasurementSerializer extends JsonSerializer<Measurement> {
+public class MeasurementSerializer extends JsonSerializer<Measurement> {
   @Override
   public void serialize(
       Measurement value,

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/PublishPayload.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/PublishPayload.java
@@ -24,7 +24,7 @@ import java.util.Map;
  * Wraps a list of measurements with a set of common tags. The common tags are
  * typically used for things like the application and instance id.
  */
-class PublishPayload {
+public class PublishPayload {
 
   private final Map<String, String> tags;
   private final List<Measurement> metrics;


### PR DESCRIPTION
I'm using AtlasRegistry, but have a different http client for publishing to atlas.
So, I would like to reuse some basic components.