### PR TITLE
move expr eval to impl package, add tests

### DIFF
--- a/codequality/checkstyle.xml
+++ b/codequality/checkstyle.xml
@@ -131,11 +131,13 @@
         <!-- <module name="AvoidInlineConditionals"/> -->
         <module name="EmptyStatement"/>
         <module name="EqualsHashCode"/>
-        <module name="HiddenField">
+        <!-- Disabled until: https://github.com/checkstyle/checkstyle/issues/619 -->
+        <!-- <module name="HiddenField">
           <property name="ignoreConstructorParameter" value="true"/>
           <property name="ignoreSetter" value="true"/>
+          <property name="ignoreFormat" value="^with.*$"/>
           <property name="severity" value="warning"/>
-        </module>
+        </module>-->
         <module name="IllegalInstantiation"/>
         <module name="InnerAssignment"/>
         <!--<module name="MagicNumber">

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/DataExpr.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/DataExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 Netflix, Inc.
+ * Copyright 2014-2017 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.spectator.atlas;
+package com.netflix.spectator.atlas.impl;
 
 import com.netflix.spectator.impl.Preconditions;
 
@@ -31,8 +31,11 @@ import java.util.stream.StreamSupport;
  * Data expressions for defining how to aggregate values. For more information see:
  *
  * https://github.com/Netflix/atlas/wiki/Reference-data
+ *
+ * <b>Classes in this package are only intended for use internally within spectator. They may
+ * change at any time and without notice.</b>
  */
