### PR TITLE
initial work on memory tests for registries

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,6 @@
 include 'spectator-api',
         'spectator-agent',
+        'spectator-perf',
         'spectator-nflx',
         'spectator-nflx-plugin',
         'spectator-ext-aws',

--- a/spectator-perf/build.gradle
+++ b/spectator-perf/build.gradle
@@ -1,0 +1,6 @@
+dependencies {
+  compile project(':spectator-api')
+  compile project(':spectator-reg-atlas')
+  compile project(':spectator-reg-servo')
+  compile 'org.openjdk.jol:jol-core:0.8'
+}

--- a/spectator-perf/src/main/java/com/netflix/spectator/perf/Main.java
+++ b/spectator-perf/src/main/java/com/netflix/spectator/perf/Main.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.perf;
+
+import com.netflix.spectator.api.Clock;
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.NoopRegistry;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.atlas.AtlasRegistry;
+import com.netflix.spectator.servo.ServoRegistry;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.openjdk.jol.info.GraphLayout;
+
+/**
+ * Runs some basic tests against Spectator registry implementations to help gauge the
+ * performance. This is used for automated tests around the memory usage and can also be
+ * used for capturing flame graphs or with flight recorder to get CPU profile information.
+ */
+public final class Main {
+
+  private Main() {
+  }
+
+  private static Registry createRegistry(String type) {
+    Registry registry = null;
+    switch (type) {
+      case "noop":
+        registry = new NoopRegistry();
+        break;
+      case "default":
+        registry = new DefaultRegistry();
+        break;
+      case "atlas":
+        registry = new AtlasRegistry(Clock.SYSTEM, System::getProperty);
+        break;
+      case "servo":
+        registry = new ServoRegistry();
+        break;
+      default:
+        throw new IllegalArgumentException("unknown registry type: '" + type + "'");
+    }
+    return registry;
+  }
+
+  private static final Map<String, Consumer<Registry>> TESTS = new HashMap<>();
+  static {
+    TESTS.put("many-tags", new ManyTags());
+    TESTS.put("name-explosion", new NameExplosion());
+    TESTS.put("tag-key-explosion", new TagKeyExplosion());
+    TESTS.put("tag-value-explosion", new TagValueExplosion());
+  }
+
+  /**
+   * Run a test for a given type of registry.
+   *
+   * @param type
+   *     Should be one of `noop`, `default`, `atlas`, or `servo`.
+   * @param test
+   *     Test name to run. See the `TESTS` map for available options.
+   */
+  public static Registry run(String type, String test) {
+    Registry registry = createRegistry(type);
+    TESTS.get(test).accept(registry);
+    return registry;
+  }
+
+  /** Run a test and output the memory footprint of the registry. */
+  @SuppressWarnings("PMD")
+  public static void main(String[] args) {
+    if (args.length < 2) {
+      System.out.println("Usage: perf <registry> <test>");
+      System.exit(1);
+    }
+
+    Registry registry = run(args[0], args[1]);
+
+    GraphLayout igraph = GraphLayout.parseInstance(registry);
+    System.out.println(igraph.toFootprint());
+  }
+}

--- a/spectator-perf/src/main/java/com/netflix/spectator/perf/ManyTags.java
+++ b/spectator-perf/src/main/java/com/netflix/spectator/perf/ManyTags.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.perf;
+
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Registry;
+
+import java.util.Random;
+import java.util.function.Consumer;
+
+/**
+ * Tests the memory overhead of many tag permutations. In general this covers: 1) the overhead
+ * per meter, and 2) whether or not strings are interned when added to the tag sets.
+ */
+final class ManyTags implements Consumer<Registry> {
+
+  @Override public void accept(Registry registry) {
+    Random random = new Random(42);
+    for (int i = 0; i < 10000; ++i) {
+      Id id = registry.createId("manyTagsTest");
+      for (int j = 0; j < 20; ++j) {
+        String v = "" + random.nextInt(10);
+        id = id.withTag("" + j, v);
+      }
+      registry.counter(id).increment();
+    }
+  }
+}

--- a/spectator-perf/src/main/java/com/netflix/spectator/perf/NameExplosion.java
+++ b/spectator-perf/src/main/java/com/netflix/spectator/perf/NameExplosion.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.perf;
+
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Registry;
+
+import java.util.function.Consumer;
+
+/**
+ * Tests the ability to cope with a name explosion. Some users try to mangle everything
+ * into the name including things like timestamps, retry numbers, etc. If these values are
+ * not bounded it can cause problems over time.
+ */
+final class NameExplosion implements Consumer<Registry> {
+
+  @Override public void accept(Registry registry) {
+    for (int i = 0; i < 1000000; ++i) {
+      Id id = registry.createId("nameExplosion-" + i);
+      registry.counter(id).increment();
+    }
+  }
+}

