### PR TITLE
add helper to create tag for ipc key

### DIFF
--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcTagKey.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcTagKey.java
@@ -15,6 +15,9 @@
  */
 package com.netflix.spectator.ipc;
 
+import com.netflix.spectator.api.BasicTag;
+import com.netflix.spectator.api.Tag;
+
 /**
  * Standard dimensions used for IPC metrics.
  */
@@ -154,5 +157,10 @@ public enum IpcTagKey {
   /** String to use as the tag key. */
   public String key() {
     return key;
+  }
+
+  /** Create a new tag with the specified value and this key. */
+  public Tag tag(String value) {
+    return new BasicTag(key, value);
   }
 }

--- a/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/IpcMetricTest.java
+++ b/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/IpcMetricTest.java
@@ -39,7 +39,7 @@ public class IpcMetricTest {
   @Test
   public void validateIdOk() {
     Id id = registry.createId(IpcMetric.clientCall.metricName())
-        .withTag(IpcTagKey.owner.key(), "test")
+        .withTag(IpcTagKey.owner.tag("test"))
         .withTag(IpcResult.success)
         .withTag(IpcAttempt.initial)
         .withTag(IpcTagKey.attemptFinal.key(), true);
@@ -49,7 +49,7 @@ public class IpcMetricTest {
   @Test(expected = IllegalArgumentException.class)
   public void validateIdBadName() {
     Id id = registry.createId("ipc.client-call")
-        .withTag(IpcTagKey.owner.key(), "test")
+        .withTag(IpcTagKey.owner.tag("test"))
         .withTag(IpcResult.success)
         .withTag(IpcAttempt.initial)
         .withTag(IpcTagKey.attemptFinal.key(), true);
@@ -59,7 +59,7 @@ public class IpcMetricTest {
   @Test(expected = IllegalArgumentException.class)
   public void validateIdMissingResult() {
     Id id = registry.createId(IpcMetric.clientCall.metricName())
-        .withTag(IpcTagKey.owner.key(), "test")
+        .withTag(IpcTagKey.owner.tag("test"))
         .withTag(IpcAttempt.initial)
         .withTag(IpcTagKey.attemptFinal.key(), true);
     IpcMetric.clientCall.validate(id);
@@ -68,7 +68,7 @@ public class IpcMetricTest {
   @Test(expected = IllegalArgumentException.class)
   public void validateIdErrorGroupOnSuccess() {
     Id id = registry.createId(IpcMetric.clientCall.metricName())
-        .withTag(IpcTagKey.owner.key(), "test")
+        .withTag(IpcTagKey.owner.tag("test"))
         .withTag(IpcResult.success)
         .withTag(IpcErrorGroup.general)
         .withTag(IpcAttempt.initial)
@@ -79,7 +79,7 @@ public class IpcMetricTest {
   @Test
   public void validateIdErrorGroupOnFailure() {
     Id id = registry.createId(IpcMetric.clientCall.metricName())
-        .withTag(IpcTagKey.owner.key(), "test")
+        .withTag(IpcTagKey.owner.tag("test"))
         .withTag(IpcResult.failure)
         .withTag(IpcErrorGroup.general)
         .withTag(IpcAttempt.initial)
@@ -90,7 +90,7 @@ public class IpcMetricTest {
   @Test(expected = IllegalArgumentException.class)
   public void validateIdErrorGroupNotOnFailure() {
     Id id = registry.createId(IpcMetric.clientCall.metricName())
-        .withTag(IpcTagKey.owner.key(), "test")
+        .withTag(IpcTagKey.owner.tag("test"))
         .withTag(IpcResult.failure)
         .withTag(IpcAttempt.initial)
         .withTag(IpcTagKey.attemptFinal.key(), true);
@@ -100,8 +100,8 @@ public class IpcMetricTest {
   @Test(expected = IllegalArgumentException.class)
   public void validateIdBadResultValue() {
     Id id = registry.createId(IpcMetric.clientCall.metricName())
-        .withTag(IpcTagKey.owner.key(), "test")
-        .withTag(IpcTagKey.result.key(), "foo")
+        .withTag(IpcTagKey.owner.tag("test"))
+        .withTag(IpcTagKey.result.tag("foo"))
         .withTag(IpcAttempt.initial)
         .withTag(IpcTagKey.attemptFinal.key(), true);
     IpcMetric.clientCall.validate(id);
@@ -110,7 +110,7 @@ public class IpcMetricTest {
   @Test(expected = IllegalArgumentException.class)
   public void validateIdBadAttemptFinalValue() {
     Id id = registry.createId(IpcMetric.clientCall.metricName())
-        .withTag(IpcTagKey.owner.key(), "test")
+        .withTag(IpcTagKey.owner.tag("test"))
         .withTag(IpcResult.success)
         .withTag(IpcAttempt.initial)
         .withTag(IpcTagKey.attemptFinal.key(), "foo");
@@ -120,7 +120,7 @@ public class IpcMetricTest {
   @Test
   public void validateRegistryOk() {
     Id id = registry.createId(IpcMetric.clientCall.metricName())
-        .withTag(IpcTagKey.owner.key(), "test")
+        .withTag(IpcTagKey.owner.tag("test"))
         .withTag(IpcResult.success)
         .withTag(IpcAttempt.initial)
         .withTag(IpcTagKey.attemptFinal.key(), true);
@@ -131,7 +131,7 @@ public class IpcMetricTest {
   @Test(expected = IllegalArgumentException.class)
   public void validateRegistryTimerWrongType() {
     Id id = registry.createId(IpcMetric.clientCall.metricName())
-        .withTag(IpcTagKey.owner.key(), "test")
+        .withTag(IpcTagKey.owner.tag("test"))
         .withTag(IpcResult.success)
         .withTag(IpcAttempt.initial)
         .withTag(IpcTagKey.attemptFinal.key(), true);
@@ -142,7 +142,7 @@ public class IpcMetricTest {
   @Test(expected = IllegalArgumentException.class)
   public void validateRegistryDistSummaryWrongType() {
     Id id = registry.createId(IpcMetric.clientInflight.metricName())
-        .withTag(IpcTagKey.owner.key(), "test");
+        .withTag(IpcTagKey.owner.tag("test"));
     registry.counter(id).increment();
     IpcMetric.validate(registry);
   }


### PR DESCRIPTION
This makes a commonly used pattern for some of the internal
integrations cleaner.