### PR TITLE
IpcLogger to help with using IPC metrics

### DIFF
--- a/codequality/findbugs-exclude.xml
+++ b/codequality/findbugs-exclude.xml
@@ -26,6 +26,24 @@
   </Match>
   <Match>
     <And>
+      <Class name="com.netflix.spectator.ipc.http.HttpResponse"/>
+      <Bug pattern="EI_EXPOSE_REP"/>
+    </And>
+  </Match>
+  <Match>
+    <And>
+      <Class name="com.netflix.spectator.ipc.http.HttpResponse"/>
+      <Bug pattern="EI_EXPOSE_REP2"/>
+    </And>
+  </Match>
+  <Match>
+    <And>
+      <Class name="com.netflix.spectator.ipc.http.HttpRequestBuilder"/>
+      <Bug pattern="EI_EXPOSE_REP2"/>
+    </And>
+  </Match>
+  <Match>
+    <And>
       <Class name="com.netflix.spectator.api.patterns.LongTaskTimer"/>
       <Bug pattern="NM_SAME_SIMPLE_NAME_AS_INTERFACE"/>
     </And>

--- a/spectator-ext-ipc/build.gradle
+++ b/spectator-ext-ipc/build.gradle
@@ -1,6 +1,8 @@
 dependencies {
   compileApi project(':spectator-api')
   jmh 'com.netflix.frigga:frigga:0.18.0'
+  testCompile 'com.fasterxml.jackson.core:jackson-core'
+  testCompile 'com.fasterxml.jackson.core:jackson-databind'
   testCompile 'com.netflix.frigga:frigga:0.18.0'
 }
 

