### PR TITLE
rename passive gauge overloads

### DIFF
--- a/docs/intro/gauge.md
+++ b/docs/intro/gauge.md
@@ -23,7 +23,7 @@ class HttpServer {
   private AtomicInteger numConnections;
 
   public HttpServer(Registry registry) {
-    numConnections = registry.gauge("server.numConnections", new AtomicInteger(0));
+    numConnections = registry.monitorNumber("server.numConnections", new AtomicInteger(0));
   }
 
   public void onConnectionCreated() {
@@ -66,14 +66,14 @@ implementation should be thread safe. For example:
 
 ```java
 AtomicInteger size = new AtomicInteger();
-registry.gauge("queue.size", size);
+registry.monitorNumber("queue.size", size);
 ```
 
 The call will return the Number so the registration can be inline on the
 assignment:
 
 ```java
-AtomicInteger size = registry.gauge("queue.size", new AtomicInteger());
+AtomicInteger size = registry.monitorNumber("queue.size", new AtomicInteger());
 ```
 
 Updates to the value are preformed by updating the number instance directly.
@@ -87,7 +87,7 @@ public class Queue {
 
   @Inject
   public Queue(Registry registry) {
-    registry.gauge("queue.size", this, Queue::size);
+    registry.monitorValue("queue.size", this, Queue::size);
   }
 
   ...
@@ -101,7 +101,7 @@ public class Queue {
     in object there will be a reference to `this`:
 
     ```
-    registry.gauge("queue.size", this, obj -> size());
+    registry.monitorValue("queue.size", this, obj -> size());
     ```
 
 ### Using Reflection

--- a/spectator-api/src/main/java/com/netflix/spectator/api/Registry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/Registry.java
@@ -318,7 +318,11 @@ public interface Registry extends Iterable<Meter> {
    *     Identifier for the metric being registered.
    * @return
    *     Timer instance with the corresponding id.
+   * @deprecated
+   *     Use {@link com.netflix.spectator.api.patterns.LongTaskTimer#get(Registry, Id)}
+   *     instead. Scheduled to be removed in 2.0.
    */
+  @Deprecated
   default LongTaskTimer longTaskTimer(Id id) {
     // Note: this method is only included in the registry for historical reasons to
     // maintain compatibility. Future patterns should just use the registry not be
@@ -333,7 +337,11 @@ public interface Registry extends Iterable<Meter> {
    *     Description of the measurement that is being collected.
    * @return
    *     Timer instance with the corresponding id.
+   * @deprecated
+   *     Use {@link com.netflix.spectator.api.patterns.LongTaskTimer#get(Registry, Id)}
+   *     instead. Scheduled to be removed in 2.0.
    */
+  @Deprecated
   default LongTaskTimer longTaskTimer(String name) {
     return longTaskTimer(createId(name));
   }
@@ -347,7 +355,11 @@ public interface Registry extends Iterable<Meter> {
    *     Other dimensions that can be used to classify the measurement.
    * @return
    *     Timer instance with the corresponding id.
+   * @deprecated
+   *     Use {@link com.netflix.spectator.api.patterns.LongTaskTimer#get(Registry, Id)}
+   *     instead. Scheduled to be removed in 2.0.
    */
+  @Deprecated
   default LongTaskTimer longTaskTimer(String name, Iterable<Tag> tags) {
     return longTaskTimer(createId(name, tags));
   }
@@ -361,16 +373,43 @@ public interface Registry extends Iterable<Meter> {
    *     Other dimensions that can be used to classify the measurement.
    * @return
    *     Timer instance with the corresponding id.
+   * @deprecated
+   *     Use {@link com.netflix.spectator.api.patterns.LongTaskTimer#get(Registry, Id)}
+   *     instead. Scheduled to be removed in 2.0.
    */
+  @Deprecated
   default LongTaskTimer longTaskTimer(String name, String... tags) {
     return longTaskTimer(createId(name, Utils.toIterable(tags)));
   }
 
   /**
-   * Register a gauge that reports the value of the {@link java.lang.Number}. The registration
-   * will keep a weak reference to the number so it will not prevent garbage collection.
-   * The number implementation used should be thread safe. See
-   * {@link #gauge(Id, Object, ToDoubleFunction)} for more information on gauges.
+   * Tells the registry to regularly poll the value of a {@link java.lang.Number} and report
+   * it as a gauge. See {@link #monitorNumber(Id, Number)} for more information.
+   *
+   * @param id
+   *     Identifier for the metric being registered.
+   * @param number
+   *     Thread-safe implementation of {@link Number} used to access the value.
+   * @return
+   *     The number that was passed in so the registration can be done as part of an assignment
+   *     statement.
+   * @deprecated
+   *     Use {@link #monitorNumber(Id, Number)} instead. This method was renamed to
+   *     {@code monitorNumber} to reduce user confusion over the difference between
+   *     active and passive gauges. Scheduled to be removed in 2.0.
+   */
+  @Deprecated
+  default <T extends Number> T gauge(Id id, T number) {
+    return monitorNumber(id, number);
+  }
+
+  /**
+   * Tells the registry to regularly poll the value of a {@link java.lang.Number} and report
+   * it as a gauge. The registry will keep a weak reference to the number so it will not prevent
+   * garbage collection. To explicitly tell the registry to ignore the value without waiting
+   * for it to be garbage collected, set the value to {@link Double#NaN}. The number
+   * implementation used should be thread safe. For more information, see
+   * {@link #monitorValue(Id, Object, ToDoubleFunction)}.
    *
    * @param id
    *     Identifier for the metric being registered.
@@ -380,13 +419,34 @@ public interface Registry extends Iterable<Meter> {
    *     The number that was passed in so the registration can be done as part of an assignment
    *     statement.
    */
-  default <T extends Number> T gauge(Id id, T number) {
-    return gauge(id, number, Number::doubleValue);
+  default <T extends Number> T monitorNumber(Id id, T number) {
+    return monitorValue(id, number, Number::doubleValue);
   }
 
   /**
-   * Register a gauge that reports the value of the {@link java.lang.Number}. See
-   * {@link #gauge(Id, Number)}.
+   * Tells the registry to regularly poll the value of a {@link java.lang.Number} and report
+   * it as a gauge. See {@link #monitorNumber(Id, Number)} for more information.
+   *
+   * @param name
+   *     Name of the metric being registered.
+   * @param number
+   *     Thread-safe implementation of {@link Number} used to access the value.
+   * @return
+   *     The number that was passed in so the registration can be done as part of an assignment
+   *     statement.
+   * @deprecated
+   *     Use {@link #monitorNumber(Id, Number)} instead. This method was renamed to
+   *     {@code monitorNumber} to reduce user confusion over the difference between
+   *     active and passive gauges. Scheduled to be removed in 2.0.
+   */
+  @Deprecated
+  default <T extends Number> T gauge(String name, T number) {
+    return monitorNumber(createId(name), number);
+  }
+
+  /**
+   * Tells the registry to regularly poll the value of a {@link java.lang.Number} and report
+   * it as a gauge. See {@link #monitorNumber(Id, Number)} for more information.
    *
    * @param name
    *     Name of the metric being registered.
@@ -396,13 +456,36 @@ public interface Registry extends Iterable<Meter> {
    *     The number that was passed in so the registration can be done as part of an assignment
    *     statement.
    */
-  default <T extends Number> T gauge(String name, T number) {
-    return gauge(createId(name), number);
+  default <T extends Number> T monitorNumber(String name, T number) {
+    return monitorNumber(createId(name), number);
   }
 
   /**
-   * Register a gauge that reports the value of the {@link java.lang.Number}. See
-   * {@link #gauge(Id, Number)}.
+   * Tells the registry to regularly poll the value of a {@link java.lang.Number} and report
+   * it as a gauge. See {@link #monitorNumber(Id, Number)} for more information.
+   *
+   * @param name
+   *     Name of the metric being registered.
+   * @param tags
+   *     Sequence of dimensions for breaking down the name.
+   * @param number
+   *     Thread-safe implementation of {@link Number} used to access the value.
+   * @return
+   *     The number that was passed in so the registration can be done as part of an assignment
+   *     statement.
+   * @deprecated
+   *     Use {@link #monitorNumber(Id, Number)} instead. This method was renamed to
+   *     {@code monitorNumber} to reduce user confusion over the difference between
+   *     active and passive gauges. Scheduled to be removed in 2.0.
+   */
+  @Deprecated
+  default <T extends Number> T gauge(String name, Iterable<Tag> tags, T number) {
+    return gauge(createId(name, tags), number);
+  }
+
+  /**
+   * Tells the registry to regularly poll the value of a {@link java.lang.Number} and report
+   * it as a gauge. See {@link #monitorNumber(Id, Number)} for more information.
    *
    * @param name
    *     Name of the metric being registered.
@@ -414,16 +497,52 @@ public interface Registry extends Iterable<Meter> {
    *     The number that was passed in so the registration can be done as part of an assignment
    *     statement.
    */
-  default <T extends Number> T gauge(String name, Iterable<Tag> tags, T number) {
-    return gauge(createId(name, tags), number);
+  default <T extends Number> T monitorNumber(String name, Iterable<Tag> tags, T number) {
+    return monitorNumber(createId(name, tags), number);
   }
 
   /**
-   * Register a gauge that reports the value of the object after the function
-   * {@code f} is applied. The registration will keep a weak reference to the object so it will
-   * not prevent garbage collection. Applying {@code f} on the object should be thread safe.
+   * See {@link #monitorValue(Id, Object, ToDoubleFunction)} for more information.
    *
-   * If multiple gauges are registered with the same id, then the values will be aggregated and
+   * @param id
+   *     Identifier for the metric being registered.
+   * @param obj
+   *     Object used to compute a value.
+   * @param f
+   *     Function that is applied on the value for the number.
+   * @return
+   *     The number that was passed in so the registration can be done as part of an assignment
+   *     statement.
+   * @deprecated
+   *     Use {@link #monitorValue(Id, Object, ToDoubleFunction)} instead. This method was
+   *     renamed to {@code monitorValue} to reduce user confusion over the difference between
+   *     active and passive gauges. Scheduled to be removed in 2.0.
+   */
+  @Deprecated
+  default <T> T gauge(Id id, T obj, ToDoubleFunction<T> f) {
+    return monitorValue(id, obj, f);
+  }
+
+  /**
+   * Tells the registry to regularly poll the object using the provided function and report
+   * the returned value as a gauge. The registry will keep a weak reference to the object so
+   * it will not prevent garbage collection. To explicitly tell the registry to ignore the value
+   * without waiting for it to be garbage collected, return a value of {@link Double#NaN}.
+   *
+   * Applying {@code f} on the object should be thread safe and cheap to execute. <b>Never
+   * perform computationally expensive or potentially long running tasks such as disk or network
+   * calls inline.</b>
+   *
+   * Polling frequency will depend on the underlying registry implementation, but users should
+   * assume it will be frequently checked and that the provided function is cheap. Users should
+   * keep in mind that polling will not capture all activity, just sample it at some frequency.
+   * For example, if monitoring a queue, then a gauge will only tell you the last sampled size
+   * when the value is reported. If more details are needed, then one of the activity based types,
+   * e.g., {@link #distributionSummary(Id)}, would need to be used and coded such that every
+   * update is reflected. In the queue example that would mean every update to the queue would
+   * need to result in the size being reported to the {@link DistributionSummary}.
+   *
+   * If multiple values are monitored with the same id, then the values will be aggregated and
    * the sum will be reported. For example, registering multiple gauges for active threads in
    * a thread pool with the same id would produce a value that is the overall number
    * of active threads. For other behaviors, manage it on the user side and avoid multiple
@@ -439,14 +558,35 @@ public interface Registry extends Iterable<Meter> {
    *     The number that was passed in so the registration can be done as part of an assignment
    *     statement.
    */
-  default <T> T gauge(Id id, T obj, ToDoubleFunction<T> f) {
+  default <T> T monitorValue(Id id, T obj, ToDoubleFunction<T> f) {
     register(new ObjectGauge<>(clock(), id, obj, f));
     return obj;
   }
 
   /**
-   * Register a gauge that reports the value of the object. See
-   * {@link #gauge(Id, Object, ToDoubleFunction)}.
+   * See {@link #monitorValue(Id, Object, ToDoubleFunction)} for more information.
+   *
+   * @param name
+   *     Name of the metric being registered.
+   * @param obj
+   *     Object used to compute a value.
+   * @param f
+   *     Function that is applied on the value for the number.
+   * @return
+   *     The number that was passed in so the registration can be done as part of an assignment
+   *     statement.
+   * @deprecated
+   *     Use {@link #monitorValue(Id, Object, ToDoubleFunction)} instead. This method was
+   *     renamed to {@code monitorValue} to reduce user confusion over the difference between
+   *     active and passive gauges. Scheduled to be removed in 2.0.
+   */
+  @Deprecated
+  default <T> T gauge(String name, T obj, ToDoubleFunction<T> f) {
+    return monitorValue(createId(name), obj, f);
+  }
+
+  /**
+   * See {@link #monitorValue(Id, Object, ToDoubleFunction)} for more information.
    *
    * @param name
    *     Name of the metric being registered.
@@ -458,16 +598,18 @@ public interface Registry extends Iterable<Meter> {
    *     The number that was passed in so the registration can be done as part of an assignment
    *     statement.
    */
-  default <T> T gauge(String name, T obj, ToDoubleFunction<T> f) {
-    return gauge(createId(name), obj, f);
+  default <T> T monitorValue(String name, T obj, ToDoubleFunction<T> f) {
+    return monitorValue(createId(name), obj, f);
   }
 
   /**
-   * Register a gauge that reports the size of the {@link java.util.Collection}. The registration
-   * will keep a weak reference to the collection so it will not prevent garbage collection.
-   * The collection implementation used should be thread safe. Note that calling
-   * {@link java.util.Collection#size()} can be expensive for some collection implementations
-   * and should be considered before registering.
+   * Tells the registry to regularly poll the collection and report its size as a gauge.
+   * The registration will keep a weak reference to the collection so it will not prevent
+   * garbage collection. The collection implementation used should be thread safe. Note that
+   * calling {@link java.util.Collection#size()} can be expensive for some collection
+   * implementations and should be considered before registering.
+   *
+   * For more information see {@link #monitorValue(Id, Object, ToDoubleFunction)}.
    *
    * @param id
    *     Identifier for the metric being registered.
@@ -478,15 +620,12 @@ public interface Registry extends Iterable<Meter> {
    *     statement.
    */
   default <T extends Collection<?>> T collectionSize(Id id, T collection) {
-    return gauge(id, collection, Collection::size);
+    return monitorValue(id, collection, Collection::size);
   }
 
   /**
-   * Register a gauge that reports the size of the {@link java.util.Collection}. The registration
-   * will keep a weak reference to the collection so it will not prevent garbage collection.
-   * The collection implementation used should be thread safe. Note that calling
-   * {@link java.util.Collection#size()} can be expensive for some collection implementations
-   * and should be considered before registering.
+   * Tells the registry to regularly poll the collection and report its size as a gauge.
+   * See {@link #collectionSize(Id, Collection)} for more information.
    *
    * @param name
    *     Name of the metric being registered.
@@ -501,11 +640,13 @@ public interface Registry extends Iterable<Meter> {
   }
 
   /**
-   * Register a gauge that reports the size of the {@link java.util.Map}. The registration
-   * will keep a weak reference to the collection so it will not prevent garbage collection.
-   * The collection implementation used should be thread safe. Note that calling
-   * {@link java.util.Map#size()} can be expensive for some collection implementations
-   * and should be considered before registering.
+   * Tells the registry to regularly poll the map and report its size as a gauge.
+   * The registration will keep a weak reference to the map so it will not prevent
+   * garbage collection. The collection implementation used should be thread safe. Note that
+   * calling {@link java.util.Map#size()} can be expensive for some map
+   * implementations and should be considered before registering.
+   *
+   * For more information see {@link #monitorValue(Id, Object, ToDoubleFunction)}.
    *
    * @param id
    *     Identifier for the metric being registered.
@@ -516,15 +657,12 @@ public interface Registry extends Iterable<Meter> {
    *     statement.
    */
   default <T extends Map<?, ?>> T mapSize(Id id, T collection) {
-    return gauge(id, collection, Map::size);
+    return monitorValue(id, collection, Map::size);
   }
 
   /**
-   * Register a gauge that reports the size of the {@link java.util.Map}. The registration
-   * will keep a weak reference to the collection so it will not prevent garbage collection.
-   * The collection implementation used should be thread safe. Note that calling
-   * {@link java.util.Map#size()} can be expensive for some collection implementations
-   * and should be considered before registering.
+   * Tells the registry to regularly poll the collection and report its size as a gauge.
+   * See {@link #mapSize(Id, Map)} for more information.
    *
    * @param name
    *     Name of the metric being registered.
@@ -539,10 +677,18 @@ public interface Registry extends Iterable<Meter> {
   }
 
   /**
-   * Register a gauge that reports the return value of invoking the method on the object. The
-   * registration will keep a weak reference to the object so it will not prevent garbage
-   * collection. The registered method should be thread safe and cheap to invoke. Any potentially
-   * long running or expensive activity such as IO should not be performed inline.
+   * Tells the registry to regularly poll the object by by using reflection to invoke the named
+   * method and report the returned value as a gauge. The registration will keep a weak reference
+   * to the object so it will not prevent garbage collection. The registered method should be
+   * thread safe and cheap to invoke. <b>Never perform any potentially long running or expensive
+   * activity such as IO inline</b>.
+   *
+   * To get better compile time type safety, {@link #monitorValue(Id, Object, ToDoubleFunction)}
+   * should be preferred. Use this technique only if there access or other restrictions prevent
+   * using a proper function reference. However, keep in mind that makes your code more brittle
+   * and prone to failure in the future.
+   *
+   * For more information see {@link #monitorValue(Id, Object, ToDoubleFunction)}.
    *
    * @param id
    *     Identifier for the metric being registered.
@@ -554,15 +700,14 @@ public interface Registry extends Iterable<Meter> {
   default void methodValue(Id id, Object obj, String method) {
     final Method m = Utils.getGaugeMethod(this, id, obj, method);
     if (m != null) {
-      gauge(id, obj, Functions.invokeMethod(m));
+      monitorValue(id, obj, Functions.invokeMethod(m));
     }
   }
 
   /**
-   * Register a gauge that reports the return value of invoking the method on the object. The
-   * registration will keep a weak reference to the object so it will not prevent garbage
-   * collection. The registered method should be thread safe and cheap to invoke. Any potentially
-   * long running or expensive activity such as IO should not be performed inline.
+   * Tells the registry to regularly poll the object by by using reflection to invoke the named
+   * method and report the returned value as a gauge. See {@link #methodValue(Id, Object, String)}
+   * for more information.
    *
    * @param name
    *     Name of the metric being registered.

--- a/spectator-api/src/main/java/com/netflix/spectator/api/patterns/IntervalCounter.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/patterns/IntervalCounter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 Netflix, Inc.
+/*
+ * Copyright 2014-2017 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,7 +69,9 @@ public final class IntervalCounter implements Counter {
     this.clock = registry.clock();
     this.id = id;
     this.counter = registry.counter(id.withTag(Statistic.count));
-    this.lastUpdated = registry.gauge(id.withTag(Statistic.duration), new AtomicLong(0L),
+    this.lastUpdated = registry.monitorValue(
+        id.withTag(Statistic.duration),
+        new AtomicLong(0L),
         Functions.age(clock));
   }
 

--- a/spectator-api/src/main/java/com/netflix/spectator/api/patterns/LongTaskTimer.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/patterns/LongTaskTimer.java
@@ -68,8 +68,8 @@ public final class LongTaskTimer implements com.netflix.spectator.api.LongTaskTi
   private LongTaskTimer(Registry registry, Id id) {
     this.clock = registry.clock();
     this.id = id;
-    registry.gauge(id.withTag(Statistic.activeTasks), this, LongTaskTimer::activeTasks);
-    registry.gauge(id.withTag(Statistic.duration),    this, t -> t.duration() / NANOS_PER_SECOND);
+    registry.monitorValue(id.withTag(Statistic.activeTasks), this, LongTaskTimer::activeTasks);
+    registry.monitorValue(id.withTag(Statistic.duration),    this, t -> t.duration() / NANOS_PER_SECOND);
   }
 
   @Override public Id id() {

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/Scheduler.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/Scheduler.java
@@ -133,7 +133,7 @@ public class Scheduler {
     this.clock = registry.clock();
 
     registry.collectionSize(newId(registry, id, "queueSize"), queue);
-    activeCount = registry.gauge(newId(registry, id, "activeThreads"), new AtomicInteger());
+    activeCount = registry.monitorNumber(newId(registry, id, "activeThreads"), new AtomicInteger());
     taskExecutionTime = registry.timer(newId(registry, id, "taskExecutionTime"));
     taskExecutionDelay = registry.timer(newId(registry, id, "taskExecutionDelay"));
     skipped = registry.counter(newId(registry, id, "skipped"));

--- a/spectator-ext-gc/src/main/java/com/netflix/spectator/gc/GcLogger.java
+++ b/spectator-ext-gc/src/main/java/com/netflix/spectator/gc/GcLogger.java
@@ -55,11 +55,11 @@ public final class GcLogger {
 
   // Max size of old generation memory pool
   private static final AtomicLong MAX_DATA_SIZE =
-    Spectator.globalRegistry().gauge("jvm.gc.maxDataSize", new AtomicLong(0L));
+    Spectator.globalRegistry().monitorNumber("jvm.gc.maxDataSize", new AtomicLong(0L));
 
   // Size of old generation memory pool after a full GC
   private static final AtomicLong LIVE_DATA_SIZE =
-    Spectator.globalRegistry().gauge("jvm.gc.liveDataSize", new AtomicLong(0L));
+    Spectator.globalRegistry().monitorNumber("jvm.gc.liveDataSize", new AtomicLong(0L));
 
   // Incremented for any positive increases in the size of the old generation memory pool
   // before GC to after GC

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasRegistryTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasRegistryTest.java
@@ -67,7 +67,7 @@ public class AtlasRegistryTest {
 
   @Test
   public void measurementsWithGauge() {
-    AtomicLong v = registry.gauge("test", new AtomicLong(0L));
+    AtomicLong v = registry.monitorNumber("test", new AtomicLong(0L));
     Assert.assertEquals(1, registry.getMeasurements().size());
   }
 

--- a/spectator-reg-metrics3/src/test/java/com/netflix/spectator/metrics3/MetricsRegistryTest.java
+++ b/spectator-reg-metrics3/src/test/java/com/netflix/spectator/metrics3/MetricsRegistryTest.java
@@ -85,11 +85,28 @@ public class MetricsRegistryTest {
   }
 
   @Test
+  public void monitorNumber() {
+    MetricRegistry codaRegistry = new MetricRegistry();
+    MetricsRegistry r = new MetricsRegistry(clock, codaRegistry);
+    AtomicInteger num = r.monitorNumber("foo", new AtomicInteger(42));
+    assertGaugeValue(r, codaRegistry, "foo", 42.0);
+  }
+
+  @Test
   public void gaugeNumberDuplicate() {
     MetricRegistry codaRegistry = new MetricRegistry();
     MetricsRegistry r = new MetricsRegistry(clock, codaRegistry);
     AtomicInteger num1 = r.gauge("foo", new AtomicInteger(42));
     AtomicInteger num2 = r.gauge("foo", new AtomicInteger(21));
+    assertGaugeValue(r, codaRegistry, "foo", 63.0);
+  }
+
+  @Test
+  public void monitorNumberDuplicate() {
+    MetricRegistry codaRegistry = new MetricRegistry();
+    MetricsRegistry r = new MetricsRegistry(clock, codaRegistry);
+    AtomicInteger num1 = r.monitorNumber("foo", new AtomicInteger(42));
+    AtomicInteger num2 = r.monitorNumber("foo", new AtomicInteger(21));
     assertGaugeValue(r, codaRegistry, "foo", 63.0);
   }
 
@@ -120,7 +137,7 @@ public class MetricsRegistryTest {
     codaRegistry.register("foo", (Gauge<Double>) () -> 42.0D);
 
     // Try to register the same gauge via spectator
-    AtomicInteger num = r.gauge("foo", new AtomicInteger(42));
+    AtomicInteger num = r.monitorNumber("foo", new AtomicInteger(42));
 
     // Should be registered with the coda
     Assert.assertEquals(42.0, (Double) codaRegistry.getGauges().get("foo").getValue(), 1e-12);


### PR DESCRIPTION
Deprecates the passive overloads that used to be named
`gauge` and replaces them with `monitorNumber` and
`monitorValue` methods. The difference between passive
and active gauge has caused some confusion and the goal
is to make the distinction more clear while maintaining
consistent naming for the core active types.

The methods have been deprecated with a note that they
will be removed in 2.0. For now the desire is to avoid
significantly breaking backwards compatibility with
the api between now and marking as 1.0.