### PR TITLE
move back to gradle 4.7 / jdk9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ matrix:
   include:
   - jdk: oraclejdk8
     env: GRADLE_PUBLISH=true
-  - jdk: openjdk10
+  - jdk: openjdk9
     env: GRADLE_PUBLISH=false
 sudo: false
 dist: trusty

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
There is a release publishing issue with nebula, the
gradle bintray plugin, and gradle 4.8. Will update
these again once that is resolved.