### PR TITLE
update gc docs to indicate jdk9 regression

### DIFF
--- a/docs/ext/jvm-gc.md
+++ b/docs/ext/jvm-gc.md
@@ -17,7 +17,11 @@ otherwise keep reading this section.
 ### Requirements
 
 This library relies on the notification emitter added in 7u4, but there are known issues prior
-to 7u40. For G1 it is recommended to be on the latest version available.
+to 7u40. There is also a regression impacting java 9 and higher, see [#502] and [JDK-8196325]
+for more information. For G1 it is recommended to be on the latest version available.
+
+[#502]: https://github.com/Netflix/spectator/issues/502
+[JDK-8196325]: https://bugs.openjdk.java.net/browse/JDK-8196325
 
 ### Dependencies
 


### PR DESCRIPTION
We'll have to wait for a fix in the jdk, so for now update
the docs to warn users.