### PR TITLE
improve error message if method is not set

### DIFF
--- a/spectator-ext-sandbox/src/main/java/com/netflix/spectator/sandbox/HttpLogEntry.java
+++ b/spectator-ext-sandbox/src/main/java/com/netflix/spectator/sandbox/HttpLogEntry.java
@@ -18,6 +18,7 @@ package com.netflix.spectator.sandbox;
 import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Spectator;
+import com.netflix.spectator.impl.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Marker;
@@ -127,6 +128,8 @@ public class HttpLogEntry {
   }
 
   private static void log(Logger logger, Marker marker, HttpLogEntry entry) {
+    Preconditions.checkNotNull(entry.method, "method");
+
     Id dimensions = REGISTRY.createId("tags")
         .withTag("mode", marker.getName())
         .withTag("status", entry.getStatusTag())

--- a/spectator-ext-sandbox/src/main/java/com/netflix/spectator/sandbox/HttpRequestBuilder.java
+++ b/spectator-ext-sandbox/src/main/java/com/netflix/spectator/sandbox/HttpRequestBuilder.java
@@ -62,7 +62,8 @@ public class HttpRequestBuilder {
     this.uri = uri;
     this.entry = new HttpLogEntry()
         .withRequestUri(uri)
-        .withClientName(clientName);
+        .withClientName(clientName)
+        .withMethod(method);
   }
 
   /** Set the request method (GET, PUT, POST, DELETE). */

--- a/spectator-ext-sandbox/src/test/java/com/netflix/spectator/sandbox/HttpLogEntryTest.java
+++ b/spectator-ext-sandbox/src/test/java/com/netflix/spectator/sandbox/HttpLogEntryTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.sandbox;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.net.URI;
+
+@RunWith(JUnit4.class)
+public class HttpLogEntryTest {
+
+  @Test(expected = NullPointerException.class)
+  public void npeIfMethodIsNotSet() {
+    HttpLogEntry entry = new HttpLogEntry()
+        .withClientName("test")
+        .withRequestUri(URI.create("http://test.com/foo"));
+    try {
+      HttpLogEntry.logClientRequest(entry);
+    } catch (NullPointerException e) {
+      Assert.assertEquals("parameter 'method' cannot be null", e.getMessage());
+      throw e;
+    }
+  }
+}


### PR DESCRIPTION
Improves the error message on HttpLogEntry to indicate
the method was not set instead of failing later when
attempting to add a null tag value to the id.

Also updates the HttpRequestBuilder to fill in the default
value for the method so it will not be null if the user
does not call `withMethod` explicitly.

/cc @copperlight 