### PR TITLE
separate out concurrent phases of CMS

### DIFF
--- a/docs/ext/jvm-gc-causes.md
+++ b/docs/ext/jvm-gc-causes.md
@@ -66,8 +66,7 @@ called `sun.hotspot.WhiteBox.youngGC()`.
 
 ### No_GC
 
-Used for CMS. Unfortunately when using the mbeans this is the cause that typically gets
-reported for a major GC.
+Used for CMS to indicate concurrent phases.
 
 ### Allocation_Failure
 

--- a/docs/ext/jvm-gc.md
+++ b/docs/ext/jvm-gc.md
@@ -113,12 +113,34 @@ pauses.
 
 * `statistic=max`: seconds
 * `statistic=count`: events/second
-* `statistic=totalTime`: seconds/second 
+* `statistic=totalTime`: seconds/second
 
 **Dimensions:**
 
-* `action`: action performed by the garbage collector ([javadoc](http://docs.oracle.com/javase/7/docs/jre/api/management/extension/com/sun/management/GarbageCollectionNotificationInfo.html#getGcAction())). There is no guarantee, but the typical values seen are `end_of_major_GC` and `end_of_minor_GC`. 
-* `cause`: cause that instigated GC ([javadoc](http://docs.oracle.com/javase/7/docs/jre/api/management/extension/com/sun/management/GarbageCollectionNotificationInfo.html#getGcCause())). For an explanation of common causes see the [[GC Causes]] page.
+* `action`: action performed by the garbage collector
+   ([javadoc](http://docs.oracle.com/javase/7/docs/jre/api/management/extension/com/sun/management/GarbageCollectionNotificationInfo.html#getGcAction())).
+   There is no guarantee, but the typical values seen are `end_of_major_GC` and `end_of_minor_GC`.
+* `cause`: cause that instigated GC ([javadoc](http://docs.oracle.com/javase/7/docs/jre/api/management/extension/com/sun/management/GarbageCollectionNotificationInfo.html#getGcCause())).
+  For an explanation of common causes see the [[GC Causes]] page.
+
+### jvm.gc.concurrentPhaseTime
+
+Timer reporting time spent in concurrent phases of CMS.
+pauses.
+
+**Unit:**
+
+* `statistic=max`: seconds
+* `statistic=count`: events/second
+* `statistic=totalTime`: seconds/second
+
+**Dimensions:**
+
+* `action`: action performed by the garbage collector
+  ([javadoc](http://docs.oracle.com/javase/7/docs/jre/api/management/extension/com/sun/management/GarbageCollectionNotificationInfo.html#getGcAction())).
+  There is no guarantee, but the typical values seen are `end_of_major_GC` and `end_of_minor_GC`.
+* `cause`: cause that instigated GC ([javadoc](http://docs.oracle.com/javase/7/docs/jre/api/management/extension/com/sun/management/GarbageCollectionNotificationInfo.html#getGcCause())).
+  For an explanation of common causes see the [[GC Causes]] page.
 
 ## Alerting
 


### PR DESCRIPTION
Move the concurrent phases of CMS out of `jvm.gc.pause`
and to a new timer `jvm.gc.concurrentPhaseTime`. This
makes it easier to use the pause time to only see the
stop the world pauses, and also makes the behavior match
the description in the docs.

Fixes #339.