### PR TITLE
override propagate in NoopRegistry

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/NoopRegistry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/NoopRegistry.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 Netflix, Inc.
+/*
+ * Copyright 2014-2017 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,5 +72,13 @@ public final class NoopRegistry implements Registry {
 
   @Override public Iterator<Meter> iterator() {
     return Collections.<Meter>emptyList().iterator();
+  }
+
+  @Override public void propagate(String msg, Throwable t) {
+    // Since everything will have the same id when using this registry, it can result
+    // in type errors when checking against the state, see #503.
+  }
+
+  @Override public void propagate(Throwable t) {
   }
 }

--- a/spectator-api/src/main/java/com/netflix/spectator/api/Utils.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/Utils.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 Netflix, Inc.
+/*
+ * Copyright 2014-2017 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -267,12 +267,11 @@ public final class Utils {
   }
 
   /**
-   * Propagate a type error exception.
-   * Used in situations where an existing id has already been registered but with a different
-   * class.
+   * Propagate a type error exception. Used in situations where an existing id has already
+   * been registered but with a different class.
    */
-  public static void propagateTypeError(Registry registry, Id id,
-                                        Class<?> desiredClass, Class<?> actualClass) {
+  public static void propagateTypeError(
+      Registry registry, Id id, Class<?> desiredClass, Class<?> actualClass) {
     final String dType = desiredClass.getName();
     final String aType = actualClass.getName();
     final String msg = String.format("cannot access '%s' as a %s, it already exists as a %s",

--- a/spectator-api/src/test/java/com/netflix/spectator/api/patterns/LongTaskTimerTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/patterns/LongTaskTimerTest.java
@@ -109,4 +109,12 @@ public class LongTaskTimerTest {
     t.stop(task2);
     assertLongTaskTimer(t, 1L, 0, 0.0);
   }
+
+  // https://github.com/Netflix/spectator/issues/503
+  @Test
+  public void usingNoopRegistry() {
+    System.setProperty("spectator.api.propagateWarnings", "true");
+    Registry noop = new NoopRegistry();
+    LongTaskTimer.get(noop, noop.createId("task"));
+  }
 }


### PR DESCRIPTION
Fixes #503. This change overrides the propagate methods
from Registry to always ensure that they are indeed noops.
Before they would follow the `spectator.api.propagateWarnings`
flag and could result in exceptions due to type errors since
there is only one Id for the noop registry.