### PR TITLE
avoid eager singleton for optional binding

### DIFF
--- a/spectator-nflx-plugin/src/main/java/com/netflix/spectator/nflx/SpectatorModule.java
+++ b/spectator-nflx-plugin/src/main/java/com/netflix/spectator/nflx/SpectatorModule.java
@@ -16,6 +16,7 @@
 package com.netflix.spectator.nflx;
 
 import com.google.inject.Inject;
+import com.google.inject.Scopes;
 import com.google.inject.multibindings.OptionalBinder;
 import com.netflix.archaius.api.Config;
 import com.netflix.archaius.config.EmptyConfig;
@@ -77,7 +78,7 @@ public final class SpectatorModule extends AbstractModule {
     OptionalBinder.newOptionalBinder(binder(), Registry.class)
         .setDefault()
         .toProvider(RegistryProvider.class)
-        .asEagerSingleton();
+        .in(Scopes.SINGLETON);
   }
 
   @Override public boolean equals(Object obj) {

--- a/spectator-nflx-plugin/src/test/java/com/netflix/spectator/nflx/SpectatorModuleTest.java
+++ b/spectator-nflx-plugin/src/test/java/com/netflix/spectator/nflx/SpectatorModuleTest.java
@@ -18,7 +18,6 @@ package com.netflix.spectator.nflx;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
-import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.ExtendedRegistry;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Spectator;


### PR DESCRIPTION
If set as eager it will force the default to be created
even if it is overridden.

/cc @elandau 