### PR TITLE
use a simple merge for adding a single tag

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,7 @@ subprojects {
     fork = 1
     threads = 1
     profilers = ['stack']
-    include '.*Counters.*'
+    include '.*Ids.*'
   }
 
   jacoco {

--- a/spectator-api/src/main/java/com/netflix/spectator/api/ArrayTagSet.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/ArrayTagSet.java
@@ -100,29 +100,31 @@ final class ArrayTagSet implements Iterable<Tag> {
   }
 
   /** Add a new tag to the set. */
+  @SuppressWarnings("PMD.AvoidArrayLoops")
   ArrayTagSet add(Tag tag) {
-    Tag[] newTags;
-    int pos = Arrays.binarySearch(tags, 0, length, tag, TAG_COMPARATOR);
-    if (pos < 0) {
-      // Not found in list
-      newTags = new Tag[length + 1];
-      int i = -pos - 1;
-      if (i == 0) { // Prepend
-        System.arraycopy(tags, 0, newTags, 1, length);
-      } else if (i == length) { // Append
-        System.arraycopy(tags, 0, newTags, 0, length);
-      } else { // Insert
-        System.arraycopy(tags, 0, newTags, 0, i);
-        System.arraycopy(tags, i, newTags, i + 1, length - i);
-      }
-      newTags[i] = BasicTag.convert(tag);
+    Tag newTag = BasicTag.convert(tag);
+    if (length == 0) {
+      return new ArrayTagSet(new Tag[] {newTag});
     } else {
-      // Override
-      newTags = new Tag[length];
-      System.arraycopy(tags, 0, newTags, 0, length);
-      newTags[pos] = BasicTag.convert(tag);
+      Tag[] newTags = new Tag[length + 1];
+      String k = newTag.key();
+      int i = 0;
+      for (; i < length && tags[i].key().compareTo(k) < 0; ++i) {
+        newTags[i] = tags[i];
+      }
+      if (i < length && tags[i].key().equals(k)) {
+        // Override
+        newTags[i++] = newTag;
+        System.arraycopy(tags, i, newTags, i, length - i);
+        i = length;
+      } else {
+        // Insert
+        newTags[i] = newTag;
+        System.arraycopy(tags, i, newTags, i + 1, length - i);
+        i = newTags.length;
+      }
+      return new ArrayTagSet(newTags, i);
     }
-    return new ArrayTagSet(newTags);
   }
 
   /** Add a collection of tags to the set. */


### PR DESCRIPTION
The binary search is typically more expensive for the
relatively short tag lists that are normally used. For
the sample append1 benchmark:

```
Ids.append1
Before      thrpt   10   19,083,890.827 ±    616,750.336  ops/s
After       thrpt   10   23,459,023.310 ±  3,610,133.557  ops/s
```