### PR TITLE
support raw substitution for jmx mappings

### DIFF
--- a/spectator-ext-jvm/src/main/java/com/netflix/spectator/jvm/MappingExpr.java
+++ b/spectator-ext-jvm/src/main/java/com/netflix/spectator/jvm/MappingExpr.java
@@ -45,7 +45,9 @@ final class MappingExpr {
   static String substitute(String pattern, Map<String, String> vars) {
     String value = pattern;
     for (Map.Entry<String, String> entry : vars.entrySet()) {
-      String v = Introspector.decapitalize(entry.getValue());
+      String raw = entry.getValue();
+      String v = Introspector.decapitalize(raw);
+      value = value.replace("{raw:" + entry.getKey() + "}", raw);
       value = value.replace("{" + entry.getKey() + "}", v);
     }
     return value;

--- a/spectator-ext-jvm/src/test/java/com/netflix/spectator/jvm/MappingExprTest.java
+++ b/spectator-ext-jvm/src/test/java/com/netflix/spectator/jvm/MappingExprTest.java
@@ -75,6 +75,14 @@ public class MappingExprTest {
   }
 
   @Test
+  public void substituteRaw() {
+    Map<String, String> vars = new HashMap<>();
+    vars.put("name", "FooBarBaz");
+    String actual = MappingExpr.substitute("abc.def.{raw:name}", vars);
+    Assert.assertEquals("abc.def.FooBarBaz", actual);
+  }
+
+  @Test
   public void evalMissing() {
     Map<String, Number> vars = new HashMap<>();
     Double v = MappingExpr.eval("{foo}", vars);


### PR DESCRIPTION
The default is to decapitalize to match the normal
naming conventions for Atlas. In some cases it is
useful to have the raw value substituted, for example,
JVM memory pool names. This can now be done by using
a placeholder with a `raw:` prefix.