### PR TITLE
update CI to build on jdk10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ matrix:
   include:
   - jdk: oraclejdk8
     env: GRADLE_PUBLISH=true
-  - jdk: oraclejdk9
+  - jdk: openjdk11
     env: GRADLE_PUBLISH=false
 sudo: false
 dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ matrix:
   include:
   - jdk: oraclejdk8
     env: GRADLE_PUBLISH=true
-  - jdk: openjdk11
+  - jdk: openjdk10
     env: GRADLE_PUBLISH=false
 sudo: false
 dist: trusty

--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,7 @@ subprojects {
   }
 
   jacoco {
-    toolVersion = "0.7.9"
+    toolVersion = "0.8.1"
   }
 
   jacocoTestReport {

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
 plugins {
   id 'nebula.netflixoss' version '5.0.0'
   id 'me.champeau.gradle.jmh' version '0.4.5'
-  id "com.github.spotbugs" version "1.6.1" apply false
+  id "com.github.spotbugs" version "1.6.2" apply false
 }
 
 // Establish version and status


### PR DESCRIPTION
JDK11 is expected to be the next long term stable release.
Switch the build to use that version to start verifying with
the early access versions.