### PR TITLE
make removeExpiredMeters public for AtlasRegistry

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
@@ -230,7 +230,9 @@ public final class AtlasRegistry extends AbstractRegistry {
    * from third parties. Behavior may change in the future. It is strongly advised to only
    * interact with AtlasRegistry using the interface provided by Registry.
    */
+  @SuppressWarnings("PMD.UselessOverridingMethod")
   @Override public void removeExpiredMeters() {
+    // Overridden to increase visibility from protected in base class to public
     super.removeExpiredMeters();
   }
 

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
@@ -225,6 +225,15 @@ public final class AtlasRegistry extends AbstractRegistry {
     removeExpiredMeters();
   }
 
+  /**
+   * Removes expired meters from the registry. This is public to allow some integration
+   * from third parties. Behavior may change in the future. It is strongly advised to only
+   * interact with AtlasRegistry using the interface provided by Registry.
+   */
+  @Override public void removeExpiredMeters() {
+    super.removeExpiredMeters();
+  }
+
   private void handleSubscriptions() {
     List<Subscription> subs = new ArrayList<>(subscriptions.keySet());
     if (!subs.isEmpty()) {


### PR DESCRIPTION
This was requested by a user in #537. The scope has been
limited as in most cases we do not want users interacting
with this method directly.

/cc @krutsko