### PR TITLE
try nebula plugin 5.1.1-rc.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
   dependencies {
     classpath 'com.github.ben-manes:gradle-versions-plugin:0.17.0'
     classpath 'com.netflix.nebula:nebula-dependency-recommender:5.0.0'
-    classpath 'com.netflix.nebula:gradle-netflixoss-project-plugin:5.1.1-rc.1'
+    classpath 'com.netflix.nebula:gradle-netflixoss-project-plugin:5.1.1-rc.2'
 
     // This is a workaround for getting the shadow plugin to work correctly
     // for some sub-projects. For more details see:


### PR DESCRIPTION
This updates to gradle-bintray-plugin 1.8.4 which should
fix some of the release build issues that we were seeing
on gradle 4.8.