### PR TITLE
fix class name for spotbugs task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -114,7 +114,7 @@ subprojects {
     ignoreFailures = false
     sourceSets = [sourceSets.main]
   }
-  tasks.withType(FindBugs) {
+  tasks.withType(com.github.spotbugs.SpotBugsTask) {
     reports {
       xml.enabled = false
       html.enabled = true


### PR DESCRIPTION
The overrides to generate the html report were being
ignored because it was getting applied to the FindBugs
task instead.