### PR TITLE
explicitly specifiy DataSourceType.GAUGE for servo

### DIFF
--- a/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoGauge.java
+++ b/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoGauge.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.spectator.servo;
 
+import com.netflix.servo.annotations.DataSourceType;
 import com.netflix.servo.monitor.AbstractMonitor;
 import com.netflix.servo.monitor.Monitor;
 import com.netflix.servo.monitor.MonitorConfig;
@@ -42,7 +43,7 @@ final class ServoGauge<T extends Number> extends AbstractMonitor<Double>
    * Create a new monitor that returns {@code value}.
    */
   ServoGauge(Clock clock, MonitorConfig config) {
-    super(config);
+    super(config.withAdditionalTag(DataSourceType.GAUGE));
     this.clock = clock;
     this.value = new AtomicDouble(Double.NaN);
     this.lastUpdated = new AtomicLong(0L);

--- a/spectator-reg-servo/src/test/java/com/netflix/spectator/servo/ServoGaugeTest.java
+++ b/spectator-reg-servo/src/test/java/com/netflix/spectator/servo/ServoGaugeTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 @RunWith(JUnit4.class)
@@ -86,6 +87,16 @@ public class ServoGaugeTest {
     g.set(1.0);
     Assert.assertEquals(g.value(), 1.0, 1e-12);
     Assert.assertFalse(g.hasExpired());
+  }
+
+  @Test
+  public void hasGaugeType() {
+    final ServoRegistry r = new ServoRegistry(clock);
+    Gauge g = r.gauge(r.createId("foo"));
+    g.set(1.0);
+
+    Map<String, String> tags = r.getMonitors().get(0).getConfig().getTags().asMap();
+    Assert.assertEquals("GAUGE", tags.get("type"));
   }
 
 }


### PR DESCRIPTION
Updates the gauges using ServoRegistry to explicity specify
`DataSourceType.GAUGE`. The Counter, Timer, and
DistributionSummary types get it automatically from using
StepCounter and MaxGauge internally.

This fixes the reporting of gauges when local
normalization is on. By default the value would get
treated as a rate and use a weighted average which
doesn't make sense for gauges.