### PR TITLE
fix #501, change package for spectator-nflx

### DIFF
--- a/spectator-nflx/src/main/java/com/netflix/spectator/nflx/governator/AutoPlugin.java
+++ b/spectator-nflx/src/main/java/com/netflix/spectator/nflx/governator/AutoPlugin.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 Netflix, Inc.
+/*
+ * Copyright 2014-2018 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,10 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.spectator.nflx;
+package com.netflix.spectator.nflx.governator;
 
 import com.google.inject.AbstractModule;
 import com.netflix.governator.annotations.AutoBindSingleton;
+import com.netflix.spectator.nflx.SpectatorModule;
 
 /**
  * Auto bind wrapper around the base plugin.


### PR DESCRIPTION
The package name for the module annotated to be an
auto-bind singleton has been moved so it does not
conflict with `spectator-nflx-plugin`. This module
was changed for two reasons:

1. It is deprecated and if we have failures for users
   we would prefer it be on this library so we can
   move users off.
2. This class is only loaded via classpath scanning
   so it shouldn't break anything.

Note, the test case has been left in the old package
because it needs package private access to the Plugin
class. Since this is internal to the code base we'll
revisit if it becomes a problem later. External users
will not be impacted.