### PR TITLE
add map for storing arbitrary state with registry

### DIFF
--- a/codequality/findbugs-exclude.xml
+++ b/codequality/findbugs-exclude.xml
@@ -24,4 +24,10 @@
       <Bug pattern="EI_EXPOSE_REP2"/>
     </And>
   </Match>
+  <Match>
+    <And>
+      <Class name="com.netflix.spectator.api.patterns.LongTaskTimer"/>
+      <Bug pattern="NM_SAME_SIMPLE_NAME_AS_INTERFACE"/>
+    </And>
+  </Match>
 </FindBugsFilter>

--- a/spectator-api/src/main/java/com/netflix/spectator/api/ExtendedRegistry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/ExtendedRegistry.java
@@ -18,6 +18,7 @@ package com.netflix.spectator.api;
 import com.netflix.spectator.impl.Preconditions;
 
 import java.util.Iterator;
+import java.util.concurrent.ConcurrentMap;
 
 /**
  * Wraps a registry and provides additional helper methods to make it easier to use.
@@ -55,6 +56,10 @@ public final class ExtendedRegistry implements Registry {
 
   @Override public void register(Meter meter) {
     impl.register(meter);
+  }
+
+  @Override public ConcurrentMap<Id, Object> state() {
+    return impl.state();
   }
 
   @Override public Counter counter(Id id) {

--- a/spectator-api/src/main/java/com/netflix/spectator/api/NoopRegistry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/NoopRegistry.java
@@ -17,6 +17,8 @@ package com.netflix.spectator.api;
 
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 /**
  * Registry implementation that does nothing. This is typically used to allow for performance tests
@@ -24,6 +26,10 @@ import java.util.Iterator;
  * minimum amount possible without requiring code changes for users.
  */
 public final class NoopRegistry implements Registry {
+
+  // Since we don't know how callers might be using this a noop implementation
+  // of the map could cause unexpected issues.
+  private final ConcurrentMap<Id, Object> state = new ConcurrentHashMap<>();
 
   @Override public Clock clock() {
     return Clock.SYSTEM;
@@ -38,6 +44,10 @@ public final class NoopRegistry implements Registry {
   }
 
   @Override public void register(Meter meter) {
+  }
+
+  @Override public ConcurrentMap<Id, Object> state() {
+    return state;
   }
 
   @Override public Counter counter(Id id) {


### PR DESCRIPTION
For long task timer (#237), interval counter (#369), and some
other uses it is necessary to maintain some state that is used
to provide values for the core types. The lifecycle of the
state should typically be tied to the lifecycle of the registry.

For example, the long task timer needs to keep track of tasks
and it is helpful if that will work across fetches of the timer
from the registry (#237).

This change introduces a concurrent map that can be accessed
from the registry to allow these composite helper types to
manage that state, but have the lifecycle of the objects tied
to the registry. That is, it will go away when the registry
goes away unless the user is maintaining references to it
elsewhere.

`LongTaskTimer` has been refactored to use this state as an
example and moved to the `patterns` package to keep this sort
of helper separate as we will likely add more over time. In
a future version the `Registry.longTaskTimer` will probably
get deprecated so that `LongTaskTimer` is not longer a special
case.