### PR TITLE
fix #392, multiple ServoRegistry instances

### DIFF
--- a/spectator-reg-servo/src/test/java/com/netflix/spectator/servo/ServoRegistryTest.java
+++ b/spectator-reg-servo/src/test/java/com/netflix/spectator/servo/ServoRegistryTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.servo;
+
+import com.netflix.servo.DefaultMonitorRegistry;
+import com.netflix.servo.MonitorRegistry;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class ServoRegistryTest {
+
+  @Test
+  public void multiRegistration() {
+    // Servo uses statics internally and the indended use of ServoRegistry
+    // is there would be one in use at a given time. We don't want to make
+    // it a singleton because that would break some existing unit tests that
+    // expect isolated counts from the spectator api. This test just verifies
+    // that multiple registrations can coexist in servo and will not clobber
+    // each other.
+    MonitorRegistry mr = DefaultMonitorRegistry.getInstance();
+
+    ServoRegistry r1 = new ServoRegistry();
+    Assert.assertTrue(mr.getRegisteredMonitors().contains(r1));
+
+    ServoRegistry r2 = new ServoRegistry();
+    Assert.assertTrue(mr.getRegisteredMonitors().contains(r1));
+    Assert.assertTrue(mr.getRegisteredMonitors().contains(r2));
+
+    ServoRegistry r3 = new ServoRegistry();
+    Assert.assertTrue(mr.getRegisteredMonitors().contains(r1));
+    Assert.assertTrue(mr.getRegisteredMonitors().contains(r2));
+    Assert.assertTrue(mr.getRegisteredMonitors().contains(r3));
+  }
+
+}


### PR DESCRIPTION
Though not advised, this change will allow multiple
ServoRegistry instances to be created without clobbering
each other. If users are relying on this behavior their
code is broken and they should fix it to properly inject
the registry or use the global registry. However, with
this change it will prevent arbitrary broken behavior
from a library from breaking all spectator reporting
when it relies on the ServoRegistry.