-interface DataExpr {
+public interface DataExpr {
 
   /** Query for selecting the input measurements that should be aggregated. */
   Query query();

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/EvalPayload.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/EvalPayload.java
@@ -25,7 +25,7 @@ import java.util.Map;
  * <b>Classes in this package are only intended for use internally within spectator. They may
  * change at any time and without notice.</b>
  */
-public class EvalPayload {
+public final class EvalPayload {
 
   private final long timestamp;
   private final List<Metric> metrics;
@@ -46,8 +46,25 @@ public class EvalPayload {
     return metrics;
   }
 
+  @Override public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    EvalPayload payload = (EvalPayload) o;
+    return timestamp == payload.timestamp && metrics.equals(payload.metrics);
+  }
+
+  @Override public int hashCode() {
+    int result = (int) (timestamp ^ (timestamp >>> 32));
+    result = 31 * result + metrics.hashCode();
+    return result;
+  }
+
+  @Override public String toString() {
+    return "EvalPayload(timestamp=" + timestamp + ", metrics=" + metrics + ")";
+  }
+
   /** Metric value. */
-  public static class Metric {
+  public static final class Metric {
     private final String id;
     private final Map<String, String> tags;
     private final double value;
@@ -72,6 +89,29 @@ public class EvalPayload {
     /** Value for the metric. */
     public double getValue() {
       return value;
+    }
+
+    @Override public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      Metric metric = (Metric) o;
+      return Double.compare(metric.value, value) == 0
+          && id.equals(metric.id)
+          && tags.equals(metric.tags);
+    }
+
+    @Override public int hashCode() {
+      int result;
+      long temp;
+      result = id.hashCode();
+      result = 31 * result + tags.hashCode();
+      temp = Double.doubleToLongBits(value);
+      result = 31 * result + (int) (temp ^ (temp >>> 32));
+      return result;
+    }
+
+    @Override public String toString() {
+      return "Metric(id=" + id + ", tags=" + tags + ", value=" + value + ")";
     }
   }
 }

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Evaluator.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Evaluator.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas.impl;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Evaluates all of the expressions for subscriptions associated with a group.
+ *
+ * <b>Classes in this package are only intended for use internally within spectator. They may
+ * change at any time and without notice.</b>
+ */
+public class Evaluator {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(Evaluator.class);
+
+  // Subscriptions by group
+  private final Map<String, List<Subscription>> subscriptions = new ConcurrentHashMap<>();
+
+  /**
+   * Synchronize the internal set of subscriptions with the map that is passed in.
+   *
+   * @param subs
+   *     Complete set of subscriptions for all groups. The keys for the map are the
+   *     group names.
+   * @return
+   *     This instance for chaining of update operations.
+   */
+  public Evaluator sync(Map<String, List<Subscription>> subs) {
+    Set<String> removed = subscriptions.keySet();
+    removed.removeAll(subs.keySet());
+    removed.forEach(this::removeGroupSubscriptions);
+    subs.forEach(this::addGroupSubscriptions);
+    return this;
+  }
+
+  /**
+   * Add subscriptions for a given group.
+   *
+   * @param group
+   *     Name of the group. At Netflix this is typically the cluster that includes
+   *     the instance reporting data.
+   * @param subs
+   *     Set of subscriptions for the group.
+   * @return
+   *     This instance for chaining of update operations.
+   */
+  public Evaluator addGroupSubscriptions(String group, List<Subscription> subs) {
+    List<Subscription> oldSubs = subscriptions.put(group, subs);
+    if (oldSubs == null) {
+      LOGGER.debug("added group {} with {} subscriptions", group, subs.size());
+    } else {
+      LOGGER.debug("updated group {}, {} subscriptions before, {} subscriptions now",
+          group, oldSubs.size(), subs.size());
+    }
+    return this;
+  }
+
+  /**
+   * Remove subscriptions for a given group.
+   *
+   * @param group
+   *     Name of the group. At Netflix this is typically the cluster that includes
+   *     the instance reporting data.
+   * @return
+   *     This instance for chaining of update operations.
+   */
+  public Evaluator removeGroupSubscriptions(String group) {
+    List<Subscription> oldSubs = subscriptions.remove(group);
+    if (oldSubs != null) {
+      LOGGER.debug("removed group {} with {} subscriptions", group, oldSubs.size());
+    }
+    return this;
+  }
+
+  /**
+   * Evaluate expressions for all subscriptions associated with the specified group using
+   * the provided data.
+   *
+   * @param group
+   *     Name of the group. At Netflix this is typically the cluster that includes
+   *     the instance reporting data.
+   * @param timestamp
+   *     Timestamp to use for the payload response.
+   * @param vs
+   *     Set of values received for the group for the current time period.
+   * @return
+   *     Payload that can be encoded and sent to Atlas streaming evaluation cluster.
+   */
+  public EvalPayload eval(String group, long timestamp, List<TagsValuePair> vs) {
+    List<Subscription> subs = subscriptions.getOrDefault(group, Collections.emptyList());
+    List<EvalPayload.Metric> metrics = new ArrayList<>();
+    for (Subscription s : subs) {
+      DataExpr expr = s.dataExpr();
+      for (TagsValuePair pair : expr.eval(vs)) {
+        EvalPayload.Metric m = new EvalPayload.Metric(s.getId(), pair.tags(), pair.value());
+        metrics.add(m);
+      }
+    }
+    return new EvalPayload(timestamp, metrics);
+  }
+}

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Parser.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Parser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 Netflix, Inc.
+ * Copyright 2014-2017 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.spectator.atlas;
+package com.netflix.spectator.atlas.impl;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -24,8 +24,11 @@ import java.util.regex.Pattern;
 
 /**
  * Parses an Atlas data or query expression.
+ *
+ * <b>Classes in this package are only intended for use internally within spectator. They may
+ * change at any time and without notice.</b>
  */
-final class Parser {
+public final class Parser {
 
   private Parser() {
   }
@@ -34,16 +37,24 @@ final class Parser {
    * Parse an <a href="https://github.com/Netflix/atlas/wiki/Reference-data">Atlas data
    * expression</a>.
    */
-  static DataExpr parseDataExpr(String expr) {
-    return (DataExpr) parse(expr);
+  public static DataExpr parseDataExpr(String expr) {
+    try {
+      return (DataExpr) parse(expr);
+    } catch (ClassCastException e) {
+      throw new IllegalArgumentException("invalid data expression: " + expr, e);
+    }
   }
 
   /**
    * Parse an <a href="https://github.com/Netflix/atlas/wiki/Reference-query">Atlas query
    * expression</a>.
    */
-  static Query parseQuery(String expr) {
-    return (Query) parse(expr);
+  public static Query parseQuery(String expr) {
+    try {
+      return (Query) parse(expr);
+    } catch (ClassCastException e) {
+      throw new IllegalArgumentException("invalid query expression: " + expr, e);
+    }
   }
 
   @SuppressWarnings({"unchecked", "PMD"})

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/PublishPayload.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/PublishPayload.java
@@ -27,7 +27,7 @@ import java.util.Map;
  * <b>Classes in this package are only intended for use internally within spectator. They may
  * change at any time and without notice.</b>
  */
-public class PublishPayload {
+public final class PublishPayload {
 
   private final Map<String, String> tags;
   private final List<Measurement> metrics;
@@ -46,5 +46,23 @@ public class PublishPayload {
   /** Return the list of measurements. Needs to be public for Jackson bean mapper. */
   public List<Measurement> getMetrics() {
     return metrics;
+  }
+
+  @Override public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    PublishPayload that = (PublishPayload) o;
+    return tags.equals(that.tags)
+        && metrics.equals(that.metrics);
+  }
+
+  @Override public int hashCode() {
+    int result = tags.hashCode();
+    result = 31 * result + metrics.hashCode();
+    return result;
+  }
+
+  @Override public String toString() {
+    return "PublishPayload(tags=" + tags + ", metrics=" + metrics + ")";
   }
 }

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Query.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Query.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 Netflix, Inc.
+ * Copyright 2014-2017 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.spectator.atlas;
+package com.netflix.spectator.atlas.impl;
 
 import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Tag;
@@ -30,8 +30,11 @@ import java.util.stream.Collectors;
  * Query for matching based on tags. For more information see:
  *
  * https://github.com/Netflix/atlas/wiki/Stack-Language#query
+ *
+ * <b>Classes in this package are only intended for use internally within spectator. They may
+ * change at any time and without notice.</b>
  */
-interface Query {
+public interface Query {
 
   /** Convert {@code id} to a map. */
   static Map<String, String> toMap(Id id) {

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Subscription.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Subscription.java
@@ -21,15 +21,25 @@ package com.netflix.spectator.atlas.impl;
  * <b>Classes in this package are only intended for use internally within spectator. They may
  * change at any time and without notice.</b>
  */
-public class Subscription {
+public final class Subscription {
 
   private String id;
   private String expression;
   private long frequency;
 
+  private DataExpr expr;
+
   /** Create a new instance. */
   public Subscription() {
     // Will get filled in with set methods
+  }
+
+  /** Return the data expression for this subscription. */
+  public DataExpr dataExpr() {
+    if (expr == null) {
+      expr = Parser.parseDataExpr(expression);
+    }
+    return expr;
   }
 
   /** Id for a subscription.  */
@@ -42,6 +52,12 @@ public class Subscription {
     this.id = id;
   }
 
+  /** Set the subscription id. */
+  public Subscription withId(String id) {
+    this.id = id;
+    return this;
+  }
+
   /** Expression for the subscription. */
   public String getExpression() {
     return expression;
@@ -52,6 +68,12 @@ public class Subscription {
     this.expression = expression;
   }
 
+  /** Set the expression for the subscription. */
+  public Subscription withExpression(String expression) {
+    this.expression = expression;
+    return this;
+  }
+
   /** Requested frequency to send data for the subscription. */
   public long getFrequency() {
     return frequency;
@@ -60,6 +82,30 @@ public class Subscription {
   /** Set the requested frequency to send data for the subscription. */
   public void setFrequency(long frequency) {
     this.frequency = frequency;
+  }
+
+  /** Set the requested frequency to send data for the subscription. */
+  public Subscription withFrequency(long frequency) {
+    this.frequency = frequency;
+    return this;
+  }
+
+  @Override public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Subscription that = (Subscription) o;
+    return frequency == that.frequency
+        && id.equals(that.id)
+        && expression.equals(that.expression)
+        && expr.equals(that.expr);
+  }
+
+  @Override public int hashCode() {
+    int result = id.hashCode();
+    result = 31 * result + expression.hashCode();
+    result = 31 * result + (int) (frequency ^ (frequency >>> 32));
+    result = 31 * result + expr.hashCode();
+    return result;
   }
 
   @Override public String toString() {

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Subscriptions.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Subscriptions.java
@@ -23,7 +23,7 @@ import java.util.List;
  * <b>Classes in this package are only intended for use internally within spectator. They may
  * change at any time and without notice.</b>
  */
-public class Subscriptions {
+public final class Subscriptions {
 
   private List<Subscription> expressions;
 
@@ -34,6 +34,9 @@ public class Subscriptions {
 
   /** Returns the subscriptions with validated expressions. */
   public List<Subscription> validated() {
+    // Get the data expression to force parsing and ensure the string
+    // from the payload is valid.
+    expressions.forEach(Subscription::dataExpr);
     return expressions;
   }
 
@@ -45,5 +48,26 @@ public class Subscriptions {
   /** Set the available subscriptions. */
   public void setExpressions(List<Subscription> expressions) {
     this.expressions = expressions;
+  }
+
+  /** Set the available subscriptions. */
+  public Subscriptions withExpressions(List<Subscription> expressions) {
+    this.expressions = expressions;
+    return this;
+  }
+
+  @Override public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Subscriptions that = (Subscriptions) o;
+    return expressions.equals(that.expressions);
+  }
+
+  @Override public int hashCode() {
+    return expressions.hashCode();
+  }
+
+  @Override public String toString() {
+    return "Subscriptions(" + expressions + ")";
   }
 }

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/TagsValuePair.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/TagsValuePair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 Netflix, Inc.
+ * Copyright 2014-2017 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,32 +13,35 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.spectator.atlas;
+package com.netflix.spectator.atlas.impl;
 
 import java.util.Collections;
 import java.util.Map;
 
 /**
  * Pair consisting of a set of tags and a double value.
+ *
+ * <b>Classes in this package are only intended for use internally within spectator. They may
+ * change at any time and without notice.</b>
  */
-class TagsValuePair {
+public final class TagsValuePair {
 
   private final Map<String, String> tags;
   private final double value;
 
   /** Create a new instance. */
-  TagsValuePair(Map<String, String> tags, double value) {
+  public TagsValuePair(Map<String, String> tags, double value) {
     this.tags = Collections.unmodifiableMap(tags);
     this.value = value;
   }
 
   /** Return the tags from the pair. */
-  Map<String, String> tags() {
+  public Map<String, String> tags() {
     return tags;
   }
 
   /** Return the value from the pair. */
-  double value() {
+  public double value() {
     return value;
   }
 

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/DataExprTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/DataExprTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.spectator.atlas;
+package com.netflix.spectator.atlas.impl;
 
 import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.Measurement;

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/EvalPayloadTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/EvalPayloadTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas.impl;
+
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.ManualClock;
+import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Tag;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+
+@RunWith(JUnit4.class)
+public class EvalPayloadTest {
+
+  @Test
+  public void metricEquals() {
+    EqualsVerifier.forClass(EvalPayload.Metric.class)
+        .suppress(Warning.NULL_FIELDS)
+        .verify();
+  }
+
+  @Test
+  public void evalPayloadEquals() {
+    EqualsVerifier.forClass(EvalPayload.class)
+        .suppress(Warning.NULL_FIELDS)
+        .verify();
+  }
+}

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/EvaluatorTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/EvaluatorTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas.impl;
+
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.ManualClock;
+import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Tag;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+
+@RunWith(JUnit4.class)
+public class EvaluatorTest {
+
+  private final ManualClock clock = new ManualClock();
+  private final Registry registry = new DefaultRegistry(clock);
+
+  private List<TagsValuePair> data(String name, double... vs) {
+    List<Measurement> ms = new ArrayList<>();
+    for (int i = 0; i < vs.length; ++i) {
+      String pos = String.format("%03d", i);
+      String value = String.format("%f", vs[i]);
+      ms.add(new Measurement(registry.createId(name, "i", pos, "v", value), 0L, vs[i]));
+    }
+    return ms.stream().map(this::newTagsValuePair).collect(Collectors.toList());
+  }
+
+  private TagsValuePair newTagsValuePair(Measurement m) {
+    Map<String, String> tags = new HashMap<>();
+    for (Tag t : m.id().tags()) {
+      tags.put(t.key(), t.value());
+    }
+    tags.put("name", m.id().name());
+    return new TagsValuePair(tags, m.value());
+  }
+
+  @Test
+  public void noSubsForGroup() {
+    Evaluator evaluator = new Evaluator();
+    EvalPayload payload = evaluator.eval("test", 0L, Collections.emptyList());
+    EvalPayload expected = new EvalPayload(0L, Collections.emptyList());
+    Assert.assertEquals(expected, payload);
+  }
+
+  @Test
+  public void sumAndMaxForGroup() {
+    List<Subscription> subs = new ArrayList<>();
+    subs.add(new Subscription().withId("sum").withExpression(":true,:sum"));
+    subs.add(new Subscription().withId("max").withExpression(":true,:max"));
+
+    Evaluator evaluator = new Evaluator().addGroupSubscriptions("local", subs);
+    EvalPayload payload = evaluator.eval("local", 0L, data("foo", 1.0, 2.0, 3.0));
+
+    List<EvalPayload.Metric> metrics = new ArrayList<>();
+    metrics.add(new EvalPayload.Metric("sum", Collections.emptyMap(), 6.0));
+    metrics.add(new EvalPayload.Metric("max", Collections.emptyMap(), 3.0));
+    EvalPayload expected = new EvalPayload(0L, metrics);
+    Assert.assertEquals(expected, payload);
+  }
+
+  @Test
+  public void removeSub() {
+    List<Subscription> subs = new ArrayList<>();
+    subs.add(new Subscription().withId("sum").withExpression(":true,:sum"));
+    subs.add(new Subscription().withId("max").withExpression(":true,:max"));
+    Evaluator evaluator = new Evaluator().addGroupSubscriptions("local", subs);
+
+    evaluator.removeGroupSubscriptions("local");
+    EvalPayload payload = evaluator.eval("test", 0L, Collections.emptyList());
+
+    EvalPayload expected = new EvalPayload(0L, Collections.emptyList());
+    Assert.assertEquals(expected, payload);
+  }
+
+  @Test
+  public void updateSub() {
+
+    // Eval with sum
+    List<Subscription> sumSub = new ArrayList<>();
+    sumSub.add(new Subscription().withId("sum").withExpression(":true,:sum"));
+    Evaluator evaluator = new Evaluator().addGroupSubscriptions("local", sumSub);
+    EvalPayload payload = evaluator.eval("local", 0L, data("foo", 1.0, 2.0, 3.0));
+    List<EvalPayload.Metric> metrics = new ArrayList<>();
+    metrics.add(new EvalPayload.Metric("sum", Collections.emptyMap(), 6.0));
+    EvalPayload expected = new EvalPayload(0L, metrics);
+    Assert.assertEquals(expected, payload);
+
+    // Update to use max instead
+    List<Subscription> maxSub = new ArrayList<>();
+    maxSub.add(new Subscription().withId("sum").withExpression(":true,:max"));
+    evaluator.addGroupSubscriptions("local", maxSub);
+    payload = evaluator.eval("local", 0L, data("foo", 1.0, 2.0, 3.0));
+    metrics = new ArrayList<>();
+    metrics.add(new EvalPayload.Metric("sum", Collections.emptyMap(), 3.0));
+    expected = new EvalPayload(0L, metrics);
+    Assert.assertEquals(expected, payload);
+  }
+}

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/MeasurementSerializerTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/MeasurementSerializerTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.spectator.atlas;
+package com.netflix.spectator.atlas.impl;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/PublishPayloadTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/PublishPayloadTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas.impl;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+
+@RunWith(JUnit4.class)
+public class PublishPayloadTest {
+
+  @Test
+  public void equalsContract() {
+    EqualsVerifier.forClass(PublishPayload.class)
+        .suppress(Warning.NULL_FIELDS)
+        .verify();
+  }
+}

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/QueryTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/QueryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 Netflix, Inc.
+ * Copyright 2014-2017 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.spectator.atlas;
+package com.netflix.spectator.atlas.impl;
 
 import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.Registry;

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/SubscriptionTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/SubscriptionTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas.impl;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+
+@RunWith(JUnit4.class)
+public class SubscriptionTest {
+
+  @Test
+  public void equalsContract() {
+    EqualsVerifier.forClass(Subscription.class)
+        .suppress(Warning.NULL_FIELDS, Warning.NONFINAL_FIELDS)
+        .verify();
+  }
+
+  @Test
+  public void dataExpr() {
+    Subscription sub = new Subscription().withExpression(":true,:sum");
+    Assert.assertEquals(new DataExpr.Sum(Query.TRUE), sub.dataExpr());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void dataExprInvalid() {
+    Subscription sub = new Subscription().withExpression(":true");
+    sub.dataExpr();
+  }
+}

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/SubscriptionsTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/SubscriptionsTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas.impl;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+
+@RunWith(JUnit4.class)
+public class SubscriptionsTest {
+
+  @Test
+  public void equalsContract() {
+    EqualsVerifier.forClass(Subscriptions.class)
+        .suppress(Warning.NULL_FIELDS, Warning.NONFINAL_FIELDS)
+        .verify();
+  }
+}

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/TagsValuePairTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/TagsValuePairTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas.impl;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+
+@RunWith(JUnit4.class)
+public class TagsValuePairTest {
+
+  @Test
+  public void equalsContract() {
+    EqualsVerifier.forClass(TagsValuePair.class)
+        .suppress(Warning.NULL_FIELDS)
+        .verify();
+  }
+}


### PR DESCRIPTION
Moves the data expression evaluation to the impl
package for easier experimentation. Also implements
equals, hashCode, and toString for the various
helper objects to make debugging easier.