### PR TITLE
use optional binding for Registry in nflx-plugin

### DIFF
--- a/spectator-nflx-plugin/build.gradle
+++ b/spectator-nflx-plugin/build.gradle
@@ -7,6 +7,7 @@ dependencies {
   compile 'javax.inject:javax.inject'
   compile 'commons-configuration:commons-configuration'
   compile "com.google.inject:guice"
+  compile "com.google.inject.extensions:guice-multibindings"
   compile "com.netflix.archaius:archaius-core"
   testCompile "com.netflix.governator:governator"
 }

--- a/spectator-nflx-plugin/src/main/java/com/netflix/spectator/nflx/SpectatorModule.java
+++ b/spectator-nflx-plugin/src/main/java/com/netflix/spectator/nflx/SpectatorModule.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 Netflix, Inc.
+/*
+ * Copyright 2014-2018 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package com.netflix.spectator.nflx;
 
+import com.google.inject.multibindings.OptionalBinder;
 import com.netflix.spectator.servo.ServoRegistry;
 
 import javax.annotation.PreDestroy;
@@ -63,8 +64,13 @@ public final class SpectatorModule extends AbstractModule {
   @Override protected void configure() {
     bind(Plugin.class).asEagerSingleton();
     bind(StaticManager.class).asEagerSingleton();
-    bind(Registry.class).toProvider(RegistryProvider.class).asEagerSingleton();
-    bind(ExtendedRegistry.class).toInstance(Spectator.registry());
+    OptionalBinder.newOptionalBinder(binder(), ExtendedRegistry.class)
+        .setDefault()
+        .toInstance(Spectator.registry());
+    OptionalBinder.newOptionalBinder(binder(), Registry.class)
+        .setDefault()
+        .toProvider(RegistryProvider.class)
+        .asEagerSingleton();
   }
 
   @Override public boolean equals(Object obj) {

--- a/spectator-nflx-plugin/src/main/java/com/netflix/spectator/nflx/TestModule.java
+++ b/spectator-nflx-plugin/src/main/java/com/netflix/spectator/nflx/TestModule.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 Netflix, Inc.
+/*
+ * Copyright 2014-2018 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package com.netflix.spectator.nflx;
 
 import com.google.inject.AbstractModule;
+import com.google.inject.multibindings.OptionalBinder;
 import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.ExtendedRegistry;
 import com.netflix.spectator.api.Registry;
@@ -31,7 +32,11 @@ import com.netflix.spectator.api.Registry;
 public final class TestModule extends AbstractModule {
   @Override protected void configure() {
     final Registry registry = new DefaultRegistry();
-    bind(ExtendedRegistry.class).toInstance(new ExtendedRegistry(registry));
-    bind(Registry.class).toInstance(registry);
+    OptionalBinder.newOptionalBinder(binder(), ExtendedRegistry.class)
+        .setBinding()
+        .toInstance(new ExtendedRegistry(registry));
+    OptionalBinder.newOptionalBinder(binder(), Registry.class)
+        .setBinding()
+        .toInstance(registry);
   }
 }

--- a/spectator-nflx-plugin/src/test/java/com/netflix/spectator/nflx/SpectatorModuleTest.java
+++ b/spectator-nflx-plugin/src/test/java/com/netflix/spectator/nflx/SpectatorModuleTest.java
@@ -46,8 +46,10 @@ public class SpectatorModuleTest {
   public void injectedRegistryAddedToGlobal() {
     Injector injector = Guice.createInjector(new SpectatorModule());
     Registry registry = injector.getInstance(Registry.class);
+    long before = Spectator.globalRegistry().counter("test").count();
     registry.counter("test").increment();
-    Assert.assertEquals(Spectator.globalRegistry().counter("test").count(), 1);
+    long after = Spectator.globalRegistry().counter("test").count();
+    Assert.assertEquals(before + 1, after);
   }
 
   @Test

--- a/spectator-nflx-plugin/src/test/java/com/netflix/spectator/nflx/SpectatorModuleTest.java
+++ b/spectator-nflx-plugin/src/test/java/com/netflix/spectator/nflx/SpectatorModuleTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 Netflix, Inc.
+/*
+ * Copyright 2014-2018 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package com.netflix.spectator.nflx;
 
 import com.google.inject.Guice;
+import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.netflix.spectator.api.ExtendedRegistry;
 import com.netflix.spectator.api.Registry;
@@ -57,5 +58,17 @@ public class SpectatorModuleTest {
   @Test
   public void hashCodeTest() {
     Assert.assertEquals(new SpectatorModule().hashCode(), new SpectatorModule().hashCode());
+  }
+
+  @Test
+  public void optionalInjectWorksWithOptionalBinder() {
+    Injector injector = Guice.createInjector(new SpectatorModule());
+    OptionalInject obj = injector.getInstance(OptionalInject.class);
+    Assert.assertNotNull(obj.registry);
+  }
+
+  private static class OptionalInject {
+    @Inject(optional = true)
+    Registry registry;
   }
 }

--- a/spectator-nflx-plugin/src/test/java/com/netflix/spectator/nflx/SpectatorModuleTest.java
+++ b/spectator-nflx-plugin/src/test/java/com/netflix/spectator/nflx/SpectatorModuleTest.java
@@ -18,6 +18,7 @@ package com.netflix.spectator.nflx;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
+import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.ExtendedRegistry;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Spectator;
@@ -46,10 +47,8 @@ public class SpectatorModuleTest {
   public void injectedRegistryAddedToGlobal() {
     Injector injector = Guice.createInjector(new SpectatorModule());
     Registry registry = injector.getInstance(Registry.class);
-    long before = Spectator.globalRegistry().counter("test").count();
-    registry.counter("test").increment();
-    long after = Spectator.globalRegistry().counter("test").count();
-    Assert.assertEquals(before + 1, after);
+    Spectator.globalRegistry().counter("test").increment();
+    Assert.assertEquals(1, registry.counter("test").count());
   }
 
   @Test

--- a/spectator-nflx-plugin/src/test/java/com/netflix/spectator/nflx/TestModuleTest.java
+++ b/spectator-nflx-plugin/src/test/java/com/netflix/spectator/nflx/TestModuleTest.java
@@ -19,6 +19,7 @@ import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Spectator;
 import org.junit.Assert;
@@ -65,5 +66,17 @@ public class TestModuleTest {
   public void notGlobal() {
     Registry r = injector.getInstance(Registry.class);
     Assert.assertNotSame(Spectator.globalRegistry(), r);
+  }
+
+  @Test
+  public void usableIfSpectatorModuleIsInstalled() {
+    Registry r = Guice
+        .createInjector(new SpectatorModule(), new TestModule())
+        .getInstance(Registry.class);
+    Assert.assertTrue(r instanceof DefaultRegistry); // SpectatorModule installs ServoRegistry
+
+    // Sanity checking global behavior, SpectatorModule will add it to the global
+    // registry which is not normally done for TestModule because it is all static.
+    Assert.assertSame(Spectator.globalRegistry().underlying(DefaultRegistry.class), r);
   }
 }


### PR DESCRIPTION
This is to work-around a problem where libraries explicitly
install `SpectatorModule` instead of deferring that to the
application. By making it an optional binding other users
can still install `TestModule` for the purposes of testing
without getting duplicate binding errors.