### PR TITLE
Updated regex patterns to capture Spark 2.0 / Spark 2.1 metrics

### DIFF
--- a/spectator-ext-spark/src/main/resources/reference.conf
+++ b/spectator-ext-spark/src/main/resources/reference.conf
@@ -2,14 +2,13 @@
 spectator.spark {
   name-patterns = [
     // EXECUTORS
-    // 97278898-4bd4-49c2-9889-aa5f969a7816-0013.97278898-4bd4-49c2-9889-aa5f969a7816-S1/2.executor.filesystem.file.largeRead_ops
+    // 97278898-4bd4-49c2-9889-aa5f969a7816-0013.2.executor.filesystem.file.largeRead_ops
     {
-      pattern = "^([^.]+)\\.(([^.]+)\/)?(\\d+)\\.((executor|jvm|CodeGenerator)\\..*)"
-      name = 5
+      pattern = "^([^.]+)\\.(\\d+)\\.((executor|jvm|HiveExternalCatalog|CodeGenerator)\\..*)"
+      name = 3
       tags = {
         "appId" = 1
-        "agentId" = 3
-        "executorId" = 4
+        "executorId" = 2
       }
     },
 
@@ -19,8 +18,9 @@ spectator.spark {
     // 97278898-4bd4-49c2-9889-aa5f969a7816-0020.driver.CodeGenerator.compilationTime
     // 97278898-4bd4-49c2-9889-aa5f969a7816-0020.driver.DAGScheduler.job.activeJobs
     // 97278898-4bd4-49c2-9889-aa5f969a7816-0020.driver.jvm.heap.committed
+    // 97278898-4bd4-49c2-9889-aa5f969a7816-0020.driver.HiveExternalCatalog.fileCacheHits
     {
-      pattern = "^([^.]+)\\.(driver)\\.((CodeGenerator|DAGScheduler|BlockManager|jvm)\\..+[^_MB])(_MB)?"
+      pattern = "^([^.]+)\\.(driver)\\.((CodeGenerator|DAGScheduler|BlockManager|HiveExternalCatalog|jvm)\\..+[^_MB])(_MB)?"
       name = 3
       tags = {
         "appId" = 1

--- a/spectator-ext-spark/src/main/resources/reference.conf
+++ b/spectator-ext-spark/src/main/resources/reference.conf
@@ -1,7 +1,20 @@
 
 spectator.spark {
   name-patterns = [
-    // EXECUTORS
+
+    // EXECUTORS Spark 1.6
+    // 97278898-4bd4-49c2-9889-aa5f969a7816-0013.97278898-4bd4-49c2-9889-aa5f969a7816-S1/2.executor.filesystem.file.largeRead_ops
+    {
+      pattern = "^([^.]+)\\.([^.]+)\\/(\\d+)\\.((executor|jvm|CodeGenerator)\\..*)"
+      name = 4
+      tags = {
+        "appId" = 1
+        "agentId" = 2
+        "executorId" = 3
+      }
+    },
+
+    // EXECUTORS Spark 2.0/2.1
     // 97278898-4bd4-49c2-9889-aa5f969a7816-0013.2.executor.filesystem.file.largeRead_ops
     {
       pattern = "^([^.]+)\\.(\\d+)\\.((executor|jvm|HiveExternalCatalog|CodeGenerator)\\..*)"
@@ -11,7 +24,6 @@ spectator.spark {
         "executorId" = 2
       }
     },
-
 
     // DRIVER
     // 97278898-4bd4-49c2-9889-aa5f969a7816-0020.driver.BlockManager.memory.remainingMem_MB

--- a/spectator-ext-spark/src/main/resources/reference.conf
+++ b/spectator-ext-spark/src/main/resources/reference.conf
@@ -4,6 +4,8 @@ spectator.spark {
 
     // EXECUTORS Spark 1.6
     // 97278898-4bd4-49c2-9889-aa5f969a7816-0013.97278898-4bd4-49c2-9889-aa5f969a7816-S1/2.executor.filesystem.file.largeRead_ops
+    // 97278898-4bd4-49c2-9889-aa5f969a7816-0013.97278898-4bd4-49c2-9889-aa5f969a7816-S1/2.jvm.heap.committed
+    // 97278898-4bd4-49c2-9889-aa5f969a7816-0013.97278898-4bd4-49c2-9889-aa5f969a7816-S1/2.CodeGenerator.compilationTime
     {
       pattern = "^([^.]+)\\.([^.]+)\\/(\\d+)\\.((executor|jvm|CodeGenerator)\\..*)"
       name = 4
@@ -16,6 +18,12 @@ spectator.spark {
 
     // EXECUTORS Spark 2.0/2.1
     // 97278898-4bd4-49c2-9889-aa5f969a7816-0013.2.executor.filesystem.file.largeRead_ops
+    // 97278898-4bd4-49c2-9889-aa5f969a7816-0013.2.jvm.heap.committed
+    // 97278898-4bd4-49c2-9889-aa5f969a7816-0013.2.CodeGenerator.compilationTime
+
+    // EXECUTORS Spark 2.1
+    // 97278898-4bd4-49c2-9889-aa5f969a7816-0013.2.HiveExternalCatalog.fileCacheHits
+
     {
       pattern = "^([^.]+)\\.(\\d+)\\.((executor|jvm|HiveExternalCatalog|CodeGenerator)\\..*)"
       name = 3
@@ -25,11 +33,12 @@ spectator.spark {
       }
     },
 
-    // DRIVER
+    // DRIVER 1.6/2.0
     // 97278898-4bd4-49c2-9889-aa5f969a7816-0020.driver.BlockManager.memory.remainingMem_MB
     // 97278898-4bd4-49c2-9889-aa5f969a7816-0020.driver.CodeGenerator.compilationTime
     // 97278898-4bd4-49c2-9889-aa5f969a7816-0020.driver.DAGScheduler.job.activeJobs
     // 97278898-4bd4-49c2-9889-aa5f969a7816-0020.driver.jvm.heap.committed
+    // DRIVER 2.1
     // 97278898-4bd4-49c2-9889-aa5f969a7816-0020.driver.HiveExternalCatalog.fileCacheHits
     {
       pattern = "^([^.]+)\\.(driver)\\.((CodeGenerator|DAGScheduler|BlockManager|HiveExternalCatalog|jvm)\\..+[^_MB])(_MB)?"
@@ -40,7 +49,8 @@ spectator.spark {
       }
     },
 
-    // STREAMING
+    // DRIVER STREAMING
+    // 52cc96b1-f89a-445d-a6e9-0e4cee70b731-0033.driver.HdfsWordCount.StreamingMetrics.streaming.lastCompletedBatch_processingDelay
     // Note: the .*Delay stats are derived from the .*Time stats. The time stats by themselves
     // aren't that useful sent to the backend.
     {

--- a/spectator-ext-spark/src/test/java/com/netflix/spectator/spark/SparkNameFunctionTest.java
+++ b/spectator-ext-spark/src/test/java/com/netflix/spectator/spark/SparkNameFunctionTest.java
@@ -41,10 +41,9 @@ public class SparkNameFunctionTest {
   //EXECUTOR
   @Test
   public void executorMetric() {
-    final String name = "97278898-4bd4-49c2-9889-aa5f969a7816-0013.97278898-4bd4-49c2-9889-aa5f969a7816-S1/2.executor.filesystem.file.largeRead_ops";
+    final String name = "97278898-4bd4-49c2-9889-aa5f969a7816-0013.2.executor.filesystem.file.largeRead_ops";
     final Id expected = registry.createId("spark.executor.filesystem.file.largeRead_ops")
         .withTag("appId", "97278898-4bd4-49c2-9889-aa5f969a7816-0013")
-        .withTag("agentId","97278898-4bd4-49c2-9889-aa5f969a7816-S1")
         .withTag("executorId", "2")
         .withTag("role", "executor");
     assertEquals(expected, f.apply(name));
@@ -52,10 +51,9 @@ public class SparkNameFunctionTest {
 
   @Test
   public void executorJvmMetric() {
-    final String name = "97278898-4bd4-49c2-9889-aa5f969a7816-0013.97278898-4bd4-49c2-9889-aa5f969a7816-S1/2.jvm.heap.committed";
+    final String name = "97278898-4bd4-49c2-9889-aa5f969a7816-0013.2.jvm.heap.committed";
     final Id expected = registry.createId("spark.jvm.heap.committed")
         .withTag("appId", "97278898-4bd4-49c2-9889-aa5f969a7816-0013")
-        .withTag("agentId","97278898-4bd4-49c2-9889-aa5f969a7816-S1")
         .withTag("executorId", "2")
         .withTag("role", "executor");
     assertEquals(expected, f.apply(name));
@@ -63,10 +61,9 @@ public class SparkNameFunctionTest {
 
   @Test
   public void executorCodeGenerator() {
-    final String name = "97278898-4bd4-49c2-9889-aa5f969a7816-0013.97278898-4bd4-49c2-9889-aa5f969a7816-S1/2.CodeGenerator.compilationTime";
+    final String name = "97278898-4bd4-49c2-9889-aa5f969a7816-0013.2.CodeGenerator.compilationTime";
     final Id expected = registry.createId("spark.CodeGenerator.compilationTime")
         .withTag("appId", "97278898-4bd4-49c2-9889-aa5f969a7816-0013")
-        .withTag("agentId","97278898-4bd4-49c2-9889-aa5f969a7816-S1")
         .withTag("executorId", "2")
         .withTag("role", "executor");
     assertEquals(expected, f.apply(name));

--- a/spectator-ext-spark/src/test/java/com/netflix/spectator/spark/SparkNameFunctionTest.java
+++ b/spectator-ext-spark/src/test/java/com/netflix/spectator/spark/SparkNameFunctionTest.java
@@ -41,6 +41,17 @@ public class SparkNameFunctionTest {
   //EXECUTOR
   @Test
   public void executorMetric() {
+    final String name = "97278898-4bd4-49c2-9889-aa5f969a7816-0013.97278898-4bd4-49c2-9889-aa5f969a7816-S1/2.executor.filesystem.file.largeRead_ops";
+    final Id expected = registry.createId("spark.executor.filesystem.file.largeRead_ops")
+        .withTag("appId", "97278898-4bd4-49c2-9889-aa5f969a7816-0013")
+        .withTag("agentId","97278898-4bd4-49c2-9889-aa5f969a7816-S1")
+        .withTag("executorId", "2")
+        .withTag("role", "executor");
+    assertEquals(expected, f.apply(name));
+  }
+
+  @Test
+  public void executorMetric20() {
     final String name = "97278898-4bd4-49c2-9889-aa5f969a7816-0013.2.executor.filesystem.file.largeRead_ops";
     final Id expected = registry.createId("spark.executor.filesystem.file.largeRead_ops")
         .withTag("appId", "97278898-4bd4-49c2-9889-aa5f969a7816-0013")
@@ -51,6 +62,17 @@ public class SparkNameFunctionTest {
 
   @Test
   public void executorJvmMetric() {
+    final String name = "97278898-4bd4-49c2-9889-aa5f969a7816-0013.97278898-4bd4-49c2-9889-aa5f969a7816-S1/2.jvm.heap.committed";
+    final Id expected = registry.createId("spark.jvm.heap.committed")
+        .withTag("appId", "97278898-4bd4-49c2-9889-aa5f969a7816-0013")
+        .withTag("agentId","97278898-4bd4-49c2-9889-aa5f969a7816-S1")
+        .withTag("executorId", "2")
+        .withTag("role", "executor");
+    assertEquals(expected, f.apply(name));
+  }
+
+  @Test
+  public void executorJvmMetric20() {
     final String name = "97278898-4bd4-49c2-9889-aa5f969a7816-0013.2.jvm.heap.committed";
     final Id expected = registry.createId("spark.jvm.heap.committed")
         .withTag("appId", "97278898-4bd4-49c2-9889-aa5f969a7816-0013")
@@ -61,6 +83,17 @@ public class SparkNameFunctionTest {
 
   @Test
   public void executorCodeGenerator() {
+    final String name = "97278898-4bd4-49c2-9889-aa5f969a7816-0013.97278898-4bd4-49c2-9889-aa5f969a7816-S1/2.CodeGenerator.compilationTime";
+    final Id expected = registry.createId("spark.CodeGenerator.compilationTime")
+        .withTag("appId", "97278898-4bd4-49c2-9889-aa5f969a7816-0013")
+        .withTag("agentId","97278898-4bd4-49c2-9889-aa5f969a7816-S1")
+        .withTag("executorId", "2")
+        .withTag("role", "executor");
+    assertEquals(expected, f.apply(name));
+  }
+
+  @Test
+  public void executorCodeGenerator20() {
     final String name = "97278898-4bd4-49c2-9889-aa5f969a7816-0013.2.CodeGenerator.compilationTime";
     final Id expected = registry.createId("spark.CodeGenerator.compilationTime")
         .withTag("appId", "97278898-4bd4-49c2-9889-aa5f969a7816-0013")

--- a/spectator-ext-spark/src/test/java/com/netflix/spectator/spark/SparkNameFunctionTest.java
+++ b/spectator-ext-spark/src/test/java/com/netflix/spectator/spark/SparkNameFunctionTest.java
@@ -40,7 +40,7 @@ public class SparkNameFunctionTest {
 
   //EXECUTOR
   @Test
-  public void executorMetric() {
+  public void executorMetric_executor() {
     final String name = "97278898-4bd4-49c2-9889-aa5f969a7816-0013.97278898-4bd4-49c2-9889-aa5f969a7816-S1/2.executor.filesystem.file.largeRead_ops";
     final Id expected = registry.createId("spark.executor.filesystem.file.largeRead_ops")
         .withTag("appId", "97278898-4bd4-49c2-9889-aa5f969a7816-0013")
@@ -51,7 +51,29 @@ public class SparkNameFunctionTest {
   }
 
   @Test
-  public void executorMetric20() {
+  public void executorMetric_jvm() {
+    final String name = "97278898-4bd4-49c2-9889-aa5f969a7816-0013.97278898-4bd4-49c2-9889-aa5f969a7816-S1/2.jvm.heap.committed";
+    final Id expected = registry.createId("spark.jvm.heap.committed")
+            .withTag("appId", "97278898-4bd4-49c2-9889-aa5f969a7816-0013")
+            .withTag("agentId","97278898-4bd4-49c2-9889-aa5f969a7816-S1")
+            .withTag("executorId", "2")
+            .withTag("role", "executor");
+    assertEquals(expected, f.apply(name));
+  }
+
+  @Test
+  public void executorMetric_CodeGenerator() {
+    final String name = "97278898-4bd4-49c2-9889-aa5f969a7816-0013.97278898-4bd4-49c2-9889-aa5f969a7816-S1/2.CodeGenerator.compilationTime";
+    final Id expected = registry.createId("spark.CodeGenerator.compilationTime")
+            .withTag("appId", "97278898-4bd4-49c2-9889-aa5f969a7816-0013")
+            .withTag("agentId","97278898-4bd4-49c2-9889-aa5f969a7816-S1")
+            .withTag("executorId", "2")
+            .withTag("role", "executor");
+    assertEquals(expected, f.apply(name));
+  }
+
+  @Test
+  public void executorMetric20_executor() {
     final String name = "97278898-4bd4-49c2-9889-aa5f969a7816-0013.2.executor.filesystem.file.largeRead_ops";
     final Id expected = registry.createId("spark.executor.filesystem.file.largeRead_ops")
         .withTag("appId", "97278898-4bd4-49c2-9889-aa5f969a7816-0013")
@@ -61,50 +83,38 @@ public class SparkNameFunctionTest {
   }
 
   @Test
-  public void executorJvmMetric() {
-    final String name = "97278898-4bd4-49c2-9889-aa5f969a7816-0013.97278898-4bd4-49c2-9889-aa5f969a7816-S1/2.jvm.heap.committed";
-    final Id expected = registry.createId("spark.jvm.heap.committed")
-        .withTag("appId", "97278898-4bd4-49c2-9889-aa5f969a7816-0013")
-        .withTag("agentId","97278898-4bd4-49c2-9889-aa5f969a7816-S1")
-        .withTag("executorId", "2")
-        .withTag("role", "executor");
-    assertEquals(expected, f.apply(name));
-  }
-
-  @Test
-  public void executorJvmMetric20() {
+  public void executorMetric20_jvm() {
     final String name = "97278898-4bd4-49c2-9889-aa5f969a7816-0013.2.jvm.heap.committed";
     final Id expected = registry.createId("spark.jvm.heap.committed")
-        .withTag("appId", "97278898-4bd4-49c2-9889-aa5f969a7816-0013")
-        .withTag("executorId", "2")
-        .withTag("role", "executor");
+            .withTag("appId", "97278898-4bd4-49c2-9889-aa5f969a7816-0013")
+            .withTag("executorId", "2")
+            .withTag("role", "executor");
     assertEquals(expected, f.apply(name));
   }
 
   @Test
-  public void executorCodeGenerator() {
-    final String name = "97278898-4bd4-49c2-9889-aa5f969a7816-0013.97278898-4bd4-49c2-9889-aa5f969a7816-S1/2.CodeGenerator.compilationTime";
-    final Id expected = registry.createId("spark.CodeGenerator.compilationTime")
-        .withTag("appId", "97278898-4bd4-49c2-9889-aa5f969a7816-0013")
-        .withTag("agentId","97278898-4bd4-49c2-9889-aa5f969a7816-S1")
-        .withTag("executorId", "2")
-        .withTag("role", "executor");
-    assertEquals(expected, f.apply(name));
-  }
-
-  @Test
-  public void executorCodeGenerator20() {
+  public void executorMetric20_CodeGenerator() {
     final String name = "97278898-4bd4-49c2-9889-aa5f969a7816-0013.2.CodeGenerator.compilationTime";
     final Id expected = registry.createId("spark.CodeGenerator.compilationTime")
-        .withTag("appId", "97278898-4bd4-49c2-9889-aa5f969a7816-0013")
-        .withTag("executorId", "2")
-        .withTag("role", "executor");
+            .withTag("appId", "97278898-4bd4-49c2-9889-aa5f969a7816-0013")
+            .withTag("executorId", "2")
+            .withTag("role", "executor");
+    assertEquals(expected, f.apply(name));
+  }
+
+  @Test
+  public void executorMetric21_HiveExternalCatalog() {
+    final String name = "97278898-4bd4-49c2-9889-aa5f969a7816-0013.2.HiveExternalCatalog.fileCacheHits";
+    final Id expected = registry.createId("spark.HiveExternalCatalog.fileCacheHits")
+            .withTag("appId", "97278898-4bd4-49c2-9889-aa5f969a7816-0013")
+            .withTag("executorId", "2")
+            .withTag("role", "executor");
     assertEquals(expected, f.apply(name));
   }
 
   // DRIVER
   @Test
-  public void driverMetric() {
+  public void driverMetric_BlockManager() {
     final String name = "97278898-4bd4-49c2-9889-aa5f969a7816-0013.driver.BlockManager.disk.diskSpaceUsed_MB";
     final Id expected = registry.createId("spark.BlockManager.disk.diskSpaceUsed")  // Trailing _MB removed
         .withTag("appId", "97278898-4bd4-49c2-9889-aa5f969a7816-0013")
@@ -113,7 +123,17 @@ public class SparkNameFunctionTest {
   }
 
   @Test
-  public void driverMetricNoUnits() {
+  public void driverMetric_CodeGenerator() {
+    final String name = "97278898-4bd4-49c2-9889-aa5f969a7816-0013.driver.CodeGenerator.compilationTime";
+    final Id expected = registry.createId("spark.CodeGenerator.compilationTime")
+            .withTag("appId", "97278898-4bd4-49c2-9889-aa5f969a7816-0013")
+            .withTag("role", "driver");
+    assertEquals(expected, f.apply(name));
+  }
+
+
+  @Test
+  public void driverMetric_DAGScheduler() {
     final String name = "97278898-4bd4-49c2-9889-aa5f969a7816-0013.driver.DAGScheduler.messageProcessingTime";
     final Id expected = registry.createId("spark.DAGScheduler.messageProcessingTime")
         .withTag("appId", "97278898-4bd4-49c2-9889-aa5f969a7816-0013")
@@ -122,11 +142,20 @@ public class SparkNameFunctionTest {
   }
 
   @Test
-  public void driverJvmMetric() {
+  public void driverMetric_jvm() {
     final String name = "97278898-4bd4-49c2-9889-aa5f969a7816-0013.driver.jvm.heap.committed";
     final Id expected = registry.createId("spark.jvm.heap.committed")
         .withTag("appId", "97278898-4bd4-49c2-9889-aa5f969a7816-0013")
         .withTag("role", "driver");
+    assertEquals(expected, f.apply(name));
+  }
+
+  @Test
+  public void driverMetric21_HiveExternalCatalog() {
+    final String name = "97278898-4bd4-49c2-9889-aa5f969a7816-0013.driver.HiveExternalCatalog.fileCacheHits";
+    final Id expected = registry.createId("spark.HiveExternalCatalog.fileCacheHits")
+            .withTag("appId", "97278898-4bd4-49c2-9889-aa5f969a7816-0013")
+            .withTag("role", "driver");
     assertEquals(expected, f.apply(name));
   }
 


### PR DESCRIPTION
Updated the patterns to capture driver and executor emitted metrics.

Compatible with Spark 2.0 / Spark 2.1 

No longer compatible Spark 1.6 and older.