### PR TITLE
zero metrics from snapshot if no change in count

### DIFF
--- a/spectator-agent/src/main/java/com/netflix/spectator/agent/JmxData.java
+++ b/spectator-agent/src/main/java/com/netflix/spectator/agent/JmxData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 Netflix, Inc.
+ * Copyright 2014-2017 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import javax.management.MBeanServer;
 import javax.management.ObjectName;
 import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -86,8 +87,8 @@ class JmxData {
    */
   JmxData(ObjectName name, Map<String, String> stringAttrs, Map<String, Number> numberAttrs) {
     this.name = name;
-    this.stringAttrs = stringAttrs;
-    this.numberAttrs = numberAttrs;
+    this.stringAttrs = Collections.unmodifiableMap(stringAttrs);
+    this.numberAttrs = Collections.unmodifiableMap(numberAttrs);
   }
 
   /** Return the name of the bean. */

--- a/spectator-agent/src/main/java/com/netflix/spectator/agent/JmxMeter.java
+++ b/spectator-agent/src/main/java/com/netflix/spectator/agent/JmxMeter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 Netflix, Inc.
+ * Copyright 2014-2017 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,6 +47,7 @@ final class JmxMeter implements Meter {
 
   @Override
   public Iterable<Measurement> measure() {
+
     List<Measurement> ms = new ArrayList<>();
     try {
       for (JmxData data : JmxData.query(config.getQuery())) {

--- a/spectator-agent/src/main/resources/cassandra.conf
+++ b/spectator-agent/src/main/resources/cassandra.conf
@@ -129,7 +129,7 @@ netflix.spectator.agent.jmx {
               value = "gauge"
             }
           ]
-          value = "{Max},1e6,:div"
+          value = "{Max},1e6,:div,{Count},{previous:Count},:if-changed"
         },
         {
           name = "cass.request.latency"
@@ -150,7 +150,7 @@ netflix.spectator.agent.jmx {
           // 50th percentile is used instead of mean because prior to metrics3 the mean
           // is for the life of the timer rather than for the last snapshot of the
           // reservoir
-          value = "{50thPercentile},1e6,:div,{OneMinuteRate},:mul"
+          value = "{50thPercentile},1e6,:div,{OneMinuteRate},:mul,{Count},{previous:Count},:if-changed"
         },
         {
           name = "cass.request.latency"
@@ -168,7 +168,7 @@ netflix.spectator.agent.jmx {
               value = "gauge"
             }
           ]
-          value = "{50thPercentile},1e6,:div"
+          value = "{50thPercentile},1e6,:div,{Count},{previous:Count},:if-changed"
         },
         {
           name = "cass.request.latency"
@@ -186,7 +186,7 @@ netflix.spectator.agent.jmx {
               value = "gauge"
             }
           ]
-          value = "{95thPercentile},1e6,:div"
+          value = "{95thPercentile},1e6,:div,{Count},{previous:Count},:if-changed"
         },
         {
           name = "cass.request.latency"
@@ -204,7 +204,7 @@ netflix.spectator.agent.jmx {
               value = "gauge"
             }
           ]
-          value = "{99thPercentile},1e6,:div"
+          value = "{99thPercentile},1e6,:div,{Count},{previous:Count},:if-changed"
         },
         {
           name = "cass.request.latency"
@@ -222,7 +222,7 @@ netflix.spectator.agent.jmx {
               value = "gauge"
             }
           ]
-          value = "{999thPercentile},1e6,:div"
+          value = "{999thPercentile},1e6,:div,{Count},{previous:Count},:if-changed"
         }
       ]
     },
@@ -350,7 +350,7 @@ netflix.spectator.agent.jmx {
           // 50th percentile is used instead of mean because prior to metrics3 the mean
           // is for the life of the timer rather than for the last snapshot of the
           // reservoir
-          value = "{50thPercentile},1e6,:div,{OneMinuteRate},:mul"
+          value = "{50thPercentile},1e6,:div,{OneMinuteRate},:mul,{Count},{previous:Count},:if-changed"
         },
         {
           name = "cass.cf.{name}"
@@ -376,7 +376,7 @@ netflix.spectator.agent.jmx {
               value = "gauge"
             }
           ]
