### PR TITLE
only publish from jdk8 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: java
-jdk:
-- oraclejdk8
-- oraclejdk9
+matrix:
+  include:
+  - jdk: oraclejdk8
+    env: GRADLE_PUBLISH=true
+  - jdk: oraclejdk9
+    env: GRADLE_PUBLISH=false
 sudo: required
 dist: trusty
 install: ./installViaTravis.sh

--- a/buildViaTravis.sh
+++ b/buildViaTravis.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This script will build the project.
 
-if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+if [ "$TRAVIS_PULL_REQUEST" != "false" ] || [ "$GRADLE_PUBLISH" == "false" ]; then
   echo -e "Build Pull Request #$TRAVIS_PULL_REQUEST => Branch [$TRAVIS_BRANCH]"
   ./gradlew build
 elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" == "" ]; then


### PR DESCRIPTION
Updates the build settings so that publication to
jcenter will only occur when using jdk8. Cross build
on jdk9 is to ensure compatibility for use on jdk9,
but jdk8 is still the primary target.