### PR TITLE
Update spectator-ext-spark

### DIFF
--- a/spectator-ext-spark/src/main/java/com/netflix/spectator/spark/SidecarRegistry.java
+++ b/spectator-ext-spark/src/main/java/com/netflix/spectator/spark/SidecarRegistry.java
@@ -58,9 +58,7 @@ public class SidecarRegistry extends AbstractRegistry {
       } else {
         Map<String, String> tagMap = new HashMap<>();
         SparkConf conf = env.conf();
-        put(tagMap, conf, "spark.app.id", "appId");
         put(tagMap, conf, "spark.app.name", "appName");
-        put(tagMap, conf, "spark.executor.id", "executorId");
         return tagMap;
       }
     }

--- a/spectator-ext-spark/src/main/java/com/netflix/spectator/spark/SparkNameFunction.java
+++ b/spectator-ext-spark/src/main/java/com/netflix/spectator/spark/SparkNameFunction.java
@@ -85,10 +85,15 @@ public final class SparkNameFunction implements NameFunction {
         for (Map.Entry<String, Integer> entry : tags.entrySet()) {
           id = id.withTag(entry.getKey(), m.group(entry.getValue()));
         }
+        // separate executor jvm metrics from driver executor metrics
+        if (!tags.containsKey("role")) {
+          id = id.withTag("role", "executor");
+        }
         return id;
       } else {
         return DROP_METRIC;
       }
+
     }
   }
 

