### PR TITLE
add helper for monotonic counters

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/AbstractRegistry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/AbstractRegistry.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 Netflix, Inc.
+/*
+ * Copyright 2014-2017 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package com.netflix.spectator.api;
 
 import com.netflix.spectator.impl.Config;
+import com.netflix.spectator.impl.GaugePoller;
 import com.netflix.spectator.impl.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -70,7 +71,7 @@ public abstract class AbstractRegistry implements Registry {
     this.gauges = new ConcurrentHashMap<>();
     this.state = new ConcurrentHashMap<>();
     GaugePoller.schedule(
-        new WeakReference<>(this),
+        new WeakReference<Registry>(this),
         config.gaugePollingFrequency().toMillis(),
         AbstractRegistry::pollGauges);
   }

--- a/spectator-api/src/main/java/com/netflix/spectator/api/CompositeRegistry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/CompositeRegistry.java
@@ -15,6 +15,8 @@
  */
 package com.netflix.spectator.api;
 
+import com.netflix.spectator.impl.GaugePoller;
+
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -64,7 +66,7 @@ public final class CompositeRegistry implements Registry {
     this.aggrGauges = new ConcurrentHashMap<>();
     this.state = new ConcurrentHashMap<>();
     GaugePoller.schedule(
-        new WeakReference<>(this),
+        new WeakReference<Registry>(this),
         10000L,
         CompositeRegistry::pollGauges);
   }

