### PR TITLE
ignore "name" when used as a tag key

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/MeasurementSerializer.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/MeasurementSerializer.java
@@ -72,12 +72,14 @@ public class MeasurementSerializer extends JsonSerializer<Measurement> {
     gen.writeStringField("name", fixValue("name", value.id().name()));
     boolean explicitDsType = false;
     for (Tag t : value.id().tags()) {
-      if ("atlas.dstype".equals(t.key())) {
-        explicitDsType = true;
+      if (!"name".equals(t.key())) {
+        if ("atlas.dstype".equals(t.key())) {
+          explicitDsType = true;
+        }
+        final String k = fixKey(t.key());
+        final String v = fixValue(k, t.value());
+        gen.writeStringField(k, v);
       }
-      final String k = fixKey(t.key());
-      final String v = fixValue(k, t.value());
-      gen.writeStringField(k, v);
     }
 
     // If the dstype has not been explicitly set, then the value must be coming in

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/MeasurementSerializerTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/MeasurementSerializerTest.java
@@ -75,6 +75,16 @@ public class MeasurementSerializerTest {
   }
 
   @Test
+  public void userTagName() throws Exception {
+    Id id = registry.createId("foo", "name", "bar");
+    Measurement m = new Measurement(id, 42L, 3.0);
+    String json = mapper.writeValueAsString(m);
+    String tags = "{\"name\":\"foo\",\"atlas.dstype\":\"gauge\"}";
+    String expected = "{\"tags\":" + tags + ",\"timestamp\":42,\"value\":3.0}";
+    Assert.assertEquals(expected, json);
+  }
+
+  @Test
   public void invalidKey() throws Exception {
     Id id = registry.createId("foo", "b$$", "baz");
     Measurement m = new Measurement(id, 42L, 3.0);


### PR DESCRIPTION
For Atlas the name will be filled in by the name
on the id. If the user used this key, then ignore
it when sending to Atlas. Otherwise it could overwrite
the name on the id depending on how the json map
is consumed.

In a separate PR we'll add some validation logging
so the user can be aware if they are doing something
wrong.