### PR TITLE
AbstractRegistry now returns swappable impl

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Sep 14 13:02:36 PDT 2015
+#Tue Aug 15 07:52:09 PDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/spectator-api/src/main/java/com/netflix/spectator/api/AbstractRegistry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/AbstractRegistry.java
@@ -85,6 +85,10 @@ public abstract class AbstractRegistry implements Registry {
    */
   protected abstract Counter newCounter(Id id);
 
+  private Counter createCounter(Id id) {
+    return new SwapCounter(newCounter(id));
+  }
+
   /**
    * Create a new distribution summary instance for a given id.
    *
@@ -94,6 +98,10 @@ public abstract class AbstractRegistry implements Registry {
    *     New distribution summary instance.
    */
   protected abstract DistributionSummary newDistributionSummary(Id id);
+
+  private DistributionSummary createDistributionSummary(Id id) {
+    return new SwapDistributionSummary(newDistributionSummary(id));
+  }
 
   /**
    * Create a new timer instance for a given id.
@@ -105,6 +113,10 @@ public abstract class AbstractRegistry implements Registry {
    */
   protected abstract Timer newTimer(Id id);
 
+  private Timer createTimer(Id id) {
+    return new SwapTimer(newTimer(id));
+  }
+
   /**
    * Create a new gauge instance for a given id.
    *
@@ -114,6 +126,10 @@ public abstract class AbstractRegistry implements Registry {
    *     New gauge instance.
    */
   protected abstract Gauge newGauge(Id id);
+
+  private Gauge createGauge(Id id) {
+    return new SwapGauge(newGauge(id));
+  }
 
   @Override public final Clock clock() {
     return clock;
@@ -213,7 +229,8 @@ public abstract class AbstractRegistry implements Registry {
   @Override public final Counter counter(Id id) {
     try {
       Preconditions.checkNotNull(id, "id");
-      Meter m = Utils.computeIfAbsent(meters, id, i -> compute(newCounter(i), NoopCounter.INSTANCE));
+      Meter m = Utils.computeIfAbsent(meters, id, i ->
+          compute(createCounter(i), NoopCounter.INSTANCE));
       if (!(m instanceof Counter)) {
         logTypeError(id, Counter.class, m.getClass());
         m = NoopCounter.INSTANCE;
@@ -229,7 +246,7 @@ public abstract class AbstractRegistry implements Registry {
     try {
       Preconditions.checkNotNull(id, "id");
       Meter m = Utils.computeIfAbsent(meters, id, i ->
-          compute(newDistributionSummary(i), NoopDistributionSummary.INSTANCE));
+          compute(createDistributionSummary(i), NoopDistributionSummary.INSTANCE));
       if (!(m instanceof DistributionSummary)) {
         logTypeError(id, DistributionSummary.class, m.getClass());
         m = NoopDistributionSummary.INSTANCE;
@@ -244,7 +261,7 @@ public abstract class AbstractRegistry implements Registry {
   @Override public final Timer timer(Id id) {
     try {
       Preconditions.checkNotNull(id, "id");
-      Meter m = Utils.computeIfAbsent(meters, id, i -> compute(newTimer(i), NoopTimer.INSTANCE));
+      Meter m = Utils.computeIfAbsent(meters, id, i -> compute(createTimer(i), NoopTimer.INSTANCE));
       if (!(m instanceof Timer)) {
         logTypeError(id, Timer.class, m.getClass());
         m = NoopTimer.INSTANCE;
@@ -259,7 +276,7 @@ public abstract class AbstractRegistry implements Registry {
   @Override public final Gauge gauge(Id id) {
     try {
       Preconditions.checkNotNull(id, "id");
-      Meter m = Utils.computeIfAbsent(meters, id, i -> compute(newGauge(i), NoopGauge.INSTANCE));
+      Meter m = Utils.computeIfAbsent(meters, id, i -> compute(createGauge(i), NoopGauge.INSTANCE));
       if (!(m instanceof Gauge)) {
         logTypeError(id, Gauge.class, m.getClass());
         m = NoopGauge.INSTANCE;

--- a/spectator-api/src/main/java/com/netflix/spectator/api/SwapCounter.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/SwapCounter.java
@@ -15,8 +15,10 @@
  */
 package com.netflix.spectator.api;
 
+import java.util.function.Supplier;
+
 /** Wraps another counter allowing the underlying type to be swapped. */
-final class SwapCounter implements Counter {
+final class SwapCounter implements Counter, Supplier<Counter> {
 
   private volatile Counter underlying;
 
@@ -51,5 +53,9 @@ final class SwapCounter implements Counter {
 
   @Override public long count() {
     return underlying.count();
+  }
+
+  @Override public Counter get() {
+    return underlying;
   }
 }

--- a/spectator-api/src/main/java/com/netflix/spectator/api/SwapDistributionSummary.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/SwapDistributionSummary.java
@@ -15,8 +15,10 @@
  */
 package com.netflix.spectator.api;
 
+import java.util.function.Supplier;
+
 /** Wraps another distribution summary allowing the underlying type to be swapped. */
-final class SwapDistributionSummary implements DistributionSummary {
+final class SwapDistributionSummary implements DistributionSummary, Supplier<DistributionSummary> {
 
   private volatile DistributionSummary underlying;
 
@@ -53,5 +55,9 @@ final class SwapDistributionSummary implements DistributionSummary {
   @Override
   public long totalAmount() {
     return underlying.totalAmount();
+  }
+
+  @Override public DistributionSummary get() {
+    return underlying;
   }
 }

--- a/spectator-api/src/main/java/com/netflix/spectator/api/SwapGauge.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/SwapGauge.java
@@ -15,8 +15,10 @@
  */
 package com.netflix.spectator.api;
 
+import java.util.function.Supplier;
+
 /** Wraps another gauge allowing the underlying type to be swapped. */
-final class SwapGauge implements Gauge {
+final class SwapGauge implements Gauge, Supplier<Gauge> {
 
   private volatile Gauge underlying;
 
@@ -47,5 +49,9 @@ final class SwapGauge implements Gauge {
 
   @Override public double value() {
     return underlying.value();
+  }
+
+  @Override public Gauge get() {
+    return underlying;
   }
 }

--- a/spectator-api/src/main/java/com/netflix/spectator/api/SwapTimer.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/SwapTimer.java
@@ -17,9 +17,10 @@ package com.netflix.spectator.api;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 /** Wraps another timer allowing the underlying type to be swapped. */
-final class SwapTimer implements Timer {
+final class SwapTimer implements Timer, Supplier<Timer> {
 
   private volatile Timer underlying;
 
@@ -62,5 +63,9 @@ final class SwapTimer implements Timer {
 
   @Override public long totalTime() {
     return underlying.totalTime();
+  }
+
+  @Override public Timer get() {
+    return underlying;
   }
 }

--- a/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoRegistry.java
+++ b/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoRegistry.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 /** Registry that maps spectator types to servo. */
 public class ServoRegistry extends AbstractRegistry implements CompositeMonitor<Integer> {
@@ -129,10 +130,22 @@ public class ServoRegistry extends AbstractRegistry implements CompositeMonitor<
   @Override public List<Monitor<?>> getMonitors() {
     List<Monitor<?>> monitors = new ArrayList<>();
     for (Meter meter : this) {
-      if (!meter.hasExpired() && meter instanceof ServoMeter) {
-        ((ServoMeter) meter).addMonitors(monitors);
+      ServoMeter sm = getServoMeter(meter);
+      if (!meter.hasExpired() && sm != null) {
+        sm.addMonitors(monitors);
       }
     }
     return monitors;
+  }
+
+  @SuppressWarnings("unchecked")
+  private ServoMeter getServoMeter(Meter meter) {
+    if (meter instanceof Supplier<?>) {
+      return getServoMeter(((Supplier<Meter>) meter).get());
+    } else if (meter instanceof ServoMeter) {
+      return (ServoMeter) meter;
+    } else {
+      return null;
+    }
   }
 }

--- a/spectator-reg-servo/src/test/java/com/netflix/spectator/servo/ServoCounterTest.java
+++ b/spectator-reg-servo/src/test/java/com/netflix/spectator/servo/ServoCounterTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 Netflix, Inc.
+/*
+ * Copyright 2014-2017 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,8 +35,8 @@ public class ServoCounterTest {
   private final ManualClock clock = new ManualClock();
 
   private Counter newCounter(String name) {
-    final Registry r = new ServoRegistry(clock);
-    return r.counter(r.createId(name));
+    final ServoRegistry r = new ServoRegistry(clock);
+    return r.newCounter(r.createId(name));
   }
 
   @Before

--- a/spectator-reg-servo/src/test/java/com/netflix/spectator/servo/ServoGaugeTest.java
+++ b/spectator-reg-servo/src/test/java/com/netflix/spectator/servo/ServoGaugeTest.java
@@ -36,8 +36,8 @@ public class ServoGaugeTest {
   private final ManualClock clock = new ManualClock();
 
   private Gauge newGauge(String name) {
-    final Registry r = new ServoRegistry(clock);
-    return r.gauge(r.createId(name));
+    final ServoRegistry r = new ServoRegistry(clock);
+    return r.newGauge(r.createId(name));
   }
 
   @Before


### PR DESCRIPTION
The AbstractRegistry which is the basis for most of the
other implementations now returns swappable implementations
of the core types. This is a first step that will allow
us to perform some additional steps later.

Why is this needed? Spectator allows the user to keep a
reference to a meter so it can be quickly updated without
an additional lookup cost. The drawback is that we cannot
safely expire the meter in the registry if someone is holding
onto a reference. If the user is running with improper tag
values this can grow over time and result in a memory leak.
For apps that pull in many libraries expecting each dependency
to be responsible with metrics is a tall order. This change
will allow us to swap out the reference when expiring to
a simple implementation that will lookup again if there is
activity.

In addition, this should give us the ability to due more
adaptive rollup work (#22) in the future.