### PR TITLE
update pmd to 5.5.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -119,7 +119,7 @@ subprojects {
   }
 
   pmd {
-    toolVersion = '5.3.3'
+    toolVersion = '5.5.4'
     ignoreFailures = false
     sourceSets = [sourceSets.main]
     ruleSets = []

--- a/codequality/pmd.xml
+++ b/codequality/pmd.xml
@@ -10,6 +10,7 @@
 
   <rule ref="rulesets/internal/all-java.xml">
     <exclude name="AbstractNaming"/>
+    <exclude name="AccessorMethodGeneration"/>
     <exclude name="AddEmptyString"/>
     <exclude name="AppendCharacterWithChar"/>
     <exclude name="ArrayIsStoredDirectly"/>
@@ -27,7 +28,7 @@
     <exclude name="AvoidUsingShortType"/>
     <exclude name="AvoidUsingVolatile"/>
     <exclude name="BeanMembersShouldSerialize"/>
-    <exclude name="BooleanInversion"/>
+    <exclude name="CommentDefaultAccessModifier"/>
     <exclude name="CommentRequired"/>
     <exclude name="CommentSize"/>
     <exclude name="CompareObjectsWithEquals"/>
@@ -36,6 +37,7 @@
     <exclude name="DataflowAnomalyAnalysis"/>
     <exclude name="DefaultPackage"/>
     <exclude name="DoNotUseThreads"/>
+    <exclude name="DontImportJavaLang"/> <!-- Incorrectly flags java.lang.invoke.* -->
     <exclude name="DuplicateImports"/>
     <exclude name="EmptyMethodInAbstractClassShouldBeAbstract"/>
     <exclude name="ExcessiveImports"/>

--- a/spectator-api/src/main/java/com/netflix/spectator/api/FilteredIterator.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/FilteredIterator.java
@@ -56,10 +56,13 @@ class FilteredIterator<T> implements Iterator<T> {
     return item != null;
   }
 
+  @SuppressWarnings("PMD.UnnecessaryLocalBeforeReturn")
   @Override public T next() throws NoSuchElementException {
     if (item == null) {
       throw new NoSuchElementException("next() called after reaching end of iterator");
     }
+    // Note: PMD flags this, but the local tmp is necessary because findNext will change
+    // the value of item
     T tmp = item;
     findNext();
     return tmp;

--- a/spectator-api/src/main/java/com/netflix/spectator/api/RegistryConfig.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/RegistryConfig.java
@@ -35,7 +35,7 @@ public interface RegistryConfig {
   /** Should an exception be thrown for warnings? */
   default boolean propagateWarnings() {
     String v = get("propagateWarnings");
-    return (v == null) ? false : Boolean.valueOf(v);
+    return v != null && Boolean.valueOf(v);
   }
 
   /**

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/Config.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/Config.java
@@ -123,7 +123,7 @@ public final class Config {
   public static <T> T createProxy(Class<T> cls, Function<String, String> props) {
     final Constructor<MethodHandles.Lookup> constructor = getConstructor();
     final Class<?>[] interfaces = new Class<?>[] {cls};
-    final Object obj = Proxy.newProxyInstance(classLoader(), interfaces, (proxy, method, args) -> {
+    return (T) Proxy.newProxyInstance(classLoader(), interfaces, (proxy, method, args) -> {
       final String name = method.getName();
       if (method.isDefault()) {
         final Class<?> declaringClass = method.getDeclaringClass();
@@ -142,7 +142,6 @@ public final class Config {
         return valueOf(rt, v);
       }
     });
-    return (T) obj;
   }
 
   /**

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasConfig.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasConfig.java
@@ -39,7 +39,7 @@ public interface AtlasConfig extends RegistryConfig {
    */
   default boolean enabled() {
     String v = get("atlas.enabled");
-    return (v == null) ? true : Boolean.valueOf(v);
+    return v == null || Boolean.valueOf(v);
   }
 
   /**
@@ -65,7 +65,7 @@ public interface AtlasConfig extends RegistryConfig {
    */
   default boolean lwcEnabled() {
     String v = get("atlas.lwc.enabled");
-    return (v == null) ? false : Boolean.valueOf(v);
+    return v != null && Boolean.valueOf(v);
   }
 
   /** Returns the frequency for refreshing config settings from the LWC service. */

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasConfigTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasConfigTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+
+@RunWith(JUnit4.class)
+public class AtlasConfigTest {
+
+  @Test
+  public void enabledByDefault() {
+    Map<String, String> props = Collections.emptyMap();
+    AtlasConfig config = props::get;
+    Assert.assertTrue(config.enabled());
+  }
+
+  @Test
+  public void explicitlyEnabled() {
+    Map<String, String> props = new HashMap<>();
+    props.put("atlas.enabled", "true");
+    AtlasConfig config = props::get;
+    Assert.assertTrue(config.enabled());
+  }
+
+  @Test
+  public void explicitlyDisabled() {
+    Map<String, String> props = new HashMap<>();
+    props.put("atlas.enabled", "false");
+    AtlasConfig config = props::get;
+    Assert.assertFalse(config.enabled());
+  }
+
+  @Test
+  public void enabledBadValue() {
+    Map<String, String> props = new HashMap<>();
+    props.put("atlas.enabled", "abc");
+    AtlasConfig config = props::get;
+    Assert.assertFalse(config.enabled());
+  }
+
+  @Test
+  public void lwcDisabledByDefault() {
+    Map<String, String> props = Collections.emptyMap();
+    AtlasConfig config = props::get;
+    Assert.assertFalse(config.lwcEnabled());
+  }
+
+  @Test
+  public void lwcExplicitlyEnabled() {
+    Map<String, String> props = new HashMap<>();
+    props.put("atlas.lwc.enabled", "true");
+    AtlasConfig config = props::get;
+    Assert.assertTrue(config.lwcEnabled());
+  }
+
+  @Test
+  public void lwcExplicitlyDisabled() {
+    Map<String, String> props = new HashMap<>();
+    props.put("atlas.lwc.enabled", "false");
+    AtlasConfig config = props::get;
+    Assert.assertFalse(config.lwcEnabled());
+  }
+
+  @Test
+  public void lwcEnabledBadValue() {
+    Map<String, String> props = new HashMap<>();
+    props.put("atlas.lwc.enabled", "abc");
+    AtlasConfig config = props::get;
+    Assert.assertFalse(config.lwcEnabled());
+  }
+}


### PR DESCRIPTION
This is mostly to work around a bug in 5.3.3:

https://sourceforge.net/p/pmd/bugs/1384/

This fixes the following errors in build logs that started
showing up after #378:

```
Exception applying rule ConsecutiveLiteralAppends on file
spectator/spectator-api/src/main/java/com/netflix/spectator/impl/AsciiSet.java,
continuing with next rule

java.lang.NullPointerException
```