### PR TITLE
minor updates for cassandra mappings for 2.1.x

### DIFF
--- a/spectator-agent/src/main/java/com/netflix/spectator/agent/JmxMeasurementConfig.java
+++ b/spectator-agent/src/main/java/com/netflix/spectator/agent/JmxMeasurementConfig.java
@@ -106,9 +106,9 @@ final class JmxMeasurementConfig {
   }
 
   private void updateCounter(Registry registry, Id id, long v) {
-    AtomicLong prev = previousCount.computeIfAbsent(id, i -> new AtomicLong(0L));
+    AtomicLong prev = previousCount.computeIfAbsent(id, i -> new AtomicLong(Long.MIN_VALUE));
     long p = prev.get();
-    if (prev.compareAndSet(p, v) && p != 0) {
+    if (prev.compareAndSet(p, v) && p != Long.MIN_VALUE) {
       registry.counter(id).increment(v - p);
     }
   }

--- a/spectator-agent/src/main/resources/agent.conf
+++ b/spectator-agent/src/main/resources/agent.conf
@@ -17,3 +17,4 @@ netflix.spectator.agent {
     mappings = []
   }
 }
+

--- a/spectator-agent/src/main/resources/cassandra.conf
+++ b/spectator-agent/src/main/resources/cassandra.conf
@@ -90,8 +90,30 @@ netflix.spectator.agent.jmx {
     },
 
     //
+    // type=Client
+    //
+    {
+      query = "org.apache.cassandra.metrics:type=Client,name=*"
+      measurements = [
+        {
+          name = "cass.client.{name}"
+          tags = [
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Value}"
+        }
+      ]
+    },
+
+    //
     // type=ClientRequest
     //
+    // TotalLatency is left out on purpose. It is a monotonic counter updated with the latency
+    // amount. That is rarely useful on its own and the same thing can be accomplished with
+    // `name,cass.request.latency,:eq,statistic,totalTime,:eq,:and,:sum`
     {
       query = "org.apache.cassandra.metrics:type=ClientRequest,name=Latency,*"
       measurements = [
@@ -261,6 +283,178 @@ netflix.spectator.agent.jmx {
             }
           ]
           value = "{OneMinuteRate}"
+        }
+      ]
+    },
+    {
+      query = "org.apache.cassandra.metrics:type=ClientRequest,name=ConditionNotMet,*"
+      measurements = [
+        {
+          name = "cass.request.conditionNotMet"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Count}"
+        }
+      ]
+    },
+    {
+      query = "org.apache.cassandra.metrics:type=ClientRequest,name=UnfinishedCommit,*"
+      measurements = [
+        {
+          name = "cass.request.unfinishedCommit"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Count}"
+        }
+      ]
+    },
+    {
+      query = "org.apache.cassandra.metrics:type=ClientRequest,name=*Histogram,*"
+      measurements = [
+        {
+          name = "cass.request.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "statistic"
+              value = "count"
+            },
+            {
+              key = "atlas.dstype"
+              value = "rate"
+            }
+          ]
+          value = "{OneMinuteRate}"
+        },
+        {
+          name = "cass.request.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "statistic"
+              value = "max"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Max}"
+        },
+        {
+          name = "cass.request.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "statistic"
+              value = "totalTime"
+            },
+            {
+              key = "atlas.dstype"
+              value = "rate"
+            }
+          ]
+          // 50th percentile is used instead of mean because prior to metrics3 the mean
+          // is for the life of the timer rather than for the last snapshot of the
+          // reservoir
+          value = "{50thPercentile},{OneMinuteRate},:mul,{Count},{previous:Count},:if-changed"
+        },
+        {
+          name = "cass.request.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "statistic"
+              value = "percentile_50"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{50thPercentile},{Count},{previous:Count},:if-changed"
+        },
+        {
+          name = "cass.request.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "statistic"
+              value = "percentile_95"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{95thPercentile},{Count},{previous:Count},:if-changed"
+        },
+        {
+          name = "cass.request.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "statistic"
+              value = "percentile_99"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{99thPercentile},{Count},{previous:Count},:if-changed"
+        },
+        {
+          name = "cass.request.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "statistic"
+              value = "percentile_99.9"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{999thPercentile},{Count},{previous:Count},:if-changed"
         }
       ]
     },
@@ -455,6 +649,196 @@ netflix.spectator.agent.jmx {
             }
           ]
           value = "{999thPercentile},1e6,:div,{Count},{previous:Count},:if-changed"