--- a/spectator-ext-spark/src/main/java/com/netflix/spectator/spark/SparkSink.java
+++ b/spectator-ext-spark/src/main/java/com/netflix/spectator/spark/SparkSink.java
@@ -63,6 +63,7 @@ public class SparkSink implements Sink {
     final Config config = loadConfig();
     sidecarRegistry = new SidecarRegistry();
     reporter = SpectatorReporter.forRegistry(registry)
+        .withSpectatorRegistry(sidecarRegistry)
         .withNameFunction(SparkNameFunction.fromConfig(config, sidecarRegistry))
         .withValueFunction(SparkValueFunction.fromConfig(config))
         .withGaugeCounters(Pattern.compile(config.getString("spectator.spark.gauge-counters")))

--- a/spectator-ext-spark/src/main/resources/reference.conf
+++ b/spectator-ext-spark/src/main/resources/reference.conf
@@ -20,7 +20,7 @@ spectator.spark {
     // 97278898-4bd4-49c2-9889-aa5f969a7816-0020.driver.DAGScheduler.job.activeJobs
     // 97278898-4bd4-49c2-9889-aa5f969a7816-0020.driver.jvm.heap.committed
     {
-      pattern = "^([^.]+)\\.(driver)\\.((CodeGenerator|DAGScheduler|BlockManager|jvm)\\..*)"
+      pattern = "^([^.]+)\\.(driver)\\.((CodeGenerator|DAGScheduler|BlockManager|jvm)\\..+[^_MB])(_MB)?"
       name = 3
       tags = {
         "appId" = 1

--- a/spectator-ext-spark/src/main/resources/reference.conf
+++ b/spectator-ext-spark/src/main/resources/reference.conf
@@ -1,85 +1,44 @@
 
 spectator.spark {
   name-patterns = [
-    // core/src/main/scala/org/apache/spark/deploy/master/ApplicationSource.scala
+    // EXECUTORS
+    // 97278898-4bd4-49c2-9889-aa5f969a7816-0013.97278898-4bd4-49c2-9889-aa5f969a7816-S1/2.executor.filesystem.file.largeRead_ops
     {
-      pattern = "^(application)\\.(.+)\\.\\d+\\.([^.]+?)(_MB|_ms)?$"
+      pattern = "^([^.]+)\\.(([^.]+)\/)?(\\d+)\\.((executor|jvm|CodeGenerator)\\..*)"
+      name = 5
+      tags = {
+        "appId" = 1
+        "agentId" = 3
+        "executorId" = 4
+      }
+    },
+
+
+    // DRIVER
+    // 97278898-4bd4-49c2-9889-aa5f969a7816-0020.driver.BlockManager.memory.remainingMem_MB
+    // 97278898-4bd4-49c2-9889-aa5f969a7816-0020.driver.CodeGenerator.compilationTime
+    // 97278898-4bd4-49c2-9889-aa5f969a7816-0020.driver.DAGScheduler.job.activeJobs
+    // 97278898-4bd4-49c2-9889-aa5f969a7816-0020.driver.jvm.heap.committed
+    {
+      pattern = "^([^.]+)\\.(driver)\\.((CodeGenerator|DAGScheduler|BlockManager|jvm)\\..*)"
       name = 3
       tags = {
-        "role" = 1
-        "appName" = 2
+        "appId" = 1
+        "role"  = 2
       }
     },
 
-    // core/src/main/scala/org/apache/spark/deploy/master/MasterSource.scala
-    // core/src/main/scala/org/apache/spark/deploy/worker/WorkerSource.scala
-    {
-      pattern = "^(master|worker)\\.([^.]+?)(_MB|_ms)?$"
-      name = 2
-      tags = {
-        "role" = 1
-      }
-    },
-
-    // core/src/main/scala/org/apache/spark/executor/ExecutorSource.scala
-    {
-      pattern = "^([^.]+)\\.([^.]+)\\.(executor)\\.(.+?)(_MB|_ms)?$"
-      name = 4
-      tags = {
-        "role" = 3
-        //"appId" = 1
-        //"executorId" = 2
-      }
-    },
-
-    // core/src/main/scala/org/apache/spark/executor/ExecutorSource.scala
-    {
-      pattern = "^(.+)\\.(executor)\\.(.+?)(_MB|_ms)?$"
-      name = 3
-      tags = {
-        "role" = 2
-        //"appId" = 1
-      }
-    },
-
-    // core/src/main/scala/org/apache/spark/scheduler/DAGSchedulerSource.scala
-    // core/src/main/scala/org/apache/spark/storage/BlockManagerSource.scala
-    {
-      pattern = "^([^.]+)\\.<?(driver)>?\\.(DAGScheduler|BlockManager)\\.(.+?)(_MB|_ms)?$"
-      name = 4
-      tags = {
-        "role" = 2
-        //"appId" = 1
-        "source" = 3
-      }
-    },
-
-    // streaming/src/main/scala/org/apache/spark/streaming/StreamingSource.scala
-    // streaming/src/main/scala/org/apache/spark/streaming/scheduler/BatchInfo.scala
+    // STREAMING
     // Note: the .*Delay stats are derived from the .*Time stats. The time stats by themselves
     // aren't that useful sent to the backend.
     {
-      pattern = "^([^.]+)\\.<?(driver)>?\\.([^.]+)\\.(StreamingMetrics)\\.(.+Delay)$"
-      name = 5
+      pattern = "^([^.]+)\\.(driver)\\.([^.]+)\\.StreamingMetrics\\.(streaming\\..*)"
+      name = 4
       tags = {
+        "appId" = 1
         "role" = 2
-        "source" = 4
-        //"appId" = 1
-        //"appName" = 3
       }
-    },
-
-    // streaming/src/main/scala/org/apache/spark/streaming/StreamingSource.scala
-    {
-      pattern = "^([^.]+)\\.<?(driver)>?\\.([^.]+)\\.(StreamingMetrics)\\.(.+(?<!Time|Delay))$"
-      name = 5
-      tags = {
-        "role" = 2
-        "source" = 4
-        //"appId" = 1
-        //"appName" = 3
-      }
-    },
+    }
 
   ]
 
@@ -89,7 +48,7 @@ spectator.spark {
       factor = 1.0e6
     },
     {
-      pattern = "^.*_ms$"
+      pattern = "^.*streaming.*_.*Time$"
       factor = 0.001
     },
     {

--- a/spectator-ext-spark/src/test/java/com/netflix/spectator/spark/SparkNameFunctionTest.java
+++ b/spectator-ext-spark/src/test/java/com/netflix/spectator/spark/SparkNameFunctionTest.java
@@ -25,6 +25,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 @RunWith(JUnit4.class)
 public class SparkNameFunctionTest {
 
@@ -35,122 +38,84 @@ public class SparkNameFunctionTest {
     Assert.assertEquals(Utils.normalize(expected), Utils.normalize(actual));
   }
 
+  //EXECUTOR
   @Test
-  public void executorName() {
-    final String name = "app-20150309231421-0000.0.executor.filesystem.file.largeRead_ops";
-    final Id expected = registry.createId("spark.filesystem.file.largeRead_ops")
+  public void executorMetric() {
+    final String name = "97278898-4bd4-49c2-9889-aa5f969a7816-0013.97278898-4bd4-49c2-9889-aa5f969a7816-S1/2.executor.filesystem.file.largeRead_ops";
+    final Id expected = registry.createId("spark.executor.filesystem.file.largeRead_ops")
+        .withTag("appId", "97278898-4bd4-49c2-9889-aa5f969a7816-0013")
+        .withTag("agentId","97278898-4bd4-49c2-9889-aa5f969a7816-S1")
+        .withTag("executorId", "2")
         .withTag("role", "executor");
     assertEquals(expected, f.apply(name));
   }
 
   @Test
-  public void executorName2() {
-    final String name = "20150626-185518-1776258826-5050-2845-S1.executor.filesystem.file.largeRead_ops";
-    final Id expected = registry.createId("spark.filesystem.file.largeRead_ops")
+  public void executorJvmMetric() {
+    final String name = "97278898-4bd4-49c2-9889-aa5f969a7816-0013.97278898-4bd4-49c2-9889-aa5f969a7816-S1/2.jvm.heap.committed";
+    final Id expected = registry.createId("spark.jvm.heap.committed")
+        .withTag("appId", "97278898-4bd4-49c2-9889-aa5f969a7816-0013")
+        .withTag("agentId","97278898-4bd4-49c2-9889-aa5f969a7816-S1")
+        .withTag("executorId", "2")
         .withTag("role", "executor");
     assertEquals(expected, f.apply(name));
   }
 
   @Test
-  public void executorName3() {
-    final String name = "12345.1.3.executor.filesystem.file.largeRead_ops";
-    final Id expected = registry.createId("spark.filesystem.file.largeRead_ops")
+  public void executorCodeGenerator() {
+    final String name = "97278898-4bd4-49c2-9889-aa5f969a7816-0013.97278898-4bd4-49c2-9889-aa5f969a7816-S1/2.CodeGenerator.compilationTime";
+    final Id expected = registry.createId("spark.CodeGenerator.compilationTime")
+        .withTag("appId", "97278898-4bd4-49c2-9889-aa5f969a7816-0013")
+        .withTag("agentId","97278898-4bd4-49c2-9889-aa5f969a7816-S1")
+        .withTag("executorId", "2")
         .withTag("role", "executor");
     assertEquals(expected, f.apply(name));
   }
 
-    @Test
-  public void driverName() {
-    final String name = "app-20150309231421-0000.driver.BlockManager.disk.diskSpaceUsed_MB";
-    final Id expected = registry.createId("spark.disk.diskSpaceUsed")
-        .withTag("role", "driver")
-        .withTag("source", "BlockManager");
+  // DRIVER
+  @Test
+  public void driverMetric() {
+    final String name = "97278898-4bd4-49c2-9889-aa5f969a7816-0013.driver.BlockManager.disk.diskSpaceUsed_MB";
+    final Id expected = registry.createId("spark.BlockManager.disk.diskSpaceUsed_MB")
+        .withTag("appId", "97278898-4bd4-49c2-9889-aa5f969a7816-0013")
+        .withTag("role", "driver");
     assertEquals(expected, f.apply(name));
   }
 
   @Test
-  public void driverName2() {
-    final String name = "app-20150309231421-0000.driver.DAGScheduler.job.activeJobs";
-    final Id expected = registry.createId("spark.job.activeJobs")
-        .withTag("role", "driver")
-        .withTag("source", "DAGScheduler");
+  public void driverJvmMetric() {
+    final String name = "97278898-4bd4-49c2-9889-aa5f969a7816-0013.driver.jvm.heap.committed";
+    final Id expected = registry.createId("spark.jvm.heap.committed")
+        .withTag("appId", "97278898-4bd4-49c2-9889-aa5f969a7816-0013")
+        .withTag("role", "driver");
     assertEquals(expected, f.apply(name));
   }
 
-  @Test
-  public void driverName3() {
-    final String name = "local-1429219722964.<driver>.DAGScheduler.job.activeJobs";
-    final Id expected = registry.createId("spark.job.activeJobs")
-        .withTag("role", "driver")
-        .withTag("source", "DAGScheduler");
-    assertEquals(expected, f.apply(name));
-  }
-
+  // Streaming
   @Test
   public void driverStreamingSimple() {
-    final String name = "app-20150527224111-0014.<driver>.SubscriptionEnded.StreamingMetrics.streaming.receivers";
-    final Id expected = registry.createId("spark.streaming.receivers")
-        .withTag("role", "driver")
-        .withTag("source", "StreamingMetrics");
+    final String name = "97278898-4bd4-49c2-9889-aa5f969a7816-0013.driver.HdfsWordCount.StreamingMetrics.streaming.lastCompletedBatch_processingDelay";
+    final Id expected = registry.createId("spark.streaming.lastCompletedBatch_processingDelay")
+        .withTag("appId", "97278898-4bd4-49c2-9889-aa5f969a7816-0013")
+        .withTag("role", "driver");
     assertEquals(expected, f.apply(name));
   }
 
-  @Test
-  public void driverStreamingTotal() {
-    final String name = "app-20150527224111-0014.<driver>.SubscriptionEnded.StreamingMetrics.streaming.totalCompletedBatches";
-    final Id expected = registry.createId("spark.streaming.totalCompletedBatches")
-        .withTag("role", "driver")
-        .withTag("source", "StreamingMetrics");
-    assertEquals(expected, f.apply(name));
+
+ @Test
+  public void JustPatternMatching() {
+
+    final String pattern_string = "^([^.]+)\\.(driver)\\.((CodeGenerator|DAGScheduler|BlockManager|jvm)\\..*)$";
+    final String metric = "97278898-4bd4-49c2-9889-aa5f969a7816-0023.driver.jvm.pools.PS-Old-Gen.used";
+    final Pattern pattern = Pattern.compile(pattern_string);
+    final Matcher m = pattern.matcher(metric);
+
+    Assert.assertEquals(true, m.matches());
+    Assert.assertEquals("97278898-4bd4-49c2-9889-aa5f969a7816-0023", m.group(1));
+    Assert.assertEquals("driver", m.group(2));
+    Assert.assertEquals("jvm.pools.PS-Old-Gen.used", m.group(3));
+    Assert.assertEquals("jvm", m.group(4));
   }
 
-  @Test
-  public void driverStreamingDelay() {
-    final String name = "app-20150527224111-0014.<driver>.SubscriptionEnded.StreamingMetrics.streaming.lastReceivedBatch_submissionDelay";
-    final Id expected = registry.createId("spark.streaming.lastReceivedBatch_submissionDelay")
-        .withTag("role", "driver")
-        .withTag("source", "StreamingMetrics");
-    assertEquals(expected, f.apply(name));
-  }
-
-  @Test
-  public void driverStreamingTime() {
-    final String name = "app-20150527224111-0014.<driver>.SubscriptionEnded.StreamingMetrics.streaming.lastReceivedBatch_submissionTime";
-    Assert.assertNull(f.apply(name));
-  }
-
-  @Test
-  public void applicationName() {
-    final String name = "application.Spark shell.1425968061869.cores";
-    final Id expected = registry.createId("spark.cores")
-        .withTag("role", "application")
-        .withTag("appName", "Spark shell");
-    assertEquals(expected, f.apply(name));
-  }
-
-  @Test
-  public void applicationName2() {
-    final String name = "application.SubscriptionEnded.1429226958083.runtime_ms";
-    final Id expected = registry.createId("spark.runtime")
-        .withTag("role", "application")
-        .withTag("appName", "SubscriptionEnded");
-    assertEquals(expected, f.apply(name));
-  }
-
-  @Test
-  public void masterName() {
-    final String name = "master.apps";
-    final Id expected = registry.createId("spark.apps")
-        .withTag("role", "master");
-    assertEquals(expected, f.apply(name));
-  }
-
-  @Test
-  public void workerName() {
-    final String name = "worker.memFree_MB";
-    final Id expected = registry.createId("spark.memFree")
-        .withTag("role", "worker");
-    assertEquals(expected, f.apply(name));
-  }
 
 }

--- a/spectator-ext-spark/src/test/java/com/netflix/spectator/spark/SparkNameFunctionTest.java
+++ b/spectator-ext-spark/src/test/java/com/netflix/spectator/spark/SparkNameFunctionTest.java
@@ -76,7 +76,16 @@ public class SparkNameFunctionTest {
   @Test
   public void driverMetric() {
     final String name = "97278898-4bd4-49c2-9889-aa5f969a7816-0013.driver.BlockManager.disk.diskSpaceUsed_MB";
-    final Id expected = registry.createId("spark.BlockManager.disk.diskSpaceUsed_MB")
+    final Id expected = registry.createId("spark.BlockManager.disk.diskSpaceUsed")  // Trailing _MB removed
+        .withTag("appId", "97278898-4bd4-49c2-9889-aa5f969a7816-0013")
+        .withTag("role", "driver");
+    assertEquals(expected, f.apply(name));
+  }
+
+  @Test
+  public void driverMetricNoUnits() {
+    final String name = "97278898-4bd4-49c2-9889-aa5f969a7816-0013.driver.DAGScheduler.messageProcessingTime";
+    final Id expected = registry.createId("spark.DAGScheduler.messageProcessingTime")
         .withTag("appId", "97278898-4bd4-49c2-9889-aa5f969a7816-0013")
         .withTag("role", "driver");
     assertEquals(expected, f.apply(name));

--- a/spectator-ext-spark/src/test/java/com/netflix/spectator/spark/SparkValueFunctionTest.java
+++ b/spectator-ext-spark/src/test/java/com/netflix/spectator/spark/SparkValueFunctionTest.java
@@ -39,6 +39,12 @@ public class SparkValueFunctionTest {
   }
 
   @Test
+  public void driverStreamingTime() {
+    final String name = "97278898-4bd4-49c2-9889-aa5f969a7816-0129.driver.HdfsWordCount.StreamingMetrics.streaming.lastCompletedBatch_processingEndTime";
+    Assert.assertEquals(42.0 / 1000.0, f.convert(name, 42.0), 1e-12);
+  }
+
+  @Test
   public void driverStreamingDelay() {
     final String name = "app-20150527224111-0014.<driver>.SubscriptionEnded.StreamingMetrics.streaming.lastReceivedBatch_submissionDelay";
     Assert.assertEquals(42.0 / 1000.0, f.convert(name, 42.0), 1e-12);
@@ -50,15 +56,4 @@ public class SparkValueFunctionTest {
     Assert.assertEquals(Double.NaN, f.convert(name, -1.0), 1e-12);
   }
 
-  @Test
-  public void applicationName2() {
-    final String name = "application.SubscriptionEnded.1429226958083.runtime_ms";
-    Assert.assertEquals(42.0 / 1000.0, f.convert(name, 42.0), 1e-12);
-  }
-
-  @Test
-  public void workerName() {
-    final String name = "worker.memFree_MB";
-    Assert.assertEquals(42.0 * 1e6, f.convert(name, 42.0), 1e-12);
-  }
 }


### PR DESCRIPTION
Updated regex to capture metrics emitted by spark 1.6.1 and spark 2.0.0. 

[BUGFIX] Added the right instance of SidecarRegistry to the SpectatorReporter constructor.