-          value = "{50thPercentile},1e6,:div"
+          value = "{50thPercentile},1e6,:div,{Count},{previous:Count},:if-changed"
         },
         {
           name = "cass.cf.{name}"
@@ -402,7 +402,7 @@ netflix.spectator.agent.jmx {
               value = "gauge"
             }
           ]
-          value = "{95thPercentile},1e6,:div"
+          value = "{95thPercentile},1e6,:div,{Count},{previous:Count},:if-changed"
         },
         {
           name = "cass.cf.{name}"
@@ -428,7 +428,7 @@ netflix.spectator.agent.jmx {
               value = "gauge"
             }
           ]
-          value = "{99thPercentile},1e6,:div"
+          value = "{99thPercentile},1e6,:div,{Count},{previous:Count},:if-changed"
         },
         {
           name = "cass.cf.{name}"
@@ -454,7 +454,7 @@ netflix.spectator.agent.jmx {
               value = "gauge"
             }
           ]
-          value = "{999thPercentile},1e6,:div"
+          value = "{999thPercentile},1e6,:div,{Count},{previous:Count},:if-changed"
         }
       ]
     },
@@ -946,7 +946,7 @@ netflix.spectator.agent.jmx {
               value = "gauge"
             }
           ]
-          value = "{Max},1e6,:div"
+          value = "{Max},1e6,:div,{Count},{previous:Count},:if-changed"
         },
         {
           name = "cass.cf.{name}"
@@ -975,7 +975,7 @@ netflix.spectator.agent.jmx {
           // 50th percentile is used instead of mean because prior to metrics3 the mean
           // is for the life of the timer rather than for the last snapshot of the
           // reservoir
-          value = "{50thPercentile},1e6,:div,{OneMinuteRate},:mul"
+          value = "{50thPercentile},1e6,:div,{OneMinuteRate},:mul,{Count},{previous:Count},:if-changed"
         },
         {
           name = "cass.cf.{name}"
@@ -1001,7 +1001,7 @@ netflix.spectator.agent.jmx {
               value = "gauge"
             }
           ]
-          value = "{50thPercentile},1e6,:div"
+          value = "{50thPercentile},1e6,:div,{Count},{previous:Count},:if-changed"
         },
         {
           name = "cass.cf.{name}"
@@ -1027,7 +1027,7 @@ netflix.spectator.agent.jmx {
               value = "gauge"
             }
           ]
-          value = "{95thPercentile},1e6,:div"
+          value = "{95thPercentile},1e6,:div,{Count},{previous:Count},:if-changed"
         },
         {
           name = "cass.cf.{name}"
@@ -1053,7 +1053,7 @@ netflix.spectator.agent.jmx {
               value = "gauge"
             }
           ]
-          value = "{99thPercentile},1e6,:div"
+          value = "{99thPercentile},1e6,:div,{Count},{previous:Count},:if-changed"
         },
         {
           name = "cass.cf.{name}"
@@ -1079,7 +1079,7 @@ netflix.spectator.agent.jmx {
               value = "gauge"
             }
           ]
-          value = "{999thPercentile},1e6,:div"
+          value = "{999thPercentile},1e6,:div,{Count},{previous:Count},:if-changed"
         }
       ]
     },
@@ -1133,7 +1133,7 @@ netflix.spectator.agent.jmx {
           // 50th percentile is used instead of mean because prior to metrics3 the mean
           // is for the life of the timer rather than for the last snapshot of the
           // reservoir
-          value = "{50thPercentile},1e6,:div,{OneMinuteRate},:mul"
+          value = "{50thPercentile},1e6,:div,{OneMinuteRate},:mul,{Count},{previous:Count},:if-changed"
         },
         {
           name = "cass.commitlog.{name}"
@@ -1147,7 +1147,7 @@ netflix.spectator.agent.jmx {
               value = "gauge"
             }
           ]
