### PR TITLE
add helper to validate ipc metrics

### DIFF
--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcMetric.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcMetric.java
@@ -15,7 +15,19 @@
  */
 package com.netflix.spectator.ipc;
 
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.DistributionSummary;
+import com.netflix.spectator.api.Gauge;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Timer;
+import com.netflix.spectator.api.Utils;
+
+import java.util.Arrays;
 import java.util.EnumSet;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 /**
  * IPC metric names and associated metadata.
@@ -24,22 +36,36 @@ public enum IpcMetric {
   /**
    * Timer recording the number and latency of outbound requests.
    */
-  clientCall("ipc.client.call", EnumSet.noneOf(IpcTagKey.class)),
+  clientCall("ipc.client.call", EnumSet.of(
+      IpcTagKey.owner,
+      IpcTagKey.result,
+      IpcTagKey.attempt,
+      IpcTagKey.attemptFinal,
+      IpcTagKey.errorGroup // For result == failure only
+  )),
 
   /**
    * Timer recording the number and latency of inbound requests.
    */
-  serverCall("ipc.server.call", EnumSet.noneOf(IpcTagKey.class)),
+  serverCall("ipc.server.call", EnumSet.of(
+      IpcTagKey.owner,
+      IpcTagKey.result,
+      IpcTagKey.errorGroup // For result == failure only
+  )),
 
   /**
    * Number of outbound requests that are currently in flight.
    */
-  clientInflight("ipc.client.inflight", EnumSet.noneOf(IpcTagKey.class)),
+  clientInflight("ipc.client.inflight", EnumSet.of(
+      IpcTagKey.owner
+  )),
 
   /**
    * Number of inbound requests that are currently in flight.
    */
-  serverInflight("ipc.server.inflight", EnumSet.noneOf(IpcTagKey.class));
+  serverInflight("ipc.server.inflight", EnumSet.of(
+      IpcTagKey.owner
+  ));
 
   private final String metricName;
   private final EnumSet<IpcTagKey> requiredDimensions;
