### PR TITLE
fix secondary expiration of cached meter

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/CompositeRegistry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/CompositeRegistry.java
@@ -101,7 +101,10 @@ public final class CompositeRegistry implements Registry {
     wlock.lock();
     try {
       registries.clear();
-      updateMeters();
+      counters.clear();
+      distSummaries.clear();
+      timers.clear();
+      gauges.clear();
     } finally {
       wlock.unlock();
     }

--- a/spectator-api/src/main/java/com/netflix/spectator/api/NoopCounter.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/NoopCounter.java
@@ -27,7 +27,7 @@ enum NoopCounter implements Counter {
   }
 
   @Override public boolean hasExpired() {
-    return true;
+    return false;
   }
 
   @Override public void add(double amount) {

--- a/spectator-api/src/main/java/com/netflix/spectator/api/NoopDistributionSummary.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/NoopDistributionSummary.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 Netflix, Inc.
+/*
+ * Copyright 2014-2018 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ enum NoopDistributionSummary implements DistributionSummary {
   }
 
   @Override public boolean hasExpired() {
-    return true;
+    return false;
   }
 
   @Override public void record(long amount) {

--- a/spectator-api/src/main/java/com/netflix/spectator/api/NoopGauge.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/NoopGauge.java
@@ -31,7 +31,7 @@ enum NoopGauge implements Gauge {
   }
 
   @Override public boolean hasExpired() {
-    return true;
+    return false;
   }
 
   @Override public void set(double v) {

--- a/spectator-api/src/main/java/com/netflix/spectator/api/NoopTimer.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/NoopTimer.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 Netflix, Inc.
+/*
+ * Copyright 2014-2018 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ enum NoopTimer implements Timer {
   }
 
   @Override public boolean hasExpired() {
-    return true;
+    return false;
   }
 
   @Override public void record(long amount, TimeUnit unit) {

--- a/spectator-api/src/main/java/com/netflix/spectator/api/SwapMaxGauge.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/SwapMaxGauge.java
@@ -17,23 +17,23 @@ package com.netflix.spectator.api;
 
 import com.netflix.spectator.impl.SwapMeter;
 
-/** Wraps another counter allowing the underlying type to be swapped. */
-final class SwapCounter extends SwapMeter<Counter> implements Counter {
+/** Wraps another gauge allowing the underlying type to be swapped. */
+final class SwapMaxGauge extends SwapMeter<Gauge> implements Gauge {
 
   /** Create a new instance. */
-  SwapCounter(Registry registry, Id id, Counter underlying) {
+  SwapMaxGauge(Registry registry, Id id, Gauge underlying) {
     super(registry, id, underlying);
   }
 
-  @Override public Counter lookup() {
-    return registry.counter(id);
+  @Override public Gauge lookup() {
+    return registry.maxGauge(id);
   }
 
-  @Override public void add(double amount) {
-    get().add(amount);
+  @Override public void set(double value) {
+    get().set(value);
   }
 
-  @Override public double actualCount() {
-    return get().actualCount();
+  @Override public double value() {
+    return get().value();
   }
 }

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/SwapMeter.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/SwapMeter.java
@@ -15,7 +15,10 @@
  */
 package com.netflix.spectator.impl;
 
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Measurement;
 import com.netflix.spectator.api.Meter;
+import com.netflix.spectator.api.Registry;
 
 /**
  * Base type for meters that allow the underlying implementation to be replaced with
@@ -25,14 +28,66 @@ import com.netflix.spectator.api.Meter;
  * <p><b>This class is an internal implementation detail only intended for use within
  * spectator. It is subject to change without notice.</b></p>
  */
-public interface SwapMeter<T extends Meter> extends Meter {
+public abstract class SwapMeter<T extends Meter> implements Meter {
+
+  /** Registry used to lookup values after expiration. */
+  protected final Registry registry;
+
+  /** Id to use when performing a lookup after expiration. */
+  protected final Id id;
+
+  /** Current meter to delegate operations. */
+  private volatile T underlying;
+
+  /** Create a new instance. */
+  public SwapMeter(Registry registry, Id id, T underlying) {
+    this.registry = registry;
+    this.id = id;
+    this.underlying = unwrap(underlying);
+  }
+
+  /**
+   * Lookup the meter from the registry.
+   */
+  public abstract T lookup();
+
+  @Override public Id id() {
+    return id;
+  }
+
+  @Override public Iterable<Measurement> measure() {
+    return get().measure();
+  }
+
+  @Override public boolean hasExpired() {
+    return underlying.hasExpired();
+  }
 
   /**
    * Set the underlying instance of the meter to use. This can be set to {@code null}
    * to indicate that the meter has expired and is no longer in the registry.
    */
-  void set(T meter);
+  public void set(T meter) {
+    underlying = unwrap(meter);
+  }
 
   /** Return the underlying instance of the meter. */
-  T get();
+  public T get() {
+    if (underlying.hasExpired()) {
+      underlying = unwrap(lookup());
+    }
+    return underlying;
+  }
+
+  /**
+   * If the values are nested, then unwrap any that have the same registry instance.
+   */
+  @SuppressWarnings("unchecked")
+  private T unwrap(T meter) {
+    T tmp = meter;
+    while (tmp instanceof SwapMeter<?> && registry == ((SwapMeter<?>) tmp).registry) {
+      tmp = ((SwapMeter<T>) tmp).underlying;
+    }
+    return tmp;
+  }
 }

--- a/spectator-api/src/test/java/com/netflix/spectator/api/CompositeRegistryTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/CompositeRegistryTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 Netflix, Inc.
+/*
+ * Copyright 2014-2018 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -141,6 +141,7 @@ public class CompositeRegistryTest {
   public void testCounterBadTypeAccessNoThrow() {
     Registry r = newRegistry(5, false);
     r.counter(r.createId("foo")).count();
+    Counter c = r.counter("foo");
     DistributionSummary ds = r.distributionSummary(r.createId("foo"));
     ds.record(42);
     Assert.assertEquals(ds.count(), 0L);
@@ -245,7 +246,7 @@ public class CompositeRegistryTest {
     CompositeRegistry r = new CompositeRegistry(clock);
 
     Counter c1 = r.counter("id1");
-    Assert.assertTrue(c1.hasExpired());
+    Assert.assertFalse(c1.hasExpired());
 
     Registry r1 = new DefaultRegistry(clock);
     r.add(r1);

--- a/spectator-api/src/test/java/com/netflix/spectator/api/ExpiringRegistry.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/ExpiringRegistry.java
@@ -52,7 +52,34 @@ public class ExpiringRegistry extends AbstractRegistry {
   }
 
   @Override protected DistributionSummary newDistributionSummary(Id id) {
-    return null;
+    return new DistributionSummary() {
+      private final long creationTime = clock().wallTime();
+      private long count = 0;
+
+      @Override public void record(long amount) {
+        ++count;
+      }
+
+      @Override public long count() {
+        return count;
+      }
+
+      @Override public long totalAmount() {
+        return 0;
+      }
+
+      @Override public Id id() {
+        return id;
+      }
+
+      @Override public Iterable<Measurement> measure() {
+        return Collections.emptyList();
+      }
+
+      @Override public boolean hasExpired() {
+        return clock().wallTime() > creationTime;
+      }
+    };
   }
 
   @Override protected Timer newTimer(Id id) {
@@ -87,11 +114,34 @@ public class ExpiringRegistry extends AbstractRegistry {
   }
 
   @Override protected Gauge newGauge(Id id) {
-    return null;
+    return new Gauge() {
+      private final long creationTime = clock().wallTime();
+      private double value = 0.0;
+
+      @Override public void set(double v) {
+        value = v;
+      }
+
+      @Override public double value() {
+        return value;
+      }
+
+      @Override public Id id() {
+        return id;
+      }
+
+      @Override public Iterable<Measurement> measure() {
+        return Collections.emptyList();
+      }
+
+      @Override public boolean hasExpired() {
+        return clock().wallTime() > creationTime;
+      }
+    };
   }
 
   @Override protected Gauge newMaxGauge(Id id) {
-    return null;
+    return newGauge(id);
   }
 
   @Override public void removeExpiredMeters() {

--- a/spectator-api/src/test/java/com/netflix/spectator/api/NoopCounterTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/NoopCounterTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 Netflix, Inc.
+/*
+ * Copyright 2014-2018 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ public class NoopCounterTest {
   @Test
   public void testId() {
     Assert.assertEquals(NoopCounter.INSTANCE.id(), NoopId.INSTANCE);
-    Assert.assertTrue(NoopCounter.INSTANCE.hasExpired());
+    Assert.assertFalse(NoopCounter.INSTANCE.hasExpired());
   }
 
   @Test

--- a/spectator-api/src/test/java/com/netflix/spectator/api/NoopDistributionSummaryTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/NoopDistributionSummaryTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 Netflix, Inc.
+/*
+ * Copyright 2014-2018 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ public class NoopDistributionSummaryTest {
   @Test
   public void testId() {
     Assert.assertEquals(NoopDistributionSummary.INSTANCE.id(), NoopId.INSTANCE);
-    Assert.assertTrue(NoopDistributionSummary.INSTANCE.hasExpired());
+    Assert.assertFalse(NoopDistributionSummary.INSTANCE.hasExpired());
   }
 
   @Test

--- a/spectator-api/src/test/java/com/netflix/spectator/api/NoopTimerTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/NoopTimerTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 Netflix, Inc.
+/*
+ * Copyright 2014-2018 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ public class NoopTimerTest {
   @Test
   public void testId() {
     Assert.assertEquals(NoopTimer.INSTANCE.id(), NoopId.INSTANCE);
-    Assert.assertTrue(NoopTimer.INSTANCE.hasExpired());
+    Assert.assertFalse(NoopTimer.INSTANCE.hasExpired());
   }
 
   @Test

--- a/spectator-api/src/test/java/com/netflix/spectator/api/SpectatorTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/SpectatorTest.java
@@ -37,7 +37,7 @@ public class SpectatorTest {
     boolean found = false;
     Counter counter = dflt.counter("testCounter");
     for (Meter m : global) {
-      found = m.id().equals(counter.id());
+      found |= m.id().equals(counter.id());
     }
     Assert.assertTrue("id for sub-registry could not be found in global iterator", found);
   }

--- a/spectator-reg-servo/src/test/java/com/netflix/spectator/servo/ServoRegistryTest.java
+++ b/spectator-reg-servo/src/test/java/com/netflix/spectator/servo/ServoRegistryTest.java
@@ -123,4 +123,29 @@ public class ServoRegistryTest {
     Assert.assertEquals(0, registry.counters().count());
   }
 
+  @Test
+  public void resurrectExpiredAndIncrement() {
+    ManualClock clock = new ManualClock();
+    ServoRegistry registry = new ServoRegistry(clock);
+    Counter c = registry.counter("test");
+
+    clock.setWallTime(60000 * 30);
+    registry.getMonitors();
+
+    Assert.assertTrue(c.hasExpired());
+
+    c.increment();
+    Assert.assertEquals(1, c.count());
+    Assert.assertEquals(1, registry.counter("test").count());
+
+    clock.setWallTime(60000 * 60);
+    registry.getMonitors();
+
+    Assert.assertTrue(c.hasExpired());
+
+    c.increment();
+    Assert.assertEquals(1, c.count());
+    Assert.assertEquals(1, registry.counter("test").count());
+  }
+
 }


### PR DESCRIPTION
If there was a cached reference to a meter and it expired
more than once, then it would be updating a dangling meter
that is no longer connected to the registry.

The first expiration would work because the SwapMeter in
the registry and the SwapMeter referenced by the user are
the same. After that, the SwapMeter in the registry is
different and so it would not null out the value for the
cached copy and force a new lookup. This has been simplified
to just check for expiration of the underlying meter and
perform a lookup if expired.