-          value = "{50thPercentile},1e6,:div"
+          value = "{50thPercentile},1e6,:div,{Count},{previous:Count},:if-changed"
         },
         {
           name = "cass.commitlog.{name}"
@@ -1161,7 +1161,7 @@ netflix.spectator.agent.jmx {
               value = "gauge"
             }
           ]
-          value = "{95thPercentile},1e6,:div"
+          value = "{95thPercentile},1e6,:div,{Count},{previous:Count},:if-changed"
         },
         {
           name = "cass.commitlog.{name}"
@@ -1175,7 +1175,7 @@ netflix.spectator.agent.jmx {
               value = "gauge"
             }
           ]
-          value = "{99thPercentile},1e6,:div"
+          value = "{99thPercentile},1e6,:div,{Count},{previous:Count},:if-changed"
         },
         {
           name = "cass.commitlog.{name}"
@@ -1189,7 +1189,7 @@ netflix.spectator.agent.jmx {
               value = "gauge"
             }
           ]
-          value = "{999thPercentile},1e6,:div"
+          value = "{999thPercentile},1e6,:div,{Count},{previous:Count},:if-changed"
         }
       ]
     },

--- a/spectator-agent/src/test/java/com/netflix/spectator/agent/CassandraTest.java
+++ b/spectator-agent/src/test/java/com/netflix/spectator/agent/CassandraTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.agent;
+
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.ManualClock;
+import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Utils;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import javax.management.ObjectName;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+@RunWith(JUnit4.class)
+public class CassandraTest {
+
+  private final Config config = ConfigFactory.load("cassandra");
+
+  private List<JmxConfig> configs() {
+    List<JmxConfig> cfgs = new ArrayList<>();
+    for (Config cfg : config.getConfigList("netflix.spectator.agent.jmx.mappings")) {
+      cfgs.add(JmxConfig.from(cfg));
+    }
+    return cfgs;
+  }
+
+  private List<Measurement> measure(Registry registry, List<JmxConfig> configs, JmxData data) {
+    List<Measurement> ms = new ArrayList<>();
+    for (JmxConfig cfg : configs) {
+      if (cfg.getQuery().apply(data.getName())) {
+        for (JmxMeasurementConfig c : cfg.getMeasurements()) {
+          c.measure(registry, data, ms);
+        }
+      }
+    }
+    return ms;
+  }
+
+  private JmxData timer(String props, int i) throws Exception {
+    ObjectName name = new ObjectName("org.apache.cassandra.metrics:" + props);
+
+    Map<String, String> stringAttrs = new HashMap<>(name.getKeyPropertyList());
+    stringAttrs.put("EventType",   "calls");
+    stringAttrs.put("LatencyUnit", "MICROSECONDS");
+    stringAttrs.put("RateUnit",    "SECONDS");
+
+    Map<String, Number> numAttrs = new HashMap<>();
+    numAttrs.put("OneMinuteRate",      100.0 + i);
+    numAttrs.put("FiveMinuteRate",     500.0 + i);
+    numAttrs.put("FifteenMinuteRate", 1500.0 + i);
+    numAttrs.put("MeanRate",           987.0 + i);
+
+    numAttrs.put("Count",               1000 + i);
+
+    numAttrs.put("Min",                   10 + i);
+    numAttrs.put("Max",                 9000 + i);
+    numAttrs.put("Mean",                1000 + i);
+    numAttrs.put("StdDev",                10 + i);
+    numAttrs.put("50thPercentile",    5000.0 + i);
+    numAttrs.put("75thPercentile",    7500.0 + i);
+    numAttrs.put("95thPercentile",    9500.0 + i);
+    numAttrs.put("99thPercentile",    9900.0 + i);
+    numAttrs.put("999thPercentile",   9990.0 + i);
+
+    return new JmxData(name, stringAttrs, numAttrs);
+  }
+
+  @Test
+  public void readLatency() throws Exception {
+    Registry r = new DefaultRegistry(new ManualClock());
+    List<JmxConfig> configs = configs();
+
+    JmxData data = timer("keyspace=test,name=ReadLatency,scope=foo,type=ColumnFamily", 0);
+    List<Measurement> ms = measure(r, configs, data);
+    Assert.assertEquals(7, ms.size());
+    Assert.assertEquals(
+        50.0e-4,
+        Utils.first(ms, "statistic", "percentile_50").value(),
+        1e-12);
+
+    data = timer("keyspace=test,name=ReadLatency,scope=foo,type=ColumnFamily", 1);
+    ms = measure(r, configs, data);
+    Assert.assertEquals(7, ms.size());
+    Assert.assertEquals(
+        50.01e-4,
+        Utils.first(ms, "statistic", "percentile_50").value(),
+        1e-12);
+  }
+
+  // Compensate for: https://github.com/dropwizard/metrics/issues/1030
+  @Test
+  public void readLatencyNoActivity() throws Exception {
+    Registry r = new DefaultRegistry(new ManualClock());
+    List<JmxConfig> configs = configs();
+
+    JmxData data = timer("keyspace=test,name=ReadLatency,scope=foo,type=ColumnFamily", 0);
+    List<Measurement> ms = measure(r, configs, data);
+    Assert.assertEquals(7, ms.size());
+    Assert.assertEquals(
+        50.0e-4,
+        Utils.first(ms, "statistic", "percentile_50").value(),
+        1e-12);
+
+    data = timer("keyspace=test,name=ReadLatency,scope=foo,type=ColumnFamily", 0);
+    ms = measure(r, configs, data);
+    Assert.assertEquals(7, ms.size());
+    Assert.assertEquals(
+        0.0,
+        Utils.first(ms, "statistic", "percentile_50").value(),
+        1e-12);
+
+    data = timer("keyspace=test,name=ReadLatency,scope=foo,type=ColumnFamily", 1);
+    ms = measure(r, configs, data);
+    Assert.assertEquals(7, ms.size());
+    Assert.assertEquals(
+        50.01e-4,
+        Utils.first(ms, "statistic", "percentile_50").value(),
+        1e-12);
+  }
+
+}