@@ -58,5 +84,132 @@ public enum IpcMetric {
   /** Returns the set of dimensions that are required for this metrics. */
   public EnumSet<IpcTagKey> requiredDimensions() {
     return requiredDimensions;
+  }
+
+  private static final Class<?>[] METER_TYPES = {
+      Counter.class,
+      Timer.class,
+      DistributionSummary.class,
+      Gauge.class
+  };
+
+  private static final SortedSet<String> ATTEMPT_FINAL_VALUES = new TreeSet<>();
+
+  static {
+    ATTEMPT_FINAL_VALUES.add(Boolean.TRUE.toString());
+    ATTEMPT_FINAL_VALUES.add(Boolean.FALSE.toString());
+  }
+
+  private static void assertTrue(boolean condition, String description, Object... args) {
+    if (!condition) {
+      throw new IllegalArgumentException(String.format(description, args));
+    }
+  }
+
+  private static String getName(Class<?> cls) {
+    for (Class<?> c : METER_TYPES) {
+      if (c.isAssignableFrom(cls)) {
+        return c.getSimpleName();
+      }
+    }
+    return cls.getSimpleName();
+  }
+
+  private static void validateIpcMeter(Registry registry, IpcMetric metric, Class<?> type) {
+    final String name = metric.metricName();
+    registry.stream()
+        .filter(m -> name.equals(m.id().name()))
+        .forEach(m -> {
+          assertTrue(type.isAssignableFrom(m.getClass()),
+              "[%s] has the wrong type, expected %s but found %s",
+              m.id(), type.getSimpleName(), getName(m.getClass()));
+          metric.validate(m.id());
+        });
+  }
+
+  /**
+   * Validate all of the common IPC metrics contained within the specified registry.
+   *
+   * @param registry
+   *     Registry to query for IPC metrics.
+   */
+  public static void validate(Registry registry) {
+    validateIpcMeter(registry, IpcMetric.clientCall, Timer.class);
+    validateIpcMeter(registry, IpcMetric.serverCall, Timer.class);
+    validateIpcMeter(registry, IpcMetric.clientInflight, DistributionSummary.class);
+    validateIpcMeter(registry, IpcMetric.serverInflight, DistributionSummary.class);
+  }
+
+  @SuppressWarnings("PMD.PreserveStackTrace")
+  private <T extends Enum<T>> void validateValues(Id id, String key, Class<T> cls) {
+    String value = Utils.getTagValue(id, key);
+    if (value != null) {
+      try {
+        Enum.valueOf(cls, value);
+      } catch (Exception e) {
+        String values = Arrays.stream(cls.getEnumConstants())
+            .map(Enum::name)
+            .collect(Collectors.joining(", "));
+        throw new IllegalArgumentException(String.format(
+            "[%s] invalid value for dimension %s, acceptable values are (%s)",
+            id, key, values));
+      }
+    }
+  }
+
+  private void validateValues(Id id, String key, SortedSet<String> allowedValues) {
+    String value = Utils.getTagValue(id, key);
+    if (value != null && !allowedValues.contains(value)) {
+      String values = allowedValues.stream()
+          .collect(Collectors.joining(", "));
+      throw new IllegalArgumentException(String.format(
+          "[%s] invalid value for dimension %s, acceptable values are (%s)",
+          id, key, values));
+    }
+  }
+
+  /**
+   * Validate that the specified id has the correct tagging for this IPC metric.
+   *
+   * @param id
+   *     Meter identifier to validate.
+   */
+  public void validate(Id id) {
+    assertTrue(metricName.equals(id.name()), "%s != %s", metricName, id.name());
+
+    // Check that required dimensions other than error group are present
+    EnumSet<IpcTagKey> dimensions = requiredDimensions.clone();
+    dimensions.remove(IpcTagKey.errorGroup);
+    dimensions.forEach(k -> {
+      String value = Utils.getTagValue(id, k.key());
+      assertTrue(value != null, "[%s] is missing required dimension %s", id, k.key());
+    });
+
+    // Check that error group is only present for failed requests
+    if (requiredDimensions.contains(IpcTagKey.errorGroup)) {
+      String result = Utils.getTagValue(id, IpcTagKey.result.key());
+      String errorGroup = Utils.getTagValue(id, IpcTagKey.errorGroup.key());
+      switch (result) {
+        case "success":
+          assertTrue(errorGroup == null,
+              "[%s] %s should not be present on successful request",
+              id, IpcTagKey.errorGroup.key());
+          break;
+        case "failure":
+          assertTrue(errorGroup != null,
+              "[%s] %s must be present on failed request",
+              id, IpcTagKey.errorGroup.key());
+          break;
+        default:
+          // Invalid value for result, will be caught later on
+          break;
+      }
+    }
+
+    // Check the values are correct for enum keys
+    validateValues(id, IpcTagKey.attemptFinal.key(), ATTEMPT_FINAL_VALUES);
+    validateValues(id, IpcTagKey.attempt.key(), IpcAttempt.class);
+    validateValues(id, IpcTagKey.result.key(), IpcResult.class);
+    validateValues(id, IpcTagKey.errorGroup.key(), IpcErrorGroup.class);
   }
 }

