### PR TITLE
add attempt final enum

### DIFF
--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcAttemptFinal.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcAttemptFinal.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.ipc;
+
+import com.netflix.spectator.api.Tag;
+
+/**
+ * Dimension indicating if it is the final attempt for a given request.
+ *
+ * @see IpcTagKey#attempt
+ * @see IpcTagKey#attemptFinal
+ */
+public enum IpcAttemptFinal implements Tag {
+  /** It is the final attempt for the request. */
+  is_true("true"),
+
+  /** Further attempts will be made if there is a retriable failure. */
+  is_false("false");
+
+  private final String value;
+
+  /** Create a new instance. */
+  IpcAttemptFinal(String value) {
+    this.value = value;
+  }
+
+  @Override public String key() {
+    return IpcTagKey.attemptFinal.key();
+  }
+
+  @Override public String value() {
+    return value;
+  }
+
+  /**
+   * Get the enum value associated with the boolean.
+   */
+  public static IpcAttemptFinal forValue(boolean v) {
+    return v ? is_true : is_false;
+  }
+}

--- a/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/IpcAttemptFinalTest.java
+++ b/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/IpcAttemptFinalTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.ipc;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class IpcAttemptFinalTest {
+
+  @Test
+  public void forValueTrue() {
+    Assert.assertEquals(IpcAttemptFinal.is_true, IpcAttemptFinal.forValue(true));
+  }
+
+  @Test
+  public void forValueFalse() {
+    Assert.assertEquals(IpcAttemptFinal.is_false, IpcAttemptFinal.forValue(false));
+  }
+}

--- a/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/IpcMetricTest.java
+++ b/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/IpcMetricTest.java
@@ -46,6 +46,26 @@ public class IpcMetricTest {
     IpcMetric.clientCall.validate(id);
   }
 
+  @Test
+  public void validateAttemptFinalTrue() {
+    Id id = registry.createId(IpcMetric.clientCall.metricName())
+        .withTag(IpcTagKey.owner.key(), "test")
+        .withTag(IpcResult.success)
+        .withTag(IpcAttempt.initial)
+        .withTag(IpcAttemptFinal.is_true);
+    IpcMetric.clientCall.validate(id);
+  }
+
+  @Test
+  public void validateAttemptFinalFalse() {
+    Id id = registry.createId(IpcMetric.clientCall.metricName())
+        .withTag(IpcTagKey.owner.key(), "test")
+        .withTag(IpcResult.success)
+        .withTag(IpcAttempt.initial)
+        .withTag(IpcAttemptFinal.is_false);
+    IpcMetric.clientCall.validate(id);
+  }
+
   @Test(expected = IllegalArgumentException.class)
   public void validateIdBadName() {
     Id id = registry.createId("ipc.client-call")


### PR DESCRIPTION
Internal users suggested this would be useful for
consistency. Since it was basically a boolean type
we left it out before.

/cc @kerumai 