### PR TITLE
Add support for CompositeData values to JMX

### DIFF
--- a/spectator-ext-jvm/src/main/java/com/netflix/spectator/jvm/JmxData.java
+++ b/spectator-ext-jvm/src/main/java/com/netflix/spectator/jvm/JmxData.java
@@ -23,6 +23,8 @@ import javax.management.MBeanAttributeInfo;
 import javax.management.MBeanInfo;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
+import javax.management.openmbean.CompositeDataSupport;
+import javax.management.openmbean.CompositeType;
 import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -91,6 +93,22 @@ class JmxData {
           stringAttrs.put(attr.getName(), (String) obj);
         } else if (obj instanceof Number) {
           numberAttrs.put(attr.getName(), ((Number) obj).doubleValue());
+        } else if (obj instanceof CompositeDataSupport) {
+          CompositeDataSupport composite = (CompositeDataSupport) obj;
+          CompositeType compositeType = composite.getCompositeType();
+          for (String key : compositeType.keySet()) {
+            if (composite.containsKey(key)) {
+              Object o = composite.get(key);
+              String attrKey = attr.getName() + "." + key;
+              if (o instanceof Number) {
+                numberAttrs.put(attrKey, ((Number) o).doubleValue());
+              } else if (o instanceof String) {
+                stringAttrs.put(attrKey, (String) o);
+              } else if (o instanceof TimeUnit) {
+                stringAttrs.put(attrKey, o.toString());
+              }
+            }
+          }
         } else if (obj instanceof TimeUnit) {
           stringAttrs.put(attr.getName(), obj.toString());
         }

--- a/spectator-ext-jvm/src/main/java/com/netflix/spectator/jvm/JmxMeasurementConfig.java
+++ b/spectator-ext-jvm/src/main/java/com/netflix/spectator/jvm/JmxMeasurementConfig.java
@@ -89,9 +89,7 @@ final class JmxMeasurementConfig {
     Map<String, Number> numberAttrs = new HashMap<>(data.getNumberAttrs());
     JmxData previous = previousData.put(data.getName(), data);
     if (previous != null) {
-      previous.getNumberAttrs().entrySet().forEach(e ->
-          numberAttrs.put("previous:" + e.getKey(), e.getValue())
-      );
+      previous.getNumberAttrs().forEach((key, value) -> numberAttrs.put("previous:" + key, value));
     }
 
     Double v = MappingExpr.eval(valueMapping, numberAttrs);


### PR DESCRIPTION
This adds support for composite values to JMX mappings. It creates keys
of the form: `name.sub-key` populated with the extracted values.

For example for type=MemoryPool, Usage is a composite:

` [java.lang:type=MemoryPool,name=Code Cache][Usage] =
javax.management.openmbean.CompositeDataSupport(compositeType=javax.management.openmbean.CompositeType(name=java.lang.management.MemoryUsage,items=((itemName=committed,itemType=javax.management.openmbean.SimpleType(name=java.lang.Long)),(itemName=init,itemType=javax.management.openmbean.SimpleType(name=java.lang.Long)),(itemName=max,itemType=javax.management.openmbean.SimpleType(name=java.lang.Long)),(itemName=used,itemType=javax.management.openmbean.SimpleType(name=java.lang.Long)))),contents={committed=29556736, init=2555904, max=251658240, used=29296064}) (type is class javax.management.openmbean.CompositeDataSupport)`

With the dotted value mapping we can use:

```
{
      query = "java.lang:type=MemoryPool,name=*"
      measurements = [
        {
          name = "committedUsage"
          tags = [
            {
              key = "class"
              value = "MemoryPoolMXBean"
            }
            {
              key = "id"
              value = "{name}"
            }
          ]
          value = "{Usage.committed}"
        }
      ]
}
```

and the above will generate a gauge `committedUsage` with the expected value.