### PR TITLE
expire inactive meters in AtlasRegistry

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasConfig.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasConfig.java
@@ -35,6 +35,15 @@ public interface AtlasConfig extends RegistryConfig {
   }
 
   /**
+   * Returns the TTL for meters that do not have any activity. After this period the meter
+   * will be considered expired and will not get reported. Default is 15 minutes.
+   */
+  default Duration meterTTL() {
+    String v = get("atlas.meterTTL");
+    return (v == null) ? Duration.ofMinutes(15) : Duration.parse(v);
+  }
+
+  /**
    * Returns true if publishing to Atlas is enabled. Default is true.
    */
   default boolean enabled() {

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasCounter.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 Netflix, Inc.
+ * Copyright 2014-2017 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,25 +28,16 @@ import java.util.Collections;
  * report the number events in the last complete interval rather than the total for
  * the life of the process.
  */
-class AtlasCounter implements Counter {
+class AtlasCounter extends AtlasMeter implements Counter {
 
-  private final Id id;
   private final StepLong value;
   private final Id stat;
 
   /** Create a new instance. */
-  AtlasCounter(Id id, Clock clock, long step) {
-    this.id = id;
+  AtlasCounter(Id id, Clock clock, long ttl, long step) {
+    super(id, clock, ttl);
     this.value = new StepLong(0L, clock, step);
     this.stat = id.withTag(DsType.rate);
-  }
-
-  @Override public Id id() {
-    return id;
-  }
-
-  @Override public boolean hasExpired() {
-    return false;
   }
 
   @Override public Iterable<Measurement> measure() {
@@ -57,10 +48,12 @@ class AtlasCounter implements Counter {
 
   @Override public void increment() {
     value.getCurrent().incrementAndGet();
+    updateLastModTime();
   }
 
   @Override public void increment(long amount) {
     value.getCurrent().addAndGet(amount);
+    updateLastModTime();
   }
 
   @Override public long count() {

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasGauge.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasGauge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 Netflix, Inc.
+ * Copyright 2014-2017 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,27 +26,16 @@ import java.util.Collections;
 /**
  * Counter that reports a rate per second to Atlas.
  */
-class AtlasGauge implements Gauge {
+class AtlasGauge extends AtlasMeter implements Gauge {
 
-  private final Id id;
-  private final Clock clock;
   private final AtomicDouble value;
   private final Id stat;
 
   /** Create a new instance. */
-  AtlasGauge(Id id, Clock clock) {
-    this.id = id;
-    this.clock = clock;
+  AtlasGauge(Id id, Clock clock, long ttl) {
+    super(id, clock, ttl);
     this.value = new AtomicDouble(0.0);
     this.stat = id.withTag(DsType.gauge);
-  }
-
-  @Override public Id id() {
-    return id;
-  }
-
-  @Override public boolean hasExpired() {
-    return false;
   }
 
   @Override public Iterable<Measurement> measure() {
@@ -56,6 +45,7 @@ class AtlasGauge implements Gauge {
 
   @Override public void set(double v) {
     value.set(v);
+    updateLastModTime();
   }
 
   @Override public double value() {

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasMeter.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasMeter.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import com.netflix.spectator.api.Clock;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Meter;
+
+/** Base class for core meter types used by AtlasRegistry. */
+abstract class AtlasMeter implements Meter {
+
+  /** Base identifier for all measurements supplied by this meter. */
+  protected final Id id;
+
+  /** Time source for checking if the meter has expired. */
+  protected final Clock clock;
+
+  /** TTL value for an inactive meter. */
+  private final long ttl;
+
+  /** Last time this meter was updated. */
+  private volatile long lastUpdated;
+
+  /** Create a new instance. */
+  AtlasMeter(Id id, Clock clock, long ttl) {
+    this.id = id;
+    this.clock = clock;
+    this.ttl = ttl;
+    lastUpdated = 0L;
+  }
+
+  /**
+   * Updates the last updated timestamp for the meter to indicate it is active and should
+   * not be considered expired.
+   */
+  void updateLastModTime() {
+    lastUpdated = clock.wallTime();
+  }
+
+  @Override public Id id() {
+    return id;
+  }
+
+  @Override public boolean hasExpired() {
+    return clock.wallTime() - lastUpdated > ttl;
+  }
+}

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasDistributionSummaryTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasDistributionSummaryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 Netflix, Inc.
+ * Copyright 2014-2017 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ public class AtlasDistributionSummaryTest {
   private ManualClock clock = new ManualClock();
   private Registry registry = new DefaultRegistry();
   private long step = 10000L;
-  private AtlasDistributionSummary dist = new AtlasDistributionSummary(registry.createId("test"), clock, step);
+  private AtlasDistributionSummary dist = new AtlasDistributionSummary(registry.createId("test"), clock, step, step);
 
   private void checkValue(long count, long amount, long square, long max) {
     int num = 0;
@@ -119,5 +119,18 @@ public class AtlasDistributionSummaryTest {
     checkValue(1, 42, 42 * 42, 42);
     clock.setWallTime(step + step + 1);
     checkValue(0, 0, 0, 0);
+  }
+
+  @Test
+  public void expiration() {
+    long start = clock.wallTime();
+    clock.setWallTime(start + step * 2);
+    Assert.assertTrue(dist.hasExpired());
+
+    dist.record(42);
+    Assert.assertFalse(dist.hasExpired());
+
+    clock.setWallTime(start + step * 3 + 1);
+    Assert.assertTrue(dist.hasExpired());
   }
 }

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasRegistryTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasRegistryTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 Netflix, Inc.
+/*
+ * Copyright 2014-2017 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
@@ -116,6 +117,20 @@ public class AtlasRegistryTest {
     clock.setWallTime(12123);
     long d = registry.getInitialDelay(10000);
     Assert.assertEquals(2123, d);
+  }
+
+  @Test
+  public void batchesExpiration() {
+    for (int i = 0; i < 9; ++i) {
+      registry.counter("" + i).increment();
+    }
+    Assert.assertEquals(3, registry.getBatches().size());
+    for (List<Measurement> batch : registry.getBatches()) {
+      Assert.assertEquals(3, batch.size());
+    }
+
+    clock.setWallTime(Duration.ofMinutes(15).toMillis() + 1);
+    Assert.assertEquals(0, registry.getBatches().size());
   }
 
 }

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasTimerTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasTimerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 Netflix, Inc.
+ * Copyright 2014-2017 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ public class AtlasTimerTest {
   private ManualClock clock = new ManualClock();
   private Registry registry = new DefaultRegistry();
   private long step = 10000L;
-  private AtlasTimer dist = new AtlasTimer(registry.createId("test"), clock, step);
+  private AtlasTimer dist = new AtlasTimer(registry.createId("test"), clock, step, step);
 
   private void checkValue(long count, long amount, double square, long max) {
     int num = 0;
@@ -155,5 +155,18 @@ public class AtlasTimerTest {
     checkValue(1, 42, 42 * 42, 42);
     clock.setWallTime(step + step + 1);
     checkValue(0, 0, 0, 0);
+  }
+
+  @Test
+  public void expiration() {
+    long start = clock.wallTime();
+    clock.setWallTime(start + step * 2);
+    Assert.assertTrue(dist.hasExpired());
+
+    dist.record(42, TimeUnit.MICROSECONDS);
+    Assert.assertFalse(dist.hasExpired());
+
+    clock.setWallTime(start + step * 3 + 1);
+    Assert.assertTrue(dist.hasExpired());
   }
 }


### PR DESCRIPTION
Updates the AtlasRegistry to expire meters that
have not seen activity within the `meterTTL` setting
of AtlasConfig.