### PR TITLE
add support for removing expired meters

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/CompositeRegistry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/CompositeRegistry.java
@@ -108,10 +108,10 @@ public final class CompositeRegistry implements Registry {
   }
 
   private void updateMeters() {
-    counters.forEach((id, c) -> c.setUnderlying(newCounter(id)));
-    distSummaries.forEach((id, d) -> d.setUnderlying(newDistributionSummary(id)));
-    timers.forEach((id, t) -> t.setUnderlying(newTimer(id)));
-    gauges.forEach((id, g) -> g.setUnderlying(newGauge(id)));
+    counters.forEach((id, c) -> c.set(newCounter(id)));
+    distSummaries.forEach((id, d) -> d.set(newDistributionSummary(id)));
+    timers.forEach((id, t) -> t.set(newTimer(id)));
+    gauges.forEach((id, g) -> g.set(newGauge(id)));
   }
 
   @Override public Clock clock() {
@@ -159,7 +159,7 @@ public final class CompositeRegistry implements Registry {
   }
 
   @Override public Counter counter(Id id) {
-    return Utils.computeIfAbsent(counters, id, i -> new SwapCounter(newCounter(i)));
+    return Utils.computeIfAbsent(counters, id, i -> new SwapCounter(this, i, newCounter(i)));
   }
 
   private DistributionSummary newDistributionSummary(Id id) {
@@ -187,7 +187,8 @@ public final class CompositeRegistry implements Registry {
   }
 
   @Override public DistributionSummary distributionSummary(Id id) {
-    return Utils.computeIfAbsent(distSummaries, id, i -> new SwapDistributionSummary(newDistributionSummary(i)));
+    return Utils.computeIfAbsent(distSummaries, id,
+        i -> new SwapDistributionSummary(this, i, newDistributionSummary(i)));
   }
 
   private Timer newTimer(Id id) {
@@ -215,7 +216,7 @@ public final class CompositeRegistry implements Registry {
   }
 
   @Override public Timer timer(Id id) {
-    return Utils.computeIfAbsent(timers, id, i -> new SwapTimer(newTimer(i)));
+    return Utils.computeIfAbsent(timers, id, i -> new SwapTimer(this, i, newTimer(i)));
   }
 
   private Gauge newGauge(Id id) {
@@ -243,7 +244,7 @@ public final class CompositeRegistry implements Registry {
   }
 
   @Override public Gauge gauge(Id id) {
-    return Utils.computeIfAbsent(gauges, id, i -> new SwapGauge(newGauge(i)));
+    return Utils.computeIfAbsent(gauges, id, i -> new SwapGauge(this, i, newGauge(i)));
   }
 
   @Override public Meter get(Id id) {

--- a/spectator-api/src/main/java/com/netflix/spectator/api/Counter.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/Counter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 Netflix, Inc.
+/*
+ * Copyright 2014-2018 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,9 @@ public interface Counter extends Meter {
    */
   void increment(long amount);
 
-  /** The cumulative count since this counter was created. */
+  /**
+   * The cumulative count since this counter was last reset. How often a counter
+   * is reset depends on the underlying registry implementation.
+   */
   long count();
 }

--- a/spectator-api/src/main/java/com/netflix/spectator/api/DistributionSummary.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/DistributionSummary.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 Netflix, Inc.
+/*
+ * Copyright 2014-2018 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,9 +35,15 @@ public interface DistributionSummary extends Meter {
    */
   void record(long amount);
 
-  /** The number of times that record has been called since this timer was created. */
+  /**
+   * The number of times that record has been called since this timer was last reset.
+   * How often a timer is reset depends on the underlying registry implementation.
+   */
   long count();
 
-  /** The total amount of all recorded events since this summary was created. */
+  /**
+   * The total amount of all recorded events since this summary was last reset.
+   * How often a timer is reset depends on the underlying registry implementation.
+   */
   long totalAmount();
 }

--- a/spectator-api/src/main/java/com/netflix/spectator/api/Timer.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/Timer.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 Netflix, Inc.
+/*
+ * Copyright 2014-2018 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,9 +58,15 @@ public interface Timer extends Meter {
    */
   void record(Runnable f);
 
-  /** The number of times that record has been called since this timer was created. */
+  /**
+   * The number of times that record has been called since this timer was last reset.
+   * How often a timer is reset depends on the underlying registry implementation.
+   */
   long count();
 
-  /** The total time in nanoseconds of all recorded events since this timer was created. */
+  /**
+   * The total time in nanoseconds of all recorded events since this timer was last reset.
+   * How often a timer is reset depends on the underlying registry implementation.
+   */
   long totalTime();
 }

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/SwapMeter.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/SwapMeter.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.impl;
+
+import com.netflix.spectator.api.Meter;
+
+/**
+ * Base type for meters that allow the underlying implementation to be replaced with
+ * another. This is used by {@link com.netflix.spectator.api.AbstractRegistry} as the
+ * basis for expiring types where a user may have a reference in their code.
+ *
+ * <p><b>This class is an internal implementation detail only intended for use within
+ * spectator. It is subject to change without notice.</b></p>
+ */
+public interface SwapMeter<T extends Meter> extends Meter {
+
+  /**
+   * Set the underlying instance of the meter to use. This can be set to {@code null}
+   * to indicate that the meter has expired and is no longer in the registry.
+   */
+  void set(T meter);
+
+  /** Return the underlying instance of the meter. */
+  T get();
+}

--- a/spectator-api/src/test/java/com/netflix/spectator/api/ExpiringRegistry.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/ExpiringRegistry.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.api;
+
+import java.util.Collections;
+
+public class ExpiringRegistry extends AbstractRegistry {
+
+  public ExpiringRegistry(Clock clock) {
+    super(clock);
+  }
+
+  @Override protected Counter newCounter(Id id) {
+    return new Counter() {
+      private final long creationTime = clock().wallTime();
+      private long count = 0;
+
+      @Override public void increment() {
+        ++count;
+      }
+
+      @Override public void increment(long amount) {
+        count += amount;
+      }
+
+      @Override public long count() {
+        return count;
+      }
+
+      @Override public Id id() {
+        return id;
+      }
+
+      @Override public Iterable<Measurement> measure() {
+        return Collections.emptyList();
+      }
+
+      @Override public boolean hasExpired() {
+        return clock().wallTime() > creationTime;
+      }
+    };
+  }
+
+  @Override protected DistributionSummary newDistributionSummary(Id id) {
+    return null;
+  }
+
+  @Override protected Timer newTimer(Id id) {
+    return null;
+  }
+
+  @Override protected Gauge newGauge(Id id) {
+    return null;
+  }
+
+  @Override public void removeExpiredMeters() {
+    super.removeExpiredMeters();
+  }
+}

--- a/spectator-api/src/test/java/com/netflix/spectator/api/RegistryTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/RegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 Netflix, Inc.
+ * Copyright 2014-2018 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -380,5 +380,26 @@ public class RegistryTest {
     RegistryConfig config = k -> "propagateWarnings".equals(k) ? "true" : null;
     Registry r = new DefaultRegistry(Clock.SYSTEM, config);
     r.propagate("foo", new RuntimeException("test"));
+  }
+
+  @Test
+  public void keepNonExpired() {
+    ManualClock clock = new ManualClock();
+    ExpiringRegistry registry = new ExpiringRegistry(clock);
+
+    registry.counter("test").increment();
+    registry.removeExpiredMeters();
+    Assert.assertEquals(1, registry.counters().count());
+  }
+
+  @Test
+  public void removeExpired() {
+    ManualClock clock = new ManualClock();
+    ExpiringRegistry registry = new ExpiringRegistry(clock);
+
+    registry.counter("test").increment();
+    clock.setWallTime(1);
+    registry.removeExpiredMeters();
+    Assert.assertEquals(0, registry.counters().count());
   }
 }

--- a/spectator-api/src/test/java/com/netflix/spectator/api/SwapMeterTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/SwapMeterTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.api;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.concurrent.TimeUnit;
+
+@RunWith(JUnit4.class)
+public class SwapMeterTest {
+  private final Registry registry = new DefaultRegistry();
+
+  private final Id counterId = registry.createId("counter");
+  private final Counter counter = registry.counter(counterId);
+
+  private final Id gaugeId = registry.createId("gauge");
+  private final Gauge gauge = registry.gauge(gaugeId);
+
+  private final Id timerId = registry.createId("timer");
+  private final Timer timer = registry.timer(timerId);
+
+  private final Id distSummaryId = registry.createId("distSummary");
+  private final DistributionSummary distSummary = registry.distributionSummary(distSummaryId);
+
+  @Test
+  public void counterNullHasExpired() {
+    SwapCounter sc = new SwapCounter(registry, counterId, null);
+    Assert.assertTrue(sc.hasExpired());
+  }
+
+  @Test
+  public void counterNullLookup() {
+    SwapCounter sc = new SwapCounter(registry, counterId, null);
+    sc.increment();
+    Assert.assertEquals(counter.count(), sc.get().count());
+  }
+
+  @Test
+  public void counterSetToNull() {
+    SwapCounter sc = new SwapCounter(registry, counterId, counter);
+    Assert.assertFalse(sc.hasExpired());
+    sc.set(null);
+    Assert.assertTrue(sc.hasExpired());
+    Assert.assertEquals(counter.count(), sc.get().count());
+  }
+
+  @Test
+  public void gaugeNullHasExpired() {
+    SwapGauge sg = new SwapGauge(registry, gaugeId, null);
+    Assert.assertTrue(sg.hasExpired());
+  }
+
+  @Test
+  public void gaugeNullLookup() {
+    SwapGauge sg = new SwapGauge(registry, gaugeId, null);
+    sg.set(42.0);
+    Assert.assertEquals(gauge.value(), sg.get().value(), 1e-12);
+  }
+
+  @Test
+  public void gaugeSetToNull() {
+    SwapGauge sg = new SwapGauge(registry, gaugeId, gauge);
+    Assert.assertFalse(sg.hasExpired());
+    sg.set(null);
+    Assert.assertTrue(sg.hasExpired());
+    Assert.assertEquals(gauge.value(), sg.get().value(), 1e-12);
+  }
+
+  @Test
+  public void timerNullHasExpired() {
+    SwapTimer st = new SwapTimer(registry, timerId, null);
+    Assert.assertTrue(st.hasExpired());
+  }
+
+  @Test
+  public void timerNullLookup() {
+    SwapTimer st = new SwapTimer(registry, timerId, null);
+    st.record(42, TimeUnit.NANOSECONDS);
+    Assert.assertEquals(timer.totalTime(), st.get().totalTime());
+  }
+
+  @Test
+  public void timerSetToNull() {
+    SwapTimer st = new SwapTimer(registry, timerId, timer);
+    Assert.assertFalse(st.hasExpired());
+    st.set(null);
+    Assert.assertTrue(st.hasExpired());
+    Assert.assertEquals(timer.totalTime(), st.get().totalTime());
+  }
+
+  @Test
+  public void distSummaryNullHasExpired() {
+    SwapDistributionSummary st = new SwapDistributionSummary(registry, distSummaryId, null);
+    Assert.assertTrue(st.hasExpired());
+  }
+
+  @Test
+  public void distSummaryNullLookup() {
+    SwapDistributionSummary st = new SwapDistributionSummary(registry, distSummaryId, null);
+    st.record(42);
+    Assert.assertEquals(distSummary.totalAmount(), st.get().totalAmount());
+  }
+
+  @Test
+  public void distSummarySetToNull() {
+    SwapDistributionSummary st = new SwapDistributionSummary(registry, distSummaryId, distSummary);
+    Assert.assertFalse(st.hasExpired());
+    st.set(null);
+    Assert.assertTrue(st.hasExpired());
+    Assert.assertEquals(distSummary.totalAmount(), st.get().totalAmount());
+  }
+}

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
@@ -191,7 +191,8 @@ public final class AtlasRegistry extends AbstractRegistry {
     }
   }
 
