### PR TITLE
Add gauge to Scheduler to record the timestamp of the last execution.

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/impl/Scheduler.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/Scheduler.java
@@ -338,7 +338,7 @@ public class Scheduler {
      *     Counter that will be incremented each time an expected execution is
      *     skipped when using {@link Policy#FIXED_RATE_SKIP_IF_LONG}.
      * @param lastSuccessfulExecutionTimestamp
-     *     AtomicLong that will be updated to the current wall clock time of a successful run. This is useful for
+     *     AtomicLong that will be updated to the current wallclock time of a successful run. This is useful for
      *     monitoring.
      * @param lastFailedExecutionTimestamp
      *     AtomicLong that will be updated to the current wallclock time of a failed run. This is useful for


### PR DESCRIPTION
This commit adds monitoring of when the last execution occurred and tags
it with the result (failure if an exception was thrown, success
otherwise).  We had a case where a scheduled thread stopped running at
some point, but had no indication due to the nature of the work it does.
This will enables a "time since last success" alert.