### PR TITLE
fix #312, preserve core types with Composite

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/CompositeRegistry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/CompositeRegistry.java
@@ -156,7 +156,23 @@ public final class CompositeRegistry implements Registry {
   }
 
   @Override public Meter get(Id id) {
-    return new CompositeMeter(id, registries);
+    for (Registry r : registries) {
+      Meter m = r.get(id);
+      if (m != null) {
+        if (m instanceof Counter) {
+          return counter(id);
+        } else if (m instanceof Timer) {
+          return timer(id);
+        } else if (m instanceof DistributionSummary) {
+          return distributionSummary(id);
+        } else if (m instanceof Gauge) {
+          return gauge(id);
+        } else {
+          return null;
+        }
+      }
+    }
+    return null;
   }
 
   @Override public Iterator<Meter> iterator() {

--- a/spectator-api/src/test/java/com/netflix/spectator/api/CompositeRegistryTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/CompositeRegistryTest.java
@@ -66,6 +66,7 @@ public class CompositeRegistryTest {
     c.increment();
     Assert.assertEquals(c.count(), 1L);
     r.register(c);
+    ((CompositeRegistry) r).pollGauges();
     Meter meter = r.get(c.id());
     for (Measurement m : meter.measure()) {
       Assert.assertEquals(m.value(), 2.0, 1e-12);
@@ -269,5 +270,41 @@ public class CompositeRegistryTest {
         Assert.assertEquals(id, m.id());
       }
     }
+  }
+
+  @Test
+  public void correctTypeForCountersStream() {
+    Registry r = newRegistry(5, false);
+    r.counter("a").increment();
+    r.counter("b").increment();
+    Assert.assertEquals(2, r.counters().count());
+    Assert.assertEquals(2, r.stream().filter(m -> m instanceof Counter).count());
+  }
+
+  @Test
+  public void correctTypeForTimersStream() {
+    Registry r = newRegistry(5, false);
+    r.timer("a").record(1, TimeUnit.MICROSECONDS);
+    r.timer("b").record(1, TimeUnit.MICROSECONDS);
+    Assert.assertEquals(2, r.timers().count());
+    Assert.assertEquals(2, r.stream().filter(m -> m instanceof Timer).count());
+  }
+
+  @Test
+  public void correctTypeForDistSummariesStream() {
+    Registry r = newRegistry(5, false);
+    r.distributionSummary("a").record(1);
+    r.distributionSummary("b").record(1);
+    Assert.assertEquals(2, r.distributionSummaries().count());
+    Assert.assertEquals(2, r.stream().filter(m -> m instanceof DistributionSummary).count());
+  }
+
+  @Test
+  public void correctTypeForGaugesStream() {
+    Registry r = newRegistry(5, false);
+    r.gauge(r.createId("a")).set(1.0);
+    r.gauge(r.createId("b")).set(2.0);
+    Assert.assertEquals(2, r.gauges().count());
+    Assert.assertEquals(2, r.stream().filter(m -> m instanceof Gauge).count());
   }
 }


### PR DESCRIPTION
The composite registry now preserves the core types
when using `get` as well as the stream methods. It
was broken before because `get` was just wrapping it
as a `CompositeMeter`. With this change `get` will now
inspect the type from the sub-registries and use the
type of the first one it finds.