-  private void collectData() {
+  /** Collect data and send to Atlas. */
+  void collectData() {
     // Send data for any subscriptions
     if (lwcEnabled) {
       try {
@@ -219,6 +220,9 @@ public final class AtlasRegistry extends AbstractRegistry {
         logger.warn("failed to send metrics", e);
       }
     }
+
+    // Clean up any expired meters
+    removeExpiredMeters();
   }
 
   private void handleSubscriptions() {
@@ -355,7 +359,8 @@ public final class AtlasRegistry extends AbstractRegistry {
   //
 
   private DoubleCounter newDoubleCounter(Id id) {
-    return new AtlasDoubleCounter(id, clock, meterTTL, stepMillis);
+    DoubleCounter c = new AtlasDoubleCounter(id, clock, meterTTL, stepMillis);
+    return new SwapDoubleCounter(this, id, c);
   }
 
   /**
@@ -372,7 +377,8 @@ public final class AtlasRegistry extends AbstractRegistry {
   }
 
   private MaxGauge newMaxGauge(Id id) {
-    return new AtlasMaxGauge(id, clock, meterTTL, stepMillis);
+    MaxGauge g = new AtlasMaxGauge(id, clock, meterTTL, stepMillis);
+    return new SwapMaxGauge(this, id, g);
   }
 
   /**

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/SwapDoubleCounter.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/SwapDoubleCounter.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.impl.SwapMeter;
+
+/**
+ * <p><b>Experimental:</b> This type may be removed in a future release.</p>
+ *
+ * Wraps a double counter to allow the implementation to be swapped out.
+ */
+final class SwapDoubleCounter implements DoubleCounter, SwapMeter<DoubleCounter> {
+
+  private final AtlasRegistry registry;
+  private final Id id;
+  private volatile DoubleCounter underlying;
+
+  /** Create a new instance. */
+  SwapDoubleCounter(AtlasRegistry registry, Id id, DoubleCounter underlying) {
+    this.registry = registry;
+    this.id = id;
+    this.underlying = underlying;
+  }
+
+  @Override public Id id() {
+    return id;
+  }
+
+  @Override public boolean hasExpired() {
+    DoubleCounter c = underlying;
+    return c == null || c.hasExpired();
+  }
+
+  @Override public void add(double amount) {
+    get().add(amount);
+  }
+
+  @Override public double actualCount() {
+    return get().actualCount();
+  }
+
+  @Override public Iterable<Measurement> measure() {
+    return get().measure();
+  }
+
+  @Override public void set(DoubleCounter c) {
+    underlying = c;
+  }
+
+  @Override public DoubleCounter get() {
+    DoubleCounter c = underlying;
+    if (c == null) {
+      c = unwrap(registry.doubleCounter(id));
+      underlying = c;
+    }
+    return c;
+  }
+
+  private DoubleCounter unwrap(DoubleCounter c) {
+    DoubleCounter tmp = c;
+    while (tmp instanceof SwapDoubleCounter) {
+      tmp = ((SwapDoubleCounter) tmp).get();
+    }
+    return tmp;
+  }
+}

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/SwapMaxGauge.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/SwapMaxGauge.java
@@ -13,19 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.spectator.api;
+package com.netflix.spectator.atlas;
 
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Measurement;
 import com.netflix.spectator.impl.SwapMeter;
 
-/** Wraps another gauge allowing the underlying type to be swapped. */
-final class SwapGauge implements Gauge, SwapMeter<Gauge> {
+/**
+ * <p><b>Experimental:</b> This type may be removed in a future release.</p>
+ *
+ * Wraps another gauge allowing the underlying type to be swapped.
+ */
+final class SwapMaxGauge implements MaxGauge, SwapMeter<MaxGauge> {
 
-  private final Registry registry;
+  private final AtlasRegistry registry;
   private final Id id;
-  private volatile Gauge underlying;
+  private volatile MaxGauge underlying;
 
   /** Create a new instance. */
-  SwapGauge(Registry registry, Id id, Gauge underlying) {
+  SwapMaxGauge(AtlasRegistry registry, Id id, MaxGauge underlying) {
     this.registry = registry;
     this.id = id;
     this.underlying = underlying;
@@ -40,7 +46,7 @@ final class SwapGauge implements Gauge, SwapMeter<Gauge> {
   }
 
   @Override public boolean hasExpired() {
-    Gauge g = underlying;
+    MaxGauge g = underlying;
     return g == null || g.hasExpired();
   }
 
@@ -52,23 +58,23 @@ final class SwapGauge implements Gauge, SwapMeter<Gauge> {
     return get().value();
   }
 
-  @Override public void set(Gauge g) {
+  @Override public void set(MaxGauge g) {
     underlying = g;
   }
 
-  @Override public Gauge get() {
-    Gauge g = underlying;
+  @Override public MaxGauge get() {
+    MaxGauge g = underlying;
     if (g == null) {
-      g = unwrap(registry.gauge(id));
+      g = unwrap(registry.maxGauge(id));
       underlying = g;
     }
     return g;
   }
 
-  private Gauge unwrap(Gauge g) {
-    Gauge tmp = g;
-    while (tmp instanceof SwapGauge) {
-      tmp = ((SwapGauge) tmp).get();
+  private MaxGauge unwrap(MaxGauge g) {
+    MaxGauge tmp = g;
+    while (tmp instanceof SwapMaxGauge) {
+      tmp = ((SwapMaxGauge) tmp).get();
     }
     return tmp;
   }

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasSwapMeterTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasSwapMeterTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.ManualClock;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class AtlasSwapMeterTest {
+  private final ManualClock clock = new ManualClock();
+  private final AtlasRegistry registry = new AtlasRegistry(clock, System::getProperty);
+
+  private final Id counterId = registry.createId("counter");
+  private final DoubleCounter counter = registry.doubleCounter(counterId);
+
+  private final Id gaugeId = registry.createId("gauge");
+  private final MaxGauge gauge = registry.maxGauge(gaugeId);
+
+  @Test
+  public void counterNullHasExpired() {
+    SwapDoubleCounter sc = new SwapDoubleCounter(registry, counterId, null);
+    Assert.assertTrue(sc.hasExpired());
+  }
+
+  @Test
+  public void counterNullLookup() {
+    SwapDoubleCounter sc = new SwapDoubleCounter(registry, counterId, null);
+    sc.increment();
+    Assert.assertEquals(counter.count(), sc.get().count());
+  }
+
+  @Test
+  public void counterSetToNull() {
+    SwapDoubleCounter sc = new SwapDoubleCounter(registry, counterId, counter);
+    Assert.assertFalse(sc.hasExpired());
+    sc.set(null);
+    Assert.assertTrue(sc.hasExpired());
+    Assert.assertEquals(counter.count(), sc.get().count());
+  }
+
+  @Test
+  public void gaugeNullHasExpired() {
+    SwapMaxGauge sg = new SwapMaxGauge(registry, gaugeId, null);
+    Assert.assertTrue(sg.hasExpired());
+  }
+
+  @Test
+  public void gaugeNullLookup() {
+    SwapMaxGauge sg = new SwapMaxGauge(registry, gaugeId, null);
+    sg.set(42.0);
+    Assert.assertEquals(gauge.value(), sg.get().value(), 1e-12);
+  }
+
+  @Test
+  public void gaugeSetToNull() {
+    SwapMaxGauge sg = new SwapMaxGauge(registry, gaugeId, gauge);
+    Assert.assertFalse(sg.hasExpired());
+    sg.set(null);
+    Assert.assertTrue(sg.hasExpired());
+    Assert.assertEquals(gauge.value(), sg.get().value(), 1e-12);
+  }
+}

--- a/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoRegistry.java
+++ b/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoRegistry.java
@@ -21,6 +21,7 @@ import com.netflix.spectator.api.*;
 import com.netflix.spectator.api.Counter;
 import com.netflix.spectator.api.Gauge;
 import com.netflix.spectator.api.Timer;
+import com.netflix.spectator.impl.SwapMeter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,7 +29,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
 
 /** Registry that maps spectator types to servo. */
 public class ServoRegistry extends AbstractRegistry implements CompositeMonitor<Integer> {
@@ -135,13 +135,14 @@ public class ServoRegistry extends AbstractRegistry implements CompositeMonitor<
         sm.addMonitors(monitors);
       }
     }
+    removeExpiredMeters();
     return monitors;
   }
 
   @SuppressWarnings("unchecked")
   private ServoMeter getServoMeter(Meter meter) {
-    if (meter instanceof Supplier<?>) {
-      return getServoMeter(((Supplier<Meter>) meter).get());
+    if (meter instanceof SwapMeter<?>) {
+      return getServoMeter(((SwapMeter<?>) meter).get());
     } else if (meter instanceof ServoMeter) {
       return (ServoMeter) meter;
     } else {

--- a/spectator-reg-servo/src/test/java/com/netflix/spectator/servo/ServoRegistryTest.java
+++ b/spectator-reg-servo/src/test/java/com/netflix/spectator/servo/ServoRegistryTest.java
@@ -20,6 +20,7 @@ import com.netflix.servo.MonitorRegistry;
 import com.netflix.spectator.api.CompositeRegistry;
 import com.netflix.spectator.api.Counter;
 import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.ManualClock;
 import com.netflix.spectator.api.Meter;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Spectator;
@@ -101,6 +102,25 @@ public class ServoRegistryTest {
   @Test
   public void globalIteratorDistSummary() {
     globalIterator(r -> r.distributionSummary("servo.testDistSummary"));
+  }
+
+  @Test
+  public void keepNonExpired() {
+    ManualClock clock = new ManualClock();
+    ServoRegistry registry = new ServoRegistry(clock);
+    registry.counter("test").increment();
+    Assert.assertEquals(1, registry.getMonitors().size());
+    Assert.assertEquals(1, registry.counters().count());
+  }
+
+  @Test
+  public void removesExpired() {
+    ManualClock clock = new ManualClock();
+    ServoRegistry registry = new ServoRegistry(clock);
+    registry.counter("test").increment();
+    clock.setWallTime(60000 * 30);
+    Assert.assertEquals(0, registry.getMonitors().size());
+    Assert.assertEquals(0, registry.counters().count());
   }
 
 }


### PR DESCRIPTION
Originally the contract for the registry was that
the meters like counter would track the state since
the meter was created. This means that meters must
stick around for the life of the process.

With some registries, e.g., AtlasRegistry, we already
removed this retriction and limited it to the count
for the last completed interval. Given we have been
running in this mode a while with no issues, we are
changing the contract to officially give the registry
implementation the choice of reset frequency. Along
with this the AbstractRegistry now has a method that
can be used to fully remove any expired meters. This
avoids a memory leak over time if the user has a bug
and the distinct meter set grows over time.