### PR TITLE
add utility for parsing server groups

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,8 +71,8 @@ subprojects {
     testCompile 'junit:junit'
     testCompile 'nl.jqno.equalsverifier:equalsverifier'
     jmh "org.slf4j:slf4j-simple"
-    jmh "org.openjdk.jmh:jmh-core:1.17"
-    jmh "org.openjdk.jmh:jmh-generator-annprocess:1.17"
+    jmh "org.openjdk.jmh:jmh-core:1.19"
+    jmh "org.openjdk.jmh:jmh-generator-annprocess:1.19"
   }
 
   jmh {
@@ -81,8 +81,10 @@ subprojects {
     iterations = 10
     fork = 1
     threads = 1
-    profilers = ['stack']
-    include = ['.*Ids.*']
+    profilers = ['stack', 'gc']
+    includeTests = false
+    duplicateClassesStrategy = 'warn'
+    include = ['.*ServerGroupParsing.*']
   }
 
   jacoco {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-all.zip

--- a/spectator-ext-ipc/build.gradle
+++ b/spectator-ext-ipc/build.gradle
@@ -1,5 +1,7 @@
 dependencies {
   compileApi project(':spectator-api')
+  jmh 'com.netflix.frigga:frigga:0.18.0'
+  testCompile 'com.netflix.frigga:frigga:0.18.0'
 }
 
 jar {

--- a/spectator-ext-ipc/src/jmh/java/com/netflix/spectator/ipc/ServerGroupParsing.java
+++ b/spectator-ext-ipc/src/jmh/java/com/netflix/spectator/ipc/ServerGroupParsing.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.ipc;
+
+import com.netflix.frigga.Names;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+
+/**
+ * <h3>Throughput</h3>
+ *
+ * <pre>
+ * Benchmark                Mode  Cnt        Score       Error   Units
+ * charSequence            thrpt   10  3216353.588 ± 87966.348   ops/s
+ * string                  thrpt   10  2476131.141 ± 32765.943   ops/s
+ * frigga                  thrpt   10    11745.242 ±  2367.298   ops/s
+ * </pre>
+ *
+ * <h3>Allocations</h3>
+ *
+ * <pre>
+ * Benchmark                Mode  Cnt        Score       Error   Units
+ * charSequence            thrpt   10      784.171 ±     0.006    B/op
+ * string                  thrpt   10     1120.221 ±     0.005    B/op
+ * frigga                  thrpt   10   124987.101 ±    11.368    B/op
+ * </pre>
+ */
+@State(Scope.Thread)
+public class ServerGroupParsing {
+
+  private final String[] asgs = {
+      "application_name",
+      "application_name-stack",
+      "application_name-stack-detail",
+      "application_name-stack-detail_1-detail_2",
+      "application_name--detail",
+      "application_name-v001",
+      "application_name-stack-v001",
+      "application_name-stack-detail-v001",
+      "application_name-stack-detail_1-detail_2-v001",
+      "application_name--detail-v001"
+  };
+
+  @Benchmark
+  public void string(Blackhole bh) {
+    for (String asg : asgs) {
+      StringServerGroup group = StringServerGroup.parse(asg);
+      bh.consume(group.app());
+      bh.consume(group.cluster());
+    }
+  }
+
+  @Benchmark
+  public void charSequence(Blackhole bh) {
+    for (String asg : asgs) {
+      ServerGroup group = ServerGroup.parse(asg);
+      bh.consume(group.app());
+      bh.consume(group.cluster());
+    }
+  }
+
+  @Benchmark
+  public void frigga(Blackhole bh) {
+    for (String asg : asgs) {
+      Names group = Names.parseName(asg);
+      bh.consume(group.getApp());
+      bh.consume(group.getCluster());
+    }
+  }
+
+}

--- a/spectator-ext-ipc/src/jmh/java/com/netflix/spectator/ipc/StringServerGroup.java
+++ b/spectator-ext-ipc/src/jmh/java/com/netflix/spectator/ipc/StringServerGroup.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.ipc;
+
+import java.util.Objects;
+
+/**
+ * This is an alternate implementation that uses String for everything rather than wrapping
+ * with a CharBuffer to reduce allocations. It is used for the benchmark to verify that the
+ * CharBuffer approach actually provides a benefit.
+ */
+public class StringServerGroup {
+
+  /**
+   * Create a new instance of a server group object by parsing the group name.
+   */
+  public static StringServerGroup parse(String asg) {
+    int d1 = asg.indexOf('-');
+    int d2 = asg.indexOf('-', d1 + 1);
+    int dN = asg.lastIndexOf('-');
+    if (dN < 0 || !isSequence(asg, dN)) {
+      dN = asg.length();
+    }
+    return new StringServerGroup(asg, d1, d2, dN);
+  }
+
+  /**
+   * Check if the last portion of the server group name is a version sequence (v\d+).
+   */
+  private static boolean isSequence(String asg, int dN) {
+    int length = asg.length();
+    if (length - dN < 3 || asg.charAt(dN + 1) != 'v') {
+      return false;
+    }
+    for (int i = dN + 2; i < length; ++i) {
+      if (!Character.isDigit(asg.charAt(i))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * The substring method will create a copy of the substring in JDK 8 and probably newer
+   * versions. To reduce the number of allocations we use a char buffer to return a view
+   * with just that subset.
+   */
+  private static String substr(String str, int s, int e) {
+    return (s >= e) ? null : str.substring(s, e);
+  }
+
+  private final String asg;
+  private final int d1;
+  private final int d2;
+  private final int dN;
+
+  StringServerGroup(String asg, int d1, int d2, int dN) {
+    this.asg = asg;
+    this.d1 = d1;
+    this.d2 = d2;
+    this.dN = dN;
+  }
+
+  public String app() {
+    if (d1 < 0) {
+      // No stack or detail is present
+      return asg.length() > 0 ? asg : null;
+    } else if (d1 == 0) {
+      // Application portion is empty
+      return null;
+    } else {
+      // Application is present along with stack, detail, or sequence
+      return substr(asg, 0, d1);
+    }
+  }
+
+  public String cluster() {
+    if (d1 == 0) {
+      // Application portion is empty
+      return null;
+    } else {
+      return (dN > 0 && dN == asg.length()) ? asg() : substr(asg, 0, dN);
+    }
+  }
+
+  public String asg() {
+    return (d1 != 0 && dN > 0) ? asg : null;
+  }
+
+  public String stack() {
+    if (d1 <= 0) {
+      // No stack, detail or sequence is present
+      return null;
+    } else if (d2 < 0) {
+      // Stack, but no detail is present
+      return substr(asg, d1 + 1, dN);
+    } else {
+      // Stack and at least one of detail or sequence is present
+      return substr(asg, d1 + 1, d2);
+    }
+  }
+
+  public String detail() {
+    return (d1 != 0 && d2 > 0) ? substr(asg, d2 + 1, dN) : null;
+  }
+
+  @Override public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    StringServerGroup that = (StringServerGroup) o;
+    return d1 == that.d1 &&
+        d2 == that.d2 &&
+        dN == that.dN &&
+        Objects.equals(asg, that.asg);
+  }
+
+  @Override public int hashCode() {
+    return Objects.hash(asg, d1, d2, dN);
+  }
+
+  @Override public String toString() {
+    return "StringServerGroup(" + asg + ", " + d1 + ", " + d2 + ", " + dN + ")";
+  }
+}

--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/ServerGroup.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/ServerGroup.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.ipc;
+
+import java.nio.CharBuffer;
+import java.util.Objects;
+
+/**
+ * Helper for parsing Netflix server group names that follow the Frigga conventions. For
+ * more information see the IEP documentation for
+ * <a href="https://github.com/Netflix/iep/tree/master/iep-nflxenv#server-group-settings">server groups</a>.
+ *
+ * <p>Frigga is not used for the actual parsing as it is quite inefficient. See the
+ * ServerGroupParsing benchmark for a comparison.</p>
+ */
+public class ServerGroup {
+
+  /**
+   * Create a new instance of a server group object by parsing the group name.
+   */
+  public static ServerGroup parse(String asg) {
+    int d1 = asg.indexOf('-');
+    int d2 = asg.indexOf('-', d1 + 1);
+    int dN = asg.lastIndexOf('-');
+    if (dN < 0 || !isSequence(asg, dN)) {
+      dN = asg.length();
+    }
+    return new ServerGroup(asg, d1, d2, dN);
+  }
+
+  /**
+   * Check if the last portion of the server group name is a version sequence (v\d+).
+   */
+  private static boolean isSequence(String asg, int dN) {
+    int length = asg.length();
+    if (length - dN < 3 || asg.charAt(dN + 1) != 'v') {
+      return false;
+    }
+    for (int i = dN + 2; i < length; ++i) {
+      if (!Character.isDigit(asg.charAt(i))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * The substring method will create a copy of the substring in JDK 8 and probably newer
+   * versions. To reduce the number of allocations we use a char buffer to return a view
+   * with just that subset.
+   */
+  private static CharSequence substr(CharSequence str, int s, int e) {
+    return (s >= e) ? null : CharBuffer.wrap(str, s, e);
+  }
+
+  private final CharSequence asg;
+  private final int d1;
+  private final int d2;
+  private final int dN;
+
+  /**
+   * Create a new instance of the server group.
+   *
+   * @param asg
+   *     Raw group name received from the user.
+   * @param d1
+   *     Position of the first dash or -1 if there are no dashes in the input.
+   * @param d2
+   *     Position of the second dash or -1 if there is not a second dash in the input.
+   * @param dN
+   *     Position indicating the end of the cluster name. For a server group with a
+   *     sequence this will be the final dash. If the sequence is not present, then
+   *     it will be the end of the string.
+   */
+  ServerGroup(CharSequence asg, int d1, int d2, int dN) {
+    this.asg = asg;
+    this.d1 = d1;
+    this.d2 = d2;
+    this.dN = dN;
+  }
+
+  /** Return the application for the server group or null if invalid. */
+  public CharSequence app() {
+    if (d1 < 0) {
+      // No stack or detail is present
+      return asg.length() > 0 ? asg : null;
+    } else if (d1 == 0) {
+      // Application portion is empty
+      return null;
+    } else {
+      // Application is present along with stack, detail, or sequence
+      return substr(asg, 0, d1);
+    }
+  }
+
+  /** Return the cluster name for the server group or null if invalid. */
+  public CharSequence cluster() {
+    if (d1 == 0) {
+      // Application portion is empty
+      return null;
+    } else {
+      return (dN > 0 && dN == asg.length()) ? asg() : substr(asg, 0, dN);
+    }
+  }
+
+  /** Return the server group name or null if invalid. */
+  public CharSequence asg() {
+    return (d1 != 0 && dN > 0) ? asg : null;
+  }
+
+  /** If the server group has a stack, then return the stack name. Otherwise return null. */
+  public CharSequence stack() {
+    if (d1 <= 0) {
+      // No stack, detail or sequence is present
+      return null;
+    } else if (d2 < 0) {
+      // Stack, but no detail is present
+      return substr(asg, d1 + 1, dN);
+    } else {
+      // Stack and at least one of detail or sequence is present
+      return substr(asg, d1 + 1, d2);
+    }
+  }
+
+  /** If the server group has a detail, then return the detail name. Otherwise return null. */
+  public CharSequence detail() {
+    return (d1 != 0 && d2 > 0) ? substr(asg, d2 + 1, dN) : null;
+  }
+
+  @Override public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    ServerGroup that = (ServerGroup) o;
+    return d1 == that.d1
+        && d2 == that.d2
+        && dN == that.dN
+        && Objects.equals(asg, that.asg);
+  }
+
+  @Override public int hashCode() {
+    return Objects.hash(asg, d1, d2, dN);
+  }
+
+  @Override public String toString() {
+    return "ServerGroup(" + asg + ", " + d1 + ", " + d2 + ", " + dN + ")";
+  }
+}

--- a/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/ServerGroupTest.java
+++ b/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/ServerGroupTest.java
@@ -1,0 +1,500 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.ipc;
+
+import com.netflix.frigga.Names;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.Random;
+
+@RunWith(JUnit4.class)
+public class ServerGroupTest {
+
+  @Test
+  public void parseApp() {
+    String asg = "app";
+    ServerGroup expected = new ServerGroup(asg, -1, -1, asg.length());
+    Assert.assertEquals(expected, ServerGroup.parse(asg));
+  }
+
+  @Test
+  public void getAppForApp() {
+    String asg = "app";
+    Assert.assertEquals("app", ServerGroup.parse(asg).app());
+  }
+
+  @Test
+  public void getClusterForApp() {
+    String asg = "app";
+    Assert.assertEquals("app", ServerGroup.parse(asg).cluster());
+  }
+
+  @Test
+  public void getAsgForApp() {
+    String asg = "app";
+    Assert.assertEquals("app", ServerGroup.parse(asg).asg());
+  }
+
+  @Test
+  public void getStackForApp() {
+    String asg = "app";
+    Assert.assertNull(ServerGroup.parse(asg).stack());
+  }
+
+  @Test
+  public void getDetailForApp() {
+    String asg = "app";
+    Assert.assertNull(ServerGroup.parse(asg).detail());
+  }
+
+  @Test
+  public void parseAppStack() {
+    String asg = "app-stack";
+    ServerGroup expected = new ServerGroup(asg, 3, -1, asg.length());
+    Assert.assertEquals(expected, ServerGroup.parse(asg));
+  }
+
+  @Test
+  public void getAppForAppStack() {
+    String asg = "app-stack";
+    Assert.assertEquals("app", ServerGroup.parse(asg).app().toString());
+  }
+
+  @Test
+  public void getClusterForAppStack() {
+    String asg = "app-stack";
+    Assert.assertEquals("app-stack", ServerGroup.parse(asg).cluster().toString());
+  }
+
+  @Test
+  public void getAsgForAppStack() {
+    String asg = "app-stack";
+    Assert.assertEquals("app-stack", ServerGroup.parse(asg).asg().toString());
+  }
+
+  @Test
+  public void getStackForAppStack() {
+    String asg = "app-stack";
+    Assert.assertEquals("stack", ServerGroup.parse(asg).stack().toString());
+  }
+
+  @Test
+  public void getDetailForAppStack() {
+    String asg = "app-stack";
+    Assert.assertNull(ServerGroup.parse(asg).detail());
+  }
+
+  @Test
+  public void parseAppStackDetail() {
+    String asg = "app-stack-detail";
+    ServerGroup expected = new ServerGroup(asg, 3, 9, asg.length());
+    Assert.assertEquals(expected, ServerGroup.parse(asg));
+  }
+
+  @Test
+  public void getAppForAppStackDetail() {
+    String asg = "app-stack-detail";
+    Assert.assertEquals("app", ServerGroup.parse(asg).app().toString());
+  }
+
+  @Test
+  public void getClusterForAppStackDetail() {
+    String asg = "app-stack-detail";
+    Assert.assertEquals("app-stack-detail", ServerGroup.parse(asg).cluster().toString());
+  }
+
+  @Test
+  public void getAsgForAppStackDetail() {
+    String asg = "app-stack-detail";
+    Assert.assertEquals("app-stack-detail", ServerGroup.parse(asg).asg().toString());
+  }
+
+  @Test
+  public void getStackForAppStackDetail() {
+    String asg = "app-stack-detail";
+    Assert.assertEquals("stack", ServerGroup.parse(asg).stack().toString());
+  }
+
+  @Test
+  public void getDetailForAppStackDetail() {
+    String asg = "app-stack-detail";
+    Assert.assertEquals("detail", ServerGroup.parse(asg).detail().toString());
+  }
+
+  @Test
+  public void parseAppStackDetails() {
+    String asg = "app-stack-detail_1-detail_2";
+    ServerGroup expected = new ServerGroup(asg, 3, 9, asg.length());
+    Assert.assertEquals(expected, ServerGroup.parse(asg));
+  }
+
+  @Test
+  public void getAppForAppStackDetails() {
+    String asg = "app-stack-detail_1-detail_2";
+    Assert.assertEquals("app", ServerGroup.parse(asg).app().toString());
+  }
+
+  @Test
+  public void getClusterForAppStackDetails() {
+    String asg = "app-stack-detail_1-detail_2";
+    Assert.assertEquals("app-stack-detail_1-detail_2", ServerGroup.parse(asg).cluster().toString());
+  }
+
+  @Test
+  public void getAsgForAppStackDetails() {
+    String asg = "app-stack-detail_1-detail_2";
+    Assert.assertEquals("app-stack-detail_1-detail_2", ServerGroup.parse(asg).asg().toString());
+  }
+
+  @Test
+  public void getStackForAppStackDetails() {
+    String asg = "app-stack-detail_1-detail_2";
+    Assert.assertEquals("stack", ServerGroup.parse(asg).stack().toString());
+  }
+
+  @Test
+  public void getDetailForAppStackDetails() {
+    String asg = "app-stack-detail_1-detail_2";
+    Assert.assertEquals("detail_1-detail_2", ServerGroup.parse(asg).detail().toString());
+  }
+
+  @Test
+  public void parseAppDetail() {
+    String asg = "app--detail";
+    ServerGroup expected = new ServerGroup(asg, 3, 4, asg.length());
+    Assert.assertEquals(expected, ServerGroup.parse(asg));
+  }
+
+  @Test
+  public void getAppForAppDetail() {
+    String asg = "app--detail";
+    Assert.assertEquals("app", ServerGroup.parse(asg).app().toString());
+  }
+
+  @Test
+  public void getClusterForAppDetail() {
+    String asg = "app--detail";
+    Assert.assertEquals("app--detail", ServerGroup.parse(asg).cluster().toString());
+  }
+
+  @Test
+  public void getAsgForAppDetail() {
+    String asg = "app--detail";
+    Assert.assertEquals("app--detail", ServerGroup.parse(asg).asg().toString());
+  }
+
+  @Test
+  public void getStackForAppDetail() {
+    String asg = "app--detail";
+    Assert.assertNull(ServerGroup.parse(asg).stack());
+  }
+
+  @Test
+  public void getDetailForAppDetail() {
+    String asg = "app--detail";
+    Assert.assertEquals("detail", ServerGroup.parse(asg).detail().toString());
+  }
+
+  @Test
+  public void parseAppSeq() {
+    String asg = "app-v001";
+    ServerGroup expected = new ServerGroup(asg, 3, -1, asg.length() - 5);
+    Assert.assertEquals(expected, ServerGroup.parse(asg));
+  }
+
+  @Test
+  public void getAppForAppSeq() {
+    String asg = "app-v001";
+    Assert.assertEquals("app", ServerGroup.parse(asg).app().toString());
+  }
+
+  @Test
+  public void getClusterForAppSeq() {
+    String asg = "app-v001";
+    Assert.assertEquals("app", ServerGroup.parse(asg).cluster().toString());
+  }
+
+  @Test
+  public void getAsgForAppSeq() {
+    String asg = "app-v001";
+    Assert.assertEquals("app-v001", ServerGroup.parse(asg).asg().toString());
+  }
+
+  @Test
+  public void getStackForAppSeq() {
+    String asg = "app-v001";
+    Assert.assertNull(ServerGroup.parse(asg).stack());
+  }
+
+  @Test
+  public void getDetailForAppSeq() {
+    String asg = "app-v001";
+    Assert.assertNull(ServerGroup.parse(asg).detail());
+  }
+
+  @Test
+  public void parseAppStackSeq() {
+    String asg = "app-stack-v001";
+    ServerGroup expected = new ServerGroup(asg, 3, 9, asg.length() - 5);
+    Assert.assertEquals(expected, ServerGroup.parse(asg));
+  }
+
+  @Test
+  public void getAppForAppStackSeq() {
+    String asg = "app-stack-v001";
+    Assert.assertEquals("app", ServerGroup.parse(asg).app().toString());
+  }
+
+  @Test
+  public void getClusterForAppStackSeq() {
+    String asg = "app-stack-v001";
+    Assert.assertEquals("app-stack", ServerGroup.parse(asg).cluster().toString());
+  }
+
+  @Test
+  public void getAsgForAppStackSeq() {
+    String asg = "app-stack-v001";
+    Assert.assertEquals("app-stack-v001", ServerGroup.parse(asg).asg().toString());
+  }
+
+  @Test
+  public void getStackForAppStackSeq() {
+    String asg = "app-stack-v001";
+    Assert.assertEquals("stack", ServerGroup.parse(asg).stack().toString());
+  }
+
+  @Test
+  public void getDetailForAppStackSeq() {
+    String asg = "app-stack-v001";
+    Assert.assertNull(ServerGroup.parse(asg).detail());
+  }
+
+  @Test
+  public void parseAppStackDetailSeq() {
+    String asg = "app-stack-detail-v001";
+    ServerGroup expected = new ServerGroup(asg, 3, 9, asg.length() - 5);
+    Assert.assertEquals(expected, ServerGroup.parse(asg));
+  }
+
+  @Test
+  public void getAppForAppStackDetailSeq() {
+    String asg = "app-stack-detail-v001";
+    Assert.assertEquals("app", ServerGroup.parse(asg).app().toString());
+  }
+
+  @Test
+  public void getClusterForAppStackDetailSeq() {
+    String asg = "app-stack-detail-v001";
+    Assert.assertEquals("app-stack-detail", ServerGroup.parse(asg).cluster().toString());
+  }
+
+  @Test
+  public void getAsgForAppStackDetailSeq() {
+    String asg = "app-stack-detail-v001";
+    Assert.assertEquals("app-stack-detail-v001", ServerGroup.parse(asg).asg().toString());
+  }
+
+  @Test
+  public void getStackForAppStackDetailSeq() {
+    String asg = "app-stack-detail-v001";
+    Assert.assertEquals("stack", ServerGroup.parse(asg).stack().toString());
+  }
+
+  @Test
+  public void getDetailForAppStackDetailSeq() {
+    String asg = "app-stack-detail-v001";
+    Assert.assertEquals("detail", ServerGroup.parse(asg).detail().toString());
+  }
+
+  @Test
+  public void parseAppStackDetailsSeq() {
+    String asg = "app-stack-detail_1-detail_2-v001";
+    ServerGroup expected = new ServerGroup(asg, 3, 9, asg.length() - 5);
+    Assert.assertEquals(expected, ServerGroup.parse(asg));
+  }
+
+  @Test
+  public void getAppForAppStackDetailsSeq() {
+    String asg = "app-stack-detail_1-detail_2-v001";
+    Assert.assertEquals("app", ServerGroup.parse(asg).app().toString());
+  }
+
+  @Test
+  public void getClusterForAppStackDetailsSeq() {
+    String asg = "app-stack-detail_1-detail_2-v001";
+    Assert.assertEquals("app-stack-detail_1-detail_2", ServerGroup.parse(asg).cluster().toString());
+  }
+
+  @Test
+  public void getAsgForAppStackDetailsSeq() {
+    String asg = "app-stack-detail_1-detail_2-v001";
+    Assert.assertEquals("app-stack-detail_1-detail_2-v001", ServerGroup.parse(asg).asg().toString());
+  }
+
+  @Test
+  public void getStackForAppStackDetailsSeq() {
+    String asg = "app-stack-detail_1-detail_2-v001";
+    Assert.assertEquals("stack", ServerGroup.parse(asg).stack().toString());
+  }
+
+  @Test
+  public void getDetailForAppStackDetailsSeq() {
+    String asg = "app-stack-detail_1-detail_2-v001";
+    Assert.assertEquals("detail_1-detail_2", ServerGroup.parse(asg).detail().toString());
+  }
+
+  @Test
+  public void parseAppDetailSeq() {
+    String asg = "app--detail-v001";
+    ServerGroup expected = new ServerGroup(asg, 3, 4, asg.length() - 5);
+    Assert.assertEquals(expected, ServerGroup.parse(asg));
+  }
+
+  @Test
+  public void getAppForAppDetailSeq() {
+    String asg = "app--detail-v001";
+    Assert.assertEquals("app", ServerGroup.parse(asg).app().toString());
+  }
+
+  @Test
+  public void getClusterForAppDetailSeq() {
+    String asg = "app--detail-v001";
+    Assert.assertEquals("app--detail", ServerGroup.parse(asg).cluster().toString());
+  }
+
+  @Test
+  public void getAsgForAppDetailSeq() {
+    String asg = "app--detail-v001";
+    Assert.assertEquals("app--detail-v001", ServerGroup.parse(asg).asg().toString());
+  }
+
+  @Test
+  public void getStackForAppDetailSeq() {
+    String asg = "app--detail-v001";
+    Assert.assertNull(ServerGroup.parse(asg).stack());
+  }
+
+  @Test
+  public void getDetailForAppDetailSeq() {
+    String asg = "app--detail-v001";
+    Assert.assertEquals("detail", ServerGroup.parse(asg).detail().toString());
+  }
+
+  @Test
+  public void parseEmptyApp() {
+    String asg = "-v1698";
+    ServerGroup expected = new ServerGroup(asg, 0, -1, 0);
+    Assert.assertEquals(expected, ServerGroup.parse(asg));
+  }
+
+  @Test
+  public void getAppEmptyApp() {
+    String asg = "-v1698";
+    Assert.assertNull(ServerGroup.parse(asg).app());
+  }
+
+  @Test
+  public void getClusterEmptyApp() {
+    String asg = "-v1698";
+    Assert.assertNull(ServerGroup.parse(asg).cluster());
+  }
+
+  @Test
+  public void parseEmptyString() {
+    String asg = "";
+    ServerGroup expected = new ServerGroup(asg, -1, -1, 0);
+    Assert.assertEquals(expected, ServerGroup.parse(asg));
+  }
+
+  @Test
+  public void getAppForEmptyString() {
+    String asg = "";
+    Assert.assertNull(ServerGroup.parse(asg).app());
+  }
+
+  @Test
+  public void getClusterForEmptyString() {
+    String asg = "";
+    Assert.assertNull(ServerGroup.parse(asg).cluster());
+  }
+
+  @Test
+  public void getAsgForEmptyString() {
+    String asg = "";
+    Assert.assertNull(ServerGroup.parse(asg).asg());
+  }
+
+  @Test
+  public void getStackForEmptyString() {
+    String asg = "";
+    Assert.assertNull(ServerGroup.parse(asg).stack());
+  }
+
+  @Test
+  public void getDetailForEmptyString() {
+    String asg = "";
+    Assert.assertNull(ServerGroup.parse(asg).detail());
+  }
+
+  private void appendRandomString(Random r, StringBuilder builder) {
+    int length = r.nextInt(20);
+    for (int i = 0; i < length; ++i) {
+      char c = (char) (r.nextInt(26) + 'a');
+      builder.append(c);
+    }
+  }
+
+  private String randomServerGroup(Random r) {
+    StringBuilder builder = new StringBuilder();
+    int parts = r.nextInt(6) + 1;
+    for (int i = 0; i < parts; ++i) {
+      if (r.nextBoolean()) {
+        appendRandomString(r, builder);
+      } else {
+        builder.append('v');
+        builder.append(r.nextInt(10000));
+      }
+      if (i != parts - 1) {
+        builder.append('-');
+      }
+    }
+    return builder.toString();
+  }
+
+  private String toStr(CharSequence s) {
+    return s == null ? null : s.toString();
+  }
+
+  @Test
+  public void compatibleWithFrigga() {
+    // Seed the RNG so that each run is deterministic. In this case we are just using it to
+    // generate a bunch of patterns to try
+    Random r = new Random(42);
+    for (int i = 0; i < 5000; ++i) {
+      String asg = randomServerGroup(r);
+      ServerGroup sg = ServerGroup.parse(asg);
+      Names frigga = Names.parseName(asg);
+      Assert.assertEquals("app: " + asg, frigga.getApp(), toStr(sg.app()));
+      Assert.assertEquals("cluster: " + asg, frigga.getCluster(), toStr(sg.cluster()));
+      Assert.assertEquals("asg: " + asg, frigga.getGroup(), toStr(sg.asg()));
+      Assert.assertEquals("stack: " + asg, frigga.getStack(), toStr(sg.stack()));
+      Assert.assertEquals("detail: " + asg, frigga.getDetail(), toStr(sg.detail()));
+    }
+  }
+}


### PR DESCRIPTION
For some of the IPC fields we may need to fill them in
using data passed via headers. To reduce the number of
headers the plan is to just send the server group and
rely on the [naming conventions] to extract the app and
cluster. Frigga is not used for the parsing as this
could be used in a hot path and it is rather inefficient.

Comparing throughput of this approach (spectator) with
the Frigga library (frigga):

```
Benchmark      Mode  Cnt        Score       Error   Units
spectator     thrpt   10  3216353.588 ± 87966.348   ops/s
frigga        thrpt   10    11745.242 ±  2367.298   ops/s
```

Comparing allocations:

```
Benchmark      Mode  Cnt        Score       Error   Units
spectator     thrpt   10      784.171 ±     0.006    B/op
frigga        thrpt   10   124987.101 ±    11.368    B/op
```

[naming conventions]: https://github.com/Netflix/iep/blob/master/iep-nflxenv/README.md#server-group-settings

/cc @twicksell @qiangdavidliu @kerumai 