### PR TITLE
fix lookup of inflight metric count

### DIFF
--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcLogger.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcLogger.java
@@ -70,7 +70,7 @@ public class IpcLogger {
 
   /** Return the number of inflight requests associated with the given id. */
   AtomicInteger inflightRequests(Id id) {
-    return inflightRequests.get(id);
+    return Utils.computeIfAbsent(inflightRequests, id, i -> new AtomicInteger());
   }
 
   /**


### PR DESCRIPTION
Switch to using compute if absent and add test cases.