### PR TITLE
reduce allocations for common withTags calls

### DIFF
--- a/spectator-api/src/jmh/java/com/netflix/spectator/perf/Ids.java
+++ b/spectator-api/src/jmh/java/com/netflix/spectator/perf/Ids.java
@@ -66,7 +66,9 @@ public class Ids {
     return m;
   }
 
-  private final Id baseId = registry.createId("http.req.complete")
+  private final Id emptyId = registry.createId("http.req.complete");
+
+  private final Id baseId = emptyId
       .withTag(    "nf.app", "test_app")
       .withTag("nf.cluster", "test_app-main")
       .withTag(    "nf.asg", "test_app-main-v042")
@@ -199,6 +201,44 @@ public class Ids {
     Id id = baseId.withTags(
         "client", "ab",
        "country", "US",
+        "device", "xbox",
+        "status", "200");
+    bh.consume(id);
+  }
+
+  @Threads(1)
+  @Benchmark
+  public void emptyAppend1(Blackhole bh) {
+    Id id = emptyId.withTag("country", "US");
+    bh.consume(id);
+  }
+
+  @Threads(1)
+  @Benchmark
+  public void emptyAppend2(Blackhole bh) {
+    Id id = emptyId.withTags(
+        "country", "US",
+        "device", "xbox");
+    bh.consume(id);
+  }
+
+  @Threads(1)
+  @Benchmark
+  public void emptyAppend4(Blackhole bh) {
+    Id id = emptyId.withTags(
+        "country", "US",
+        "device", "xbox",
+        "status", "200",
+        "client", "ab");
+    bh.consume(id);
+  }
+
+  @Threads(1)
+  @Benchmark
+  public void emptyAppend4sorted(Blackhole bh) {
+    Id id = emptyId.withTags(
+        "client", "ab",
+        "country", "US",
         "device", "xbox",
         "status", "200");
     bh.consume(id);

--- a/spectator-api/src/main/java/com/netflix/spectator/api/Id.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/Id.java
@@ -27,13 +27,48 @@ public interface Id {
   /** Other dimensions that can be used to classify the measurement. */
   Iterable<Tag> tags();
 
-  /** New id with an additional tag value. */
+  /** Return a new id with an additional tag value. */
   Id withTag(String k, String v);
 
-  /** New id with an additional tag value. */
+  /** Return a new id with an additional tag value. */
   Id withTag(Tag t);
 
-  /** New id with additional tag values. */
+  /**
+   * Return a new id with additional tag values. This overload is to avoid allocating a
+   * parameters array for the more generic varargs method {@link #withTags(String...)}.
+   */
+  default Id withTags(String k1, String v1) {
+    return withTag(k1, v1);
+  }
+
+  /**
+   * Return a new id with additional tag values. This overload is to avoid allocating a
+   * parameters array for the more generic varargs method {@link #withTags(String...)}.
+   */
+  @SuppressWarnings("PMD.UseObjectForClearerAPI")
+  default Id withTags(String k1, String v1, String k2, String v2) {
+    final Tag[] ts = new Tag[] {
+        new BasicTag(k1, v1),
+        new BasicTag(k2, v2)
+    };
+    return withTags(ts);
+  }
+
+  /**
+   * Return a new id with additional tag values. This overload is to avoid allocating a
+   * parameters array for the more generic varargs method {@link #withTags(String...)}.
+   */
+  @SuppressWarnings("PMD.UseObjectForClearerAPI")
+  default Id withTags(String k1, String v1, String k2, String v2, String k3, String v3) {
+    final Tag[] ts = new Tag[] {
+        new BasicTag(k1, v1),
+        new BasicTag(k2, v2),
+        new BasicTag(k3, v3)
+    };
+    return withTags(ts);
+  }
+
+  /** Return a new id with additional tag values. */
   default Id withTags(String... tags) {
     Id tmp = this;
     for (int i = 0; i < tags.length; i += 2) {
@@ -42,7 +77,7 @@ public interface Id {
     return tmp;
   }
 
-  /** New id with additional tag values. */
+  /** Return a new id with additional tag values. */
   default Id withTags(Tag... tags) {
     Id tmp = this;
     for (Tag t : tags) {
@@ -51,7 +86,7 @@ public interface Id {
     return tmp;
   }
 
-  /** New id with additional tag values. */
+  /** Return a new id with additional tag values. */
   default Id withTags(Iterable<Tag> tags) {
     Id tmp = this;
     for (Tag t : tags) {
@@ -60,7 +95,7 @@ public interface Id {
     return tmp;
   }
 
-  /** New id with additional tag values. */
+  /** Return a new id with additional tag values. */
   default Id withTags(Map<String, String> tags) {
     Id tmp = this;
     for (Map.Entry<String, String> entry : tags.entrySet()) {


### PR DESCRIPTION
Though there are typically better options, the variable
args `withTags(String... tags)` call is quite popular. This
change reduces the number of allocations for a number of
common calling patterns. In particular when using 4 or fewer
tags there are now overloads that will avoid the parameter
array from being created. Also if there are no existing
tags to merge with, it will dedup using the existing tags
array instead of allocating an new one can merging in.