### PR TITLE
merge subscriptions from lwc response

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasConfig.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasConfig.java
@@ -74,6 +74,11 @@ public interface AtlasConfig extends RegistryConfig {
     return (v == null) ? Duration.ofSeconds(10) : Duration.parse(v);
   }
 
+  /** Returns the TTL for subscriptions from the LWC service. */
+  default Duration configTTL() {
+    return configRefreshFrequency().multipliedBy(15);
+  }
+
   /**
    * Returns the URI for the Atlas LWC endpoint to retrieve current subscriptions.
    * The default is {@code http://localhost:7101/lwc/api/v1/expressions/local-dev}.

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Subscription.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Subscription.java
@@ -36,9 +36,6 @@ public final class Subscription {
 
   /** Return the data expression for this subscription. */
   public DataExpr dataExpr() {
-    if (expr == null) {
-      expr = Parser.parseDataExpr(expression);
-    }
     return expr;
   }
 
@@ -66,11 +63,12 @@ public final class Subscription {
   /** Set the expression for the subscription. */
   public void setExpression(String expression) {
     this.expression = expression;
+    this.expr = Parser.parseDataExpr(expression);
   }
 
   /** Set the expression for the subscription. */
   public Subscription withExpression(String expression) {
-    this.expression = expression;
+    setExpression(expression);
     return this;
   }
 
@@ -95,17 +93,25 @@ public final class Subscription {
     if (o == null || getClass() != o.getClass()) return false;
     Subscription that = (Subscription) o;
     return frequency == that.frequency
-        && id.equals(that.id)
-        && expression.equals(that.expression)
-        && expr.equals(that.expr);
+        && equalsOrNull(id, that.id)
+        && equalsOrNull(expression, that.expression)
+        && equalsOrNull(expr, that.expr);
+  }
+
+  private boolean equalsOrNull(Object a, Object b) {
+    return (a == null && b == null) || (a != null && a.equals(b));
   }
 
   @Override public int hashCode() {
-    int result = id.hashCode();
-    result = 31 * result + expression.hashCode();
+    int result = hashCodeOrZero(id);
+    result = 31 * result + hashCodeOrZero(expression);
     result = 31 * result + (int) (frequency ^ (frequency >>> 32));
-    result = 31 * result + expr.hashCode();
+    result = 31 * result + hashCodeOrZero(expr);
     return result;
+  }
+
+  private int hashCodeOrZero(Object o) {
+    return (o == null) ? 0 : o.hashCode();
   }
 
   @Override public String toString() {

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/SubscriptionTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/SubscriptionTest.java
@@ -29,7 +29,7 @@ public class SubscriptionTest {
   @Test
   public void equalsContract() {
     EqualsVerifier.forClass(Subscription.class)
-        .suppress(Warning.NULL_FIELDS, Warning.NONFINAL_FIELDS)
+        .suppress(Warning.NONFINAL_FIELDS)
         .verify();
   }
 
@@ -41,7 +41,6 @@ public class SubscriptionTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void dataExprInvalid() {
-    Subscription sub = new Subscription().withExpression(":true");
-    sub.dataExpr();
+    new Subscription().withExpression(":true");
   }
 }

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/SubscriptionsTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/SubscriptionsTest.java
@@ -17,9 +17,14 @@ package com.netflix.spectator.atlas.impl;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
 
 @RunWith(JUnit4.class)
@@ -30,5 +35,64 @@ public class SubscriptionsTest {
     EqualsVerifier.forClass(Subscriptions.class)
         .suppress(Warning.NULL_FIELDS, Warning.NONFINAL_FIELDS)
         .verify();
+  }
+
+  private Map<Subscription, Long> map(long ttl, Subscription... subs) {
+    Map<Subscription, Long> m = new HashMap<>();
+    for (Subscription sub : subs) {
+      m.put(sub, ttl);
+    }
+    return m;
+  }
+
+  private Subscription newSub(String id, String expr, long freq) {
+    return new Subscription().withId(id).withExpression(expr).withFrequency(freq);
+  }
+
+  private Subscriptions newSubs(Subscription... subs) {
+    return new Subscriptions().withExpressions(Arrays.asList(subs));
+  }
+
+  @Test
+  public void updateInit() {
+    Map<Subscription, Long> subs = new HashMap<>();
+    Subscription a = newSub("a", ":true,:sum", 10L);
+    Subscription b = newSub("b", ":true,:sum", 60L);
+    newSubs(a, b).update(subs, 0L, 15L);
+
+    Assert.assertEquals(map(15L, a, b), subs);
+  }
+
+  @Test
+  public void updateComplete() {
+    Subscription a = newSub("a", ":true,:sum", 10L);
+    Subscription b = newSub("b", ":true,:sum", 60L);
+    Map<Subscription, Long> subs = map(15L, a, b);
+    newSubs(a, b).update(subs, 10L, 30L);
+
+    Assert.assertEquals(map(30L, a, b), subs);
+  }
+
+  @Test
+  public void updatePartial() {
+    Subscription a = newSub("a", ":true,:sum", 10L);
+    Subscription b = newSub("b", ":true,:sum", 60L);
+    Map<Subscription, Long> subs = map(15L, a, b);
+    newSubs(b).update(subs, 10L, 30L);
+
+    Map<Subscription, Long> expected = map(15L, a, b);
+    expected.put(b, 30L);
+    Assert.assertEquals(expected, subs);
+  }
+
+  @Test
+  public void updatePartialExpire() {
+    Subscription a = newSub("a", ":true,:sum", 10L);
+    Subscription b = newSub("b", ":true,:sum", 60L);
+    Map<Subscription, Long> subs = map(15L, a, b);
+    newSubs(b).update(subs, 16L, 30L);
+
+    Map<Subscription, Long> expected = map(30L, b);
+    Assert.assertEquals(expected, subs);
   }
 }


### PR DESCRIPTION
The set of expressions on each server instance can vary
over a small window of time. To avoid expressions coming
and going unnecessarily the client merges the results
with a small TTL (right now 15 times the refresh rate).