### PR TITLE
remove defaults for Registry.gauge

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/Gauge.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/Gauge.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 Netflix, Inc.
+/*
+ * Copyright 2014-2017 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,8 @@ public interface Gauge extends Meter {
    *     Most recent measured value.
    */
   default void set(double value) {
+    // For backwards compatibility with older versions of spectator prior to set being
+    // required on the gauge. Default implementation should be removed in a future release.
   }
 
   /** Returns the current value. */

--- a/spectator-api/src/main/java/com/netflix/spectator/api/NoopGauge.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/NoopGauge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 Netflix, Inc.
+ * Copyright 2014-2017 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,9 @@ enum NoopGauge implements Gauge {
 
   @Override public boolean hasExpired() {
     return true;
+  }
+
+  @Override public void set(double v) {
   }
 
   @Override public double value() {

--- a/spectator-api/src/main/java/com/netflix/spectator/api/ObjectGauge.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/ObjectGauge.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 Netflix, Inc.
+/*
+ * Copyright 2014-2017 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import java.util.function.ToDoubleFunction;
 /**
  * Gauge that is defined by executing a {@link ToDoubleFunction} on an object.
  */
-class ObjectGauge<T> extends AbstractMeter<T> implements Gauge {
+class ObjectGauge<T> extends AbstractMeter<T> {
 
   private final ToDoubleFunction<T> f;
 
@@ -47,7 +47,8 @@ class ObjectGauge<T> extends AbstractMeter<T> implements Gauge {
     return Collections.singleton(new Measurement(id, clock.wallTime(), value()));
   }
 
-  @Override public double value() {
+  /** Return the current value for evaluating `f` over `obj`. */
+  double value() {
     final T obj = ref.get();
     return (obj == null) ? Double.NaN : f.applyAsDouble(obj);
   }

--- a/spectator-api/src/main/java/com/netflix/spectator/api/Registry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/Registry.java
@@ -127,11 +127,7 @@ public interface Registry extends Iterable<Meter> {
    * @param id
    *     Identifier created by a call to {@link #createId}
    */
-  default Gauge gauge(Id id) {
-    // Added in 0.45.0. For backwards compatibility we use a default implementation here that
-    // returns a noop implementation.
-    return NoopGauge.INSTANCE;
-  }
+  Gauge gauge(Id id);
 
   /**
    * Returns the meter associated with a given id.


### PR DESCRIPTION
The default implementations that do nothing were added
to avoid breaking compatibility for external classes
that implementated those interfaces. However, that comes
at the cost of correctness if those methods are not
implemented. Current estimate is that it is low risk
to remove those defaults and it makes the api cleaner
and less error prone.