--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcLogEntry.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcLogEntry.java
@@ -1,0 +1,1052 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.ipc;
+
+import com.netflix.spectator.api.Clock;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Tag;
+import com.netflix.spectator.api.histogram.PercentileTimer;
+import org.slf4j.Marker;
+import org.slf4j.event.Level;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+/**
+ * Builder used to fill in and submit a log entry associated with an IPC request.
+ */
+@SuppressWarnings({"PMD.ExcessiveClassLength", "PMD.AvoidStringBufferField"})
+public final class IpcLogEntry {
+
+  private final Clock clock;
+
+  private Registry registry;
+  private IpcLogger logger;
+  private Level level;
+  private Marker marker;
+
+  private long startNanos;
+  private long startTime;
+  private long latency;
+
+  private String owner;
+  private IpcResult result;
+
+  private String protocol;
+
+  private IpcErrorGroup errorGroup;
+  private String errorReason;
+  private Throwable exception;
+
+  private IpcAttempt attempt;
+  private IpcAttemptFinal attemptFinal;
+
+  private String vip;
+  private String endpoint;
+
+  private String clientRegion;
+  private String clientZone;
+  private String clientApp;
+  private String clientCluster;
+  private String clientAsg;
+  private String clientNode;
+
+  private String serverRegion;
+  private String serverZone;
+  private String serverApp;
+  private String serverCluster;
+  private String serverAsg;
+  private String serverNode;
+
+  private String httpMethod;
+  private int httpStatus;
+
+  private String uri;
+  private String path;
+
+  private List<Header> requestHeaders = new ArrayList<>();
+  private List<Header> responseHeaders = new ArrayList<>();
+
+  private String remoteAddress;
+  private int remotePort;
+
+  private Map<String, String> additionalTags = new HashMap<>();
+
+  private StringBuilder builder = new StringBuilder();
+
+  private Id inflightId;
+
+  /** Create a new instance. */
+  IpcLogEntry(Clock clock) {
+    this.clock = clock;
+    reset();
+  }
+
+  /** Set the registry to use for recording metrics. */
+  IpcLogEntry withRegistry(Registry registry) {
+    this.registry = registry;
+    return this;
+  }
+
+  /**
+   * Set the logger instance to use for tracking state such as the number of inflight
+   * requests.
+   */
+  IpcLogEntry withLogger(IpcLogger logger) {
+    this.logger = logger;
+    return this;
+  }
+
+  /**
+   * Set the marker indicating whether it is a client or server request.
+   */
+  IpcLogEntry withMarker(Marker marker) {
+    this.marker = marker;
+    return this;
+  }
+
+  /**
+   * Set the log level to use when sending to SLF4j. The default level is DEBUG. For
+   * high volume use-cases it is recommended to set the level to TRACE to avoid excessive
+   * logging.
+   */
+  public IpcLogEntry withLogLevel(Level level) {
+    this.level = level;
+    return this;
+  }
+
+  /**
+   * Set the latency for the request. This will typically be set automatically using
+   * {@link #markStart()} and {@link #markEnd()}. Use this method if the latency value
+   * is provided by the implementation rather than measured using this entry.
+   */
+  public IpcLogEntry withLatency(long latency, TimeUnit unit) {
+    this.latency = unit.toNanos(latency);
+    return this;
+  }
+
+  /**
+   * Record the starting time for the request and update the number of inflight requests.
+   * This should be called just before starting the execution of the request. As soon as
+   * the request completes it is recommended to call {@link #markEnd()}.
+   */
+  public IpcLogEntry markStart() {
+    if (registry != null) {
+      inflightId = getInflightId();
+      int n = logger.inflightRequests(inflightId).incrementAndGet();
+      registry.distributionSummary(inflightId).record(n);
+    }
+
+    startTime = clock.wallTime();
+    startNanos = clock.monotonicTime();
+    return this;
+  }
+
+  /**
+   * Record the latency for the request based on the completion time. This will be
+   * implicitly called when the request is logged, but it is advisable to call as soon
+   * as the response is received to minimize the amount of response processing that is
+   * counted as part of the request latency.
+   */
+  public IpcLogEntry markEnd() {
+    return withLatency(clock.monotonicTime() - startNanos, TimeUnit.NANOSECONDS);
+  }
+
+  /**
+   * Set the library that produced the metric.
+   */
+  public IpcLogEntry withOwner(String owner) {
+    this.owner = owner;
+    return this;
+  }
+
+  /**
+   * Set the protocol used for this request. See {@link IpcProtocol} for more information.
+   */
+  public IpcLogEntry withProtocol(IpcProtocol protocol) {
+    return withProtocol(protocol.value());
+  }
+
+  /**
+   * Set the protocol used for this request. See {@link IpcProtocol} for more information.
+   */
+  public IpcLogEntry withProtocol(String protocol) {
+    this.protocol = protocol;
+    return this;
+  }
+
+  /**
+   * Set the result for this request. See {@link IpcResult} for more information.
+   */
+  public IpcLogEntry withResult(IpcResult result) {
+    this.result = result;
+    return this;
+  }
+
+  /**
+   * Set the high level cause for a request failure. See {@link IpcErrorGroup} for more
+   * information.
+   */
+  public IpcLogEntry withErrorGroup(IpcErrorGroup errorGroup) {
+    this.errorGroup = errorGroup;
+    return this;
+  }
+
+  /**
+   * Set the implementation specific reason for the request failure. In most cases it
+   * is preferable to use {@link #withException(Throwable)} or {@link #withHttpStatus(int)}
+   * instead of calling this directly.
+   */
+  public IpcLogEntry withErrorReason(String errorReason) {
+    this.errorReason = errorReason;
+    return this;
+  }
+
+  /**
+   * Set the exception that was thrown while trying to execute the request. This will be
+   * logged and can be used to fill in the error reason.
+   */
+  public IpcLogEntry withException(Throwable exception) {
+    this.exception = exception;
+    return this;
+  }
+
+  /**
+   * Set the attempt number for the request.
+   */
+  public IpcLogEntry withAttempt(IpcAttempt attempt) {
+    this.attempt = attempt;
+    return this;
+  }
+
+  /**
+   * Set the attempt number for the request.
+   */
+  public IpcLogEntry withAttempt(int attempt) {
+    return withAttempt(IpcAttempt.forAttemptNumber(attempt));
+  }
+
+  /**
+   * Set whether or not this is the final attempt for the request.
+   */
+  public IpcLogEntry withAttemptFinal(boolean isFinal) {
+    this.attemptFinal = IpcAttemptFinal.forValue(isFinal);
+    return this;
+  }
+
+  /**
+   * Set the vip that was used to determine which server to contact. This will only be
+   * present if using client side load balancing via Eureka.
+   */
+  public IpcLogEntry withVip(String vip) {
+    this.vip = vip;
+    return this;
+  }
+
+  /**
+   * Set the endpoint for this request.
+   */
+  public IpcLogEntry withEndpoint(String endpoint) {
+    this.endpoint = endpoint;
+    return this;
+  }
+
+  /**
+   * Set the client region for the request. In the case of the server side this will be
+   * automatically filled in if the {@link NetflixHeader#Zone} is specified on the client
+   * request.
+   */
+  public IpcLogEntry withClientRegion(String region) {
+    this.clientRegion = region;
+    return this;
+  }
+
+  /**
+   * Set the client zone for the request. In the case of the server side this will be
+   * automatically filled in if the {@link NetflixHeader#Zone} is specified on the client
+   * request.
+   */
+  public IpcLogEntry withClientZone(String zone) {
+    this.clientZone = zone;
+    if (clientRegion == null) {
+      clientRegion = extractRegionFromZone(zone);
+    }
+    return this;
+  }
+
+  /**
+   * Set the client app for the request. In the case of the server side this will be
+   * automatically filled in if the {@link NetflixHeader#ASG} is specified on the client
+   * request. The ASG value must follow the
+   * <a href="https://github.com/Netflix/iep/tree/master/iep-nflxenv#server-group-settings">
+   * Frigga server group</a> naming conventions.
+   */
+  public IpcLogEntry withClientApp(String app) {
+    this.clientApp = app;
+    return this;
+  }
+
+  /**
+   * Set the client cluster for the request. In the case of the server side this will be
+   * automatically filled in if the {@link NetflixHeader#ASG} is specified on the client
+   * request. The ASG value must follow the
+   * <a href="https://github.com/Netflix/iep/tree/master/iep-nflxenv#server-group-settings">
+   * Frigga server group</a> naming conventions.
+   */
+  public IpcLogEntry withClientCluster(String cluster) {
+    this.clientCluster = cluster;
+    return this;
+  }
+
+  /**
+   * Set the client ASG for the request. In the case of the server side this will be
+   * automatically filled in if the {@link NetflixHeader#ASG} is specified on the client
+   * request. The ASG value must follow the
+   * <a href="https://github.com/Netflix/iep/tree/master/iep-nflxenv#server-group-settings">
+   * Frigga server group</a> naming conventions.
+   */
+  public IpcLogEntry withClientAsg(String asg) {
+    this.clientAsg = asg;
+    if (clientApp == null || clientCluster == null) {
+      ServerGroup group = ServerGroup.parse(asg);
+      clientApp = (clientApp == null) ? group.app() : clientApp;
+      clientCluster = (clientCluster == null) ? group.cluster() : clientCluster;
+    }
+    return this;
+  }
+
+  /**
+   * Set the client node for the request. This will be used for access logging only and will
+   * not be present on metrics. The server will log this value if the {@link NetflixHeader#Node}
+   * header is present on the client request.
+   */
+  public IpcLogEntry withClientNode(String node) {
+    this.clientNode = node;
+    return this;
+  }
+
+  /**
+   * Set the server region for the request. In the case of the client side this will be
+   * automatically filled in if the {@link NetflixHeader#Zone} is specified on the server
+   * response.
+   */
+  public IpcLogEntry withServerRegion(String region) {
+    this.serverRegion = region;
+    return this;
+  }
+
+  /**
+   * Set the server zone for the request. In the case of the client side this will be
+   * automatically filled in if the {@link NetflixHeader#Zone} is specified on the server
+   * response.
+   */
+  public IpcLogEntry withServerZone(String zone) {
+    this.serverZone = zone;
+    if (serverRegion == null) {
+      serverRegion = extractRegionFromZone(zone);
+    }
+    return this;
+  }
+
+  /**
+   * Set the server app for the request. In the case of the client side this will be
+   * automatically filled in if the {@link NetflixHeader#ASG} is specified on the server
+   * response. The ASG value must follow the
+   * <a href="https://github.com/Netflix/iep/tree/master/iep-nflxenv#server-group-settings">
+   * Frigga server group</a> naming conventions.
+   */
+  public IpcLogEntry withServerApp(String app) {
+    this.serverApp = app;
+    return this;
+  }
+
+  /**
+   * Set the server cluster for the request. In the case of the client side this will be
+   * automatically filled in if the {@link NetflixHeader#ASG} is specified on the server
+   * response. The ASG value must follow the
+   * <a href="https://github.com/Netflix/iep/tree/master/iep-nflxenv#server-group-settings">
+   * Frigga server group</a> naming conventions.
+   */
+  public IpcLogEntry withServerCluster(String cluster) {
+    this.serverCluster = cluster;
+    return this;
+  }
+
+  /**
+   * Set the server ASG for the request. In the case of the client side this will be
+   * automatically filled in if the {@link NetflixHeader#ASG} is specified on the server
+   * response. The ASG value must follow the
+   * <a href="https://github.com/Netflix/iep/tree/master/iep-nflxenv#server-group-settings">
+   * Frigga server group</a> naming conventions.
+   */
+  public IpcLogEntry withServerAsg(String asg) {
+    this.serverAsg = asg;
+    if (serverApp == null || serverCluster == null) {
+      ServerGroup group = ServerGroup.parse(asg);
+      serverApp = (serverApp == null) ? group.app() : serverApp;
+      serverCluster = (serverCluster == null) ? group.cluster() : serverCluster;
+    }
+    return this;
+  }
+
+  /**
+   * Set the server node for the request. This will be used for access logging only and will
+   * not be present on metrics. The client will log this value if the {@link NetflixHeader#Node}
+   * header is present on the server response.
+   */
+  public IpcLogEntry withServerNode(String node) {
+    this.serverNode = node;
+    return this;
+  }
+
+  /**
+   * Set the HTTP method used for this request.
+   */
+  public IpcLogEntry withHttpMethod(String method) {
+    this.httpMethod = method;
+    return this;
+  }
+
+  /**
+   * Set the HTTP status code for this request. For the metrics this will be used to populate
+   * the {@link #withErrorReason(String)}.
+   */
+  public IpcLogEntry withHttpStatus(int status) {
+    this.httpStatus = status;
+    if (result == null) {
+      withResult((status < 400) ? IpcResult.success : IpcResult.failure);
+    }
+    if (errorGroup == null) {
+      switch (status) {
+        case 429:
+          errorGroup = IpcErrorGroup.client_throttled;
+          break;
+        case 503:
+          errorGroup = IpcErrorGroup.server_throttled;
+          break;
+        default:
+          if (status >= 400 && status < 500) {
+            errorGroup = IpcErrorGroup.client_error;
+          } else if (status >= 500) {
+            errorGroup = IpcErrorGroup.server_error;
+          }
+          break;
+      }
+    }
+    return this;
+  }
+
+  /**
+   * Set the URI and path for the request.
+   */
+  public IpcLogEntry withUri(String uri, String path) {
+    this.uri = uri;
+    this.path = path;
+    return this;
+  }
+
+  /**
+   * Set the URI and path for the request. The path will get extracted from the URI. If the
+   * URI is non-strict and cannot be parsed with the java URI class, then use
+   * {@link #withUri(String, String)} instead.
+   */
+  public IpcLogEntry withUri(URI uri) {
+    return withUri(uri.toString(), uri.getPath());
+  }
+
+  /**
+   * Add a request header value. For special headers in {@link NetflixHeader} it will
+   * automatically fill in the more specific fields based on the header values.
+   */
+  public IpcLogEntry addRequestHeader(String name, String value) {
+    if (clientAsg == null && name.equalsIgnoreCase(NetflixHeader.ASG.headerName())) {
+        withClientAsg(value);
+    } else if (clientZone == null && name.equalsIgnoreCase(NetflixHeader.Zone.headerName())) {
+      withClientZone(value);
+    } else if (clientNode == null && name.equalsIgnoreCase(NetflixHeader.Node.headerName())) {
+      withClientNode(value);
+    } else if (vip == null && name.equalsIgnoreCase(NetflixHeader.Vip.headerName())) {
+      withVip(value);
+    } else {
+      this.requestHeaders.add(new Header(name, value));
+    }
+    return this;
+  }
+
+  /**
+   * Add a response header value. For special headers in {@link NetflixHeader} it will
+   * automatically fill in the more specific fields based on the header values.
+   */
+  public IpcLogEntry addResponseHeader(String name, String value) {
+    if (serverAsg == null && name.equalsIgnoreCase(NetflixHeader.ASG.headerName())) {
+      withServerAsg(value);
+    } else if (serverZone == null && name.equalsIgnoreCase(NetflixHeader.Zone.headerName())) {
+      withServerZone(value);
+    } else if (serverNode == null && name.equalsIgnoreCase(NetflixHeader.Node.headerName())) {
+      withServerNode(value);
+    } else if (endpoint == null && name.equalsIgnoreCase(NetflixHeader.Endpoint.headerName())) {
+      withEndpoint(value);
+    } else {
+      this.responseHeaders.add(new Header(name, value));
+    }
+    return this;
+  }
+
+  /**
+   * Set the remote address for the request.
+   */
+  public IpcLogEntry withRemoteAddress(String remoteAddress) {
+    this.remoteAddress = remoteAddress;
+    return this;
+  }
+
+  /**
+   * Set the remote port for the request.
+   */
+  public IpcLogEntry withRemotePort(int remotePort) {
+    this.remotePort = remotePort;
+    return this;
+  }
+
+  /**
+   * Add custom tags to the request metrics. Note, IPC metrics already have many tags and it
+   * is not recommended for users to tack on additional context. In particular, any additional
+   * tags should have a <b>guaranteed</b> low cardinality. If additional tagging causes these
+   * metrics to exceed limits, then you may lose all visibility into requests.
+   */
+  public IpcLogEntry addTag(Tag tag) {
+    this.additionalTags.put(tag.key(), tag.value());
+    return this;
+  }
+
+  /**
+   * Add custom tags to the request metrics. Note, IPC metrics already have many tags and it
+   * is not recommended for users to tack on additional context. In particular, any additional
+   * tags should have a <b>guaranteed</b> low cardinality. If additional tagging causes these
+   * metrics to exceed limits, then you may lose all visibility into requests.
+   */
+  public IpcLogEntry addTag(String k, String v) {
+    this.additionalTags.put(k, v);
+    return this;
+  }
+
+  private void putTag(Map<String, String> tags, Tag tag) {
+    tags.put(tag.key(), tag.value());
+  }
+
+  private void putTag(Map<String, String> tags, String k, String v) {
+    if (!isNullOrEmpty(v)) {
+      String value = logger.limiterForKey(k).apply(v);
+      tags.put(k, value);
+    }
+  }
+
+  private String getErrorReason() {
+    if (isNullOrEmpty(errorReason)) {
+      if (exception != null) {
+        errorReason = exception.getClass().getSimpleName();
+      } else if (httpStatus > 0) {
+        errorReason = "HTTP_" + httpStatus;
+      }
+    }
+    return errorReason;
+  }
+
+  private boolean isClient() {
+    return marker != null && "ipc-client".equals(marker.getName());
+  }
+
+  private Id createCallId(String name) {
+    Map<String, String> tags = new HashMap<>();
+
+    // User specified custom tags, add individually to ensure that limiter is applied
+    // to the values
+    for (Map.Entry<String, String> entry : additionalTags.entrySet()) {
+      putTag(tags, entry.getKey(), entry.getValue());
+    }
+
+    // Required for both client and server
+    putTag(tags, IpcTagKey.owner.key(), owner);
+    putTag(tags, result);
+    putTag(tags, errorGroup);
+
+    if (isClient()) {
+      // Required for client, should be null on server
+      putTag(tags, attempt);
+      putTag(tags, attemptFinal);
+
+      // Optional for client
+      putTag(tags, IpcTagKey.serverRegion.key(), serverRegion);
+      putTag(tags, IpcTagKey.serverZone.key(), serverZone);
+      putTag(tags, IpcTagKey.serverApp.key(), serverApp);
+      putTag(tags, IpcTagKey.serverCluster.key(), serverCluster);
+      putTag(tags, IpcTagKey.serverAsg.key(), serverAsg);
+    } else {
+      // Optional for server
+      putTag(tags, IpcTagKey.clientRegion.key(), clientRegion);
+      putTag(tags, IpcTagKey.clientZone.key(), clientZone);
+      putTag(tags, IpcTagKey.clientApp.key(), clientApp);
+      putTag(tags, IpcTagKey.clientCluster.key(), clientCluster);
+      putTag(tags, IpcTagKey.clientAsg.key(), clientAsg);
+    }
+
+    // Optional for both client and server
+    putTag(tags, IpcTagKey.endpoint.key(), endpoint);
+    putTag(tags, IpcTagKey.vip.key(), vip);
+    putTag(tags, IpcTagKey.protocol.key(), protocol);
+    putTag(tags, IpcTagKey.errorReason.key(), getErrorReason());
+    putTag(tags, IpcTagKey.httpMethod.key(), httpMethod);
+
+    return registry.createId(name, tags);
+  }
+
+  private Id getInflightId() {
+    if (inflightId == null) {
+      Map<String, String> tags = new HashMap<>();
+
+      // Required for both client and server
+      putTag(tags, IpcTagKey.owner.key(), owner);
+
+      // Optional for both client and server
+      putTag(tags, IpcTagKey.vip.key(), vip);
+
+      String name = isClient()
+          ? IpcMetric.clientInflight.metricName()
+          : IpcMetric.serverInflight.metricName();
+      inflightId = registry.createId(name, tags);
+    }
+    return inflightId;
+  }
+
+  private void recordClientMetrics() {
+    Id clientCall = createCallId(IpcMetric.clientCall.metricName());
+    PercentileTimer.builder(registry)
+        .withId(clientCall)
+        .build()
+        .record(getLatency(), TimeUnit.NANOSECONDS);
+  }
+
+  private void recordServerMetrics() {
+    Id serverCall = createCallId(IpcMetric.serverCall.metricName());
+    PercentileTimer.builder(registry)
+        .withId(serverCall)
+        .build()
+        .record(getLatency(), TimeUnit.NANOSECONDS);
+  }
+
+  /**
+   * Log the request. This entry will potentially be reused after this is called. The user
+   * should not attempt any further modifications to the state of this entry.
+   */
+  public void log() {
+    if (logger != null) {
+      if (registry != null) {
+        if (isClient()) {
+          recordClientMetrics();
+        } else {
+          recordServerMetrics();
+        }
+      }
+      if (inflightId != null) {
+        logger.inflightRequests(inflightId).decrementAndGet();
+      }
+
+      logger.log(this);
+    } else {
+      reset();
+    }
+  }
+
+  /** Return the log level set for this log entry. */
+  Level getLevel() {
+    return level;
+  }
+
+  /** Return the marker set for this log entry. */
+  Marker getMarker() {
+    return marker;
+  }
+
+  /** Return true if the request is successful and the entry can be reused. */
+  boolean isSuccessful() {
+    return result == IpcResult.success;
+  }
+
+  private String extractRegionFromZone(String zone) {
+    int n = zone.length();
+    if (n < 4) {
+      return null;
+    } else {
+      char c = zone.charAt(n - 2);
+      if (Character.isDigit(c) && zone.charAt(n - 3) == '-') {
+        // AWS zones have a pattern of `${region}[a-f]`, for example: `us-east-1a`
+        return zone.substring(0, n - 1);
+      } else if (c == '-') {
+        // GCE zones have a pattern of `${region}-[a-f]`, for example: `us-east1-c`
+        // https://cloud.google.com/compute/docs/regions-zones/
+        return zone.substring(0, n - 2);
+      } else {
+        // Pattern doesn't look familiar
+        return null;
+      }
+    }
+  }
+
+  private long getLatency() {
+    if (startNanos >= 0L && latency < 0L) {
+      // If latency was not explicitly set but the start time was, then compute the
+      // time since the start. The field is updated so subsequent calls will return
+      // a consistent value for the latency.
+      latency = clock.monotonicTime() - startNanos;
+    }
+    return latency;
+  }
+
+  private String getExceptionClass() {
+    return (exception == null)
+        ? null
+        : exception.getClass().getName();
+  }
+
+  private String getExceptionMessage() {
+    return (exception == null)
+        ? null
+        : exception.getMessage();
+  }
+
+  @Override
+  public String toString() {
+    return new JsonStringBuilder(builder)
+        .startObject()
+        .addField("owner", owner)
+        .addField("start", startTime)
+        .addField("latency", getLatency() / 1e9)
+        .addField("protocol", protocol)
+        .addField("uri", uri)
+        .addField("path", path)
+        .addField("endpoint", endpoint)
+        .addField("vip", vip)
+        .addField("clientRegion", clientRegion)
+        .addField("clientZone", clientZone)
+        .addField("clientApp", clientApp)
+        .addField("clientCluster", clientCluster)
+        .addField("clientAsg", clientAsg)
+        .addField("clientNode", clientNode)
+        .addField("serverRegion", serverRegion)
+        .addField("serverZone", serverZone)
+        .addField("serverApp", serverApp)
+        .addField("serverCluster", serverCluster)
+        .addField("serverAsg", serverAsg)
+        .addField("serverNode", serverNode)
+        .addField("remoteAddress", remoteAddress)
+        .addField("remotePort", remotePort)
+        .addField("attempt", attempt)
+        .addField("attemptFinal", attemptFinal)
+        .addField("result", result)
+        .addField("errorGroup", errorGroup)
+        .addField("errorReason", errorReason)
+        .addField("exceptionClass", getExceptionClass())
+        .addField("exceptionMessage", getExceptionMessage())
+        .addField("httpMethod", httpMethod)
+        .addField("httpStatus", httpStatus)
+        .addField("requestHeaders", requestHeaders)
+        .addField("responseHeaders", responseHeaders)
+        .addField("additionalTags", additionalTags)
+        .endObject()
+        .toString();
+  }
+
+  /**
+   * Resets this log entry so the instance can be reused. This helps to reduce allocations.
+   */
+  void reset() {
+    logger = null;
+    level = Level.DEBUG;
+    marker = null;
+    startTime = -1L;
+    startNanos = -1L;
+    latency = -1L;
+    owner = null;
+    result = null;
+    protocol = null;
+    errorGroup = null;
+    errorReason = null;
+    exception = null;
+    attempt = null;
+    attemptFinal = null;
+    vip = null;
+    endpoint = null;
+    clientRegion = null;
+    clientZone = null;
+    clientApp = null;
+    clientCluster = null;
+    clientAsg = null;
+    clientNode = null;
+    serverRegion = null;
+    serverZone = null;
+    serverApp = null;
+    serverCluster = null;
+    serverAsg = null;
+    serverNode = null;
+    httpMethod = null;
+    httpStatus = -1;
+    uri = null;
+    path = null;
+    requestHeaders.clear();
+    responseHeaders.clear();
+    remoteAddress = null;
+    remotePort = -1;
+    additionalTags.clear();
+    builder.delete(0, builder.length());
+    inflightId = null;
+  }
+
+  /**
+   * Partially reset this log entry so it can be used for another request attempt. Any
+   * attributes that can change for a given request need to be cleared.
+   */
+  void resetForRetry() {
+    startTime = -1L;
+    startNanos = -1L;
+    latency = -1L;
+    result = null;
+    errorGroup = null;
+    errorReason = null;
+    exception = null;
+    attempt = null;
+    attemptFinal = null;
+    vip = null;
+    serverRegion = null;
+    serverZone = null;
+    serverApp = null;
+    serverCluster = null;
+    serverAsg = null;
+    serverNode = null;
+    httpStatus = -1;
+    requestHeaders.clear();
+    responseHeaders.clear();
+    remoteAddress = null;
+    remotePort = -1;
+    builder.delete(0, builder.length());
+    inflightId = null;
+  }
+
+  /**
+   * Apply a mapping function to this log entry. This method is mostly used to allow the
+   * final mapping to be applied to the entry without breaking the operator chaining.
+   */
+  public <T> T convert(Function<IpcLogEntry, T> mapper) {
+    return mapper.apply(this);
+  }
+
+  private static boolean isNullOrEmpty(String s) {
+    return s == null || s.isEmpty();
+  }
+
+  private static class Header {
+    private final String name;
+    private final String value;
+
+    Header(String name, String value) {
+      this.name = name;
+      this.value = value;
+    }
+
+    String name() {
+      return name;
+    }
+
+    String value() {
+      return value;
+    }
+  }
+
+  private static class JsonStringBuilder {
+    private final StringBuilder builder;
+    private boolean firstEntry = true;
+
+    JsonStringBuilder(StringBuilder builder) {
+      this.builder = builder;
+    }
+
+    JsonStringBuilder startObject() {
+      builder.append('{');
+      return this;
+    }
+
+    JsonStringBuilder endObject() {
+      builder.append('}');
+      return this;
+    }
+
+    private void addSep() {
+      if (firstEntry) {
+        firstEntry = false;
+      } else {
+        builder.append(',');
+      }
+    }
+
+    JsonStringBuilder addField(String k, String v) {
+      if (!isNullOrEmpty(v)) {
+        addSep();
+        builder.append('"');
+        escapeAndAppend(builder, k);
+        builder.append("\":\"");
+        escapeAndAppend(builder, v);
+        builder.append('"');
+      }
+      return this;
+    }
+
+    JsonStringBuilder addField(String k, Tag tag) {
+      if (tag != null) {
+        addField(k, tag.value());
+      }
+      return this;
+    }
+
+    JsonStringBuilder addField(String k, int v) {
+      if (v >= 0) {
+        addSep();
+        builder.append('"');
+        escapeAndAppend(builder, k);
+        builder.append("\":").append(v);
+      }
+      return this;
+    }
+
+    JsonStringBuilder addField(String k, long v) {
+      if (v >= 0L) {
+        addSep();
+        builder.append('"');
+        escapeAndAppend(builder, k);
+        builder.append("\":").append(v);
+      }
+      return this;
+    }
+
+    JsonStringBuilder addField(String k, double v) {
+      if (v >= 0.0) {
+        addSep();
+        builder.append('"');
+        escapeAndAppend(builder, k);
+        builder.append("\":").append(v);
+      }
+      return this;
+    }
+
+    JsonStringBuilder addField(String k, List<Header> headers) {
+      if (!headers.isEmpty()) {
+        addSep();
+        builder.append('"');
+        escapeAndAppend(builder, k);
+        builder.append("\":[");
+
+        boolean first = true;
+        for (Header h : headers) {
+          if (first) {
+            first = false;
+          } else {
+            builder.append(',');
+          }
+          builder.append("{\"name\":\"");
+          escapeAndAppend(builder, h.name());
+          builder.append("\",\"value\":\"");
+          escapeAndAppend(builder, h.value());
+          builder.append("\"}");
+        }
+        builder.append(']');
+      }
+      return this;
+    }
+
+    JsonStringBuilder addField(String k, Map<String, String> tags) {
+      if (!tags.isEmpty()) {
+        addSep();
+        builder.append('"');
+        escapeAndAppend(builder, k);
+        builder.append("\":{");
+
+        boolean first = true;
+        for (Map.Entry<String, String> entry : tags.entrySet()) {
+          if (first) {
+            first = false;
+          } else {
+            builder.append(',');
+          }
+          builder.append('"');
+          escapeAndAppend(builder, entry.getKey());
+          builder.append("\":\"");
+          escapeAndAppend(builder, entry.getValue());
+          builder.append('"');
+        }
+        builder.append('}');
+      }
+      return this;
+    }
+
+    private void escapeAndAppend(StringBuilder builder, String str) {
+      int length = str.length();
+      for (int i = 0; i < length; ++i) {
+        char c = str.charAt(i);
+        switch (c) {
+          case '"':
+            builder.append("\\\"");
+            break;
+          case '\\':
+            builder.append("\\\\");
+            break;
+          case '\b':
+            builder.append("\\b");
+            break;
+          case '\f':
+            builder.append("\\f");
+            break;
+          case '\n':
+            builder.append("\\n");
+            break;
+          case '\r':
+            builder.append("\\r");
+            break;
+          case '\t':
+            builder.append("\\t");
+            break;
+          case ' ':
+            builder.append(' ');
+            break;
+          default:
+            // Ignore control characters that are not matched explicitly above
+            if (!Character.isISOControl(c)) {
+              builder.append(c);
+            }
+            break;
+        }
+      }
+    }
+
+    @Override
+    public String toString() {
+      return builder.toString();
+    }
+  }
+}

