### PR TITLE
Helper method to specify the gzip compression level

### DIFF
--- a/spectator-ext-sandbox/src/main/java/com/netflix/spectator/sandbox/HttpRequestBuilder.java
+++ b/spectator-ext-sandbox/src/main/java/com/netflix/spectator/sandbox/HttpRequestBuilder.java
@@ -32,6 +32,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.zip.Deflater;
 
 /**
  * Helper for executing simple HTTP client requests using {@link HttpURLConnection}
@@ -137,10 +138,21 @@ public class HttpRequestBuilder {
     return this;
   }
 
-  /** Compress the request body. The content must have already been set on the builder. */
+  /**
+   * Compress the request body using the default compression level.
+   * The content must have already been set on the builder.
+   */
   public HttpRequestBuilder compress() throws IOException {
+    return compress(Deflater.DEFAULT_COMPRESSION);
+  }
+
+  /**
+   * Compress the request body using the specified compression level.
+   * The content must have already been set on the builder.
+   */
+  public HttpRequestBuilder compress(int level) throws IOException {
     addHeader("Content-Encoding", "gzip");
-    entity = HttpUtils.gzip(entity);
+    entity = HttpUtils.gzip(entity, level);
     return this;
   }
 

--- a/spectator-ext-sandbox/src/main/java/com/netflix/spectator/sandbox/HttpUtils.java
+++ b/spectator-ext-sandbox/src/main/java/com/netflix/spectator/sandbox/HttpUtils.java
@@ -23,6 +23,7 @@ import java.io.OutputStream;
 import java.net.URI;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.zip.Deflater;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
@@ -67,10 +68,33 @@ final class HttpUtils {
     return (host == null) ? DEFAULT : clientNameForHost(host);
   }
 
-  /** Compress a byte array using GZIP. */
+  /** Wrap GZIPOutputStream allowing the user to override the compression level. */
+  static class GzipLevelOutputStream extends GZIPOutputStream {
+    /** Creates a new output stream with a default compression level. */
+    GzipLevelOutputStream(OutputStream outputStream) throws IOException {
+      super(outputStream);
+    }
+
+    /** Set the compression level for the underlying deflater. */
+    void setLevel(int level) {
+      def.setLevel(level);
+    }
+  }
+
+  /**
+   * Compress a byte array using GZIP's default compression level.
+   */
   static byte[] gzip(byte[] data) throws IOException {
+    return gzip(data, Deflater.DEFAULT_COMPRESSION);
+  }
+
+  /**
+   * Compress a byte array using GZIP with the given compression level.
+   */
+  static byte[] gzip(byte[] data, int level) throws IOException {
     ByteArrayOutputStream baos = new ByteArrayOutputStream(data.length);
-    try (OutputStream out = new GZIPOutputStream(baos)) {
+    try (GzipLevelOutputStream out = new GzipLevelOutputStream(baos)) {
+      out.setLevel(level);
       out.write(data);
     }
     return baos.toByteArray();

--- a/spectator-ext-sandbox/src/test/java/com/netflix/spectator/sandbox/HttpUtilsTest.java
+++ b/spectator-ext-sandbox/src/test/java/com/netflix/spectator/sandbox/HttpUtilsTest.java
@@ -23,6 +23,7 @@ import org.junit.runners.JUnit4;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.zip.Deflater;
 
 @RunWith(JUnit4.class)
 public class HttpUtilsTest {
@@ -50,6 +51,13 @@ public class HttpUtilsTest {
   public void gzip() throws IOException {
     byte[] data = "foo bar baz".getBytes(StandardCharsets.UTF_8);
     String result = new String(HttpUtils.gunzip(HttpUtils.gzip(data)), StandardCharsets.UTF_8);
+    Assert.assertEquals("foo bar baz", result);
+  }
+
+  @Test
+  public void gzipWithLevel() throws IOException {
+    byte[] data = "foo bar baz".getBytes(StandardCharsets.UTF_8);
+    String result = new String(HttpUtils.gunzip(HttpUtils.gzip(data, Deflater.BEST_SPEED)), StandardCharsets.UTF_8);
     Assert.assertEquals("foo bar baz", result);
   }
 }


### PR DESCRIPTION
This should allow us to specify a faster compression level to
regain some CPU cycles, or a more aggressive one if reducing the size
of the payload is the goal.