### PR TITLE
fix NPE for ServoGauge.measure()

### DIFF
--- a/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoGauge.java
+++ b/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoGauge.java
@@ -26,6 +26,7 @@ import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Measurement;
 import com.netflix.spectator.impl.AtomicDouble;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -59,7 +60,8 @@ final class ServoGauge<T extends Number> extends AbstractMonitor<Double>
   }
 
   @Override public Iterable<Measurement> measure() {
-    return null;
+    long now = clock.wallTime();
+    return Collections.singleton(new Measurement(id(), now, value.get()));
   }
 
   @Override public void set(double v) {

--- a/spectator-reg-servo/src/test/java/com/netflix/spectator/servo/ServoGaugeTest.java
+++ b/spectator-reg-servo/src/test/java/com/netflix/spectator/servo/ServoGaugeTest.java
@@ -18,7 +18,7 @@ package com.netflix.spectator.servo;
 import com.netflix.servo.monitor.Monitor;
 import com.netflix.spectator.api.Gauge;
 import com.netflix.spectator.api.ManualClock;
-import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Measurement;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -26,6 +26,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -100,6 +101,20 @@ public class ServoGaugeTest {
 
     Map<String, String> tags = r.getMonitors().get(0).getConfig().getTags().asMap();
     Assert.assertEquals("GAUGE", tags.get("type"));
+  }
+
+  @Test
+  public void measure() {
+    final ServoRegistry r = new ServoRegistry(clock);
+    Gauge g = r.gauge(r.createId("foo"));
+    g.set(1.0);
+
+    Iterator<Measurement> ms = g.measure().iterator();
+    Assert.assertTrue(ms.hasNext());
+    Measurement m = ms.next();
+    Assert.assertFalse(ms.hasNext());
+    Assert.assertEquals("foo", m.id().name());
+    Assert.assertEquals(1.0, 1.0, 1e-12);
   }
 
   @Test


### PR DESCRIPTION
Before it was incorrectly returning null instead of
a set of measurements.