### PR TITLE
fix loading of multiple configs for agent

### DIFF
--- a/spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java
+++ b/spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java
@@ -43,10 +43,11 @@ public final class Agent {
   private Agent() {
   }
 
-  private static Config loadConfig(String userResources) {
+  /** Helper to load config files specified by the user. */
+  static Config loadConfig(String userResources) {
     Config config = ConfigFactory.load("agent");
     if (userResources != null && !"".equals(userResources)) {
-      for (String userResource : userResources.split("[,\\s]+]")) {
+      for (String userResource : userResources.split("[,\\s]+")) {
         if (userResource.startsWith("file:")) {
           File file = new File(userResource.substring("file:".length()));
           LOGGER.info("loading configuration from file: {}", file);

--- a/spectator-agent/src/test/java/com/netflix/spectator/agent/AgentTest.java
+++ b/spectator-agent/src/test/java/com/netflix/spectator/agent/AgentTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.agent;
+
+import com.typesafe.config.Config;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class AgentTest {
+
+  @Test
+  public void loadConfigA() {
+    Config config = Agent.loadConfig("a");
+    Assert.assertEquals("a", config.getString("option"));
+    Assert.assertTrue(config.getBoolean("a"));
+  }
+
+  @Test
+  public void loadConfigAB() {
+    Config config = Agent.loadConfig("a,b");
+    Assert.assertEquals("b", config.getString("option"));
+    Assert.assertTrue(config.getBoolean("a"));
+    Assert.assertTrue(config.getBoolean("b"));
+  }
+
+  @Test
+  public void loadConfigABC() {
+    Config config = Agent.loadConfig("a\tb, \nc");
+    Assert.assertEquals("c", config.getString("option"));
+    Assert.assertTrue(config.getBoolean("a"));
+    Assert.assertTrue(config.getBoolean("b"));
+    Assert.assertTrue(config.getBoolean("c"));
+  }
+}

--- a/spectator-agent/src/test/resources/a.conf
+++ b/spectator-agent/src/test/resources/a.conf
@@ -1,0 +1,5 @@
+
+netflix.spectator.agent {
+  option = "a"
+  a = true
+}

--- a/spectator-agent/src/test/resources/b.conf
+++ b/spectator-agent/src/test/resources/b.conf
@@ -1,0 +1,5 @@
+
+netflix.spectator.agent {
+  option = "b"
+  b = true
+}

--- a/spectator-agent/src/test/resources/c.conf
+++ b/spectator-agent/src/test/resources/c.conf
@@ -1,0 +1,5 @@
+
+netflix.spectator.agent {
+  option = "c"
+  c = true
+}


### PR DESCRIPTION
There was a typo in the regex so it was not properly
splitting by the comma. This fixes the regex and adds
a test case for the config loading.

/cc @ebukoski