### PR TITLE
enable jdk9 build on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: java
 jdk:
 - oraclejdk8
+- oraclejdk9
 sudo: required
 dist: trusty
 install: ./installViaTravis.sh


### PR DESCRIPTION
Verify that the build and tests work when running
on jdk8 and jdk9.