### PR TITLE
fix #490, cannot invoke default methods with args

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/impl/Config.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/Config.java
@@ -124,7 +124,7 @@ public final class Config {
           .bindTo(proxy)
           .invokeWithArguments(args);
     } else {
-      MethodType rt = MethodType.methodType(method.getReturnType());
+      MethodType rt = MethodType.methodType(method.getReturnType(), method.getParameterTypes());
       return MethodHandles.lookup()
           .findSpecial(declaringClass, method.getName(), rt, declaringClass)
           .bindTo(proxy)

--- a/spectator-api/src/test/java/com/netflix/spectator/impl/ConfigTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/ConfigTest.java
@@ -32,6 +32,7 @@ import java.time.zone.ZoneRulesException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 @RunWith(JUnit4.class)
@@ -376,6 +377,14 @@ public class ConfigTest {
   }
 
   @Test
+  public void proxyDurationIn() {
+    Map<String, String> props = new HashMap<>();
+    TestConfig cfg = Config.usingMap(TestConfig.class, props);
+    props.put("valueDuration", "PT5M");
+    Assert.assertEquals(5, cfg.durationIn(TimeUnit.MINUTES));
+  }
+
+  @Test
   public void proxyPeriod() {
     Map<String, String> props = new HashMap<>();
     TestConfig cfg = Config.usingMap(TestConfig.class, props);
@@ -460,5 +469,11 @@ public class ConfigTest {
     Instant valueInstant();
     ZonedDateTime valueZonedDateTime();
     ZoneId valueZoneId();
+
+    // Test invoking of default method that takes arguments
+    default long durationIn(TimeUnit unit) {
+      final long nanos = valueDuration().toNanos();
+      return unit.convert(nanos, TimeUnit.NANOSECONDS);
+    }
   }
 }


### PR DESCRIPTION
Before if a configuration interface used a default method
that takes parameters, then it would fail because the paramter
type list was not being passed to the lookup.