### PR TITLE
Issue #419 Add thread pool monitor.

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/patterns/ThreadPoolMonitor.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/patterns/ThreadPoolMonitor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.spectator.api.patterns;
 
 import com.netflix.spectator.api.BasicTag;
@@ -49,37 +64,37 @@ public final class ThreadPoolMonitor {
   /**
    * Task count meter name.
    */
-  public static final String TASK_COUNT = "threadpool.taskCount";
+  static final String TASK_COUNT = "threadpool.taskCount";
 
   /**
    * Completed task count meter name.
    */
-  public static final String COMPLETED_TASK_COUNT = "threadpool.completedTaskCount";
+  static final String COMPLETED_TASK_COUNT = "threadpool.completedTaskCount";
 
   /**
    * Current threads busy meter name.
    */
-  public static final String CURRENT_THREADS_BUSY = "threadpool.currentThreadsBusy";
+  static final String CURRENT_THREADS_BUSY = "threadpool.currentThreadsBusy";
 
   /**
    * Max threads meter name.
    */
-  public static final String MAX_THREADS = "threadpool.maxThreads";
+  static final String MAX_THREADS = "threadpool.maxThreads";
 
   /**
    * Pool size meter name.
    */
-  public static final String POOL_SIZE = "threadpool.poolSize";
+  static final String POOL_SIZE = "threadpool.poolSize";
 
   /**
    * Core pool size meter name.
    */
-  public static final String CORE_POOL_SIZE = "threadpool.corePoolSize";
+  static final String CORE_POOL_SIZE = "threadpool.corePoolSize";
 
   /**
    * Queue size meter name.
    */
-  public static final String QUEUE_SIZE = "threadpool.queueSize";
+  static final String QUEUE_SIZE = "threadpool.queueSize";
 
   // prevent direct instantiation.
   private ThreadPoolMonitor() { }

--- a/spectator-api/src/main/java/com/netflix/spectator/api/patterns/ThreadPoolMonitor.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/patterns/ThreadPoolMonitor.java
@@ -103,10 +103,10 @@ public final class ThreadPoolMonitor {
    * Register the provided thread pool, optionally tagged with a name.
    *
    * @param registry the registry to use
-   * @param threadPool the thread pool to monitor
+   * @param threadPool the thread pool on which to attach monitoring
    * @param threadPoolName a name with which to tag the metrics or {@code null} for the default name
    */
-  public static void monitor(
+  public static void attach(
       final Registry registry,
       final ThreadPoolExecutor threadPool,
       final String threadPoolName) {

--- a/spectator-api/src/main/java/com/netflix/spectator/api/patterns/ThreadPoolMonitor.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/patterns/ThreadPoolMonitor.java
@@ -53,13 +53,12 @@ public final class ThreadPoolMonitor {
   /**
    * The default ID tag name.
    */
-  // visible for testing
   static final String ID_TAG_NAME = "id";
 
   /**
    * The default ID value.
    */
-  private static final String DEFAULT_ID = "default";
+  static final String DEFAULT_ID = "default";
 
   /**
    * Task count meter name.
@@ -104,7 +103,7 @@ public final class ThreadPoolMonitor {
    *
    * @param registry the registry to use
    * @param threadPool the thread pool on which to attach monitoring
-   * @param threadPoolName a name with which to tag the metrics or {@code null} for the default name
+   * @param threadPoolName a name with which to tag the metrics (default name used if {@code null} or empty)
    */
   public static void attach(
       final Registry registry,
@@ -114,7 +113,14 @@ public final class ThreadPoolMonitor {
     Preconditions.checkNotNull(registry, "registry");
     Preconditions.checkNotNull(threadPool, "threadPool");
 
-    final Tag idTag = new BasicTag(ID_TAG_NAME, threadPoolName != null ? threadPoolName : DEFAULT_ID);
+    final String idValue;
+    if (threadPoolName == null || threadPoolName.isEmpty()) {
+      idValue = DEFAULT_ID;
+    } else {
+      idValue = threadPoolName;
+    }
+
+    final Tag idTag = new BasicTag(ID_TAG_NAME, idValue);
 
     PolledMeter.using(registry)
         .withName(TASK_COUNT)

--- a/spectator-api/src/main/java/com/netflix/spectator/api/patterns/ThreadPoolMonitor.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/patterns/ThreadPoolMonitor.java
@@ -1,0 +1,133 @@
+package com.netflix.spectator.api.patterns;
+
+import com.netflix.spectator.api.BasicTag;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Tag;
+import com.netflix.spectator.impl.Preconditions;
+
+import java.util.concurrent.ThreadPoolExecutor;
+
+/**
+ * Monitors and reports a common set of metrics for thread pools.
+ *
+ * <p>The following is the list of metrics reported followed by which {@link ThreadPoolExecutor}
+ * method populates it.</p>
+ *
+ * <pre>
+ *  +-----------------------------------------------------------------------------+
+ *  | Metric Name                  | Data Source                                  |
+ *  +------------------------------+----------------------------------------------+
+ *  |threadpool.taskCount          | {@link ThreadPoolExecutor#getTaskCount()}            |
+ *  +------------------------------+----------------------------------------------+
+ *  |threadpool.completedTaskCount | {@link ThreadPoolExecutor#getCompletedTaskCount()}   |
+ *  +------------------------------+----------------------------------------------+
+ *  |threadpool.currentThreadsBusy | {@link ThreadPoolExecutor#getActiveCount()}          |
+ *  +------------------------------+----------------------------------------------+
+ *  |threadpool.maxThreads         | {@link ThreadPoolExecutor#getMaximumPoolSize()}      |
+ *  +------------------------------+----------------------------------------------+
+ *  |threadpool.poolSize           | {@link ThreadPoolExecutor#getPoolSize()}             |
+ *  +------------------------------+----------------------------------------------+
+ *  |threadpool.corePoolSize       | {@link ThreadPoolExecutor#getCorePoolSize()}         |
+ *  +------------------------------+----------------------------------------------+
+ *  |threadpool.queueSize          | {@link ThreadPoolExecutor#getQueue()}.size()         |
+ *  +-----------------------------------------------------------------------------+
+ * </pre>
+ */
+public final class ThreadPoolMonitor {
+
+  /**
+   * The default ID tag name.
+   */
+  // visible for testing
+  static final String ID_TAG_NAME = "id";
+
+  /**
+   * The default ID value.
+   */
+  private static final String DEFAULT_ID = "default";
+
+  /**
+   * Task count meter name.
+   */
+  public static final String TASK_COUNT = "threadpool.taskCount";
+
+  /**
+   * Completed task count meter name.
+   */
+  public static final String COMPLETED_TASK_COUNT = "threadpool.completedTaskCount";
+
+  /**
+   * Current threads busy meter name.
+   */
+  public static final String CURRENT_THREADS_BUSY = "threadpool.currentThreadsBusy";
+
+  /**
+   * Max threads meter name.
+   */
+  public static final String MAX_THREADS = "threadpool.maxThreads";
+
+  /**
+   * Pool size meter name.
+   */
+  public static final String POOL_SIZE = "threadpool.poolSize";
+
+  /**
+   * Core pool size meter name.
+   */
+  public static final String CORE_POOL_SIZE = "threadpool.corePoolSize";
+
+  /**
+   * Queue size meter name.
+   */
+  public static final String QUEUE_SIZE = "threadpool.queueSize";
+
+  // prevent direct instantiation.
+  private ThreadPoolMonitor() { }
+
+  /**
+   * Register the provided thread pool, optionally tagged with a name.
+   *
+   * @param registry the registry to use
+   * @param threadPool the thread pool to monitor
+   * @param threadPoolName a name with which to tag the metrics or {@code null} for the default name
+   */
+  public static void monitor(
+      final Registry registry,
+      final ThreadPoolExecutor threadPool,
+      final String threadPoolName) {
+
+    Preconditions.checkNotNull(registry, "registry");
+    Preconditions.checkNotNull(threadPool, "threadPool");
+
+    final Tag idTag = new BasicTag(ID_TAG_NAME, threadPoolName != null ? threadPoolName : DEFAULT_ID);
+
+    PolledMeter.using(registry)
+        .withName(TASK_COUNT)
+        .withTag(idTag)
+        .monitorMonotonicCounter(threadPool, ThreadPoolExecutor::getTaskCount);
+    PolledMeter.using(registry)
+        .withName(COMPLETED_TASK_COUNT)
+        .withTag(idTag)
+        .monitorMonotonicCounter(threadPool, ThreadPoolExecutor::getCompletedTaskCount);
+    PolledMeter.using(registry)
+        .withName(CURRENT_THREADS_BUSY)
+        .withTag(idTag)
+        .monitorValue(threadPool, ThreadPoolExecutor::getActiveCount);
+    PolledMeter.using(registry)
+        .withName(MAX_THREADS)
+        .withTag(idTag)
+        .monitorValue(threadPool, ThreadPoolExecutor::getMaximumPoolSize);
+    PolledMeter.using(registry)
+        .withName(POOL_SIZE)
+        .withTag(idTag)
+        .monitorValue(threadPool, ThreadPoolExecutor::getPoolSize);
+    PolledMeter.using(registry)
+        .withName(CORE_POOL_SIZE)
+        .withTag(idTag)
+        .monitorValue(threadPool, ThreadPoolExecutor::getCorePoolSize);
+    PolledMeter.using(registry)
+        .withName(QUEUE_SIZE)
+        .withTag(idTag)
+        .monitorValue(threadPool, tp -> tp.getQueue().size());
+  }
+}

--- a/spectator-api/src/test/java/com/netflix/spectator/api/patterns/ThreadPoolMonitorTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/patterns/ThreadPoolMonitorTest.java
@@ -30,12 +30,10 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import java.util.Iterator;
-import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -224,7 +222,7 @@ public class ThreadPoolMonitorTest {
   }
 
   @Test
-  public void taskCountUpdates() throws InterruptedException, BrokenBarrierException, TimeoutException {
+  public void taskCountUpdates() throws InterruptedException {
     final Counter counter = getCounter(ThreadPoolMonitor.TASK_COUNT);
     assertEquals(0, counter.count());
 
@@ -241,7 +239,7 @@ public class ThreadPoolMonitorTest {
   }
 
   @Test
-  public void currentThreadsBusyCountUpdates() throws InterruptedException, BrokenBarrierException, TimeoutException {
+  public void currentThreadsBusyCountUpdates() throws InterruptedException {
     final Gauge gauge = getGauge(ThreadPoolMonitor.CURRENT_THREADS_BUSY);
     assertEquals(0.0, gauge.value(), 0.0);
 
@@ -262,7 +260,7 @@ public class ThreadPoolMonitorTest {
   }
 
   @Test
-  public void completedTaskCountUpdates() throws InterruptedException, BrokenBarrierException, TimeoutException {
+  public void completedTaskCountUpdates() throws InterruptedException {
     final Counter counter = getCounter(ThreadPoolMonitor.COMPLETED_TASK_COUNT);
     assertEquals(0, counter.count());
 
@@ -292,7 +290,7 @@ public class ThreadPoolMonitorTest {
   }
 
   @Test
-  public void poolSizeUpdates() throws InterruptedException, BrokenBarrierException, TimeoutException {
+  public void poolSizeUpdates() throws InterruptedException {
     final Gauge gauge = getGauge(ThreadPoolMonitor.POOL_SIZE);
     assertEquals(0.0, gauge.value(), 0.0);
 
@@ -314,7 +312,7 @@ public class ThreadPoolMonitorTest {
   }
 
   @Test
-  public void queueSizeUpdates() throws InterruptedException, BrokenBarrierException, TimeoutException {
+  public void queueSizeUpdates() throws InterruptedException {
     latchedExecutor.setCorePoolSize(1);
     latchedExecutor.setMaximumPoolSize(1);
     final Gauge gauge = getGauge(ThreadPoolMonitor.QUEUE_SIZE);

--- a/spectator-api/src/test/java/com/netflix/spectator/api/patterns/ThreadPoolMonitorTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/patterns/ThreadPoolMonitorTest.java
@@ -103,21 +103,21 @@ public class ThreadPoolMonitorTest {
 
   @Test(expected = NullPointerException.class)
   public void monitorThrowsIfNullRegistry() throws Exception {
-    ThreadPoolMonitor.monitor(null, latchedExecutor, THREAD_POOL_NAME);
+    ThreadPoolMonitor.attach(null, latchedExecutor, THREAD_POOL_NAME);
   }
 
   @Test(expected = NullPointerException.class)
   public void monitorThrowsIfNullThreadPool() throws Exception {
-    ThreadPoolMonitor.monitor(registry, null, THREAD_POOL_NAME);
+    ThreadPoolMonitor.attach(registry, null, THREAD_POOL_NAME);
   }
 
   @Test
   public void monitorAcceptsNullThreadPoolName() {
-    ThreadPoolMonitor.monitor(registry, latchedExecutor, null);
+    ThreadPoolMonitor.attach(registry, latchedExecutor, null);
   }
 
   private Meter getMeter(String meterName) {
-    ThreadPoolMonitor.monitor(registry, latchedExecutor, THREAD_POOL_NAME);
+    ThreadPoolMonitor.attach(registry, latchedExecutor, THREAD_POOL_NAME);
     PolledMeter.update(registry);
     final Id id = registry.createId(meterName).withTag(ThreadPoolMonitor.ID_TAG_NAME, THREAD_POOL_NAME);
     return registry.get(id);

--- a/spectator-api/src/test/java/com/netflix/spectator/api/patterns/ThreadPoolMonitorTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/patterns/ThreadPoolMonitorTest.java
@@ -1,0 +1,280 @@
+package com.netflix.spectator.api.patterns;
+
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.Meter;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Tag;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.Iterator;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.*;
+
+@RunWith(JUnit4.class)
+public class ThreadPoolMonitorTest {
+
+  private static final String THREAD_POOL_NAME = ThreadPoolMonitorTest.class.getSimpleName();
+
+  private Registry registry;
+  private ThreadPoolExecutor threadPoolExecutor;
+
+  @Before
+  public void setUp() throws Exception {
+    registry = new DefaultRegistry();
+    threadPoolExecutor = new ThreadPoolExecutor(3, 10, 0L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>());
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    registry = null;
+    threadPoolExecutor.shutdown();
+    threadPoolExecutor = null;
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void monitorThrowsIfNullRegistry() throws Exception {
+    ThreadPoolMonitor.monitor(null, threadPoolExecutor, THREAD_POOL_NAME);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void monitorThrowsIfNullThreadPool() throws Exception {
+    ThreadPoolMonitor.monitor(registry, null, THREAD_POOL_NAME);
+  }
+
+  @Test
+  public void monitorAcceptsNullThreadPoolName() {
+    ThreadPoolMonitor.monitor(registry, threadPoolExecutor, null);
+  }
+
+  private Meter getMeter(String meterName) {
+    ThreadPoolMonitor.monitor(registry, threadPoolExecutor, THREAD_POOL_NAME);
+    PolledMeter.update(registry);
+    Id id = registry.createId(meterName).withTag(ThreadPoolMonitor.ID_TAG_NAME, THREAD_POOL_NAME);
+    return registry.get(id);
+  }
+
+  @Test
+  public void metricsAreTaggedWithProvidedThreadPoolName() {
+    Meter meter = getMeter(ThreadPoolMonitor.MAX_THREADS);
+
+    Iterable<Measurement> measurements = meter.measure();
+    Iterator<Measurement> measurementIterator = measurements.iterator();
+    assertTrue(measurementIterator.hasNext());
+
+    Iterator<Tag> tags = measurementIterator.next().id().tags().iterator();
+    assertTrue(tags.hasNext());
+    assertEquals(getClass().getSimpleName(), tags.next().value());
+  }
+
+  @Test
+  public void threadPoolMonitorHasTaskCountMeter() {
+    assertNotNull(getMeter(ThreadPoolMonitor.TASK_COUNT));
+  }
+
+  @Test
+  public void threadPoolMonitorHasCompletedTaskCountMeter() {
+    assertNotNull(getMeter(ThreadPoolMonitor.COMPLETED_TASK_COUNT));
+  }
+
+  @Test
+  public void threadPoolMonitorHasCurrentThreadsBusyMeter() {
+    assertNotNull(getMeter(ThreadPoolMonitor.CURRENT_THREADS_BUSY));
+  }
+
+  @Test
+  public void threadPoolMonitorHasMaxThreadsMeter() {
+    assertNotNull(getMeter(ThreadPoolMonitor.MAX_THREADS));
+  }
+
+  @Test
+  public void threadPoolMonitorHasPoolSizeMeter() {
+    assertNotNull(getMeter(ThreadPoolMonitor.POOL_SIZE));
+  }
+
+  @Test
+  public void threadPoolMonitorHasCorePoolSizeMeter() {
+    assertNotNull(getMeter(ThreadPoolMonitor.CORE_POOL_SIZE));
+  }
+
+  @Test
+  public void threadPoolMonitorHasQueueSizeMeter() {
+    assertNotNull(getMeter(ThreadPoolMonitor.QUEUE_SIZE));
+  }
+
+  @Test
+  public void maxThreadsUpdatesWhenRegistryIsUpdated() {
+    Meter meter = getMeter(ThreadPoolMonitor.MAX_THREADS);
+    Iterator<Measurement> measurements = meter.measure().iterator();
+    assertEquals(10.0, measurements.next().value(), 0.0);
+
+    threadPoolExecutor.setMaximumPoolSize(42);
+    PolledMeter.update(registry);
+    measurements = meter.measure().iterator();
+    assertEquals(42.0, measurements.next().value(), 0.0);
+  }
+
+  @Test
+  public void corePoolSizeUpdatesWhenRegistryIsUpdated() {
+    Meter meter = getMeter(ThreadPoolMonitor.CORE_POOL_SIZE);
+    Iterator<Measurement> measurements = meter.measure().iterator();
+    assertEquals(3.0, measurements.next().value(), 0.0);
+
+    threadPoolExecutor.setCorePoolSize(42);
+    PolledMeter.update(registry);
+    measurements = meter.measure().iterator();
+    assertEquals(42.0, measurements.next().value(), 0.0);
+  }
+
+  @Test
+  public void taskCountUpdates() throws InterruptedException {
+    Meter meter = getMeter(ThreadPoolMonitor.TASK_COUNT);
+    Iterator<Measurement> measurements = meter.measure().iterator();
+    assertEquals(0.0, measurements.next().value(), 0.0);
+
+    Cancellable command = new Cancellable();
+    threadPoolExecutor.execute(command);
+
+    Thread.sleep(60);
+    PolledMeter.update(registry);
+    measurements = meter.measure().iterator();
+    assertEquals(1.0, measurements.next().value(), 0.0);
+
+    command.canceled = true;
+  }
+
+  @Test
+  public void currentThreadsBusyCountUpdates() throws InterruptedException {
+    Meter meter = getMeter(ThreadPoolMonitor.CURRENT_THREADS_BUSY);
+    Iterator<Measurement> measurements = meter.measure().iterator();
+    assertEquals(0.0, measurements.next().value(), 0.0);
+
+    Cancellable command = new Cancellable();
+    threadPoolExecutor.execute(command);
+
+    Thread.sleep(60);
+    PolledMeter.update(registry);
+    measurements = meter.measure().iterator();
+    assertEquals(1.0, measurements.next().value(), 0.0);
+
+    command.canceled = true;
+    Thread.sleep(60);
+    PolledMeter.update(registry);
+    measurements = meter.measure().iterator();
+    assertEquals(0.0, measurements.next().value(), 0.0);
+  }
+
+  @Test
+  public void completedTaskCountUpdates() throws InterruptedException {
+    Meter meter = getMeter(ThreadPoolMonitor.COMPLETED_TASK_COUNT);
+    Iterator<Measurement> measurements = meter.measure().iterator();
+    assertEquals(0.0, measurements.next().value(), 0.0);
+
+    Cancellable command1 = new Cancellable();
+    Cancellable command2 = new Cancellable();
+    threadPoolExecutor.execute(command1);
+    threadPoolExecutor.execute(command2);
+
+    Thread.sleep(60);
+    PolledMeter.update(registry);
+    measurements = meter.measure().iterator();
+    assertEquals(0.0, measurements.next().value(), 0.0);
+
+    command1.canceled = true;
+    Thread.sleep(60);
+    PolledMeter.update(registry);
+    measurements = meter.measure().iterator();
+    assertEquals(1.0, measurements.next().value(), 0.0);
+
+    command2.canceled = true;
+    Thread.sleep(60);
+    PolledMeter.update(registry);
+    measurements = meter.measure().iterator();
+    assertEquals(2.0, measurements.next().value(), 0.0);
+  }
+
+  @Test
+  public void poolSizeUpdates() throws InterruptedException {
+    Meter meter = getMeter(ThreadPoolMonitor.POOL_SIZE);
+    Iterator<Measurement> measurements = meter.measure().iterator();
+    assertEquals(0.0, measurements.next().value(), 0.0);
+
+    Cancellable command1 = new Cancellable();
+    Cancellable command2 = new Cancellable();
+    threadPoolExecutor.execute(command1);
+    threadPoolExecutor.execute(command2);
+
+    Thread.sleep(60);
+    PolledMeter.update(registry);
+    measurements = meter.measure().iterator();
+    assertEquals(2.0, measurements.next().value(), 0.0);
+
+    command1.canceled = true;
+    command2.canceled = true;
+    threadPoolExecutor.shutdown();
+    Thread.sleep(60);
+    PolledMeter.update(registry);
+    measurements = meter.measure().iterator();
+    assertEquals(0.0, measurements.next().value(), 0.0);
+
+  }
+
+  @Test
+  public void queueSizeUpdates() throws InterruptedException {
+    threadPoolExecutor.setCorePoolSize(1);
+    threadPoolExecutor.setMaximumPoolSize(1);
+    Meter meter = getMeter(ThreadPoolMonitor.QUEUE_SIZE);
+    Iterator<Measurement> measurements = meter.measure().iterator();
+    assertEquals(0.0, measurements.next().value(), 0.0);
+
+    Cancellable command1 = new Cancellable();
+    Cancellable command2 = new Cancellable();
+    Cancellable command3 = new Cancellable();
+    Cancellable command4 = new Cancellable();
+    Cancellable command5 = new Cancellable();
+    Cancellable command6 = new Cancellable();
+    Cancellable command7 = new Cancellable();
+    threadPoolExecutor.execute(command1);
+    threadPoolExecutor.execute(command2);
+    threadPoolExecutor.execute(command3);
+    threadPoolExecutor.execute(command4);
+    threadPoolExecutor.execute(command5);
+    threadPoolExecutor.execute(command6);
+    threadPoolExecutor.execute(command7);
+
+    PolledMeter.update(registry);
+    measurements = meter.measure().iterator();
+    assertEquals(6.0, measurements.next().value(), 0.0);
+
+    command1.canceled = true;
+    command2.canceled = true;
+    command3.canceled = true;
+    Thread.sleep(60);
+    PolledMeter.update(registry);
+    measurements = meter.measure().iterator();
+    assertEquals(3.0, measurements.next().value(), 0.0);
+
+  }
+
+  private static class Cancellable implements Runnable {
+    volatile boolean canceled = false;
+    @Override
+    public void run() {
+      while (!canceled) {
+        try {
+          Thread.sleep(10);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Added polled monitoring of common thread pool properties.  Where
possible, Tomcat thread pool and executor metric names were used for
consistency.