### PR TITLE
delay resolving agent configs

### DIFF
--- a/spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java
+++ b/spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java
@@ -51,16 +51,16 @@ public final class Agent {
         if (userResource.startsWith("file:")) {
           File file = new File(userResource.substring("file:".length()));
           LOGGER.info("loading configuration from file: {}", file);
-          Config user = ConfigFactory.parseFile(file).resolve();
+          Config user = ConfigFactory.parseFile(file);
           config = user.withFallback(config);
         } else {
           LOGGER.info("loading configuration from resource: {}", userResource);
-          Config user = ConfigFactory.load(userResource);
+          Config user = ConfigFactory.parseResourcesAnySyntax(userResource);
           config = user.withFallback(config);
         }
       }
     }
-    return config.getConfig("netflix.spectator.agent");
+    return config.resolve().getConfig("netflix.spectator.agent");
   }
 
   /**
@@ -82,6 +82,7 @@ public final class Agent {
   public static void premain(String arg, Instrumentation instrumentation) throws Exception {
     // Setup logging
     Config config = loadConfig(arg);
+    LOGGER.debug("loaded configuration: {}", config.root().render());
     createDependencyProperties(config);
 
     // Setup Registry

--- a/spectator-agent/src/test/java/com/netflix/spectator/agent/AgentTest.java
+++ b/spectator-agent/src/test/java/com/netflix/spectator/agent/AgentTest.java
@@ -21,6 +21,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 @RunWith(JUnit4.class)
 public class AgentTest {
 
@@ -46,5 +50,19 @@ public class AgentTest {
     Assert.assertTrue(config.getBoolean("a"));
     Assert.assertTrue(config.getBoolean("b"));
     Assert.assertTrue(config.getBoolean("c"));
+  }
+
+  @Test
+  public void loadConfigListsAppend() {
+    Config config = Agent.loadConfig("a,b,c");
+    List<String> items = config.getStringList("list");
+    Collections.sort(items);
+
+    List<String> expected = new ArrayList<>();
+    expected.add("a");
+    expected.add("b");
+    expected.add("c");
+
+    Assert.assertEquals(expected, items);
   }
 }

--- a/spectator-agent/src/test/resources/a.conf
+++ b/spectator-agent/src/test/resources/a.conf
@@ -2,4 +2,8 @@
 netflix.spectator.agent {
   option = "a"
   a = true
+
+  list = ${?netflix.spectator.agent.list} [
+    "a"
+  ]
 }

--- a/spectator-agent/src/test/resources/b.conf
+++ b/spectator-agent/src/test/resources/b.conf
@@ -2,4 +2,8 @@
 netflix.spectator.agent {
   option = "b"
   b = true
+
+  list = ${?netflix.spectator.agent.list} [
+    "b"
+  ]
 }

--- a/spectator-agent/src/test/resources/c.conf
+++ b/spectator-agent/src/test/resources/c.conf
@@ -2,4 +2,8 @@
 netflix.spectator.agent {
   option = "c"
   c = true
+
+  list = ${?netflix.spectator.agent.list} [
+    "c"
+  ]
 }

--- a/spectator-ext-jvm/src/main/java/com/netflix/spectator/jvm/JmxData.java
+++ b/spectator-ext-jvm/src/main/java/com/netflix/spectator/jvm/JmxData.java
@@ -51,6 +51,7 @@ class JmxData {
   }
 
   /** Convert object to string and checking if it fails. */
+  @SuppressWarnings("PMD.AvoidCatchingThrowable")
   static String mkString(Object obj) {
     if (obj == null) {
       return "null";


### PR DESCRIPTION
This delays the resolution of the user specfied agent
configs so that the mappings lists will merge properly
if multiple files are specified.

To aid in debugging the final loaded config is now logged
and the jmx query results and types can be enabled at the
TRACE level.

/cc @ebukoski 