### PR TITLE
update to spotbugs gradle plugin 1.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
 plugins {
   id 'nebula.netflixoss' version '3.6.0'
   id 'me.champeau.gradle.jmh' version '0.3.0'
-  id "com.github.spotbugs" version "1.0" apply false
+  id "com.github.spotbugs" version "1.2" apply false
 }
 
 // Establish version and status


### PR DESCRIPTION
This version pulls in the latest spotbugs 3.1.0
release candidate instead of using the old findbugs
release.