--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcLogger.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcLogger.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.ipc;
+
+import com.netflix.spectator.api.Clock;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Utils;
+import com.netflix.spectator.api.patterns.CardinalityLimiters;
+import org.slf4j.Logger;
+import org.slf4j.Marker;
+import org.slf4j.MarkerFactory;
+import org.slf4j.event.Level;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/**
+ * Logger for recording IPC metrics and providing a basic access log. A single logger instance
+ * should be reused for all requests in a given context because it maintains the state such as
+ * number of inflight requests.
+ */
+public class IpcLogger {
+
+  private static final Marker CLIENT = MarkerFactory.getMarker("ipc-client");
+  private static final Marker SERVER = MarkerFactory.getMarker("ipc-server");
+
+  private final Registry registry;
+  private final Clock clock;
+  private final Logger logger;
+
+  private final ConcurrentHashMap<Id, AtomicInteger> inflightRequests;
+  private final ConcurrentHashMap<String, Function<String, String>> limiters;
+
+  private final LinkedBlockingQueue<IpcLogEntry> entries;
+
+  /**
+   * Create a new instance. Allows the clock to be explicitly set for unit tests.
+   */
+  IpcLogger(Registry registry, Clock clock, Logger logger) {
+    this.registry = registry;
+    this.clock = clock;
+    this.logger = logger;
+    this.inflightRequests = new ConcurrentHashMap<>();
+    this.limiters = new ConcurrentHashMap<>();
+    this.entries = new LinkedBlockingQueue<>(1000);
+  }
+
+  /** Create a new instance. */
+  public IpcLogger(Registry registry, Logger logger) {
+    this(registry, Clock.SYSTEM, logger);
+  }
+
+  /** Return the number of inflight requests associated with the given id. */
+  AtomicInteger inflightRequests(Id id) {
+    return inflightRequests.get(id);
+  }
+
+  /**
+   * Return the cardinality limiter for a given key. This is used to protect the metrics
+   * backend from a metrics explosion if some dimensions have a high cardinality.
+   */
+  Function<String, String> limiterForKey(String key) {
+    return Utils.computeIfAbsent(limiters, key, k -> CardinalityLimiters.mostFrequent(25));
+  }
+
+  private IpcLogEntry newEntry() {
+    IpcLogEntry entry = entries.poll();
+    return (entry == null) ? new IpcLogEntry(clock) : entry;
+  }
+
+  /**
+   * Create a new log entry for client requests. Log entry objects may be reused to minimize
+   * the number of allocations so they should only be modified in the context of a single
+   * request.
+   */
+  public IpcLogEntry createClientEntry() {
+    return newEntry()
+        .withRegistry(registry)
+        .withLogger(this)
+        .withMarker(CLIENT);
+  }
+
+  /**
+   * Create a new log entry for server requests. Log entry objects may be reused to minimize
+   * the number of allocations so they should only be modified in the context of a single
+   * request.
+   */
+  public IpcLogEntry createServerEntry() {
+    return newEntry()
+        .withRegistry(registry)
+        .withLogger(this)
+        .withMarker(SERVER);
+  }
+
+  /**
+   * Called by the entry to log the request.
+   */
+  void log(IpcLogEntry entry) {
+    Level level = entry.getLevel();
+    Predicate<Marker> isEnabled;
+    BiConsumer<Marker, String> log;
+    switch (level) {
+      case TRACE:
+        isEnabled = logger::isTraceEnabled;
+        log = logger::trace;
+        break;
+      case DEBUG:
+        isEnabled = logger::isDebugEnabled;
+        log = logger::debug;
+        break;
+      case INFO:
+        isEnabled = logger::isInfoEnabled;
+        log = logger::info;
+        break;
+      case WARN:
+        isEnabled = logger::isWarnEnabled;
+        log = logger::warn;
+        break;
+      case ERROR:
+        isEnabled = logger::isErrorEnabled;
+        log = logger::error;
+        break;
+      default:
+        isEnabled = logger::isDebugEnabled;
+        log = logger::debug;
+        break;
+    }
+
+    if (isEnabled.test(entry.getMarker())) {
+      log.accept(entry.getMarker(), entry.toString());
+    }
+
+    // For successful responses we can reuse the entry to avoid additional allocations. Failed
+    // requests might have retries so we just reset the response portion to avoid incorrectly
+    // having state bleed through from one request to the next.
+    if (entry.isSuccessful()) {
+      entry.reset();
+      entries.offer(entry);
+    } else {
+      entry.resetForRetry();
+    }
+  }
+}

