### PR TITLE
ensure ids for servo meters are consistent

### DIFF
--- a/spectator-api/src/test/java/com/netflix/spectator/api/SpectatorTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/SpectatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 Netflix, Inc.
+/*
+ * Copyright 2014-2018 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,4 +27,35 @@ public class SpectatorTest {
     Assert.assertNotNull(Spectator.registry());
   }
 
+  @Test
+  public void globalIterator() {
+    Registry dflt = new DefaultRegistry();
+    CompositeRegistry global = Spectator.globalRegistry();
+    global.removeAll();
+    global.add(dflt);
+
+    boolean found = false;
+    Counter counter = dflt.counter("testCounter");
+    for (Meter m : global) {
+      found = m.id().equals(counter.id());
+    }
+    Assert.assertTrue("id for sub-registry could not be found in global iterator", found);
+  }
+
+  @Test
+  public void globalIteratorWithDifferences() {
+    Registry r1 = new DefaultRegistry();
+    Registry r2 = new DefaultRegistry();
+    CompositeRegistry global = Spectator.globalRegistry();
+    global.removeAll();
+    global.add(r1);
+    global.add(r2);
+
+    boolean found = false;
+    Counter counter = r2.counter("testCounter");
+    for (Meter m : global) {
+      found |= m.id().equals(counter.id());
+    }
+    Assert.assertTrue("id for sub-registry could not be found in global iterator", found);
+  }
 }

--- a/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoCounter.java
+++ b/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoCounter.java
@@ -28,13 +28,15 @@ import java.util.concurrent.atomic.AtomicLong;
 /** Counter implementation for the servo registry. */
 class ServoCounter implements Counter, ServoMeter {
 
+  private final Id id;
   private final Clock clock;
   private final com.netflix.servo.monitor.StepCounter impl;
   private final AtomicLong count;
   private final AtomicLong lastUpdated;
 
   /** Create a new instance. */
-  ServoCounter(Clock clock, com.netflix.servo.monitor.StepCounter impl) {
+  ServoCounter(Id id, Clock clock, com.netflix.servo.monitor.StepCounter impl) {
+    this.id = id;
     this.clock = clock;
     this.impl = impl;
     this.count = new AtomicLong(0L);
@@ -46,7 +48,7 @@ class ServoCounter implements Counter, ServoMeter {
   }
 
   @Override public Id id() {
-    return new ServoId(impl.getConfig());
+    return id;
   }
 
   @Override public boolean hasExpired() {

--- a/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoGauge.java
+++ b/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoGauge.java
@@ -36,6 +36,7 @@ import java.util.concurrent.atomic.AtomicLong;
 final class ServoGauge<T extends Number> extends AbstractMonitor<Double>
     implements Gauge, ServoMeter, NumericMonitor<Double> {
 
+  private final Id id;
   private final Clock clock;
   private final AtomicDouble value;
   private final AtomicLong lastUpdated;
@@ -43,15 +44,16 @@ final class ServoGauge<T extends Number> extends AbstractMonitor<Double>
   /**
    * Create a new monitor that returns {@code value}.
    */
-  ServoGauge(Clock clock, MonitorConfig config) {
+  ServoGauge(Id id, Clock clock, MonitorConfig config) {
     super(config.withAdditionalTag(DataSourceType.GAUGE));
+    this.id = id;
     this.clock = clock;
     this.value = new AtomicDouble(Double.NaN);
     this.lastUpdated = new AtomicLong(0L);
   }
 
   @Override public Id id() {
-    return new ServoId(config);
+    return id;
   }
 
   @Override public boolean hasExpired() {

--- a/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoRegistry.java
+++ b/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoRegistry.java
@@ -100,7 +100,7 @@ public class ServoRegistry extends AbstractRegistry implements CompositeMonitor<
   @Override protected Counter newCounter(Id id) {
     MonitorConfig cfg = toMonitorConfig(id, Statistic.count);
     StepCounter counter = new StepCounter(cfg, new ServoClock(clock()));
-    return new ServoCounter(clock(), counter);
+    return new ServoCounter(id, clock(), counter);
   }
 
   @Override protected DistributionSummary newDistributionSummary(Id id) {
@@ -112,7 +112,7 @@ public class ServoRegistry extends AbstractRegistry implements CompositeMonitor<
   }
 
   @Override protected Gauge newGauge(Id id) {
-    return new ServoGauge(clock(), toMonitorConfig(id, Statistic.gauge));
+    return new ServoGauge(id, clock(), toMonitorConfig(id, Statistic.gauge));
   }
 
   @Override public Integer getValue() {


### PR DESCRIPTION
Before the servo registry would return instances of ServoId
for Counter and Gauge types that would have additional tagging
and fail to match the id for the meter in the base registry
map. This would lead to null values when using the iterator
with a composite registry.

Fixes #530.