### PR TITLE
clarify usage of `Registry.register` method

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/Registry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/Registry.java
@@ -65,7 +65,13 @@ public interface Registry extends Iterable<Meter> {
   Id createId(String name, Iterable<Tag> tags);
 
   /**
-   * Add a custom meter to the registry.
+   * Register a passive gauge. In most cases users should not use this method directly. Use
+   * one of the helper methods for working with gauges.
+   *
+   * @see #gauge(Id, Number)
+   * @see #gauge(Id, Object, ToDoubleFunction)
+   * @see #collectionSize(Id, Collection)
+   * @see #mapSize(Id, Map)
    */
   void register(Meter meter);
 


### PR DESCRIPTION
This has caused some confusion for both internal and
external users. See this mail thread for more context:

https://groups.google.com/forum/#!topic/netflix-atlas/hdMCAniOWOA