--- a/spectator-agent/src/test/java/com/netflix/spectator/agent/MappingExprTest.java
+++ b/spectator-agent/src/test/java/com/netflix/spectator/agent/MappingExprTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 Netflix, Inc.
+ * Copyright 2014-2017 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,7 +78,7 @@ public class MappingExprTest {
   public void evalMissing() {
     Map<String, Number> vars = new HashMap<>();
     Double v = MappingExpr.eval("{foo}", vars);
-    Assert.assertNull(v);
+    Assert.assertTrue(v.isNaN());
   }
 
   @Test
@@ -126,5 +126,23 @@ public class MappingExprTest {
     vars.put("foo", 2.0);
     Double v = MappingExpr.eval("42.0,{foo},:div", vars);
     Assert.assertEquals(21.0, v, 1e-12);
+  }
+
+  @Test
+  public void evalIfChangedYes() {
+    Map<String, Number> vars = new HashMap<>();
+    vars.put("foo", 2.0);
+    vars.put("previous:foo", 3.0);
+    Double v = MappingExpr.eval("42.0,{foo},{previous:foo},:if-changed", vars);
+    Assert.assertEquals(42.0, v, 1e-12);
+  }
+
+  @Test
+  public void evalIfChangedNo() {
+    Map<String, Number> vars = new HashMap<>();
+    vars.put("foo", 2.0);
+    vars.put("previous:foo", 2.0);
+    Double v = MappingExpr.eval("42.0,{foo},{previous:foo},:if-changed", vars);
+    Assert.assertEquals(0.0, v, 1e-12);
   }
 }


### PR DESCRIPTION
When mapping in metrics from cassandra and possibly
other sources using metrics2/metrics3, the histograms
are based on a reservoir that is only rescaled during
updates. This can give a false impression of incorrect
sustained activity because the old value will keep
getting reported if no updates are received on the
underlying timer.

This change modifies the expressions to check that
the `Count` has changed since the previous time the
values were sampled. If the count has not changed,
then there was no activity so we zero out those values.
Otherwise the sampled value is returned without
modification.