### PR TITLE
use eager singleton for Registry binding

### DIFF
--- a/spectator-nflx-plugin/src/main/java/com/netflix/spectator/nflx/SpectatorModule.java
+++ b/spectator-nflx-plugin/src/main/java/com/netflix/spectator/nflx/SpectatorModule.java
@@ -19,10 +19,9 @@ import com.netflix.spectator.servo.ServoRegistry;
 
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
-import javax.inject.Singleton;
+import javax.inject.Provider;
 
 import com.google.inject.AbstractModule;
-import com.google.inject.Provides;
 import com.netflix.spectator.api.ExtendedRegistry;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Spectator;
@@ -64,18 +63,8 @@ public final class SpectatorModule extends AbstractModule {
   @Override protected void configure() {
     bind(Plugin.class).asEagerSingleton();
     bind(StaticManager.class).asEagerSingleton();
-  }
-
-  @Provides
-  @Singleton
-  ExtendedRegistry getExtendedRegistry() {
-    return Spectator.registry();
-  }
-
-  @Provides
-  @Singleton
-  Registry getRegistry() {
-    return new ServoRegistry();
+    bind(Registry.class).toProvider(RegistryProvider.class).asEagerSingleton();
+    bind(ExtendedRegistry.class).toInstance(Spectator.registry());
   }
 
   @Override public boolean equals(Object obj) {
@@ -98,6 +87,15 @@ public final class SpectatorModule extends AbstractModule {
     @PreDestroy
     void onShutdown() {
       Spectator.globalRegistry().remove(registry);
+    }
+  }
+
+  private static class RegistryProvider implements Provider<Registry> {
+
+    private ServoRegistry registry = new ServoRegistry();
+
+    @Override public Registry get() {
+      return registry;
     }
   }
 }

--- a/spectator-nflx-plugin/src/test/java/com/netflix/spectator/nflx/SpectatorModuleTest.java
+++ b/spectator-nflx-plugin/src/test/java/com/netflix/spectator/nflx/SpectatorModuleTest.java
@@ -15,6 +15,12 @@
  */
 package com.netflix.spectator.nflx;
 
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.netflix.spectator.api.ExtendedRegistry;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Spectator;
+import com.netflix.spectator.servo.ServoRegistry;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -22,6 +28,26 @@ import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class SpectatorModuleTest {
+
+  @Test
+  public void servoRegistryIsBound() {
+    Injector injector = Guice.createInjector(new SpectatorModule());
+    Assert.assertTrue(injector.getInstance(Registry.class) instanceof ServoRegistry);
+  }
+
+  @Test
+  public void extendedRegistryIsBound() {
+    Injector injector = Guice.createInjector(new SpectatorModule());
+    Assert.assertNotNull(injector.getInstance(ExtendedRegistry.class));
+  }
+
+  @Test
+  public void injectedRegistryAddedToGlobal() {
+    Injector injector = Guice.createInjector(new SpectatorModule());
+    Registry registry = injector.getInstance(Registry.class);
+    registry.counter("test").increment();
+    Assert.assertEquals(Spectator.globalRegistry().counter("test").count(), 1);
+  }
 
   @Test
   public void equals() {


### PR DESCRIPTION
This is mostly to help avoid issues with some internal
users that are using spring along with a bridge that
brings in guice bindings. If the bindings are lazy, then
apparently the bridge cannot tell the type for the binding
and use the concrete type of the class. For the registry
this means it cannot tell there is already a binding for
the Registry interface because it just sees the concrete
ServoRegistry type.