### PR TITLE
update docs version to 0.57.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To instrument your code you need to depend on the api library. This provides the
 for you to code against and build test cases. The only dependency is slf4j.
 
 ```
-com.netflix.spectator:spectator-api:0.57.0
+com.netflix.spectator:spectator-api:0.57.1
 ```
 
 If running at Netflix with the standard platform, see the

--- a/docs/ext/jvm-gc.md
+++ b/docs/ext/jvm-gc.md
@@ -22,7 +22,7 @@ to 7u40. For G1 it is recommended to be on the latest version available.
 ### Dependencies
 
 ```
-com.netflix.spectator:spectator-ext-gc:0.57.0
+com.netflix.spectator:spectator-ext-gc:0.57.1
 ```
 
 ### Start Reporting

--- a/docs/ext/log4j1.md
+++ b/docs/ext/log4j1.md
@@ -14,7 +14,7 @@ log messages reported.
 To use it simply add a dependency:
 
 ```
-com.netflix.spectator:spectator-ext-log4j1:0.57.0
+com.netflix.spectator:spectator-ext-log4j1:0.57.1
 ```
 
 Then in your log4j configuration specify the `com.netflix.spectator.log4j.SpectatorAppender`.

--- a/docs/ext/log4j2.md
+++ b/docs/ext/log4j2.md
@@ -8,7 +8,7 @@ log messages reported.
 To use it simply add a dependency:
 
 ```
-com.netflix.spectator:spectator-ext-log4j2:0.57.0
+com.netflix.spectator:spectator-ext-log4j2:0.57.1
 ```
 
 Then in your application initialization:

--- a/docs/ext/placeholders.md
+++ b/docs/ext/placeholders.md
@@ -13,7 +13,7 @@ are to support:
 To use the placeholders support add a dependency on:
 
 ```
-com.netflix.spectator:spectator-ext-placeholders:0.57.0
+com.netflix.spectator:spectator-ext-placeholders:0.57.1
 ```
 
 ## Usage

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ you are new to the library it is highly recommended to read the pages in the
 At a minimum you will need to:
 
 1. Depend on the api library. It is in maven central, for gradle the dependency
-   would be `com.netflix.spectator:spectator-api:0.57.0`.
+   would be `com.netflix.spectator:spectator-api:0.57.1`.
 2. Instrument some code, see the usage guides for [counters](intro/counter.md),
    [timers](intro/timer.md), and [gauges](intro/gauge.md).
 3. Pick a registry to bind to when initializing the application. See the sidebar

--- a/docs/intro/netflix.md
+++ b/docs/intro/netflix.md
@@ -13,7 +13,7 @@ section for the type of project you are working on:
 For libraries, the only dependency that should be needed is:
 
 ```
-com.netflix.spectator:spectator-api:0.57.0
+com.netflix.spectator:spectator-api:0.57.1
 ```
 
 The bindings to integrate internally should be included with the application. In your code,
@@ -80,7 +80,7 @@ If you are only interested in getting the GC logging, there is a library with an
 singleton that can be used:
 
 ```
-com.netflix.spectator:spectator-nflx:0.57.0
+com.netflix.spectator:spectator-nflx:0.57.1
 ```
 
 Assuming you are using karyon/base-server or governator with `com.netflix` in the list of base

--- a/docs/registry/metrics3.md
+++ b/docs/registry/metrics3.md
@@ -5,7 +5,7 @@ underlying implementation. To use the metrics registry, add a dependency on the
 `spectator-reg-metrics3` library. For gradle:
 
 ```
-com.netflix.spectator:spectator-reg-metrics3:0.57.0
+com.netflix.spectator:spectator-reg-metrics3:0.57.1
 ```
 
 Then when initializing the application, use the `MetricsRegistry`. For more

--- a/docs/registry/servo.md
+++ b/docs/registry/servo.md
@@ -5,7 +5,7 @@ implementation. To use the servo registry, add a dependency on the
 `spectator-reg-servo` library. For gradle:
 
 ```
-com.netflix.spectator:spectator-reg-servo:0.57.0
+com.netflix.spectator:spectator-reg-servo:0.57.1
 ```
 
 Then when initializing the application, use the `ServoRegistry`. If using guice


### PR DESCRIPTION
There is a bug with the publication of the log4j1
extension in 0.57.0. See #445 for details.