--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/NetflixHeader.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/NetflixHeader.java
@@ -34,6 +34,11 @@ public enum NetflixHeader {
   Zone,
 
   /**
+   * Instance id of the client or server.
+   */
+  Node,
+
+  /**
    * Route or route handler for a given path. It should have a fixed cardinality. For HTTP
    * this would need to come from the server so there is agreement and the client will report
    * the same value.

--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/http/HttpClient.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/http/HttpClient.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.ipc.http;
+
+import com.netflix.spectator.api.Spectator;
+import com.netflix.spectator.ipc.IpcLogger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+
+/**
+ * Simple blocking http client using {@link IpcLogger} and {@link java.net.HttpURLConnection}.
+ * This can be used as an example of the logging or for light use-cases where it is more desirable
+ * not to have dependencies on a more robust HTTP library. Usage:
+ *
+ * <pre>
+ * HttpClient client = HttpClient.DEFAULT_CLIENT;
+ * HttpResponse response = client.get(URI.create("http://example.com")).send();
+ * </pre>
+ *
+ * For testing an alternative client implementation can be used to customize the
+ * send. For example to create a client that will always fail:
+ *
+ * <pre>
+ * HttpClient client = (n, u) -> new HttpRequestBuilder(n, u) {
+ *   {@literal @}Override protected HttpResponse sendImpl() throws IOException {
+ *     throw new ConnectException("could not connect to " + u.getHost());
+ *   }
+ * };
+ * </pre>
+ */
+public interface HttpClient {
+
+  /**
+   * Default {@link IpcLogger} instance. It will report metrics to
+   * {@link Spectator#globalRegistry()}.
+   */
+  IpcLogger DEFAULT_LOGGER = new IpcLogger(
+      Spectator.globalRegistry(),
+      LoggerFactory.getLogger(HttpClient.class));
+
+  /**
+   * Default client instance that can be used in static contexts where it is not
+   * possible to inject the {@link IpcLogger} instance. It will use {@link #DEFAULT_LOGGER}.
+   */
+  HttpClient DEFAULT_CLIENT = create(DEFAULT_LOGGER);
+
+  /**
+   * Create a new client instance.
+   *
+   * @param logger
+   *     Logger instance for recording metrics and providing an access log.
+   * @return
+   *     Client instance based on {@link java.net.HttpURLConnection}.
+   */
+  static HttpClient create(IpcLogger logger) {
+    return uri -> new HttpRequestBuilder(logger, uri);
+  }
+
+  /**
+   * Create a new request builder.
+   *
+   * @param uri
+   *     URI to use for the request.
+   * @return
+   *     Builder for creating and executing a request.
+   */
+  HttpRequestBuilder newRequest(URI uri);
+
+  /**
+   * Create a new GET request builder. The client name will be selected based
+   * on a prefix of the host name.
+   *
+   * @param uri
+   *     URI to use for the request.
+   * @return
+   *     Builder for creating and executing a request.
+   */
+  default HttpRequestBuilder get(URI uri) {
+    return newRequest(uri).withMethod("GET");
+  }
+
+  /**
+   * Create a new POST request builder. The client name will be selected based
+   * on a prefix of the host name.
+   *
+   * @param uri
+   *     URI to use for the request.
+   * @return
+   *     Builder for creating and executing a request.
+   */
+  default HttpRequestBuilder post(URI uri) {
+    return newRequest(uri).withMethod("POST");
+  }
+
+  /**
+   * Create a new PUT request builder. The client name will be selected based
+   * on a prefix of the host name.
+   *
+   * @param uri
+   *     URI to use for the request.
+   * @return
+   *     Builder for creating and executing a request.
+   */
+  default HttpRequestBuilder put(URI uri) {
+    return newRequest(uri).withMethod("PUT");
+  }
+
+  /**
+   * Create a new DELETE request builder. The client name will be selected based
+   * on a prefix of the host name.
+   *
+   * @param uri
+   *     URI to use for the request.
+   * @return
+   *     Builder for creating and executing a request.
+   */
+  default HttpRequestBuilder delete(URI uri) {
+    return newRequest(uri).withMethod("DELETE");
+  }
+}

--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/http/HttpRequestBuilder.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/http/HttpRequestBuilder.java
@@ -1,0 +1,358 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.ipc.http;
+
+import com.netflix.spectator.impl.Preconditions;
+import com.netflix.spectator.ipc.IpcLogEntry;
+import com.netflix.spectator.ipc.IpcLogger;
+import com.netflix.spectator.ipc.NetflixHeader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLSocketFactory;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.Deflater;
+
+/**
+ * Helper for executing simple HTTP client requests using {@link HttpURLConnection}
+ * and logging via {@link com.netflix.spectator.ipc.IpcLogger}. This is mostly used for simple
+ * use-cases where it is undesirable to have additional dependencies on a more robust HTTP
+ * library.
+ */
+public class HttpRequestBuilder {
+  private static final Logger LOGGER = LoggerFactory.getLogger(HttpRequestBuilder.class);
+
+  private static final String[] NETFLIX_ASG = {
+      "NETFLIX_AUTO_SCALE_GROUP",
+      "CLOUD_AUTO_SCALE_GROUP"
+  };
+
+  private static final String[] NETFLIX_NODE = {
+      "TITUS_TASK_ID",
+      "EC2_INSTANCE_ID"
+  };
+
+  private static final String[] NETFLIX_ZONE = {
+      "EC2_AVAILABILITY_ZONE"
+  };
+
+  private static final Map<String, String> NETFLIX_HEADERS = new LinkedHashMap<>();
+
+  static {
+    addHeader(NetflixHeader.ASG, NETFLIX_ASG);
+    addHeader(NetflixHeader.Node, NETFLIX_NODE);
+    addHeader(NetflixHeader.Zone, NETFLIX_ZONE);
+  }
+
+  private static void addHeader(NetflixHeader header, String[] names) {
+    for (String name : names) {
+      String value = System.getenv(name);
+      if (value != null && !value.isEmpty()) {
+        NETFLIX_HEADERS.put(header.headerName(), value);
+        break;
+      }
+    }
+  }
+
+  private final URI uri;
+  private final IpcLogEntry entry;
+  private String method = "GET";
+  private Map<String, String> reqHeaders = new LinkedHashMap<>();
+  private byte[] entity = HttpUtils.EMPTY;
+
+  private int connectTimeout = 1000;
+  private int readTimeout = 30000;
+
+  private long initialRetryDelay = 1000L;
+  private int numAttempts = 1;
+
+  private HostnameVerifier hostVerifier = null;
+  private SSLSocketFactory sslFactory = null;
+
+  /** Create a new instance for the specified URI. */
+  HttpRequestBuilder(IpcLogger logger, URI uri) {
+    this.uri = uri;
+    this.entry = logger.createClientEntry()
+        .withUri(uri)
+        .withHttpMethod(method);
+    this.reqHeaders.putAll(NETFLIX_HEADERS);
+  }
+
+  /** Set the request method (GET, PUT, POST, DELETE). */
+  public HttpRequestBuilder withMethod(String m) {
+    this.method = m;
+    entry.withHttpMethod(method);
+    return this;
+  }
+
+  /**
+   * Add a header to the request. Note the content type will be set automatically
+   * when providing the content payload and should not be set here.
+   */
+  public HttpRequestBuilder addHeader(String name, String value) {
+    reqHeaders.put(name, value);
+    return this;
+  }
+
+  /** Add user-agent header. */
+  public HttpRequestBuilder userAgent(String agent) {
+    return addHeader("User-Agent", agent);
+  }
+
+  /** Add header to accept {@code application/json} data. */
+  public HttpRequestBuilder acceptJson() {
+    return addHeader("Accept", "application/json");
+  }
+
+  /** Add accept header. */
+  public HttpRequestBuilder accept(String type) {
+    return addHeader("Accept", type);
+  }
+
+  /** Add header to accept-encoding of gzip. */
+  public HttpRequestBuilder acceptGzip() {
+    return acceptEncoding("gzip");
+  }
+
+  /** Add accept-encoding header. */
+  public HttpRequestBuilder acceptEncoding(String enc) {
+    return addHeader("Accept-Encoding", enc);
+  }
+
+  /** Set the connection timeout for the request in milliseconds. */
+  public HttpRequestBuilder withConnectTimeout(int timeout) {
+    this.connectTimeout = timeout;
+    return this;
+  }
+
+  /** Set the read timeout for the request milliseconds. */
+  public HttpRequestBuilder withReadTimeout(int timeout) {
+    this.readTimeout = timeout;
+    return this;
+  }
+
+  /** Set the request body as JSON. */
+  public HttpRequestBuilder withJsonContent(String content) {
+    return withContent("application/json", content);
+  }
+
+  /** Set the request body. */
+  public HttpRequestBuilder withContent(String type, String content) {
+    return withContent(type, content.getBytes(StandardCharsets.UTF_8));
+  }
+
+  /** Set the request body. */
+  public HttpRequestBuilder withContent(String type, byte[] content) {
+    addHeader("Content-Type", type);
+    entity = content;
+    return this;
+  }
+
+  /**
+   * Compress the request body using the default compression level.
+   * The content must have already been set on the builder.
+   */
+  public HttpRequestBuilder compress() throws IOException {
+    return compress(Deflater.DEFAULT_COMPRESSION);
+  }
+
+  /**
+   * Compress the request body using the specified compression level.
+   * The content must have already been set on the builder.
+   */
+  public HttpRequestBuilder compress(int level) throws IOException {
+    addHeader("Content-Encoding", "gzip");
+    entity = HttpUtils.gzip(entity, level);
+    return this;
+  }
+
+  /** How many times to retry if the intial attempt fails? */
+  public HttpRequestBuilder withRetries(int n) {
+    Preconditions.checkArg(n >= 0, "number of retries must be >= 0");
+    this.numAttempts = n + 1;
+    return this;
+  }
+
+  /**
+   * How long to delay before retrying if the request is throttled. This will get doubled
+   * for each attempt that is throttled. Unit is milliseconds.
+   */
+  public HttpRequestBuilder withInitialRetryDelay(long delay) {
+    Preconditions.checkArg(delay >= 0L, "initial retry delay must be >= 0");
+    this.initialRetryDelay = delay;
+    return this;
+  }
+
+  private void requireHttps(String msg) {
+    Preconditions.checkState("https".equals(uri.getScheme()), msg);
+  }
+
+  /** Sets the policy used to verify hostnames when using HTTPS. */
+  public HttpRequestBuilder withHostnameVerifier(HostnameVerifier verifier) {
+    requireHttps("hostname verification cannot be used with http, switch to https");
+    this.hostVerifier = verifier;
+    return this;
+  }
+
+  /**
+   * Specify that all hosts are allowed. Using this option effectively disables hostname
+   * verification. Use with caution.
+   */
+  public HttpRequestBuilder allowAllHosts() {
+    return withHostnameVerifier((host, session) -> true);
+  }
+
+  /** Sets the socket factory to use with HTTPS. */
+  public HttpRequestBuilder withSSLSocketFactory(SSLSocketFactory factory) {
+    requireHttps("ssl cannot be used with http, use https");
+    this.sslFactory = factory;
+    return this;
+  }
+
+  /** Send the request and log/update metrics for the results. */
+  @SuppressWarnings("PMD.ExceptionAsFlowControl")
+  public HttpResponse send() throws IOException {
+    HttpResponse response = null;
+    for (int attempt = 1; attempt <= numAttempts; ++attempt) {
+      entry.withAttempt(attempt).withAttemptFinal(attempt == numAttempts);
+      try {
+        response = sendImpl();
+        int s = response.status();
+        if (s == 429 || s == 503) {
+          // Request is getting throttled, exponentially back off
+          // - 429 client sending too many requests
+          // - 503 server unavailable
+          try {
+            long delay = initialRetryDelay << (attempt - 1);
+            LOGGER.debug("request throttled, delaying for {}ms: {} {}", delay, method, uri);
+            Thread.sleep(delay);
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("request failed " + method + " " + uri, e);
+          }
+        } else if (s < 500) {
+          // 4xx errors other than 429 are not considered retriable, so for anything
+          // less than 500 just return the response to the user
+          return response;
+        }
+      } catch (IOException e) {
+        // All exceptions are considered retriable. Some like UnknownHostException are
+        // debatable, but we have seen them in some cases if there is a high latency for
+        // DNS lookups. So for now assume all exceptions are transient issues.
+        if (attempt == numAttempts) {
+          throw e;
+        } else {
+          LOGGER.warn("attempt {} of {} failed: {} {}", attempt, numAttempts, method, uri);
+        }
+      }
+    }
+
+    if (response == null) {
+      // Should not get here
+      throw new IOException("request failed " + method + " " + uri);
+    }
+    return response;
+  }
+
+  private void configureHTTPS(HttpURLConnection http) {
+    if (http instanceof HttpsURLConnection) {
+      HttpsURLConnection https = (HttpsURLConnection) http;
+      if (hostVerifier != null) {
+        https.setHostnameVerifier(hostVerifier);
+      }
+      if (sslFactory != null) {
+        https.setSSLSocketFactory(sslFactory);
+      }
+    }
+  }
+
+  /** Send the request and log/update metrics for the results. */
+  protected HttpResponse sendImpl() throws IOException {
+    HttpURLConnection con = (HttpURLConnection) uri.toURL().openConnection();
+    con.setConnectTimeout(connectTimeout);
+    con.setReadTimeout(readTimeout);
+    con.setRequestMethod(method);
+    for (Map.Entry<String, String> h : reqHeaders.entrySet()) {
+      entry.addRequestHeader(h.getKey(), h.getValue());
+      con.setRequestProperty(h.getKey(), h.getValue());
+    }
+    configureHTTPS(con);
+
+    try {
+      con.setDoInput(true);
+
+      // HttpURLConnection will change method to POST if there is a body associated
+      // with a GET request. Only try to write entity if it is not empty.
+      entry.markStart();
+      if (entity.length > 0) {
+        con.setDoOutput(true);
+        try (OutputStream out = con.getOutputStream()) {
+          out.write(entity);
+        }
+      }
+
+      int status = con.getResponseCode();
+      entry.markEnd().withHttpStatus(status);
+
+      // A null key is used to return the status line, remove it before sending to
+      // the log entry or creating the response object
+      Map<String, List<String>> headers = new LinkedHashMap<>(con.getHeaderFields());
+      headers.remove(null);
+      for (Map.Entry<String, List<String>> h : headers.entrySet()) {
+        for (String v : h.getValue()) {
+          entry.addResponseHeader(h.getKey(), v);
+        }
+      }
+
+      try (InputStream in = (status >= 400) ? con.getErrorStream() : con.getInputStream()) {
+        byte[] data = readAll(in);
+        return new HttpResponse(status, headers, data);
+      }
+    } catch (IOException e) {
+      entry.markEnd().withException(e);
+      throw e;
+    } finally {
+      entry.log();
+    }
+  }
+
+  @SuppressWarnings("PMD.AssignmentInOperand")
+  private byte[] readAll(InputStream in) throws IOException {
+    if (in == null) {
+      // For error status codes with a content-length of 0 we see this case
+      return new byte[0];
+    } else {
+      ByteArrayOutputStream baos = new ByteArrayOutputStream();
+      byte[] buffer = new byte[4096];
+      int length;
+      while ((length = in.read(buffer)) > 0) {
+        baos.write(buffer, 0, length);
+      }
+      return baos.toByteArray();
+    }
+  }
+}

--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/http/HttpResponse.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/http/HttpResponse.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.ipc.http;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+/**
+ * Response for an HTTP request made via {@link HttpRequestBuilder}.
+ */
+public class HttpResponse {
+
+  private final int status;
+  private final Map<String, List<String>> headers;
+  private final byte[] data;
+
+  /** Create a new response instance with an empty entity. */
+  public HttpResponse(int status, Map<String, List<String>> headers) {
+    this(status, headers, HttpUtils.EMPTY);
+  }
+
+  /** Create a new response instance. */
+  public HttpResponse(int status, Map<String, List<String>> headers, byte[] data) {
+    this.status = status;
+    Map<String, List<String>> hs = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    hs.putAll(headers);
+    this.headers = Collections.unmodifiableMap(hs);
+    this.data = data;
+  }
+
+  /** Return the status code of the response. */
+  public int status() {
+    return status;
+  }
+
+  /**
+   * Return the headers for the response as an unmodifiable map with case-insensitive keys.
+   */
+  public Map<String, List<String>> headers() {
+    return headers;
+  }
+
+  /** Return the value for the first occurrence of a given header or null if not found. */
+  public String header(String k) {
+    List<String> vs = headers.get(k);
+    return (vs == null || vs.isEmpty()) ? null : vs.get(0);
+  }
+
+  /**
+   * Return the value for a date header. The return value will be null if the header does
+   * not exist or if it cannot be parsed correctly as a date.
+   */
+  public Instant dateHeader(String k) {
+    String d = header(k);
+    return (d == null) ? null : parseDate(d);
+  }
+
+  private Instant parseDate(String d) {
+    try {
+      return LocalDateTime.parse(d, DateTimeFormatter.RFC_1123_DATE_TIME)
+          .atZone(ZoneOffset.UTC)
+          .toInstant();
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  /** Return the entity for the response. */
+  public byte[] entity() {
+    return data;
+  }
+
+  /** Return the entity as a UTF-8 string. */
+  public String entityAsString() {
+    return new String(data, StandardCharsets.UTF_8);
+  }
+
+  /** Return a copy of the response with the entity decompressed. */
+  public HttpResponse decompress() throws IOException {
+    String enc = header("Content-Encoding");
+    return (enc != null && enc.contains("gzip")) ? unzip() : this;
+  }
+
+  private HttpResponse unzip() throws IOException {
+    Map<String, List<String>> newHeaders = headers.entrySet().stream()
+        .filter(e -> !e.getKey().equalsIgnoreCase("Content-Encoding"))
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    if (data.length == 0) {
+      return new HttpResponse(status, newHeaders);
+    } else {
+      return new HttpResponse(status, newHeaders, HttpUtils.gunzip(data));
+    }
+  }
+
+  @Override public String toString() {
+    StringBuilder builder = new StringBuilder(50);
+    builder.append("HTTP/1.1 ").append(status).append('\n');
+    for (Map.Entry<String, List<String>> h : headers.entrySet()) {
+      for (String v : h.getValue()) {
+        builder.append(h.getKey()).append(": ").append(v).append('\n');
+      }
+    }
+    builder.append("\n... ")
+        .append(data.length)
+        .append(" bytes ...\n");
+    return builder.toString();
+  }
+}

--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/http/HttpUtils.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/http/HttpUtils.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.ipc.http;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.zip.Deflater;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+
+/**
+ * Helper functions for the http client.
+ */
+final class HttpUtils {
+  private HttpUtils() {
+  }
+
+  /** Empty byte array constant. */
+  static final byte[] EMPTY = new byte[0];
+
+  private static final String DEFAULT = "default";
+
+  private static final Pattern PREFIX = Pattern.compile("^([^.-]+).*$");
+
+  /**
+   * Extract a client name based on the host. This will currently select up
+   * to the first dash or dot in the name. The goal is to have a reasonable
+   * name, but avoid a large explosion in number of names in dynamic environments
+   * such as EC2. Examples:
+   *
+   * <pre>
+   * name      host
+   * ----------------------------------------------------
+   * foo       foo.test.netflix.com
+   * ec2       ec2-127-0-0-1.compute-1.amazonaws.com
+   * </pre>
+   */
+  static String clientNameForHost(String host) {
+    Matcher m = PREFIX.matcher(host);
+    return m.matches() ? m.group(1) : DEFAULT;
+  }
+
+  /**
+   * Extract a client name based on the uri host. See {@link #clientNameForHost(String)}
+   * for more details.
+   */
+  static String clientNameForURI(URI uri) {
+    String host = uri.getHost();
+    return (host == null) ? DEFAULT : clientNameForHost(host);
+  }
+
+  /** Wrap GZIPOutputStream allowing the user to override the compression level. */
+  static class GzipLevelOutputStream extends GZIPOutputStream {
+    /** Creates a new output stream with a default compression level. */
+    GzipLevelOutputStream(OutputStream outputStream) throws IOException {
+      super(outputStream);
+    }
+
+    /** Set the compression level for the underlying deflater. */
+    void setLevel(int level) {
+      def.setLevel(level);
+    }
+  }
+
+  /**
+   * Compress a byte array using GZIP's default compression level.
+   */
+  static byte[] gzip(byte[] data) throws IOException {
+    return gzip(data, Deflater.DEFAULT_COMPRESSION);
+  }
+
+  /**
+   * Compress a byte array using GZIP with the given compression level.
+   */
+  static byte[] gzip(byte[] data, int level) throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream(data.length);
+    try (GzipLevelOutputStream out = new GzipLevelOutputStream(baos)) {
+      out.setLevel(level);
+      out.write(data);
+    }
+    return baos.toByteArray();
+  }
+
+  /** Decompress a GZIP compressed byte array. */
+  @SuppressWarnings("PMD.AssignmentInOperand")
+  static byte[] gunzip(byte[] data) throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream(data.length * 10);
+    try (InputStream in = new GZIPInputStream(new ByteArrayInputStream(data))) {
+      byte[] buffer = new byte[4096];
+      int length;
+      while ((length = in.read(buffer)) > 0) {
+        baos.write(buffer, 0, length);
+      }
+    }
+    return baos.toByteArray();
+  }
+}

--- a/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/IpcLogEntryTest.java
+++ b/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/IpcLogEntryTest.java
@@ -1,0 +1,609 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.ipc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spectator.api.BasicTag;
+import com.netflix.spectator.api.ManualClock;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@RunWith(JUnit4.class)
+public class IpcLogEntryTest {
+
+  private final ManualClock clock = new ManualClock();
+  private final ObjectMapper mapper = new ObjectMapper();
+  private final IpcLogEntry entry = new IpcLogEntry(clock);
+
+  @Before
+  public void before() {
+    clock.setWallTime(0L);
+    clock.setMonotonicTime(0L);
+    entry.reset();
+  }
+
+  @SuppressWarnings("unchecked")
+  private Map<String, Object> toMap(IpcLogEntry entry) {
+    try {
+      return (Map<String, Object>) mapper.readValue(entry.toString(), Map.class);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Test
+  public void startTime() {
+    long expected = 1234567890L;
+    clock.setWallTime(expected);
+    long actual = (int) entry
+        .markStart()
+        .convert(this::toMap)
+        .get("start");
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void startTimeOnlyComputedLatency() {
+    long expected = 157;
+    long t = 1234567890L;
+    clock.setMonotonicTime(TimeUnit.MILLISECONDS.toNanos(t));
+    entry.markStart();
+    clock.setMonotonicTime(TimeUnit.MILLISECONDS.toNanos(t + expected));
+    double actual = (double) entry
+        .convert(this::toMap)
+        .get("latency");
+    Assert.assertEquals(expected / 1000.0, actual, 1e-12);
+  }
+
+  @Test
+  public void latency() {
+    long expected = 157L;
+    double actual = (double) entry
+        .withLatency(expected, TimeUnit.MILLISECONDS)
+        .convert(this::toMap)
+        .get("latency");
+    Assert.assertEquals(expected / 1000.0, actual, 1e-12);
+  }
+
+  @Test
+  public void latencyAndStart() {
+    long expected = 157L;
+    long t = 1234567890L;
+    clock.setWallTime(t);
+    entry.markStart();
+    clock.setWallTime(t + expected + 42);
+    double actual = (double) entry
+        .withLatency(expected, TimeUnit.MILLISECONDS)
+        .convert(this::toMap)
+        .get("latency");
+    Assert.assertEquals(expected / 1000.0, actual, 1e-12);
+  }
+
+  @Test
+  public void owner() {
+    String expected = "runtime";
+    String actual = (String) entry
+        .withOwner(expected)
+        .convert(this::toMap)
+        .get("owner");
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void standardProtocol() {
+    String expected = IpcProtocol.http_2.value();
+    String actual = (String) entry
+        .withProtocol(IpcProtocol.http_2)
+        .convert(this::toMap)
+        .get("protocol");
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void customProtocol() {
+    String expected = "nflx-proto";
+    String actual = (String) entry
+        .withProtocol(expected)
+        .convert(this::toMap)
+        .get("protocol");
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void errorGroup() {
+    String expected = IpcErrorGroup.cancelled.value();
+    String actual = (String) entry
+        .withErrorGroup(IpcErrorGroup.cancelled)
+        .convert(this::toMap)
+        .get("errorGroup");
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void errorReason() {
+    String expected = "connection_failed";
+    String actual = (String) entry
+        .withErrorReason(expected)
+        .convert(this::toMap)
+        .get("errorReason");
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void exceptionClass() {
+    IOException io = new IOException("host not found exception");
+    String expected = "java.io.IOException";
+    String actual = (String) entry
+        .withException(io)
+        .convert(this::toMap)
+        .get("exceptionClass");
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void exceptionMessage() {
+    String expected = "host not found exception";
+    IOException io = new IOException(expected);
+    String actual = (String) entry
+        .withException(io)
+        .convert(this::toMap)
+        .get("exceptionMessage");
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void attempt() {
+    String expected = IpcAttempt.third_up.value();
+    String actual = (String) entry
+        .withAttempt(7)
+        .convert(this::toMap)
+        .get("attempt");
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void attemptFinal() {
+    String expected = IpcAttemptFinal.is_true.value();
+    String actual = (String) entry
+        .withAttemptFinal(true)
+        .convert(this::toMap)
+        .get("attemptFinal");
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void vip() {
+    String expected = "www:7001";
+    String actual = (String) entry
+        .withVip(expected)
+        .convert(this::toMap)
+        .get("vip");
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void endpoint() {
+    String expected = "/api/v1/test";
+    String actual = (String) entry
+        .withEndpoint(expected)
+        .convert(this::toMap)
+        .get("endpoint");
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void clientNode() {
+    String expected = "i-12345";
+    String actual = (String) entry
+        .withClientNode(expected)
+        .convert(this::toMap)
+        .get("clientNode");
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void serverNode() {
+    String expected = "i-12345";
+    String actual = (String) entry
+        .withServerNode(expected)
+        .convert(this::toMap)
+        .get("serverNode");
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void addRequestZoneHeader() {
+    Map<String, Object> map = entry
+        .addRequestHeader(NetflixHeader.Zone.headerName(), "us-east-1e")
+        .convert(this::toMap);
+    Assert.assertEquals("us-east-1", map.get("clientRegion"));
+    Assert.assertEquals("us-east-1e", map.get("clientZone"));
+  }
+
+  @Test
+  public void addRequestZoneHeaderExplicitRegion() {
+    Map<String, Object> map = entry
+        .withClientRegion("us-west-1")
+        .addRequestHeader(NetflixHeader.Zone.headerName(), "us-east-1e")
+        .convert(this::toMap);
+    Assert.assertEquals("us-west-1", map.get("clientRegion"));
+    Assert.assertEquals("us-east-1e", map.get("clientZone"));
+  }
+
+  @Test
+  public void addRequestZoneHeaderExplicitZone() {
+    Map<String, Object> map = entry
+        .withClientZone("us-west-1b")
+        .addRequestHeader(NetflixHeader.Zone.headerName(), "us-east-1e")
+        .convert(this::toMap);
+    Assert.assertEquals("us-west-1", map.get("clientRegion"));
+    Assert.assertEquals("us-west-1b", map.get("clientZone"));
+  }
+
+  @Test
+  public void addResponseZoneHeader() {
+    Map<String, Object> map = entry
+        .addResponseHeader(NetflixHeader.Zone.headerName(), "us-east-1e")
+        .convert(this::toMap);
+    Assert.assertEquals("us-east-1", map.get("serverRegion"));
+    Assert.assertEquals("us-east-1e", map.get("serverZone"));
+  }
+
+  @Test
+  public void addResponseZoneHeaderExplicitRegion() {
+    Map<String, Object> map = entry
+        .withServerRegion("us-west-1")
+        .addResponseHeader(NetflixHeader.Zone.headerName(), "us-east-1e")
+        .convert(this::toMap);
+    Assert.assertEquals("us-west-1", map.get("serverRegion"));
+    Assert.assertEquals("us-east-1e", map.get("serverZone"));
+  }
+
+  @Test
+  public void addResponseZoneHeaderExplicitZone() {
+    Map<String, Object> map = entry
+        .withServerZone("us-west-1b")
+        .addResponseHeader(NetflixHeader.Zone.headerName(), "us-east-1e")
+        .convert(this::toMap);
+    Assert.assertEquals("us-west-1", map.get("serverRegion"));
+    Assert.assertEquals("us-west-1b", map.get("serverZone"));
+  }
+
+  @Test
+  public void addRequestAsgHeader() {
+    Map<String, Object> map = entry
+        .addRequestHeader(NetflixHeader.ASG.headerName(), "www-test-v011")
+        .convert(this::toMap);
+    Assert.assertEquals("www", map.get("clientApp"));
+    Assert.assertEquals("www-test", map.get("clientCluster"));
+    Assert.assertEquals("www-test-v011", map.get("clientAsg"));
+  }
+
+  @Test
+  public void addRequestAsgHeaderCaseSensitivty() {
+    Map<String, Object> map = entry
+        .addRequestHeader("netflix-asg", "www-test-v011")
+        .convert(this::toMap);
+    Assert.assertEquals("www", map.get("clientApp"));
+    Assert.assertEquals("www-test", map.get("clientCluster"));
+    Assert.assertEquals("www-test-v011", map.get("clientAsg"));
+  }
+
+  @Test
+  public void addRequestAsgHeaderExplicitApp() {
+    Map<String, Object> map = entry
+        .withClientApp("foo")
+        .addRequestHeader(NetflixHeader.ASG.headerName(), "www-test-v011")
+        .convert(this::toMap);
+    Assert.assertEquals("foo", map.get("clientApp"));
+    Assert.assertEquals("www-test", map.get("clientCluster"));
+    Assert.assertEquals("www-test-v011", map.get("clientAsg"));
+  }
+
+  @Test
+  public void addRequestAsgHeaderExplicitCluster() {
+    Map<String, Object> map = entry
+        .withClientCluster("foo")
+        .addRequestHeader(NetflixHeader.ASG.headerName(), "www-test-v011")
+        .convert(this::toMap);
+    Assert.assertEquals("www", map.get("clientApp"));
+    Assert.assertEquals("foo", map.get("clientCluster"));
+    Assert.assertEquals("www-test-v011", map.get("clientAsg"));
+  }
+
+  @Test
+  public void addRequestAsgHeaderExplicitAsg() {
+    Map<String, Object> map = entry
+        .withClientAsg("foo")
+        .addRequestHeader(NetflixHeader.ASG.headerName(), "www-test-v011")
+        .convert(this::toMap);
+    Assert.assertEquals("foo", map.get("clientApp"));
+    Assert.assertEquals("foo", map.get("clientCluster"));
+    Assert.assertEquals("foo", map.get("clientAsg"));
+  }
+
+  @Test
+  public void addResponseAsgHeader() {
+    Map<String, Object> map = entry
+        .addResponseHeader(NetflixHeader.ASG.headerName(), "www-test-v011")
+        .convert(this::toMap);
+    Assert.assertEquals("www", map.get("serverApp"));
+    Assert.assertEquals("www-test", map.get("serverCluster"));
+    Assert.assertEquals("www-test-v011", map.get("serverAsg"));
+  }
+
+  @Test
+  public void addResponseAsgHeaderCaseSensitivty() {
+    Map<String, Object> map = entry
+        .addResponseHeader("netflix-asg", "www-test-v011")
+        .convert(this::toMap);
+    Assert.assertEquals("www", map.get("serverApp"));
+    Assert.assertEquals("www-test", map.get("serverCluster"));
+    Assert.assertEquals("www-test-v011", map.get("serverAsg"));
+  }
+
+  @Test
+  public void addResponseAsgHeaderExplicitApp() {
+    Map<String, Object> map = entry
+        .withServerApp("foo")
+        .addResponseHeader(NetflixHeader.ASG.headerName(), "www-test-v011")
+        .convert(this::toMap);
+    Assert.assertEquals("foo", map.get("serverApp"));
+    Assert.assertEquals("www-test", map.get("serverCluster"));
+    Assert.assertEquals("www-test-v011", map.get("serverAsg"));
+  }
+
+  @Test
+  public void addResponseAsgHeaderExplicitCluster() {
+    Map<String, Object> map = entry
+        .withServerCluster("foo")
+        .addResponseHeader(NetflixHeader.ASG.headerName(), "www-test-v011")
+        .convert(this::toMap);
+    Assert.assertEquals("www", map.get("serverApp"));
+    Assert.assertEquals("foo", map.get("serverCluster"));
+    Assert.assertEquals("www-test-v011", map.get("serverAsg"));
+  }
+
+  @Test
+  public void addResponseAsgHeaderExplicitAsg() {
+    Map<String, Object> map = entry
+        .withServerAsg("foo")
+        .addResponseHeader(NetflixHeader.ASG.headerName(), "www-test-v011")
+        .convert(this::toMap);
+    Assert.assertEquals("foo", map.get("serverApp"));
+    Assert.assertEquals("foo", map.get("serverCluster"));
+    Assert.assertEquals("foo", map.get("serverAsg"));
+  }
+
+  @Test
+  public void addRequestNodeHeader() {
+    Map<String, Object> map = entry
+        .addRequestHeader(NetflixHeader.Node.headerName(), "i-12345")
+        .convert(this::toMap);
+    Assert.assertEquals("i-12345", map.get("clientNode"));
+  }
+
+  @Test
+  public void addResponseNodeHeader() {
+    Map<String, Object> map = entry
+        .addResponseHeader(NetflixHeader.Node.headerName(), "i-12345")
+        .convert(this::toMap);
+    Assert.assertEquals("i-12345", map.get("serverNode"));
+  }
+
+  @Test
+  public void addRequestVipHeader() {
+    Map<String, Object> map = entry
+        .addRequestHeader(NetflixHeader.Vip.headerName(), "www:7001")
+        .convert(this::toMap);
+    Assert.assertEquals("www:7001", map.get("vip"));
+  }
+
+  @Test
+  public void addResponseEndpointHeader() {
+    Map<String, Object> map = entry
+        .addResponseHeader(NetflixHeader.Endpoint.headerName(), "/api/v1/test")
+        .convert(this::toMap);
+    Assert.assertEquals("/api/v1/test", map.get("endpoint"));
+  }
+
+  @Test
+  public void httpStatusOk() {
+    String actual = (String) entry
+        .withHttpStatus(200)
+        .convert(this::toMap)
+        .get("result");
+    Assert.assertEquals(IpcResult.success.value(), actual);
+  }
+
+  @Test
+  public void httpStatus400() {
+    String actual = (String) entry
+        .withHttpStatus(400)
+        .convert(this::toMap)
+        .get("result");
+    Assert.assertEquals(IpcResult.failure.value(), actual);
+  }
+
+  @Test
+  public void httpStatusWithExplicitResult() {
+    String actual = (String) entry
+        .withResult(IpcResult.failure)
+        .withHttpStatus(200)
+        .convert(this::toMap)
+        .get("result");
+    Assert.assertEquals(IpcResult.failure.value(), actual);
+  }
+
+  @Test
+  public void httpStatus429() {
+    String actual = (String) entry
+        .withHttpStatus(429)
+        .convert(this::toMap)
+        .get("errorGroup");
+    Assert.assertEquals(IpcErrorGroup.client_throttled.value(), actual);
+  }
+
+  @Test
+  public void httpStatus503() {
+    String actual = (String) entry
+        .withHttpStatus(503)
+        .convert(this::toMap)
+        .get("errorGroup");
+    Assert.assertEquals(IpcErrorGroup.server_throttled.value(), actual);
+  }
+
+  @Test
+  public void httpMethod() {
+    String expected = "GET";
+    String actual = (String) entry
+        .withHttpMethod(expected)
+        .convert(this::toMap)
+        .get("httpMethod");
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void uri() {
+    String expected = "http://foo.com/api/v1/test";
+    String actual = (String) entry
+        .withUri(URI.create(expected))
+        .convert(this::toMap)
+        .get("uri");
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void uriPath() {
+    String expected = "http://foo.com/api/v1/test";
+    String actual = (String) entry
+        .withUri(URI.create(expected))
+        .convert(this::toMap)
+        .get("path");
+    Assert.assertEquals("/api/v1/test", actual);
+  }
+
+  @Test
+  public void remoteAddress() {
+    String expected = "123.45.67.89";
+    String actual = (String) entry
+        .withRemoteAddress(expected)
+        .convert(this::toMap)
+        .get("remoteAddress");
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void remotePort() {
+    int expected = 42;
+    int actual = (int) entry
+        .withRemotePort(expected)
+        .convert(this::toMap)
+        .get("remotePort");
+    Assert.assertEquals(expected, actual);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void addTags() {
+    Map<String, String> actual = (Map<String, String>) entry
+        .addTag(new BasicTag("k1", "v1"))
+        .addTag("k2", "v2")
+        .convert(this::toMap)
+        .get("additionalTags");
+    Assert.assertEquals(2, actual.size());
+    Assert.assertEquals("v1", actual.get("k1"));
+    Assert.assertEquals("v2", actual.get("k2"));
+  }
+
+  @Test
+  public void regionFromZoneAWS() {
+    String expected = "us-east-1";
+    String actual = (String) entry
+        .withClientZone(expected + "e")
+        .convert(this::toMap)
+        .get("clientRegion");
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void regionFromZoneGCE() {
+    String expected = "us-east1";
+    String actual = (String) entry
+        .withClientZone(expected + "-e")
+        .convert(this::toMap)
+        .get("clientRegion");
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void regionFromZoneUnknownShort() {
+    String expected = "foo";
+    String actual = (String) entry
+        .withClientZone(expected)
+        .convert(this::toMap)
+        .get("clientRegion");
+    Assert.assertNull(actual);
+  }
+
+  @Test
+  public void regionFromZoneUnknownLong() {
+    String expected = "foobarbaz";
+    String actual = (String) entry
+        .withClientZone(expected)
+        .convert(this::toMap)
+        .get("clientRegion");
+    Assert.assertNull(actual);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void customHeaders() {
+    List<Map<String, Object>> actual = (List<Map<String, Object>>) entry
+        .addRequestHeader("foo", "bar")
+        .addRequestHeader("foo", "bar2")
+        .addRequestHeader("abc", "def")
+        .convert(this::toMap)
+        .get("requestHeaders");
+    Assert.assertEquals(3, actual.size());
+  }
+
+  @Test
+  public void stringEscape() {
+    for (char c = 0; c < 65535; ++c) {
+      String actual = (String) entry
+          .withErrorReason("" + c)
+          .convert(this::toMap)
+          .get("errorReason");
+      if (actual.length() == 0) {
+        Assert.assertTrue(Character.isISOControl(c));
+        Assert.assertEquals("", actual);
+      } else {
+        Assert.assertEquals("" + c, actual);
+      }
+      entry.reset();
+    }
+  }
+}

--- a/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/http/HttpRequestBuilderTest.java
+++ b/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/http/HttpRequestBuilderTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.ipc.http;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@RunWith(JUnit4.class)
+public class HttpRequestBuilderTest {
+
+  private static final HttpResponse OK           = new HttpResponse(200, Collections.emptyMap());
+  private static final HttpResponse REDIRECT     = new HttpResponse(302, Collections.emptyMap());
+  private static final HttpResponse BAD_REQUEST  = new HttpResponse(400, Collections.emptyMap());
+  private static final HttpResponse THROTTLED    = new HttpResponse(429, Collections.emptyMap());
+  private static final HttpResponse SERVER_ERROR = new HttpResponse(500, Collections.emptyMap());
+  private static final HttpResponse UNAVAILABLE  = new HttpResponse(503, Collections.emptyMap());
+
+  @Test
+  public void ok() throws IOException {
+    HttpResponse res = new TestRequestBuilder(() -> OK).send();
+    Assert.assertEquals(200, res.status());
+  }
+
+  @Test(expected = IOException.class)
+  public void retry0() throws Exception {
+    new TestRequestBuilder(() -> { throw new IOException("failed"); }).send();
+  }
+
+  @Test
+  public void retry2() {
+    AtomicInteger attempts = new AtomicInteger();
+    boolean failed = false;
+    try {
+      HttpResponseSupplier supplier = () -> {
+        attempts.incrementAndGet();
+        throw new IOException("failed");
+      };
+      new TestRequestBuilder(supplier).withRetries(2).send();
+    } catch (IOException e) {
+      failed = true;
+    }
+    Assert.assertEquals(3, attempts.get());
+    Assert.assertTrue(failed);
+  }
+
+  private void retryStatus(HttpResponse expectedRes, int expectedAttempts) throws IOException {
+    AtomicInteger attempts = new AtomicInteger();
+    HttpResponseSupplier supplier = () -> {
+      attempts.incrementAndGet();
+      return expectedRes;
+    };
+    HttpResponse res = new TestRequestBuilder(supplier)
+        .withInitialRetryDelay(0L)
+        .withRetries(2)
+        .send();
+    Assert.assertEquals(expectedAttempts, attempts.get());
+    Assert.assertEquals(expectedRes.status(), res.status());
+  }
+
+  @Test
+  public void retry2xx() throws IOException {
+    retryStatus(OK, 1);
+  }
+
+  @Test
+  public void retry3xx() throws IOException {
+    retryStatus(REDIRECT, 1);
+  }
+
+  @Test
+  public void retry4xx() throws IOException {
+    retryStatus(BAD_REQUEST, 1);
+  }
+
+  @Test
+  public void retry5xx() throws IOException {
+    retryStatus(SERVER_ERROR, 3);
+  }
+
+  @Test
+  public void retry429() throws IOException {
+    retryStatus(THROTTLED, 3);
+  }
+
+  @Test
+  public void retry503() throws IOException {
+    retryStatus(UNAVAILABLE, 3);
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void hostnameVerificationWithHTTP() throws IOException {
+    new TestRequestBuilder(() -> OK).allowAllHosts();
+  }
+
+  @Test
+  public void hostnameVerificationWithHTTPS() throws IOException {
+    HttpResponse res = new TestRequestBuilder(() -> OK, URI.create("https://foo.com/path"))
+        .allowAllHosts()
+        .send();
+    Assert.assertEquals(200, res.status());
+  }
+
+  private static class TestRequestBuilder extends HttpRequestBuilder {
+    private HttpResponseSupplier supplier;
+
+    TestRequestBuilder(HttpResponseSupplier supplier) {
+      this(supplier, URI.create("/path"));
+    }
+
+    TestRequestBuilder(HttpResponseSupplier supplier, URI uri) {
+      super(HttpClient.DEFAULT_LOGGER, uri);
+      this.supplier = supplier;
+    }
+
+    @Override protected HttpResponse sendImpl() throws IOException {
+      return supplier.get();
+    }
+  }
+
+  private interface HttpResponseSupplier {
+    HttpResponse get() throws IOException;
+  }
+}

--- a/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/http/HttpResponseTest.java
+++ b/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/http/HttpResponseTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.ipc.http;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.GZIPOutputStream;
+
+@RunWith(JUnit4.class)
+public class HttpResponseTest {
+
+  @Test
+  public void toStringEmpty() {
+    HttpResponse res = new HttpResponse(200, Collections.emptyMap());
+    String expected = "HTTP/1.1 200\n\n... 0 bytes ...\n";
+    Assert.assertEquals(expected, res.toString());
+  }
+
+  @Test
+  public void toStringContent() {
+    byte[] entity = "content".getBytes(StandardCharsets.UTF_8);
+    HttpResponse res = new HttpResponse(200, Collections.emptyMap(), entity);
+    String expected = "HTTP/1.1 200\n\n... 7 bytes ...\n";
+    Assert.assertEquals(expected, res.toString());
+  }
+
+  @Test
+  public void toStringHeaders() {
+    Map<String, List<String>> headers = new HashMap<>();
+    headers.put("Date", Collections.singletonList("Mon, 27 Jul 2012 17:21:03 GMT"));
+    headers.put("Content-Type", Collections.singletonList("application/json"));
+    byte[] entity = "{}".getBytes(StandardCharsets.UTF_8);
+    HttpResponse res = new HttpResponse(200, headers, entity);
+    String expected = "HTTP/1.1 200\nContent-Type: application/json\nDate: Mon, 27 Jul 2012 17:21:03 GMT\n\n... 2 bytes ...\n";
+    Assert.assertEquals(expected, res.toString());
+  }
+
+  @Test
+  public void header() {
+    Map<String, List<String>> headers = new HashMap<>();
+    headers.put("Content-Type", Collections.singletonList("application/json"));
+    HttpResponse res = new HttpResponse(200, headers);
+    Assert.assertEquals("application/json", res.header("content-type"));
+    Assert.assertEquals("application/json", res.header("Content-Type"));
+  }
+
+  @Test
+  public void dateHeaderNull() {
+    Map<String, List<String>> headers = new HashMap<>();
+    HttpResponse res = new HttpResponse(200, headers);
+    Assert.assertNull(res.dateHeader("Date"));
+  }
+
+  @Test
+  public void dateHeaderGMT() {
+    Map<String, List<String>> headers = new HashMap<>();
+    headers.put("Date", Collections.singletonList("Fri, 27 Jul 2012 17:21:03 GMT"));
+    HttpResponse res = new HttpResponse(200, headers);
+    Instant expected = Instant.ofEpochMilli(1343409663000L);
+    Assert.assertEquals(expected, res.dateHeader("Date"));
+  }
+
+  @Test
+  public void decompressNoChange() throws IOException {
+    Map<String, List<String>> headers = new HashMap<>();
+    headers.put("Content-Type", Collections.singletonList("application/json"));
+    byte[] entity = HttpUtils.gzip("foo bar baz foo bar baz".getBytes(StandardCharsets.UTF_8));
+    HttpResponse res = new HttpResponse(200, headers, entity);
+    Assert.assertSame(res, res.decompress());
+  }
+
+  @Test
+  public void decompress() throws IOException {
+    Map<String, List<String>> headers = new HashMap<>();
+    headers.put("Content-Type", Collections.singletonList("application/json"));
+    headers.put("Content-Encoding", Collections.singletonList("gzip"));
+    byte[] entity = HttpUtils.gzip("foo bar baz foo bar baz".getBytes(StandardCharsets.UTF_8));
+    HttpResponse res = new HttpResponse(200, headers, entity);
+    Assert.assertEquals("foo bar baz foo bar baz", res.decompress().entityAsString());
+    Assert.assertNull(res.decompress().header("content-encoding"));
+  }
+
+  @Test
+  public void decompressEmpty() throws IOException {
+    Map<String, List<String>> headers = new HashMap<>();
+    headers.put("Content-Type", Collections.singletonList("application/json"));
+    headers.put("Content-Encoding", Collections.singletonList("gzip"));
+    HttpResponse res = new HttpResponse(200, headers);
+    Assert.assertEquals("", res.decompress().entityAsString());
+    Assert.assertEquals(0, res.decompress().entity().length);
+  }
+}

--- a/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/http/HttpUtilsTest.java
+++ b/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/http/HttpUtilsTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.ipc.http;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.Deflater;
+
+@RunWith(JUnit4.class)
+public class HttpUtilsTest {
+
+  private String extract(String u) {
+    return HttpUtils.clientNameForURI(URI.create(u));
+  }
+
+  @Test
+  public void relativeUri() {
+    Assert.assertEquals("default", extract("/foo"));
+  }
+
+  @Test
+  public void dashFirst() {
+    Assert.assertEquals("ec2", extract("http://ec2-127-0-0-1.compute-1.amazonaws.com/foo"));
+  }
+
+  @Test
+  public void dotFirst() {
+    Assert.assertEquals("foo", extract("http://foo.test.netflix.com/foo"));
+  }
+
+  @Test
+  public void gzip() throws IOException {
+    byte[] data = "foo bar baz".getBytes(StandardCharsets.UTF_8);
+    String result = new String(HttpUtils.gunzip(HttpUtils.gzip(data)), StandardCharsets.UTF_8);
+    Assert.assertEquals("foo bar baz", result);
+  }
+
+  @Test
+  public void gzipWithLevel() throws IOException {
+    byte[] data = "foo bar baz".getBytes(StandardCharsets.UTF_8);
+    String result = new String(HttpUtils.gunzip(HttpUtils.gzip(data, Deflater.BEST_SPEED)), StandardCharsets.UTF_8);
+    Assert.assertEquals("foo bar baz", result);
+  }
+}


### PR DESCRIPTION
Initial version of some basic helpers to aid in using the
common IPC metrics in a consistent manner. As an example
of using the a simple HTTP client based on the java
HttpURLConnection is instrumented. This will replace
the version from the sandbox lib.