--- a/spectator-api/src/main/java/com/netflix/spectator/api/Registry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/Registry.java
@@ -507,7 +507,7 @@ public interface Registry extends Iterable<Meter> {
    * @param f
    *     Function that is applied on the value for the number.
    * @return
-   *     The number that was passed in so the registration can be done as part of an assignment
+   *     The object that was passed in so the registration can be done as part of an assignment
    *     statement.
    * @deprecated
    *     Use {@link #monitorValue(Id, Object, ToDoubleFunction)} instead. This method was
@@ -551,7 +551,7 @@ public interface Registry extends Iterable<Meter> {
    * @param f
    *     Function that is applied on the value for the number.
    * @return
-   *     The number that was passed in so the registration can be done as part of an assignment
+   *     The object that was passed in so the registration can be done as part of an assignment
    *     statement.
    */
   default <T> T monitorValue(Id id, T obj, ToDoubleFunction<T> f) {
@@ -569,7 +569,7 @@ public interface Registry extends Iterable<Meter> {
    * @param f
    *     Function that is applied on the value for the number.
    * @return
-   *     The number that was passed in so the registration can be done as part of an assignment
+   *     The object that was passed in so the registration can be done as part of an assignment
    *     statement.
    * @deprecated
    *     Use {@link #monitorValue(Id, Object, ToDoubleFunction)} instead. This method was
@@ -591,7 +591,7 @@ public interface Registry extends Iterable<Meter> {
    * @param f
    *     Function that is applied on the value for the number.
    * @return
-   *     The number that was passed in so the registration can be done as part of an assignment
+   *     The object that was passed in so the registration can be done as part of an assignment
    *     statement.
    */
   default <T> T monitorValue(String name, T obj, ToDoubleFunction<T> f) {
@@ -612,7 +612,7 @@ public interface Registry extends Iterable<Meter> {
    * @param collection
    *     Thread-safe implementation of {@link Collection} used to access the value.
    * @return
-   *     The number that was passed in so the registration can be done as part of an assignment
+   *     The collection that was passed in so the registration can be done as part of an assignment
    *     statement.
    */
   default <T extends Collection<?>> T collectionSize(Id id, T collection) {
@@ -628,7 +628,7 @@ public interface Registry extends Iterable<Meter> {
    * @param collection
    *     Thread-safe implementation of {@link Collection} used to access the value.
    * @return
-   *     The number that was passed in so the registration can be done as part of an assignment
+   *     The collection that was passed in so the registration can be done as part of an assignment
    *     statement.
    */
   default <T extends Collection<?>> T collectionSize(String name, T collection) {
@@ -649,7 +649,7 @@ public interface Registry extends Iterable<Meter> {
    * @param collection
    *     Thread-safe implementation of {@link Map} used to access the value.
    * @return
-   *     The number that was passed in so the registration can be done as part of an assignment
+   *     The map that was passed in so the registration can be done as part of an assignment
    *     statement.
    */
   default <T extends Map<?, ?>> T mapSize(Id id, T collection) {
@@ -665,7 +665,7 @@ public interface Registry extends Iterable<Meter> {
    * @param collection
    *     Thread-safe implementation of {@link Map} used to access the value.
    * @return
-   *     The number that was passed in so the registration can be done as part of an assignment
+   *     The map that was passed in so the registration can be done as part of an assignment
    *     statement.
    */
   default <T extends Map<?, ?>> T mapSize(String name, T collection) {

--- a/spectator-api/src/main/java/com/netflix/spectator/api/patterns/MonotonicCounter.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/patterns/MonotonicCounter.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.api.patterns;
+
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Utils;
+import com.netflix.spectator.impl.GaugePoller;
+
+import java.lang.ref.WeakReference;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.ToLongFunction;
+
+/**
+ * Helper for mapping a monotonically increasing long value to a counter. Monotonic counters
+ * are frequently used as a simple way for exposing the amount of change. In order to be
+ * useful, they need to be polled frequently so the change can be measured regularly over
+ * time. This class provides helper methods that will regularly poll the source and report
+ * the deltas to a {@link Counter}.
+ *
+ * Example monotonic counters provided by the JDK:
+ *
+ * <ul>
+ *   <li>{@link java.util.concurrent.ThreadPoolExecutor#getCompletedTaskCount()}</li>
+ *   <li>{@link com.sun.management.OperatingSystemMXBean#getProcessCpuTime()}</li>
+ * </ul>
+ */
+public final class MonotonicCounter {
+
+  /**
+   * Tells the registry to regularly poll the number and report the delta to a counter with
+   * the given id. The registry will keep a weak reference to the number so it will not prevent
+   * garbage collection. The number implementation used should be thread safe. Common examples
+   * are {@link java.util.concurrent.atomic.AtomicLong} and
+   * {@link java.util.concurrent.atomic.LongAdder}. For more information, see
+   * {@link #monitorValue(Registry, Id, Object, ToLongFunction)}.
+   *
+   * @param registry
+   *     Registry to use for maintaining state.
+   * @param id
+   *     Identifier for the metric being registered.
+   * @param number
+   *     Thread-safe implementation of {@link Number} used to access the value.
+   * @return
+   *     The number that was passed in so the registration can be done as part of an assignment
+   *     statement.
+   */
+  public static <T extends Number> T monitorNumber(Registry registry, Id id, T number) {
+    return monitorValue(registry, id, number, Number::longValue);
+  }
+
+  /**
+   * Tells the registry to regularly poll the object using the provided function and report
+   * the delta to a counger with the given id. The registry will keep a weak reference to the
+   * object so it will not prevent garbage collection.
+   *
+   * Applying {@code f} on the object should be thread safe and cheap to execute. <b>Never
+   * perform computationally expensive or potentially long running tasks such as disk or network
+   * calls inline.</b>
+   *
+   * @param registry
+   *     Registry to use for maintaining state.
+   * @param id
+   *     Identifier for the metric being registered.
+   * @param obj
+   *     Object used to compute a value.
+   * @param f
+   *     Function that is applied on the value for the number.
+   * @return
+   *     The number that was passed in so the registration can be done as part of an assignment
+   *     statement.
+   */
+  public static <T> T monitorValue(Registry registry, Id id, T obj, ToLongFunction<T> f) {
+    Tuple<T> tuple = new Tuple<>(registry.counter(id), obj, f);
+    return monitor(registry, tuple, id, obj);
+  }
+
+  private static <T> T monitor(Registry registry, Tuple<T> tuple, Id id, T value) {
+    ConcurrentMap<Id, Object> state = registry.state();
+    Object c = Utils.computeIfAbsent(state, id, i -> tuple);
+    if (!(c instanceof Tuple)) {
+      Utils.propagateTypeError(registry, id, MonotonicCounter.class, c.getClass());
+    } else {
+      ((Tuple<?>) c).schedule(registry);
+    }
+    return value;
+  }
+
+  /** Keep track of the object reference, counter, and other associated bookkeeping info. */
+  static final class Tuple<T> {
+    private final Counter counter;
+    private final WeakReference<T> ref;
+    private final ToLongFunction<T> f;
+    private long prev;
+    private boolean scheduled;
+
+    /** Create new instance. */
+    Tuple(Counter counter, T obj, ToLongFunction<T> f) {
+      this.counter = counter;
+      this.ref = new WeakReference<T>(obj);
+      this.f = f;
+      this.prev = f.applyAsLong(obj);
+      this.scheduled = false;
+    }
+
+    private boolean isExpired() {
+      return ref.get() == null;
+    }
+
+    private void update() {
+      final T obj = ref.get();
+      if (obj != null) {
+        final long value = f.applyAsLong(obj);
+        final long delta = value - prev;
+        prev = value;
+        if (delta > 0L) {
+          counter.increment(delta);
+        }
+      }
+    }
+
+    private synchronized void schedule(Registry registry) {
+      if (!scheduled) {
+        long delay = registry.config().gaugePollingFrequency().toMillis();
+        WeakReference<Tuple<T>> tupleRef = new WeakReference<>(this);
+        GaugePoller.schedule(tupleRef, delay, t -> updateCounter(registry, t));
+      }
+    }
+  }
+
+  /** Helper to update the counter with the delta or to remove the state if expired. */
+  static void updateCounter(Registry registry, Tuple<?> tuple) {
+    if (tuple.isExpired()) {
+      registry.state().remove(tuple.counter.id());
+    } else {
+      tuple.update();
+    }
+  }
+
+  private MonotonicCounter() {
+  }
+}

--- a/spectator-api/src/test/java/com/netflix/spectator/api/patterns/MonotonicCounterTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/patterns/MonotonicCounterTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.api.patterns;
+
+import com.netflix.spectator.api.*;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.lang.ref.WeakReference;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAdder;
+
+@RunWith(JUnit4.class)
+public class MonotonicCounterTest {
+  private final ManualClock clock = new ManualClock();
+  private final Registry registry = new DefaultRegistry(clock);
+  private final Id id = registry.createId("test");
+
+  private void update() {
+    registry.state().forEach((id, obj) -> {
+      if (obj instanceof MonotonicCounter.Tuple<?>) {
+        MonotonicCounter.updateCounter(registry, ((MonotonicCounter.Tuple<?>) obj));
+      }
+    });
+  }
+
+  @Test
+  public void usingAtomicLong() {
+    AtomicLong count = new AtomicLong();
+    AtomicLong c = MonotonicCounter.monitorNumber(registry, id, count);
+    Assert.assertSame(count, c);
+
+    Counter counter = registry.counter(id);
+    update();
+    Assert.assertEquals(0L, counter.count());
+
+    c.incrementAndGet();
+    update();
+    Assert.assertEquals(1L, counter.count());
+
+    c.addAndGet(42);
+    update();
+    Assert.assertEquals(43L, counter.count());
+  }
+
+  @Test
+  public void usingLongAdder() {
+    LongAdder count = new LongAdder();
+    LongAdder c = MonotonicCounter.monitorNumber(registry, id, count);
+    Assert.assertSame(count, c);
+
+    Counter counter = registry.counter(id);
+    update();
+    Assert.assertEquals(0L, counter.count());
+
+    c.increment();
+    update();
+    Assert.assertEquals(1L, counter.count());
+
+    c.add(42);
+    update();
+    Assert.assertEquals(43L, counter.count());
+  }
+
+  @Test
+  public void nonMonotonicUpdates() {
+    AtomicLong count = new AtomicLong();
+    AtomicLong c = MonotonicCounter.monitorNumber(registry, id, count);
+
+    Counter counter = registry.counter(id);
+    update();
+    Assert.assertEquals(0L, counter.count());
+
+    c.set(42L);
+    update();
+    Assert.assertEquals(42L, counter.count());
+
+    // Should not update the counter because it is lower, but must update
+    // the previous recorded value
+    c.set(21L);
+    update();
+    Assert.assertEquals(42L, counter.count());
+
+    // Make sure a subsequent increase is detected
+    c.set(23L);
+    update();
+    Assert.assertEquals(44L, counter.count());
+  }
+
+  @Test
+  public void expire() throws Exception {
+    WeakReference<LongAdder> ref = new WeakReference<>(
+      MonotonicCounter.monitorNumber(registry, id, new LongAdder()));
+    while (ref.get() != null) {
+      System.gc();
+    }
+
+    Assert.assertEquals(1, registry.state().size());
+    update();
+    Assert.assertEquals(0, registry.state().size());
+  }
+
+
+}


### PR DESCRIPTION
Monotonic counters are fairly common, this change
adds a pattern that is used internally for regularly
polling them and updating an associated counter.