### PR TITLE
add Automatic-Module-Name to manifest

### DIFF
--- a/spectator-api/build.gradle
+++ b/spectator-api/build.gradle
@@ -8,3 +8,10 @@ javadoc {
   title "Spectator"
 }
 
+jar {
+  manifest {
+    attributes(
+      "Automatic-Module-Name": "com.netflix.spectator.api"
+    )
+  }
+}

--- a/spectator-ext-aws/build.gradle
+++ b/spectator-ext-aws/build.gradle
@@ -3,3 +3,11 @@ dependencies {
   compileApi "com.amazonaws:aws-java-sdk-core"
   testCompile "com.amazonaws:aws-java-sdk-cloudwatch"
 }
+
+jar {
+  manifest {
+    attributes(
+      "Automatic-Module-Name": "com.netflix.spectator.aws"
+    )
+  }
+}

--- a/spectator-ext-aws2/build.gradle
+++ b/spectator-ext-aws2/build.gradle
@@ -6,3 +6,11 @@ dependencies {
   compile "com.fasterxml.jackson.jr:jackson-jr-objects"
   testCompile "software.amazon.awssdk:cloudwatch:2.0.0-preview-2"
 }
+
+jar {
+  manifest {
+    attributes(
+      "Automatic-Module-Name": "com.netflix.spectator.aws2"
+    )
+  }
+}

--- a/spectator-ext-gc/build.gradle
+++ b/spectator-ext-gc/build.gradle
@@ -1,3 +1,11 @@
 dependencies {
   compileApi project(':spectator-api')
 }
+
+jar {
+  manifest {
+    attributes(
+      "Automatic-Module-Name": "com.netflix.spectator.gc"
+    )
+  }
+}

--- a/spectator-ext-jvm/build.gradle
+++ b/spectator-ext-jvm/build.gradle
@@ -1,3 +1,11 @@
 dependencies {
   compileApi project(':spectator-api')
 }
+
+jar {
+  manifest {
+    attributes(
+      "Automatic-Module-Name": "com.netflix.spectator.jvm"
+    )
+  }
+}

--- a/spectator-ext-log4j1/build.gradle
+++ b/spectator-ext-log4j1/build.gradle
@@ -2,3 +2,11 @@ dependencies {
   compileApi project(':spectator-api')
   compileApi "log4j:log4j:1.2.17"
 }
+
+jar {
+  manifest {
+    attributes(
+      "Automatic-Module-Name": "com.netflix.spectator.log4j1"
+    )
+  }
+}

--- a/spectator-ext-log4j2/build.gradle
+++ b/spectator-ext-log4j2/build.gradle
@@ -3,3 +3,11 @@ dependencies {
   compileApi "org.apache.logging.log4j:log4j-api"
   compileApi "org.apache.logging.log4j:log4j-core"
 }
+
+jar {
+  manifest {
+    attributes(
+      "Automatic-Module-Name": "com.netflix.spectator.log4j2"
+    )
+  }
+}

--- a/spectator-ext-placeholders/build.gradle
+++ b/spectator-ext-placeholders/build.gradle
@@ -6,3 +6,11 @@ dependencies {
   testCompile "org.slf4j:slf4j-log4j12"
   testCompile "log4j:log4j"
 }
+
+jar {
+  manifest {
+    attributes(
+      "Automatic-Module-Name": "com.netflix.spectator.placeholders"
+    )
+  }
+}

--- a/spectator-ext-sandbox/build.gradle
+++ b/spectator-ext-sandbox/build.gradle
@@ -1,3 +1,11 @@
 dependencies {
   compileApi project(':spectator-api')
 }
+
+jar {
+  manifest {
+    attributes(
+      "Automatic-Module-Name": "com.netflix.spectator.sandbox"
+    )
+  }
+}

--- a/spectator-ext-spark/build.gradle
+++ b/spectator-ext-spark/build.gradle
@@ -12,6 +12,14 @@ dependencies {
   compile 'org.apache.spark:spark-core_2.10:1.6.1'
 }
 
+jar {
+  manifest {
+    attributes(
+      "Automatic-Module-Name": "com.netflix.spectator.spark"
+    )
+  }
+}
+
 shadowJar {
   classifier = 'shadow'
 

--- a/spectator-nflx-plugin/build.gradle
+++ b/spectator-nflx-plugin/build.gradle
@@ -10,3 +10,11 @@ dependencies {
   compile "com.netflix.archaius:archaius-core"
   testCompile "com.netflix.governator:governator"
 }
+
+jar {
+  manifest {
+    attributes(
+      "Automatic-Module-Name": "com.netflix.spectator.nflx"
+    )
+  }
+}

--- a/spectator-nflx/build.gradle
+++ b/spectator-nflx/build.gradle
@@ -7,3 +7,11 @@ dependencies {
   testCompile 'com.netflix.archaius:archaius-core'
   testCompile 'commons-configuration:commons-configuration'
 }
+
+jar {
+  manifest {
+    attributes(
+      "Automatic-Module-Name": "com.netflix.spectator.nflx.governator"
+    )
+  }
+}

--- a/spectator-perf/build.gradle
+++ b/spectator-perf/build.gradle
@@ -4,3 +4,11 @@ dependencies {
   compile project(':spectator-reg-servo')
   compile 'org.openjdk.jol:jol-core:0.8'
 }
+
+jar {
+  manifest {
+    attributes(
+      "Automatic-Module-Name": "com.netflix.spectator.perf"
+    )
+  }
+}

--- a/spectator-reg-atlas/build.gradle
+++ b/spectator-reg-atlas/build.gradle
@@ -6,3 +6,11 @@ dependencies {
   compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-smile'
   jmh project(':spectator-api')
 }
+
+jar {
+  manifest {
+    attributes(
+      "Automatic-Module-Name": "com.netflix.spectator.atlas"
+    )
+  }
+}

--- a/spectator-reg-metrics3/build.gradle
+++ b/spectator-reg-metrics3/build.gradle
@@ -3,3 +3,11 @@ dependencies {
   compileApi 'io.dropwizard.metrics:metrics-core:3.1.2'
   jmh project(':spectator-api')
 }
+
+jar {
+  manifest {
+    attributes(
+      "Automatic-Module-Name": "com.netflix.spectator.metrics3"
+    )
+  }
+}

--- a/spectator-reg-servo/build.gradle
+++ b/spectator-reg-servo/build.gradle
@@ -4,3 +4,11 @@ dependencies {
   compileApi 'com.netflix.servo:servo-core'
   jmh project(':spectator-api')
 }
+
+jar {
+  manifest {
+    attributes(
+      "Automatic-Module-Name": "com.netflix.spectator.servo"
+    )
+  }
+}

--- a/spectator-web-spring/build.gradle
+++ b/spectator-web-spring/build.gradle
@@ -21,3 +21,11 @@ dependencies {
   compile 'org.springframework:spring-web:4.1.9.RELEASE'
   compile 'com.fasterxml.jackson.core:jackson-databind'
 }
+
+jar {
+  manifest {
+    attributes(
+      "Automatic-Module-Name": "com.netflix.spectator.spring"
+    )
+  }
+}


### PR DESCRIPTION
Should help avoid compatibility problems in the future
if users try to pull these in before we support a proper
`module-info.java`. For more details see:

http://blog.joda.org/2017/05/java-se-9-jpms-automatic-modules.html