### PR TITLE
fix interpretation of nested parens for Atlas expr

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Parser.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Parser.java
@@ -62,6 +62,7 @@ public final class Parser {
     DataExpr.AggregateFunction af;
     Query q, q1, q2;
     String k, v;
+    int depth = 0;
     List<String> tmp;
     List<String> vs = null;
     String[] parts = expr.split(",");
@@ -71,7 +72,12 @@ public final class Parser {
       if (token.isEmpty()) {
         continue;
       }
-      if (vs != null && !")".equals(token)) {
+      if (vs != null && (depth > 0 || !")".equals(token))) {
+        if ("(".equals(token)) {
+          ++depth;
+        } else if (")".equals(token)) {
+          --depth;
+        }
         vs.add(token);
         continue;
       }
@@ -80,8 +86,12 @@ public final class Parser {
           vs = new ArrayList<>();
           break;
         case ")":
+          if (vs == null) {
+            throw new IllegalArgumentException("unmatched closing paren: " + expr);
+          }
           stack.push(vs);
           vs = null;
+          depth = 0;
           break;
         case ":true":
           stack.push(Query.TRUE);


### PR DESCRIPTION
Updates the Atlas expression parsing to match the behavior
of the backend. Before it would fail with nested lists and
throw a NullPointerException:

```
Caused by: java.lang.NullPointerException
	at java.util.ArrayDeque.addFirst(ArrayDeque.java:228)
	at java.util.ArrayDeque.push(ArrayDeque.java:503)
	at com.netflix.spectator.atlas.impl.Parser.parse(Parser.java:83)
	at com.netflix.spectator.atlas.impl.Parser.parseDataExpr(Parser.java:42)
	at com.netflix.spectator.atlas.impl.Subscription.setExpression(Subscription.java:66)
	at sun.reflect.GeneratedMethodAccessor2.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.fasterxml.jackson.databind.deser.impl.MethodProperty.deserializeAndSet(MethodProperty.java:139)
	... 63 more
```

Now it will behave the same way as the backend and treat
this as a list of strings.