### PR TITLE
switch to material theme for mkdocs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,10 +28,11 @@ pages:
   - Metrics3: registry/metrics3.md
   - Servo: registry/servo.md
 - 'Build Reports': reports.md
-theme: readthedocs
+theme: material
 extra_css:
 - css/custom.css
 markdown_extensions:
 - admonition
+- codehilite
 - toc:
     permalink: True


### PR DESCRIPTION
The navigation is better as some of the
sections are collapsed and it generates
the TOC for the page that is being viewed
on the right.