### PR TITLE
fix code samples in PolledMeter javadoc

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/Registry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/Registry.java
@@ -117,13 +117,8 @@ public interface Registry extends Iterable<Meter> {
    * Represents a value sampled from another source. For example, the size of queue. The caller
    * is responsible for sampling the value regularly and calling {@link Gauge#set(double)}.
    * Registry implementations are free to expire the gauge if it has not been updated in the
-   * last minute. If you do not want to worry about the sampling, then use one of the helpers
-   * linked below instead.
-   *
-   * @see #gauge(Id, Number)
-   * @see #gauge(Id, Object, ToDoubleFunction)
-   * @see #collectionSize(Id, Collection)
-   * @see #mapSize(Id, Map)
+   * last minute. If you do not want to worry about the sampling, then use {@link PolledMeter}
+   * instead.
    *
    * @param id
    *     Identifier created by a call to {@link #createId}

--- a/spectator-api/src/main/java/com/netflix/spectator/api/patterns/PolledMeter.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/patterns/PolledMeter.java
@@ -44,7 +44,7 @@ import java.util.function.ToLongFunction;
  *   Registry registry = ...
  *   AtomicLong connections = PolledMeter.using(registry)
  *     .withName("server.currentConnections")
- *     .monitor(new AtomicLong());
+ *     .monitorValue(new AtomicLong());
  *
  *   // When a connection is added
  *   connections.incrementAndGet();
@@ -246,7 +246,7 @@ public final class PolledMeter {
      *   Registry registry = ...
      *   MonotonicCounter.using(registry)
      *     .withName("pool.completedTasks")
-     *     .monitor(executor, ThreadPoolExecutor::getCompletedTaskCount);
+     *     .monitorMonotonicCounter(executor, ThreadPoolExecutor::getCompletedTaskCount);
      * </pre>
      *
      * <p>The value is polled by executing {@code f(obj)} and a counter will be updated with


### PR DESCRIPTION
Fixes the method names used in two of the code samples.