### PR TITLE
add contextual gauge support

### DIFF
--- a/spectator-ext-placeholders/src/main/java/com/netflix/spectator/placeholders/DefaultPlaceholderFactory.java
+++ b/spectator-ext-placeholders/src/main/java/com/netflix/spectator/placeholders/DefaultPlaceholderFactory.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2016 Netflix, Inc.
+/*
+ * Copyright 2014-2017 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package com.netflix.spectator.placeholders;
 
 import com.netflix.spectator.api.Counter;
 import com.netflix.spectator.api.DistributionSummary;
+import com.netflix.spectator.api.Gauge;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Timer;
 
@@ -46,6 +47,10 @@ final class DefaultPlaceholderFactory implements PlaceholderFactory {
   @Override
   public PlaceholderId createId(String name, Iterable<TagFactory> tagFactories) {
     return DefaultPlaceholderId.createWithFactories(name, tagFactories, registry);
+  }
+
+  @Override public Gauge gauge(PlaceholderId id) {
+    return new DefaultPlaceholderGauge(id, registry);
   }
 
   @Override

--- a/spectator-ext-placeholders/src/main/java/com/netflix/spectator/placeholders/DefaultPlaceholderGauge.java
+++ b/spectator-ext-placeholders/src/main/java/com/netflix/spectator/placeholders/DefaultPlaceholderGauge.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.placeholders;
+
+import com.netflix.spectator.api.Gauge;
+import com.netflix.spectator.api.Registry;
+
+/**
+ * Gauge implementation that delegates the value tracking to component gauges
+ * based on the current value of the tags associated with the PlaceholderId when the
+ * increment methods are called.
+ */
+class DefaultPlaceholderGauge extends AbstractDefaultPlaceholderMeter<Gauge> implements Gauge {
+  /**
+   * Constructs a new counter with the specified dynamic id.
+   *
+   * @param id
+   *     The dynamic (template) id for generating the individual counters.
+   * @param registry
+   *     The registry to use to instantiate the individual counters.
+   */
+  DefaultPlaceholderGauge(PlaceholderId id, Registry registry) {
+    super(id, registry::gauge);
+  }
+
+  @Override public void set(double value) {
+    resolveToCurrentMeter().set(value);
+  }
+
+  @Override public double value() {
+    return resolveToCurrentMeter().value();
+  }
+}

--- a/spectator-ext-placeholders/src/main/java/com/netflix/spectator/placeholders/PlaceholderFactory.java
+++ b/spectator-ext-placeholders/src/main/java/com/netflix/spectator/placeholders/PlaceholderFactory.java
@@ -17,6 +17,7 @@ package com.netflix.spectator.placeholders;
 
 import com.netflix.spectator.api.Counter;
 import com.netflix.spectator.api.DistributionSummary;
+import com.netflix.spectator.api.Gauge;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Timer;
 
@@ -58,6 +59,14 @@ public interface PlaceholderFactory {
    *     The newly created identifier.
    */
   PlaceholderId createId(String name, Iterable<TagFactory> tagFactories);
+
+  /**
+   * Represents a value sampled at a given time.
+   *
+   * @param id
+   *     Identifier created by a call to {@link #createId}
+   */
+  Gauge gauge(PlaceholderId id);
 
   /**
    * Measures the rate of some activity.  A counter is for continuously incrementing sources like

--- a/spectator-ext-placeholders/src/test/java/com/netflix/spectator/placeholders/DefaultPlaceholderGaugeTest.java
+++ b/spectator-ext-placeholders/src/test/java/com/netflix/spectator/placeholders/DefaultPlaceholderGaugeTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.placeholders;
+
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.Gauge;
+import com.netflix.spectator.api.ManualClock;
+import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Utils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.Collections;
+import java.util.List;
+
+@RunWith(JUnit4.class)
+public class DefaultPlaceholderGaugeTest {
+  private final ManualClock clock = new ManualClock();
+  private final Registry registry = new DefaultRegistry(clock);
+  private final PlaceholderFactory factory = PlaceholderFactory.from(registry);
+
+  @Test
+  public void testInit() {
+    Gauge g = new DefaultPlaceholderGauge(new DefaultPlaceholderId("unused", registry), registry);
+    Assert.assertEquals(g.value(), Double.NaN, 1e-12);
+  }
+
+  @Test
+  public void testIncrement() {
+    String[] tagValue = new String[] { "default" };
+    Gauge g = factory.gauge(factory.createId("testIncrement",
+        Collections.singleton(new TestTagFactory(tagValue))));
+    Assert.assertEquals(Double.NaN, g.value(), 1e-12);
+    Assert.assertEquals("testIncrement:tag=default", g.id().toString());
+    g.set(1);
+    Assert.assertEquals(1.0, g.value(), 1e-12);
+    g.set(3);
+    Assert.assertEquals(3.0, g.value(), 1e-12);
+
+    tagValue[0] = "value2";
+    Assert.assertEquals("testIncrement:tag=value2", g.id().toString());
+    g.set(1);
+    Assert.assertEquals(1.0, g.value(), 1e-12);
+
+    tagValue[0] = "default";
+    Assert.assertEquals("testIncrement:tag=default", g.id().toString());
+    g.set(4);
+    Assert.assertEquals(4.0, g.value(), 1e-12);
+  }
+
+  @Test
+  public void testIncrementAmount() {
+    String[] tagValue = new String[] { "default" };
+    Gauge g = factory.gauge(factory.createId("testIncrementAmount",
+        Collections.singleton(new TestTagFactory(tagValue))));
+
+    g.set(42);
+    Assert.assertEquals(42.0, g.value(), 1e-12);
+
+    tagValue[0] = "value2";
+    g.set(54);
+    Assert.assertEquals(54.0, g.value(), 1e-12);
+  }
+
+  @Test
+  public void testMeasure() {
+    String[] tagValue = new String[] { "default" };
+    Gauge g = factory.gauge(factory.createId("testMeasure",
+        Collections.singleton(new TestTagFactory(tagValue))));
+
+    doMeasurementTest(g, 42, 3712345L);
+    tagValue[0] = "value2";
+    doMeasurementTest(g, 54, 3712346L);
+  }
+
+  private void doMeasurementTest(Gauge g, int expectedValue, long expectedTime) {
+    g.set(expectedValue);
+    clock.setWallTime(expectedTime);
+    List<Measurement> measurements = Utils.toList(g.measure());
+
+    Assert.assertEquals(1, measurements.size());
+
+    Measurement m = measurements.get(0);
+    Assert.assertEquals(g.id(), m.id());
+    Assert.assertEquals(expectedTime, m.timestamp());
+    Assert.assertEquals(expectedValue, m.value(), 0.1e-12);
+  }
+
+  @Test
+  public void testHasExpired() {
+    String[] tagValue = new String[] { "default" };
+    Gauge g = factory.gauge(factory.createId("testHasExpired",
+        Collections.singleton(new TestTagFactory(tagValue))));
+
+    Assert.assertFalse(g.hasExpired());
+  }
+}


### PR DESCRIPTION
Adds support for active gauges to the placeholder
extension. This makes gauges consistent with other
core types. Fixes #412.