### PR TITLE
remove copyDepsToBuild

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -131,15 +131,5 @@ subprojects {
   tasks.withType(Pmd) {
     exclude '**/tdunning/**'
   }
-
-  task copyDepsToBuild << {
-    ['compile', 'runtime', 'testCompile', 'testRuntime'].each { conf ->
-      delete "${buildDir}/dependencies/${conf}"
-      copy {
-        from configurations[conf]
-        into "${buildDir}/dependencies/${conf}"
-      }
-    }
-  }
 }
 


### PR DESCRIPTION
This was an old helper task to get a copy of the
dependency jars in a local directory. It hasn't
been used in a long time and is causing some build
warnings.