### PR TITLE
nebula 4.0.0 and gradle 4.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ buildscript {
   repositories { jcenter() }
   dependencies {
     classpath 'com.github.ben-manes:gradle-versions-plugin:0.15.0'
-    classpath 'com.netflix.nebula:nebula-dependency-recommender:3.6.3'
+    classpath 'com.netflix.nebula:nebula-dependency-recommender:5.0.0'
 
     // This is a workaround for getting the shadow plugin to work correctly
     // for some sub-projects. For more details see:
@@ -12,7 +12,7 @@ buildscript {
 }
 
 plugins {
-  id 'nebula.netflixoss' version '3.6.0'
+  id 'nebula.netflixoss' version '4.0.0'
   id 'me.champeau.gradle.jmh' version '0.3.0'
   id "com.github.spotbugs" version "1.2" apply false
 }
@@ -93,7 +93,7 @@ subprojects {
     reports {
       xml.enabled false
       csv.enabled false
-      html.destination "${buildDir}/reports/jacoco"
+      html.destination file("${buildDir}/reports/jacoco")
     }
   }
   

--- a/build.gradle
+++ b/build.gradle
@@ -131,5 +131,10 @@ subprojects {
   tasks.withType(Pmd) {
     exclude '**/tdunning/**'
   }
+
+  test {
+    dependsOn cleanTest
+    testLogging.showStandardStreams = true
+  }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-bin.zip

--- a/spectator-api/src/test/java/com/netflix/spectator/api/CompatibilityTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/CompatibilityTest.java
@@ -199,6 +199,9 @@ public class CompatibilityTest {
     for (int i = 0; i < length; ++i) {
       String exp = (i < EXPECTED.size()) ? EXPECTED.get(i) : null;
       String found = (i < actual.size()) ? actual.get(i) : null;
+      if (!exp.equals(found)) {
+        System.err.printf("[%s] != [%s]%n", exp, found);
+      }
       Assert.assertEquals(exp, found);
     }
   }


### PR DESCRIPTION
Updates the versions of nebula and gradle. A number of
smaller benefits including better jdk9 compatibility.