### PR TITLE
fix possible missed timer updates using lambda

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/SwapTimer.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/SwapTimer.java
@@ -17,11 +17,10 @@ package com.netflix.spectator.api;
 
 import com.netflix.spectator.impl.SwapMeter;
 
-import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 /** Wraps another timer allowing the underlying type to be swapped. */
-final class SwapTimer implements Timer, SwapMeter<Timer> {
+final class SwapTimer extends AbstractTimer implements SwapMeter<Timer> {
 
   private final Registry registry;
   private final Id id;
@@ -29,6 +28,7 @@ final class SwapTimer implements Timer, SwapMeter<Timer> {
 
   /** Create a new instance. */
   SwapTimer(Registry registry, Id id, Timer underlying) {
+    super(registry.clock());
     this.registry = registry;
     this.id = id;
     this.underlying = underlying;
@@ -49,14 +49,6 @@ final class SwapTimer implements Timer, SwapMeter<Timer> {
 
   @Override public void record(long amount, TimeUnit unit) {
     get().record(amount, unit);
-  }
-
-  @Override public <T> T record(Callable<T> f) throws Exception {
-    return get().record(f);
-  }
-
-  @Override public void record(Runnable f) {
-    get().record(f);
   }
 
   @Override public long count() {

--- a/spectator-api/src/test/java/com/netflix/spectator/api/ExpiringRegistry.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/ExpiringRegistry.java
@@ -16,6 +16,7 @@
 package com.netflix.spectator.api;
 
 import java.util.Collections;
+import java.util.concurrent.TimeUnit;
 
 public class ExpiringRegistry extends AbstractRegistry {
 
@@ -59,7 +60,34 @@ public class ExpiringRegistry extends AbstractRegistry {
   }
 
   @Override protected Timer newTimer(Id id) {
-    return null;
+    return new AbstractTimer(clock()) {
+      private final long creationTime = clock().wallTime();
+      private long count = 0;
+
+      @Override public void record(long amount, TimeUnit unit) {
+        ++count;
+      }
+
+      @Override public long count() {
+        return count;
+      }
+
+      @Override public long totalTime() {
+        return 0;
+      }
+
+      @Override public Id id() {
+        return id;
+      }
+
+      @Override public Iterable<Measurement> measure() {
+        return Collections.emptyList();
+      }
+
+      @Override public boolean hasExpired() {
+        return clock().wallTime() > creationTime;
+      }
+    };
   }
 
   @Override protected Gauge newGauge(Id id) {

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasMeter.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasMeter.java
@@ -39,7 +39,7 @@ abstract class AtlasMeter implements Meter {
     this.id = id;
     this.clock = clock;
     this.ttl = ttl;
-    lastUpdated = 0L;
+    lastUpdated = clock.wallTime();
   }
 
   /**

--- a/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoCounter.java
+++ b/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoCounter.java
@@ -40,7 +40,7 @@ class ServoCounter implements Counter, ServoMeter {
     this.clock = clock;
     this.impl = impl;
     this.count = new AtomicLong(0L);
-    this.lastUpdated = new AtomicLong(0L);
+    this.lastUpdated = new AtomicLong(clock.wallTime());
   }
 
   @Override public void addMonitors(List<Monitor<?>> monitors) {

--- a/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoDistributionSummary.java
+++ b/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoDistributionSummary.java
@@ -59,7 +59,7 @@ class ServoDistributionSummary implements DistributionSummary, ServoMeter {
         r.toMonitorConfig(id.withTag(Statistic.totalOfSquares), null));
     servoMax = new MaxGauge(r.toMonitorConfig(id.withTag(Statistic.max), null));
 
-    lastUpdated = new AtomicLong(0L);
+    lastUpdated = new AtomicLong(clock.wallTime());
   }
 
   @Override public void addMonitors(List<Monitor<?>> monitors) {

--- a/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoGauge.java
+++ b/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoGauge.java
@@ -49,7 +49,7 @@ final class ServoGauge<T extends Number> extends AbstractMonitor<Double>
     this.id = id;
     this.clock = clock;
     this.value = new AtomicDouble(Double.NaN);
-    this.lastUpdated = new AtomicLong(0L);
+    this.lastUpdated = new AtomicLong(clock.wallTime());
   }
 
   @Override public Id id() {

--- a/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoTimer.java
+++ b/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoTimer.java
@@ -66,7 +66,7 @@ class ServoTimer extends AbstractTimer implements ServoMeter {
     // Constructor that takes a clock param is not public
     servoMax = new MaxGauge(r.toMonitorConfig(id.withTag(Statistic.max), null));
 
-    lastUpdated = new AtomicLong(0L);
+    lastUpdated = new AtomicLong(clock.wallTime());
   }
 
   @Override public void addMonitors(List<Monitor<?>> monitors) {

--- a/spectator-reg-servo/src/test/java/com/netflix/spectator/servo/ServoCounterTest.java
+++ b/spectator-reg-servo/src/test/java/com/netflix/spectator/servo/ServoCounterTest.java
@@ -58,10 +58,10 @@ public class ServoCounterTest {
     final long initTime = TimeUnit.MINUTES.toMillis(30);
     final long fifteenMinutes = TimeUnit.MINUTES.toMillis(15);
 
-    // Expired on init, wait for activity to mark as active
+    // Not expired on init, wait for activity to mark as active
     clock.setWallTime(initTime);
     Counter c = newCounter("foo");
-    Assert.assertTrue(c.hasExpired());
+    Assert.assertFalse(c.hasExpired());
     c.increment(42);
     Assert.assertFalse(c.hasExpired());
 

--- a/spectator-reg-servo/src/test/java/com/netflix/spectator/servo/ServoGaugeTest.java
+++ b/spectator-reg-servo/src/test/java/com/netflix/spectator/servo/ServoGaugeTest.java
@@ -70,10 +70,10 @@ public class ServoGaugeTest {
     final long initTime = TimeUnit.MINUTES.toMillis(30);
     final long fifteenMinutes = TimeUnit.MINUTES.toMillis(15);
 
-    // Expired on init, wait for activity to mark as active
+    // Not expired on init, wait for activity to mark as active
     clock.setWallTime(initTime);
     Gauge g = newGauge("foo");
-    Assert.assertTrue(g.hasExpired());
+    Assert.assertFalse(g.hasExpired());
     g.set(42.0);
     Assert.assertFalse(g.hasExpired());
     Assert.assertEquals(g.value(), 42.0, 1e-12);

--- a/spectator-reg-servo/src/test/java/com/netflix/spectator/servo/ServoTimerTest.java
+++ b/spectator-reg-servo/src/test/java/com/netflix/spectator/servo/ServoTimerTest.java
@@ -215,10 +215,10 @@ public class ServoTimerTest {
     final long initTime = TimeUnit.MINUTES.toMillis(30);
     final long fifteenMinutes = TimeUnit.MINUTES.toMillis(15);
 
-    // Expired on init, wait for activity to mark as active
+    // Not expired on init, wait for activity to mark as active
     clock.setWallTime(initTime);
     Timer t = newTimer("foo");
-    Assert.assertTrue(t.hasExpired());
+    Assert.assertFalse(t.hasExpired());
     t.record(1, TimeUnit.SECONDS);
     Assert.assertFalse(t.hasExpired());
 


### PR DESCRIPTION
The SwapTimer implementation allows us to swap or null out
the underlying timer implementation and recreate it if the
user still had a reference somewhere and there is new
activity.

There was a bug in the record calls that took a lambda where
it would cache the underlying timer before the lambda was
called and reuse it again after. For a lambda with a longer
duration, it was quite likely the underlying timer would be
removed before this completed and the update would get dropped.

This change also modifies the initial state of the meters when
first created to not be expired. Before they were initially
expired until the first activity occurred.