--- a/spectator-perf/src/main/java/com/netflix/spectator/perf/TagKeyExplosion.java
+++ b/spectator-perf/src/main/java/com/netflix/spectator/perf/TagKeyExplosion.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.perf;
+
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Registry;
+
+import java.util.function.Consumer;
+
+/**
+ * Tests the ability to cope with an explosion of tag keys.
+ */
+final class TagKeyExplosion implements Consumer<Registry> {
+
+  @Override public void accept(Registry registry) {
+    for (int i = 0; i < 1000000; ++i) {
+      Id id = registry.createId("tagKeyExplosion").withTag("k-" + i, "foo");
+      registry.counter(id).increment();
+    }
+  }
+}

--- a/spectator-perf/src/main/java/com/netflix/spectator/perf/TagValueExplosion.java
+++ b/spectator-perf/src/main/java/com/netflix/spectator/perf/TagValueExplosion.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.perf;
+
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Registry;
+
+import java.util.function.Consumer;
+
+/**
+ * Tests the ability to cope with a tag value explosion. This is a single tag value that has
+ * many distinct values that are typically only updated once.
+ */
+final class TagValueExplosion implements Consumer<Registry> {
+
+  @Override public void accept(Registry registry) {
+    Id baseId = registry.createId("tagValueExplosion");
+    for (int i = 0; i < 1_000_000; ++i) {
+      registry.counter(baseId.withTag("i", "" + i)).increment();
+    }
+  }
+}

--- a/spectator-perf/src/test/java/com/netflix/spectator/perf/AtlasMemoryUseTest.java
+++ b/spectator-perf/src/test/java/com/netflix/spectator/perf/AtlasMemoryUseTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.perf;
+
+import org.junit.Ignore;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+@Ignore
+public class AtlasMemoryUseTest extends MemoryUseTest {
+
+  public AtlasMemoryUseTest() {
+    super("atlas");
+  }
+}

--- a/spectator-perf/src/test/java/com/netflix/spectator/perf/DefaultMemoryUseTest.java
+++ b/spectator-perf/src/test/java/com/netflix/spectator/perf/DefaultMemoryUseTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.perf;
+
+import org.junit.Ignore;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+@Ignore
+public class DefaultMemoryUseTest extends MemoryUseTest {
+
+  public DefaultMemoryUseTest() {
+    super("default");
+  }
+}

--- a/spectator-perf/src/test/java/com/netflix/spectator/perf/MemoryUseTest.java
+++ b/spectator-perf/src/test/java/com/netflix/spectator/perf/MemoryUseTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.perf;
+
+import com.netflix.spectator.api.Registry;
+import org.junit.Assert;
+import org.junit.Test;
+import org.openjdk.jol.info.GraphLayout;
+
+public abstract class MemoryUseTest {
+
+  private String registryType;
+
+  public MemoryUseTest(String registryType) {
+    this.registryType = registryType;
+  }
+
+  private void checkMemoryUsage(Registry registry, long limit) {
+    GraphLayout graph = GraphLayout.parseInstance(registry);
+    long size = graph.totalSize();
+    String details = "memory use exceeds limit: " + size + " > " + limit + "\n\n" + graph.toFootprint();
+    //System.out.println(details);
+    Assert.assertTrue(details, size <= limit);
+  }
+
+  @Test
+  public void manyTags() {
+    Registry registry = Main.run(registryType, "many-tags");
+    checkMemoryUsage(registry, 8_000_000);
+  }
+
+  @Test
+  public void tagKeyExplosion() {
+    Registry registry = Main.run(registryType, "tag-key-explosion");
+    checkMemoryUsage(registry, 8_000_000);
+  }
+
+  @Test
+  public void tagValueExplosion() {
+    Registry registry = Main.run(registryType, "tag-value-explosion");
+    checkMemoryUsage(registry, 8_000_000);
+  }
+
+  @Test
+  public void nameExplosion() {
+    Registry registry = Main.run(registryType, "name-explosion");
+    checkMemoryUsage(registry, 8_000_000);
+  }
+}

--- a/spectator-perf/src/test/java/com/netflix/spectator/perf/NoopMemoryUseTest.java
+++ b/spectator-perf/src/test/java/com/netflix/spectator/perf/NoopMemoryUseTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.perf;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class NoopMemoryUseTest extends MemoryUseTest {
+
+  public NoopMemoryUseTest() {
+    super("noop");
+  }
+}

--- a/spectator-perf/src/test/java/com/netflix/spectator/perf/ServoMemoryUseTest.java
+++ b/spectator-perf/src/test/java/com/netflix/spectator/perf/ServoMemoryUseTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.perf;
+
+import org.junit.Ignore;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+@Ignore
+public class ServoMemoryUseTest extends MemoryUseTest {
+
+  public ServoMemoryUseTest() {
+    super("servo");
+  }
+}


### PR DESCRIPTION
Start for a project to add automated memory use tests
as part of the build. The main tests for registries
other than noop are ignored for now. Will follow up
after some improvements to the memory use.