+        }
+      ]
+    },
+    {
+      query = "org.apache.cassandra.metrics:type=*ColumnFamily,name=*Histogram,keyspace=*,*"
+      measurements = [
+        {
+          name = "cass.cf.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "keyspace"
+              value = "{keyspace}"
+            },
+            {
+              key = "familyType"
+              value = "{type}"
+            },
+            {
+              key = "statistic"
+              value = "count"
+            },
+            {
+              key = "atlas.dstype"
+              value = "rate"
+            }
+          ]
+          value = "{OneMinuteRate}"
+        },
+        {
+          name = "cass.cf.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "keyspace"
+              value = "{keyspace}"
+            },
+            {
+              key = "familyType"
+              value = "{type}"
+            },
+            {
+              key = "statistic"
+              value = "max"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Max}"
+        },
+        {
+          name = "cass.cf.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "keyspace"
+              value = "{keyspace}"
+            },
+            {
+              key = "familyType"
+              value = "{type}"
+            },
+            {
+              key = "statistic"
+              value = "totalTime"
+            },
+            {
+              key = "atlas.dstype"
+              value = "rate"
+            }
+          ]
+          // 50th percentile is used instead of mean because prior to metrics3 the mean
+          // is for the life of the timer rather than for the last snapshot of the
+          // reservoir
+          value = "{50thPercentile},{OneMinuteRate},:mul,{Count},{previous:Count},:if-changed"
+        },
+        {
+          name = "cass.cf.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "keyspace"
+              value = "{keyspace}"
+            },
+            {
+              key = "familyType"
+              value = "{type}"
+            },
+            {
+              key = "statistic"
+              value = "percentile_50"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{50thPercentile},{Count},{previous:Count},:if-changed"
+        },
+        {
+          name = "cass.cf.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "keyspace"
+              value = "{keyspace}"
+            },
+            {
+              key = "familyType"
+              value = "{type}"
+            },
+            {
+              key = "statistic"
+              value = "percentile_95"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{95thPercentile},{Count},{previous:Count},:if-changed"
+        },
+        {
+          name = "cass.cf.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "keyspace"
+              value = "{keyspace}"
+            },
+            {
+              key = "familyType"
+              value = "{type}"
+            },
+            {
+              key = "statistic"
+              value = "percentile_99"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{99thPercentile},{Count},{previous:Count},:if-changed"
+        },
+        {
+          name = "cass.cf.{name}"
+          tags = [
+            {
+              key = "scope"
+              value = "{scope}"
+            },
+            {
+              key = "keyspace"
+              value = "{keyspace}"
+            },
+            {
+              key = "familyType"
+              value = "{type}"
+            },
+            {
+              key = "statistic"
+              value = "percentile_99.9"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{999thPercentile},{Count},{previous:Count},:if-changed"
         }
       ]
     },
@@ -1277,6 +1661,9 @@ netflix.spectator.agent.jmx {
     //
     // type=Connection
     //
+    // Scoped (scope is IP address) metrics are left out as the combination of src/dst
+    // pairs across large clusters would be quite high. Might be supported in the future
+    // if we add an option to rollup the scope.
     {
       query = "org.apache.cassandra.metrics:type=Connection,name=TotalTimeouts"
       measurements = [
@@ -1319,6 +1706,8 @@ netflix.spectator.agent.jmx {
     //
     // type=Streaming
     //
+    // Scoped (scope is IP address) metrics are left out as the combination of src/dst
+    // pairs across large clusters would be quite high.
     {
       query = "org.apache.cassandra.metrics:type=Streaming,name=ActiveOutboundStreams"
       measurements = [
@@ -1545,7 +1934,7 @@ netflix.spectator.agent.jmx {
       query = "org.apache.cassandra.metrics:type=CQL,name=RegularStatementsExecuted"
       measurements = [
         {
-          name = "cass.threadpool.statementsExecuted"
+          name = "cass.cql.statementsExecuted"
           tags = [
             {
               key = "id"
@@ -1565,7 +1954,7 @@ netflix.spectator.agent.jmx {
       query = "org.apache.cassandra.metrics:type=CQL,name=PreparedStatementsExecuted"
       measurements = [
         {
-          name = "cass.threadpool.statementsExecuted"
+          name = "cass.cql.statementsExecuted"
           tags = [
             {
               key = "id"
@@ -1585,7 +1974,7 @@ netflix.spectator.agent.jmx {
       query = "org.apache.cassandra.metrics:type=CQL,name=PreparedStatementsEvicted"
       measurements = [
         {
-          name = "cass.threadpool.{name}"
+          name = "cass.cql.{name}"
           tags = [
             {
               key = "id"
@@ -1605,7 +1994,7 @@ netflix.spectator.agent.jmx {
       query = "org.apache.cassandra.metrics:type=CQL,name=PreparedStatementsCount"
       measurements = [
         {
-          name = "cass.threadpool.{name}"
+          name = "cass.cql.{name}"
           tags = [
             {
               key = "id"
@@ -1677,7 +2066,7 @@ netflix.spectator.agent.jmx {
       query = "org.apache.cassandra.metrics:type=ReadRepair,name=*"
       measurements = [
         {
-          name = "cass.filecache.{name}"
+          name = "cass.readrepair.{name}"
           tags = [
             {
               key = "atlas.dstype"


### PR DESCRIPTION
Updates the agent mappings for Cassandra, specifically
testing with 2.1.x to:

1. Fix some naming issues: `s/threadpool/cql/` for `type=CQL`
   and `s/filecache/readrerepair/` for `type=ReadRepair`.
2. Added mappings for `type=Client`.
3. Added a few metrics for `type=ClientRequest`.
4. Added mappings for column family histograms.
5. Added some comments about omissions.
6. Fix delta handling for monotonic counters that would not
   get reported if they did not deviate from 0.