--- a/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/IpcMetricTest.java
+++ b/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/IpcMetricTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.ipc;
+
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Registry;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.time.Duration;
+
+@RunWith(JUnit4.class)
+public class IpcMetricTest {
+
+  private Registry registry = null;
+
+  @Before
+  public void init() {
+    registry = new DefaultRegistry();
+  }
+
+  @Test
+  public void validateIdOk() {
+    Id id = registry.createId(IpcMetric.clientCall.metricName())
+        .withTag(IpcTagKey.owner.key(), "test")
+        .withTag(IpcResult.success)
+        .withTag(IpcAttempt.initial)
+        .withTag(IpcTagKey.attemptFinal.key(), true);
+    IpcMetric.clientCall.validate(id);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void validateIdBadName() {
+    Id id = registry.createId("ipc.client-call")
+        .withTag(IpcTagKey.owner.key(), "test")
+        .withTag(IpcResult.success)
+        .withTag(IpcAttempt.initial)
+        .withTag(IpcTagKey.attemptFinal.key(), true);
+    IpcMetric.clientCall.validate(id);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void validateIdMissingResult() {
+    Id id = registry.createId(IpcMetric.clientCall.metricName())
+        .withTag(IpcTagKey.owner.key(), "test")
+        .withTag(IpcAttempt.initial)
+        .withTag(IpcTagKey.attemptFinal.key(), true);
+    IpcMetric.clientCall.validate(id);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void validateIdErrorGroupOnSuccess() {
+    Id id = registry.createId(IpcMetric.clientCall.metricName())
+        .withTag(IpcTagKey.owner.key(), "test")
+        .withTag(IpcResult.success)
+        .withTag(IpcErrorGroup.general)
+        .withTag(IpcAttempt.initial)
+        .withTag(IpcTagKey.attemptFinal.key(), true);
+    IpcMetric.clientCall.validate(id);
+  }
+
+  @Test
+  public void validateIdErrorGroupOnFailure() {
+    Id id = registry.createId(IpcMetric.clientCall.metricName())
+        .withTag(IpcTagKey.owner.key(), "test")
+        .withTag(IpcResult.failure)
+        .withTag(IpcErrorGroup.general)
+        .withTag(IpcAttempt.initial)
+        .withTag(IpcTagKey.attemptFinal.key(), true);
+    IpcMetric.clientCall.validate(id);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void validateIdErrorGroupNotOnFailure() {
+    Id id = registry.createId(IpcMetric.clientCall.metricName())
+        .withTag(IpcTagKey.owner.key(), "test")
+        .withTag(IpcResult.failure)
+        .withTag(IpcAttempt.initial)
+        .withTag(IpcTagKey.attemptFinal.key(), true);
+    IpcMetric.clientCall.validate(id);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void validateIdBadResultValue() {
+    Id id = registry.createId(IpcMetric.clientCall.metricName())
+        .withTag(IpcTagKey.owner.key(), "test")
+        .withTag(IpcTagKey.result.key(), "foo")
+        .withTag(IpcAttempt.initial)
+        .withTag(IpcTagKey.attemptFinal.key(), true);
+    IpcMetric.clientCall.validate(id);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void validateIdBadAttemptFinalValue() {
+    Id id = registry.createId(IpcMetric.clientCall.metricName())
+        .withTag(IpcTagKey.owner.key(), "test")
+        .withTag(IpcResult.success)
+        .withTag(IpcAttempt.initial)
+        .withTag(IpcTagKey.attemptFinal.key(), "foo");
+    IpcMetric.clientCall.validate(id);
+  }
+
+  @Test
+  public void validateRegistryOk() {
+    Id id = registry.createId(IpcMetric.clientCall.metricName())
+        .withTag(IpcTagKey.owner.key(), "test")
+        .withTag(IpcResult.success)
+        .withTag(IpcAttempt.initial)
+        .withTag(IpcTagKey.attemptFinal.key(), true);
+    registry.timer(id).record(Duration.ofSeconds(42));
+    IpcMetric.validate(registry);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void validateRegistryTimerWrongType() {
+    Id id = registry.createId(IpcMetric.clientCall.metricName())
+        .withTag(IpcTagKey.owner.key(), "test")
+        .withTag(IpcResult.success)
+        .withTag(IpcAttempt.initial)
+        .withTag(IpcTagKey.attemptFinal.key(), true);
+    registry.counter(id).increment();
+    IpcMetric.validate(registry);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void validateRegistryDistSummaryWrongType() {
+    Id id = registry.createId(IpcMetric.clientInflight.metricName())
+        .withTag(IpcTagKey.owner.key(), "test");
+    registry.counter(id).increment();
+    IpcMetric.validate(registry);
+  }
+}


### PR DESCRIPTION
Adds a helper function that can be used to perform basic
validation of the IPC metrics as part of a unit test. To
use it run the test with a registry and then call:

```java
IpcMetric.validate(registry);
```

/cc @kerumai 