### PR TITLE
jackson 2.9.1

### DIFF
--- a/dependencies.properties
+++ b/dependencies.properties
@@ -2,10 +2,12 @@
 com.amazonaws:aws-java-sdk-core = 1.11.158
 com.amazonaws:aws-java-sdk-cloudwatch = 1.11.158
 com.eclipsesource.minimal-json:minimal-json = 0.9.4
-com.fasterxml.jackson.core:jackson-annotations = 2.8.8
-com.fasterxml.jackson.core:jackson-core = 2.8.8
-com.fasterxml.jackson.core:jackson-databind = 2.8.8
-com.fasterxml.jackson.dataformat:jackson-dataformat-smile = 2.8.8
+com.fasterxml.jackson.core:jackson-annotations = 2.9.1
+com.fasterxml.jackson.core:jackson-core = 2.9.1
+com.fasterxml.jackson.core:jackson-databind = 2.9.1
+com.fasterxml.jackson.dataformat:jackson-dataformat-cbor = 2.9.1
+com.fasterxml.jackson.dataformat:jackson-dataformat-smile = 2.9.1
+com.fasterxml.jackson.jr:jackson-jr-objects = 2.9.1
 com.google.inject.extensions:guice-multibindings = 4.1.0
 com.google.inject:guice = 4.1.0
 com.netflix.archaius:archaius-core = 0.7.5

--- a/spectator-ext-aws2/build.gradle
+++ b/spectator-ext-aws2/build.gradle
@@ -1,5 +1,8 @@
 dependencies {
   compileApi project(":spectator-api")
   compileApi "software.amazon.awssdk:core:2.0.0-preview-2"
+  compile "com.fasterxml.jackson.core:jackson-databind"
+  compile "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor"
+  compile "com.fasterxml.jackson.jr:jackson-jr-objects"
   testCompile "software.amazon.awssdk:cloudwatch:2.0.0-preview-2"
 }


### PR DESCRIPTION
Update to jackson 2.9.1 to workaround bug in jdk9
with backticks in the manifest. For more information
see FasterXML/jackson-jr#55.