### PR TITLE
add statistic to counters and gauges

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/AbstractRegistry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/AbstractRegistry.java
@@ -243,6 +243,7 @@ public abstract class AbstractRegistry implements Registry {
 
   @Override public final Timer timer(Id id) {
     try {
+      Preconditions.checkNotNull(id, "id");
       Meter m = Utils.computeIfAbsent(meters, id, i -> compute(newTimer(i), NoopTimer.INSTANCE));
       if (!(m instanceof Timer)) {
         logTypeError(id, Timer.class, m.getClass());
@@ -257,6 +258,7 @@ public abstract class AbstractRegistry implements Registry {
 
   @Override public final Gauge gauge(Id id) {
     try {
+      Preconditions.checkNotNull(id, "id");
       Meter m = Utils.computeIfAbsent(meters, id, i -> compute(newGauge(i), NoopGauge.INSTANCE));
       if (!(m instanceof Gauge)) {
         logTypeError(id, Gauge.class, m.getClass());

--- a/spectator-api/src/main/java/com/netflix/spectator/api/ArrayTagSet.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/ArrayTagSet.java
@@ -46,7 +46,7 @@ final class ArrayTagSet implements Iterable<Tag> {
 
   /** Create a new tag set. */
   static ArrayTagSet create(Iterable<Tag> tags) {
-    return EMPTY.addAll(tags);
+    return (tags instanceof ArrayTagSet) ? (ArrayTagSet) tags : EMPTY.addAll(tags);
   }
 
   /** Create a new tag set. */

--- a/spectator-api/src/main/java/com/netflix/spectator/api/Statistic.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/Statistic.java
@@ -19,6 +19,9 @@ package com.netflix.spectator.api;
  * The valid set of statistics that can be reported by timers and distribution summaries.
  */
 public enum Statistic implements Tag {
+  /** A value sampled at a point in time. */
+  gauge,
+
   /** Rate per second for calls to record. */
   count,
 

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasCounter.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasCounter.java
@@ -19,6 +19,7 @@ import com.netflix.spectator.api.Clock;
 import com.netflix.spectator.api.Counter;
 import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.Statistic;
 import com.netflix.spectator.impl.StepLong;
 
 import java.util.Collections;
@@ -37,7 +38,9 @@ class AtlasCounter extends AtlasMeter implements Counter {
   AtlasCounter(Id id, Clock clock, long ttl, long step) {
     super(id, clock, ttl);
     this.value = new StepLong(0L, clock, step);
-    this.stat = id.withTag(DsType.rate);
+    // Add the statistic for typing. Re-adding the tags from the id is to retain
+    // the statistic from the id if it was already set
+    this.stat = id.withTag(Statistic.count).withTags(id.tags()).withTag(DsType.rate);
   }
 
   @Override public Iterable<Measurement> measure() {

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasGauge.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasGauge.java
@@ -19,6 +19,7 @@ import com.netflix.spectator.api.Clock;
 import com.netflix.spectator.api.Gauge;
 import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.Statistic;
 import com.netflix.spectator.impl.AtomicDouble;
 
 import java.util.Collections;
@@ -35,7 +36,9 @@ class AtlasGauge extends AtlasMeter implements Gauge {
   AtlasGauge(Id id, Clock clock, long ttl) {
     super(id, clock, ttl);
     this.value = new AtomicDouble(0.0);
-    this.stat = id.withTag(DsType.gauge);
+    // Add the statistic for typing. Re-adding the tags from the id is to retain
+    // the statistic from the id if it was already set
+    this.stat = id.withTag(Statistic.gauge).withTags(id.tags()).withTag(DsType.gauge);
   }
 
   @Override public Iterable<Measurement> measure() {

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasCounterTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasCounterTest.java
@@ -19,6 +19,7 @@ import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.ManualClock;
 import com.netflix.spectator.api.Measurement;
 import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Statistic;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,7 +37,7 @@ public class AtlasCounterTest {
   private void checkValue(long expected) {
     int count = 0;
     for (Measurement m : counter.measure()) {
-      Assert.assertEquals(counter.id().withTag(DsType.rate), m.id());
+      Assert.assertEquals(counter.id().withTags(Statistic.count, DsType.rate), m.id());
       Assert.assertEquals(expected / 10.0, m.value(), 1e-12);
       Assert.assertEquals(expected, counter.count());
       ++count;

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasGaugeTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasGaugeTest.java
@@ -19,6 +19,7 @@ import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.ManualClock;
 import com.netflix.spectator.api.Measurement;
 import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Statistic;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,7 +37,7 @@ public class AtlasGaugeTest {
   private void checkValue(long expected) {
     int count = 0;
     for (Measurement m : gauge.measure()) {
-      Assert.assertEquals(gauge.id().withTag(DsType.gauge), m.id());
+      Assert.assertEquals(gauge.id().withTags(Statistic.gauge, DsType.gauge), m.id());
       Assert.assertEquals(expected, m.value(), 1e-12);
       ++count;
     }

--- a/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoDistributionSummary.java
+++ b/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoDistributionSummary.java
@@ -53,11 +53,11 @@ class ServoDistributionSummary implements DistributionSummary, ServoMeter {
     count = new AtomicLong(0L);
     totalAmount = new AtomicLong(0L);
 
-    servoCount = new StepCounter(r.toMonitorConfig(id.withTag(Statistic.count)));
-    servoTotal = new StepCounter(r.toMonitorConfig(id.withTag(Statistic.totalAmount)));
+    servoCount = new StepCounter(r.toMonitorConfig(id.withTag(Statistic.count), null));
+    servoTotal = new StepCounter(r.toMonitorConfig(id.withTag(Statistic.totalAmount), null));
     servoTotalOfSquares = new StepCounter(
-        r.toMonitorConfig(id.withTag(Statistic.totalOfSquares)));
-    servoMax = new MaxGauge(r.toMonitorConfig(id.withTag(Statistic.max)));
+        r.toMonitorConfig(id.withTag(Statistic.totalOfSquares), null));
+    servoMax = new MaxGauge(r.toMonitorConfig(id.withTag(Statistic.max), null));
 
     lastUpdated = new AtomicLong(0L);
   }

--- a/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoRegistry.java
+++ b/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoRegistry.java
@@ -85,8 +85,11 @@ public class ServoRegistry extends AbstractRegistry implements CompositeMonitor<
   }
 
   /** Converts a spectator id into a MonitorConfig that can be used by servo. */
-  MonitorConfig toMonitorConfig(Id id) {
+  MonitorConfig toMonitorConfig(Id id, Tag stat) {
     MonitorConfig.Builder builder = new MonitorConfig.Builder(id.name());
+    if (stat != null) {
+      builder.withTag(stat.key(), stat.value());
+    }
     for (Tag t : id.tags()) {
       builder.withTag(t.key(), t.value());
     }
@@ -94,7 +97,7 @@ public class ServoRegistry extends AbstractRegistry implements CompositeMonitor<
   }
 
   @Override protected Counter newCounter(Id id) {
-    MonitorConfig cfg = toMonitorConfig(id);
+    MonitorConfig cfg = toMonitorConfig(id, Statistic.count);
     StepCounter counter = new StepCounter(cfg, new ServoClock(clock()));
     return new ServoCounter(clock(), counter);
   }
@@ -108,7 +111,7 @@ public class ServoRegistry extends AbstractRegistry implements CompositeMonitor<
   }
 
   @Override protected Gauge newGauge(Id id) {
-    return new ServoGauge(clock(), toMonitorConfig(id));
+    return new ServoGauge(clock(), toMonitorConfig(id, Statistic.gauge));
   }
 
   @Override public Integer getValue() {

--- a/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoTimer.java
+++ b/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoTimer.java
@@ -58,13 +58,13 @@ class ServoTimer extends AbstractTimer implements ServoMeter {
     totalTime = new AtomicLong(0L);
 
     ServoClock sc = new ServoClock(clock);
-    servoCount = new StepCounter(r.toMonitorConfig(id.withTag(Statistic.count)), sc);
-    servoTotal = new StepCounter(r.toMonitorConfig(id.withTag(Statistic.totalTime)), sc);
+    servoCount = new StepCounter(r.toMonitorConfig(id.withTag(Statistic.count), null), sc);
+    servoTotal = new StepCounter(r.toMonitorConfig(id.withTag(Statistic.totalTime), null), sc);
     servoTotalOfSquares = new DoubleCounter(
-        r.toMonitorConfig(id.withTag(Statistic.totalOfSquares)), sc);
+        r.toMonitorConfig(id.withTag(Statistic.totalOfSquares), null), sc);
 
     // Constructor that takes a clock param is not public
-    servoMax = new MaxGauge(r.toMonitorConfig(id.withTag(Statistic.max)));
+    servoMax = new MaxGauge(r.toMonitorConfig(id.withTag(Statistic.max), null));
 
     lastUpdated = new AtomicLong(0L);
   }

--- a/spectator-reg-servo/src/test/java/com/netflix/spectator/servo/ServoCounterTest.java
+++ b/spectator-reg-servo/src/test/java/com/netflix/spectator/servo/ServoCounterTest.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.spectator.servo;
 
+import com.netflix.servo.monitor.Monitor;
 import com.netflix.spectator.api.Counter;
 import com.netflix.spectator.api.ManualClock;
 import com.netflix.spectator.api.Registry;
@@ -24,6 +25,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 @RunWith(JUnit4.class)
@@ -75,6 +78,15 @@ public class ServoCounterTest {
     c.increment();
     Assert.assertEquals(c.count(), 43);
     Assert.assertFalse(c.hasExpired());
+  }
+
+  @Test
+  public void hasStatistic() {
+    List<Monitor<?>> ms = new ArrayList<>();
+    Counter c = newCounter("foo");
+    ((ServoCounter) c).addMonitors(ms);
+    Assert.assertEquals(1, ms.size());
+    Assert.assertEquals("count", ms.get(0).getConfig().getTags().getValue("statistic"));
   }
 
 }

--- a/spectator-reg-servo/src/test/java/com/netflix/spectator/servo/ServoGaugeTest.java
+++ b/spectator-reg-servo/src/test/java/com/netflix/spectator/servo/ServoGaugeTest.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.spectator.servo;
 
+import com.netflix.servo.monitor.Monitor;
 import com.netflix.spectator.api.Gauge;
 import com.netflix.spectator.api.ManualClock;
 import com.netflix.spectator.api.Registry;
@@ -24,6 +25,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -97,6 +100,16 @@ public class ServoGaugeTest {
 
     Map<String, String> tags = r.getMonitors().get(0).getConfig().getTags().asMap();
     Assert.assertEquals("GAUGE", tags.get("type"));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void hasStatistic() {
+    List<Monitor<?>> ms = new ArrayList<>();
+    Gauge g = newGauge("foo");
+    ((ServoGauge) g).addMonitors(ms);
+    Assert.assertEquals(1, ms.size());
+    Assert.assertEquals("gauge", ms.get(0).getConfig().getTags().getValue("statistic"));
   }
 
 }


### PR DESCRIPTION
This is for Netflix/atlas#597. Adds a statistic to
the counters and gauges to help with querying for
conceptual types when sent to Atlas.