### PR TITLE
always increment count for recorded values

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasDistributionSummary.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasDistributionSummary.java
@@ -107,8 +107,8 @@ class AtlasDistributionSummary implements DistributionSummary {
   }
 
   @Override public void record(long amount) {
+    count.getCurrent().incrementAndGet();
     if (amount > 0) {
-      count.getCurrent().incrementAndGet();
       total.getCurrent().addAndGet(amount);
       totalOfSquares.getCurrent().addAndGet((double) amount * amount);
       updateMax(max.getCurrent(), amount);

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasTimer.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasTimer.java
@@ -111,9 +111,9 @@ class AtlasTimer implements Timer {
   }
 
   @Override public void record(long amount, TimeUnit unit) {
+    count.getCurrent().incrementAndGet();
     if (amount > 0) {
       final long nanos = unit.toNanos(amount);
-      count.getCurrent().incrementAndGet();
       total.getCurrent().addAndGet(nanos);
       totalOfSquares.getCurrent().addAndGet((double) nanos * nanos);
       updateMax(max.getCurrent(), nanos);

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasDistributionSummaryTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasDistributionSummaryTest.java
@@ -92,14 +92,14 @@ public class AtlasDistributionSummaryTest {
   public void recordZero() {
     dist.record(0);
     clock.setWallTime(step + 1);
-    checkValue(0, 0, 0, 0);
+    checkValue(1, 0, 0, 0);
   }
 
   @Test
   public void recordNegativeValue() {
     dist.record(-2);
     clock.setWallTime(step + 1);
-    checkValue(0, 0, 0, 0);
+    checkValue(1, 0, 0, 0);
   }
 
   @Test

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasTimerTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasTimerTest.java
@@ -110,14 +110,14 @@ public class AtlasTimerTest {
   public void recordZero() {
     dist.record(0, TimeUnit.NANOSECONDS);
     clock.setWallTime(step + 1);
-    checkValue(0, 0, 0, 0);
+    checkValue(1, 0, 0, 0);
   }
 
   @Test
   public void recordNegativeValue() {
     dist.record(-2, TimeUnit.NANOSECONDS);
     clock.setWallTime(step + 1);
-    checkValue(0, 0, 0, 0);
+    checkValue(1, 0, 0, 0);
   }
 
   @Test


### PR DESCRIPTION
The Atlas registry was only incrementing the timer and
distribution summary objects if the recorded amount was
positive. If the amount was zero or negative it was
ignored.

Negative latency values are sometimes seen due to clock
adjustments on a machine. Also really quick events that
call `System.currentTimeMillis` for getting the time can
get a latency of 0. These should be reflected in the count
statistic for the timer or else it causes confusion
because the number of events will not match what the user
expects.

With this change negative and 0 values will update the
count, but not other statistics.