### PR TITLE
add JMX mappings for Tomcat JDBC connection pools

### DIFF
--- a/spectator-ext-jvm/src/main/resources/tomcat.conf
+++ b/spectator-ext-jvm/src/main/resources/tomcat.conf
@@ -320,6 +320,246 @@ netflix.spectator.agent.jmx {
           counter = true
         }
       ]
+    },
+
+    //
+    // type=ConnectionPool
+    //
+    {
+      query = "tomcat.jdbc:class=org.apache.tomcat.jdbc.pool.DataSource,type=ConnectionPool,name=*"
+      measurements = [
+        {
+          name = "tomcat.jdbc.poolSize"
+          tags = [
+            {
+              key = "id"
+              value = "{name}"
+            },
+            {
+              key = "class"
+              value = "{type}"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{Size}"
+        },
+        {
+          name = "tomcat.jdbc.currentConnectionsBusy"
+          tags = [
+            {
+              key = "id"
+              value = "{name}"
+            },
+            {
+              key = "class"
+              value = "{type}"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{NumActive}"
+        },
+        {
+          name = "tomcat.jdbc.currentConnectionsIdle"
+          tags = [
+            {
+              key = "id"
+              value = "{name}"
+            },
+            {
+              key = "class"
+              value = "{type}"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{NumIdle}"
+        },
+        {
+          name = "tomcat.jdbc.maxConnections"
+          tags = [
+            {
+              key = "id"
+              value = "{name}"
+            },
+            {
+              key = "class"
+              value = "{type}"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{MaxActive}"
+        },
+        {
+          name = "tomcat.jdbc.currentThreadsWaiting"
+          tags = [
+            {
+              key = "id"
+              value = "{name}"
+            },
+            {
+              key = "class"
+              value = "{type}"
+            },
+            {
+              key = "atlas.dstype"
+              value = "gauge"
+            }
+          ]
+          value = "{WaitCount}"
+        },
+        {
+          name = "tomcat.jdbc.connectionsBorrowed"
+          tags = [
+            {
+              key = "id"
+              value = "{name}"
+            },
+            {
+              key = "class"
+              value = "{type}"
+            },
+            {
+              key = "atlas.dstype"
+              value = "rate"
+            }
+          ]
+          value = "{BorrowedCount}"
+          counter = true
+        },
+        {
+          name = "tomcat.jdbc.connectionsReturned"
+          tags = [
+            {
+              key = "id"
+              value = "{name}"
+            },
+            {
+              key = "class"
+              value = "{type}"
+            },
+            {
+              key = "atlas.dstype"
+              value = "rate"
+            }
+          ]
+          value = "{ReturnedCount}"
+          counter = true
+        },
+        {
+          name = "tomcat.jdbc.connectionsCreated"
+          tags = [
+            {
+              key = "id"
+              value = "{name}"
+            },
+            {
+              key = "class"
+              value = "{type}"
+            },
+            {
+              key = "atlas.dstype"
+              value = "rate"
+            }
+          ]
+          value = "{CreatedCount}"
+          counter = true
+        },
+        {
+          name = "tomcat.jdbc.connectionsReleased"
+          tags = [
+            {
+              key = "id"
+              value = "{name}"
+            },
+            {
+              key = "class"
+              value = "{type}"
+            },
+            {
+              key = "atlas.dstype"
+              value = "rate"
+            }
+          ]
+          value = "{ReleasedCount}"
+          counter = true
+        },
+        {
+          name = "tomcat.jdbc.connectionsReconnected"
+          tags = [
+            {
+              key = "id"
+              value = "{name}"
+            },
+            {
+              key = "class"
+              value = "{type}"
+            },
+            {
+              key = "atlas.dstype"
+              value = "rate"
+            }
+          ]
+          value = "{ReconnectedCount}"
+          counter = true
+        },
+        {
+          name = "tomcat.jdbc.connectionsCleaned"
+          tags = [
+            {
+              key = "id"
+              value = "{name}"
+            },
+            {
+              key = "class"
+              value = "{type}"
+            },
+            {
+              key = "reason"
+              value = "idle"
+            },
+            {
+              key = "atlas.dstype"
+              value = "rate"
+            }
+          ]
+          value = "{ReleasedIdleCount}"
+          counter = true
+        },
+        {
+          name = "tomcat.jdbc.connectionsCleaned"
+          tags = [
+            {
+              key = "id"
+              value = "{name}"
+            },
+            {
+              key = "class"
+              value = "{type}"
+            },
+            {
+              key = "reason"
+              value = "abandoned"
+            },
+            {
+              key = "atlas.dstype"
+              value = "rate"
+            }
+          ]
+          value = "{RemoveAbandonedCount}"
+          counter = true
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
These aren't documented particularly well in the Tomcat
docs, but are fairly easy to follow by looking at the
connection pool [source].

[source]: https://github.com/apache/tomcat/blob/trunk/modules/jdbc-pool/src/main/java/org/apache/tomcat/jdbc/pool/ConnectionPool.java