### PR TITLE
Fix: don't leave totalTime at zero when using a metrics3 registry

### DIFF
--- a/spectator-reg-metrics3/src/main/java/com/netflix/spectator/metrics3/MetricsTimer.java
+++ b/spectator-reg-metrics3/src/main/java/com/netflix/spectator/metrics3/MetricsTimer.java
@@ -48,6 +48,7 @@ class MetricsTimer extends AbstractTimer {
   }
 
   @Override public void record(long amount, TimeUnit unit) {
+    totalTime.addAndGet(unit.toNanos(amount));
     impl.update(amount, unit);
   }
 


### PR DESCRIPTION
The totalTime is always zero when the registry is backed by metrics3.
