### PR TITLE
add helper for recording java.time.Duration

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/Timer.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/Timer.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.spectator.api;
 
+import java.time.Duration;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
@@ -39,6 +40,16 @@ public interface Timer extends Meter {
    *     Time unit for the amount being recorded.
    */
   void record(long amount, TimeUnit unit);
+
+  /**
+   * Updates the statistics kept by the counter with the specified amount.
+   *
+   * @param amount
+   *     Duration of a single event being measured by this timer.
+   */
+  default void record(Duration amount) {
+    record(amount.toNanos(), TimeUnit.NANOSECONDS);
+  }
 
   /**
    * Executes the callable `f` and records the time taken.

--- a/spectator-api/src/test/java/com/netflix/spectator/api/DefaultTimerTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/DefaultTimerTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 @RunWith(JUnit4.class)
@@ -39,6 +40,14 @@ public class DefaultTimerTest {
   public void testRecord() {
     Timer t = new DefaultTimer(clock, NoopId.INSTANCE);
     t.record(42, TimeUnit.MILLISECONDS);
+    Assert.assertEquals(t.count(), 1L);
+    Assert.assertEquals(t.totalTime(), 42000000L);
+  }
+
+  @Test
+  public void testRecordDuration() {
+    Timer t = new DefaultTimer(clock, NoopId.INSTANCE);
+    t.record(Duration.ofMillis(42));
     Assert.assertEquals(t.count(), 1L);
     Assert.assertEquals(t.totalTime(), 42000000L);
   }


### PR DESCRIPTION
Updates the Timer interface to support recording a
`java.time.Duration`. A lot of newer code uses the
java.time types and it is less error prone than
having to keep track of the unit.