### PR TITLE
fix #391, ClassCastException with :in

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Parser.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Parser.java
@@ -62,6 +62,7 @@ public final class Parser {
     DataExpr.AggregateFunction af;
     Query q, q1, q2;
     String k, v;
+    List<String> tmp;
     List<String> vs = null;
     String[] parts = expr.split(",");
     Deque<Object> stack = new ArrayDeque<>(parts.length);
@@ -112,9 +113,9 @@ public final class Parser {
           stack.push(new Query.Equal(k, v));
           break;
         case ":in":
-          vs = (List<String>) stack.pop();
+          tmp = (List<String>) stack.pop();
           k = (String) stack.pop();
-          stack.push(new Query.In(k, new TreeSet<>(vs)));
+          stack.push(new Query.In(k, new TreeSet<>(tmp)));
           break;
         case ":lt":
           v = (String) stack.pop();
@@ -167,19 +168,19 @@ public final class Parser {
           stack.push(new DataExpr.Count(q));
           break;
         case ":by":
-          vs = (List<String>) stack.pop();
+          tmp = (List<String>) stack.pop();
           af = (DataExpr.AggregateFunction) stack.pop();
-          stack.push(new DataExpr.GroupBy(af, vs));
+          stack.push(new DataExpr.GroupBy(af, tmp));
           break;
         case ":rollup-drop":
-          vs = (List<String>) stack.pop();
+          tmp = (List<String>) stack.pop();
           af = (DataExpr.AggregateFunction) stack.pop();
-          stack.push(new DataExpr.DropRollup(af, vs));
+          stack.push(new DataExpr.DropRollup(af, tmp));
           break;
         case ":rollup-keep":
-          vs = (List<String>) stack.pop();
+          tmp = (List<String>) stack.pop();
           af = (DataExpr.AggregateFunction) stack.pop();
-          stack.push(new DataExpr.KeepRollup(af, vs));
+          stack.push(new DataExpr.KeepRollup(af, tmp));
           break;
         default:
           if (token.startsWith(":")) {

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/DataExprTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/DataExprTest.java
@@ -200,6 +200,12 @@ public class DataExprTest {
   }
 
   @Test
+  public void inWithGroupBy() {
+    // https://github.com/Netflix/spectator/issues/391
+    parse("statistic,(,totalAmount,totalTime,),:in,name,jvm.gc.pause,:eq,:and,:sum,(,nf.asg,nf.node,),:by");
+  }
+
+  @Test
   public void allEqualsContract() {
     EqualsVerifier
         .forClass(DataExpr.All.class)


### PR DESCRIPTION
The same variable was being used for keeping track
of a list being created from the stack and popping
a list value off the stack to use for an operator.
The result is that operators like `:in` that take
a list would change the parse to list mode after
popping off the list argument and all subsequent
values on the stack would get added to the list until
another list terminator was found or the end of the
expression was reached.