### PR TITLE
add stateless registry for FaaS use-cases

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -16,6 +16,7 @@ include 'spectator-api',
         'spectator-reg-atlas',
         'spectator-reg-metrics3',
         'spectator-reg-servo',
+        'spectator-reg-stateless',
         'spectator-web-spring'
 
 enableFeaturePreview("STABLE_PUBLISHING")

--- a/spectator-api/src/main/java/com/netflix/spectator/api/ArrayTagSet.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/ArrayTagSet.java
@@ -321,6 +321,11 @@ final class ArrayTagSet implements Iterable<Tag> {
     }
   }
 
+  /** Return the current size of this tag set. */
+  public int size() {
+    return length / 2;
+  }
+
   @Override public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;

--- a/spectator-api/src/main/java/com/netflix/spectator/api/Utils.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 Netflix, Inc.
+ * Copyright 2014-2018 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ConcurrentMap;
@@ -231,6 +232,26 @@ public final class Utils {
       buf.add(iter.next());
     }
     return buf;
+  }
+
+  /**
+   * Returns the size of an iterable. This method should only be used with fixed size
+   * collections. It will attempt to find an efficient method to get the size before falling
+   * back to a traversal of the iterable.
+   */
+  @SuppressWarnings("PMD.UnusedLocalVariable")
+  public static <T> int size(Iterable<T> iter) {
+    if (iter instanceof ArrayTagSet) {
+      return ((ArrayTagSet) iter).size();
+    } else if (iter instanceof Collection<?>) {
+      return ((Collection<?>) iter).size();
+    } else {
+      int size = 0;
+      for (T v : iter) {
+        ++size;
+      }
+      return size;
+    }
   }
 
   /**

--- a/spectator-reg-stateless/build.gradle
+++ b/spectator-reg-stateless/build.gradle
@@ -1,0 +1,13 @@
+dependencies {
+  compileApi project(':spectator-api')
+  compile project(':spectator-ext-sandbox')
+  compile 'com.fasterxml.jackson.core:jackson-core'
+}
+
+jar {
+  manifest {
+    attributes(
+      "Automatic-Module-Name": "com.netflix.spectator.stateless"
+    )
+  }
+}

--- a/spectator-reg-stateless/src/main/java/com/netflix/spectator/stateless/JsonUtils.java
+++ b/spectator-reg-stateless/src/main/java/com/netflix/spectator/stateless/JsonUtils.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.stateless;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.Tag;
+import com.netflix.spectator.api.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Helper for encoding measurements into a JSON array that can be read by the aggregator
+ * service. For more information see:
+ *
+ * https://github.com/Netflix-Skunkworks/iep-apps/tree/master/atlas-aggregator
+ */
+final class JsonUtils {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(JsonUtils.class);
+
+  private static final JsonFactory FACTORY = new JsonFactory();
+
+  private static final int UNKNOWN = -1;
+  private static final int ADD = 0;
+  private static final int MAX = 10;
+
+  private JsonUtils() {
+  }
+
+  /** Encode the measurements to a JSON payload that can be sent to the aggregator. */
+  static byte[] encode(
+      Map<String, String> commonTags,
+      List<Measurement> measurements) throws IOException {
+
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    JsonGenerator gen = FACTORY.createGenerator(baos);
+    gen.writeStartArray();
+    Map<String, Integer> strings = buildStringTable(gen, commonTags, measurements);
+    for (Measurement m : measurements) {
+      appendMeasurement(gen, strings, commonTags, m.id(), m.value());
+    }
+    gen.writeEndArray();
+    gen.close();
+    return baos.toByteArray();
+  }
+
+  private static Map<String, Integer> buildStringTable(
+      JsonGenerator gen,
+      Map<String, String> commonTags,
+      List<Measurement> measurements) throws IOException {
+    Map<String, Integer> strings = new HashMap<>();
+
+    strings.put("name", 0);
+    commonTags.forEach((k, v) -> {
+      strings.put(k, 0);
+      strings.put(v, 0);
+    });
+
+    for (Measurement m : measurements) {
+      Id id = m.id();
+      strings.put(id.name(), 0);
+      for (Tag t : id.tags()) {
+        strings.put(t.key(), 0);
+        strings.put(t.value(), 0);
+      }
+    }
+
+    String[] sorted = strings.keySet().toArray(new String[0]);
+    Arrays.sort(sorted);
+
+    gen.writeNumber(sorted.length);
+    for (int i = 0; i < sorted.length; ++i) {
+      gen.writeString(sorted[i]);
+      strings.put(sorted[i], i);
+    }
+
+    return strings;
+  }
+
+  private static void appendMeasurement(
+      JsonGenerator gen,
+      Map<String, Integer> strings,
+      Map<String, String> commonTags,
+      Id id,
+      double value) throws IOException {
+
+    int op = operation(id);
+    if (shouldSend(op, value)) {
+      // Number of tag entries, commonTags + name + tags
+      int n = commonTags.size() + 1 + Utils.size(id.tags());
+      gen.writeNumber(n);
+
+      // Write out the key/value pairs for the tags
+      for (Map.Entry<String, String> entry : commonTags.entrySet()) {
+        gen.writeNumber(strings.get(entry.getKey()));
+        gen.writeNumber(strings.get(entry.getValue()));
+      }
+      for (Tag t : id.tags()) {
+        gen.writeNumber(strings.get(t.key()));
+        gen.writeNumber(strings.get(t.value()));
+      }
+      gen.writeNumber(strings.get("name"));
+      gen.writeNumber(strings.get(id.name()));
+
+      // Write out the operation and delta value
+      gen.writeNumber(op);
+      gen.writeNumber(value);
+    }
+  }
+
+  private static int operation(Id id) {
+    for (Tag t : id.tags()) {
+      if ("statistic".equals(t.key())) {
+        return operation(t.value());
+      }
+    }
+    LOGGER.warn("invalid statistic for {}, value will be dropped", id);
+    return UNKNOWN;
+  }
+
+  private static int operation(String stat) {
+    int op;
+    switch (stat) {
+      case "count":          op = ADD; break;
+      case "totalAmount":    op = ADD; break;
+      case "totalTime":      op = ADD; break;
+      case "totalOfSquares": op = ADD; break;
+      case "percentile":     op = ADD; break;
+      case "max":            op = MAX; break;
+      case "gauge":          op = MAX; break;
+      case "activeTasks":    op = MAX; break;
+      case "duration":       op = MAX; break;
+      default:               op = UNKNOWN; break;
+    }
+    return op;
+  }
+
+  private static boolean shouldSend(int op, double value) {
+    return op != UNKNOWN && !Double.isNaN(value) && (value > 0.0 || op == MAX);
+  }
+}

--- a/spectator-reg-stateless/src/main/java/com/netflix/spectator/stateless/StatelessConfig.java
+++ b/spectator-reg-stateless/src/main/java/com/netflix/spectator/stateless/StatelessConfig.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.stateless;
+
+import com.netflix.spectator.api.RegistryConfig;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Configuration for stateless registry.
+ */
+public interface StatelessConfig extends RegistryConfig {
+
+  /**
+   * Returns true if publishing is enabled. Default is true.
+   */
+  default boolean enabled() {
+    String v = get("stateless.enabled");
+    return v == null || Boolean.valueOf(v);
+  }
+
+  /**
+   * Returns the frequency to collect data and forward to the aggregation service. The
+   * default is 5 seconds.
+   */
+  default Duration frequency() {
+    String v = get("stateless.enabled");
+    return v == null ? Duration.ofSeconds(5) : Duration.parse(v);
+  }
+
+  /**
+   * Returns the TTL for meters that do not have any activity. After this period the meter
+   * will be considered expired and will not get reported. Default is 15 minutes.
+   */
+  default Duration meterTTL() {
+    String v = get("stateless.meterTTL");
+    return (v == null) ? Duration.ofMinutes(15) : Duration.parse(v);
+  }
+
+  /**
+   * Returns the connection timeout for requests to the backend. The default is
+   * 1 second.
+   */
+  default Duration connectTimeout() {
+    String v = get("stateless.connectTimeout");
+    return (v == null) ? Duration.ofSeconds(1) : Duration.parse(v);
+  }
+
+  /**
+   * Returns the read timeout for requests to the backend. The default is
+   * 10 seconds.
+   */
+  default Duration readTimeout() {
+    String v = get("stateless.readTimeout");
+    return (v == null) ? Duration.ofSeconds(10) : Duration.parse(v);
+  }
+
+  /**
+   * Returns the URI for the aggregation service. The default is
+   * {@code http://localhost:7101/api/v4/update}.
+   */
+  default String uri() {
+    String v = get("stateless.uri");
+    return (v == null) ? "http://localhost:7101/api/v4/update" : v;
+  }
+
+  /**
+   * Returns the number of measurements per request to use for the backend. If more
+   * measurements are found, then multiple requests will be made. The default is
+   * 10,000.
+   */
+  default int batchSize() {
+    String v = get("stateless.batchSize");
+    return (v == null) ? 10000 : Integer.parseInt(v);
+  }
+
+  /**
+   * Returns the common tags to apply to all metrics. The default is an empty map.
+   */
+  default Map<String, String> commonTags() {
+    return Collections.emptyMap();
+  }
+}

--- a/spectator-reg-stateless/src/main/java/com/netflix/spectator/stateless/StatelessCounter.java
+++ b/spectator-reg-stateless/src/main/java/com/netflix/spectator/stateless/StatelessCounter.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.stateless;
+
+import com.netflix.spectator.api.Clock;
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.Statistic;
+import com.netflix.spectator.impl.AtomicDouble;
+
+import java.util.Collections;
+
+/**
+ * Counter that keeps track of the delta since the last time it was measured.
+ */
+class StatelessCounter extends StatelessMeter implements Counter {
+
+  private final AtomicDouble count;
+  private final Id stat;
+
+  /** Create a new instance. */
+  StatelessCounter(Id id, Clock clock, long ttl) {
+    super(id, clock, ttl);
+    count = new AtomicDouble(0.0);
+    stat = id.withTag(Statistic.count).withTags(id.tags());
+  }
+
+  @Override public Iterable<Measurement> measure() {
+    final double delta = count.getAndSet(0.0);
+    if (delta > 0.0) {
+      final Measurement m = new Measurement(stat, clock.wallTime(), delta);
+      return Collections.singletonList(m);
+    } else {
+      return Collections.emptyList();
+    }
+  }
+
+  @Override public void add(double amount) {
+    if (amount > 0.0) {
+      count.addAndGet(amount);
+      updateLastModTime();
+    }
+  }
+
+  @Override public double actualCount() {
+    return count.get();
+  }
+}

--- a/spectator-reg-stateless/src/main/java/com/netflix/spectator/stateless/StatelessDistributionSummary.java
+++ b/spectator-reg-stateless/src/main/java/com/netflix/spectator/stateless/StatelessDistributionSummary.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.stateless;
+
+import com.netflix.spectator.api.Clock;
+import com.netflix.spectator.api.DistributionSummary;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.Statistic;
+import com.netflix.spectator.impl.AtomicDouble;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongToDoubleFunction;
+
+/**
+ * Distribution summary that keeps track of the deltas since the last time it was measured.
+ */
+class StatelessDistributionSummary extends StatelessMeter implements DistributionSummary {
+
+  private final AtomicLong count;
+  private final AtomicLong totalAmount;
+  private final AtomicDouble totalOfSquares;
+  private final AtomicLong max;
+
+  private final Id[] stats;
+
+  /** Create a new instance. */
+  StatelessDistributionSummary(Id id, Clock clock, long ttl) {
+    super(id, clock, ttl);
+    count = new AtomicLong(0);
+    totalAmount = new AtomicLong(0);
+    totalOfSquares = new AtomicDouble(0.0);
+    max = new AtomicLong(0);
+    stats = new Id[] {
+        id.withTags(Statistic.count),
+        id.withTags(Statistic.totalAmount),
+        id.withTags(Statistic.totalOfSquares),
+        id.withTags(Statistic.max)
+    };
+  }
+
+  @Override public void record(long amount) {
+    if (amount >= 0) {
+      count.incrementAndGet();
+      totalAmount.addAndGet(amount);
+      totalOfSquares.addAndGet(1.0 * amount * amount);
+      updateMax(amount);
+      updateLastModTime();
+    }
+  }
+
+  private void updateMax(long v) {
+    long p = max.get();
+    while (v > p && !max.compareAndSet(p, v)) {
+      p = max.get();
+    }
+  }
+
+  @Override public long count() {
+    return count.get();
+  }
+
+  @Override public long totalAmount() {
+    return totalAmount.get();
+  }
+
+  @Override public Iterable<Measurement> measure() {
+    if (count.get() == 0) {
+      return Collections.emptyList();
+    } else {
+      List<Measurement> ms = new ArrayList<>(4);
+      ms.add(newMeasurement(stats[0], count::getAndSet));
+      ms.add(newMeasurement(stats[1], totalAmount::getAndSet));
+      ms.add(newMeasurement(stats[2], totalOfSquares::getAndSet));
+      ms.add(newMeasurement(stats[3], max::getAndSet));
+      return ms;
+    }
+  }
+
+  private Measurement newMeasurement(Id mid, LongToDoubleFunction getAndSet) {
+    double delta = getAndSet.applyAsDouble(0);
+    long timestamp = clock.wallTime();
+    return new Measurement(mid, timestamp, delta);
+  }
+}

--- a/spectator-reg-stateless/src/main/java/com/netflix/spectator/stateless/StatelessGauge.java
+++ b/spectator-reg-stateless/src/main/java/com/netflix/spectator/stateless/StatelessGauge.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.stateless;
+
+import com.netflix.spectator.api.Clock;
+import com.netflix.spectator.api.Gauge;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.Statistic;
+import com.netflix.spectator.impl.AtomicDouble;
+
+import java.util.Collections;
+
+/**
+ * Gauge that keeps track of the latest received value since the last time it was measured.
+ */
+class StatelessGauge extends StatelessMeter implements Gauge {
+
+  private final AtomicDouble value;
+  private final Id stat;
+
+  /** Create a new instance. */
+  StatelessGauge(Id id, Clock clock, long ttl) {
+    super(id, clock, ttl);
+    value = new AtomicDouble(Double.NaN);
+    stat = id.withTag(Statistic.gauge).withTags(id.tags());
+  }
+
+  @Override public void set(double v) {
+    value.set(v);
+    updateLastModTime();
+  }
+
+  @Override public double value() {
+    return value.get();
+  }
+
+  @Override public Iterable<Measurement> measure() {
+    final double delta = value.getAndSet(Double.NaN);
+    if (Double.isNaN(delta)) {
+      return Collections.emptyList();
+    } else {
+      final Measurement m = new Measurement(stat, clock.wallTime(), delta);
+      return Collections.singletonList(m);
+    }
+  }
+}

--- a/spectator-reg-stateless/src/main/java/com/netflix/spectator/stateless/StatelessMaxGauge.java
+++ b/spectator-reg-stateless/src/main/java/com/netflix/spectator/stateless/StatelessMaxGauge.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.stateless;
+
+import com.netflix.spectator.api.Clock;
+import com.netflix.spectator.api.Gauge;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.Statistic;
+import com.netflix.spectator.impl.AtomicDouble;
+
+import java.util.Collections;
+
+/**
+ * Max gauge that keeps track of the maximum value since the last time it was measured.
+ */
+class StatelessMaxGauge extends StatelessMeter implements Gauge {
+
+  private final AtomicDouble value;
+  private final Id stat;
+
+  /** Create a new instance. */
+  StatelessMaxGauge(Id id, Clock clock, long ttl) {
+    super(id, clock, ttl);
+    value = new AtomicDouble(0.0);
+    stat = id.withTag(Statistic.max).withTags(id.tags());
+  }
+
+  @Override public void set(double v) {
+    if (v > 0.0) {
+      value.max(v);
+      updateLastModTime();
+    }
+  }
+
+  @Override public double value() {
+    return value.get();
+  }
+
+  @Override public Iterable<Measurement> measure() {
+    final double delta = value.getAndSet(0.0);
+    if (delta > 0.0) {
+      final Measurement m = new Measurement(stat, clock.wallTime(), delta);
+      return Collections.singletonList(m);
+    } else {
+      return Collections.emptyList();
+    }
+  }
+}

--- a/spectator-reg-stateless/src/main/java/com/netflix/spectator/stateless/StatelessMeter.java
+++ b/spectator-reg-stateless/src/main/java/com/netflix/spectator/stateless/StatelessMeter.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.stateless;
+
+import com.netflix.spectator.api.Clock;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Meter;
+
+/** Base class for core meter types used by {@link StatelessRegistry}. */
+abstract class StatelessMeter implements Meter {
+
+  /** Base identifier for all measurements supplied by this meter. */
+  protected final Id id;
+
+  /** Time source for checking if the meter has expired. */
+  protected final Clock clock;
+
+  /** TTL value for an inactive meter. */
+  private final long ttl;
+
+  /** Last time this meter was updated. */
+  private volatile long lastUpdated;
+
+  /** Create a new instance. */
+  StatelessMeter(Id id, Clock clock, long ttl) {
+    this.id = id;
+    this.clock = clock;
+    this.ttl = ttl;
+    lastUpdated = clock.wallTime();
+  }
+
+  /**
+   * Updates the last updated timestamp for the meter to indicate it is active and should
+   * not be considered expired.
+   */
+  void updateLastModTime() {
+    lastUpdated = clock.wallTime();
+  }
+
+  @Override public Id id() {
+    return id;
+  }
+
+  @Override public boolean hasExpired() {
+    return clock.wallTime() - lastUpdated > ttl;
+  }
+}

--- a/spectator-reg-stateless/src/main/java/com/netflix/spectator/stateless/StatelessRegistry.java
+++ b/spectator-reg-stateless/src/main/java/com/netflix/spectator/stateless/StatelessRegistry.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.stateless;
+
+import com.netflix.spectator.api.AbstractRegistry;
+import com.netflix.spectator.api.Clock;
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.DistributionSummary;
+import com.netflix.spectator.api.Gauge;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.Timer;
+import com.netflix.spectator.impl.Scheduler;
+import com.netflix.spectator.sandbox.HttpClient;
+import com.netflix.spectator.sandbox.HttpResponse;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+/**
+ * Registry for reporting deltas to an aggregation service. This registry is intended for
+ * use-cases where the instance cannot maintain state over the step interval. For example,
+ * if running via a FaaS system like AWS Lambda, the lifetime of an invocation can be quite
+ * small. Thus this registry would track the deltas and rely on a separate service to
+ * consolidate the state over time if needed.
+ *
+ * The registry should be tied to the lifecyle of the container to ensure that the last set
+ * of deltas are flushed properly. This will happen automatically when calling {@link #stop()}.
+ */
+public final class StatelessRegistry extends AbstractRegistry {
+
+  private final boolean enabled;
+  private final Duration frequency;
+  private final long meterTTL;
+  private final int connectTimeout;
+  private final int readTimeout;
+  private final URI uri;
+  private final int batchSize;
+  private final Map<String, String> commonTags;
+
+  private Scheduler scheduler;
+
+  /** Create a new instance. */
+  public StatelessRegistry(Clock clock, StatelessConfig config) {
+    super(clock, config);
+    this.enabled = config.enabled();
+    this.frequency = config.frequency();
+    this.meterTTL = config.meterTTL().toMillis();
+    this.connectTimeout = (int) config.connectTimeout().toMillis();
+    this.readTimeout = (int) config.readTimeout().toMillis();
+    this.uri = URI.create(config.uri());
+    this.batchSize = config.batchSize();
+    this.commonTags = config.commonTags();
+  }
+
+  /**
+   * Start the scheduler to collect metrics data.
+   */
+  public void start() {
+    if (scheduler == null) {
+      if (enabled) {
+        Scheduler.Options options = new Scheduler.Options()
+            .withFrequency(Scheduler.Policy.FIXED_DELAY, frequency)
+            .withInitialDelay(frequency)
+            .withStopOnFailure(false);
+        scheduler = new Scheduler(this, "spectator-reg-stateless", 1);
+        scheduler.schedule(options, this::collectData);
+        logger.info("started collecting metrics every {} reporting to {}", frequency, uri);
+        logger.info("common tags: {}", commonTags);
+      } else {
+        logger.info("publishing is not enabled");
+      }
+    } else {
+      logger.warn("registry already started, ignoring duplicate request");
+    }
+  }
+
+  /**
+   * Stop the scheduler reporting data.
+   */
+  public void stop() {
+    if (scheduler != null) {
+      scheduler.shutdown();
+      scheduler = null;
+      logger.info("flushing metrics before stopping the registry");
+      collectData();
+      logger.info("stopped collecting metrics every {} reporting to {}", frequency, uri);
+    } else {
+      logger.warn("registry stopped, but was never started");
+    }
+  }
+
+  private void collectData() {
+    try {
+      for (List<Measurement> batch : getBatches()) {
+        byte[] payload = JsonUtils.encode(commonTags, batch);
+        HttpResponse res = HttpClient.DEFAULT
+            .newRequest("spectator-reg-stateless", uri)
+            .withMethod("POST")
+            .withConnectTimeout(connectTimeout)
+            .withReadTimeout(readTimeout)
+            .withContent("application/json", payload)
+            .send();
+        if (res.status() != 200) {
+          logger.warn("failed to send metrics, status {}: {}", res.status(), res.entityAsString());
+        }
+      }
+    } catch (Exception e) {
+      logger.warn("failed to send metrics", e);
+    }
+  }
+
+  /** Get a list of all measurements from the registry. */
+  List<Measurement> getMeasurements() {
+    return stream()
+        .filter(m -> !m.hasExpired())
+        .flatMap(m -> StreamSupport.stream(m.measure().spliterator(), false))
+        .collect(Collectors.toList());
+  }
+
+  /** Get a list of all measurements and break them into batches. */
+  List<List<Measurement>> getBatches() {
+    List<List<Measurement>> batches = new ArrayList<>();
+    List<Measurement> ms = getMeasurements();
+    for (int i = 0; i < ms.size(); i += batchSize) {
+      List<Measurement> batch = ms.subList(i, Math.min(ms.size(), i + batchSize));
+      batches.add(batch);
+    }
+    return batches;
+  }
+
+  @Override protected Counter newCounter(Id id) {
+    return new StatelessCounter(id, clock(), meterTTL);
+  }
+
+  @Override protected DistributionSummary newDistributionSummary(Id id) {
+    return new StatelessDistributionSummary(id, clock(), meterTTL);
+  }
+
+  @Override protected Timer newTimer(Id id) {
+    return new StatelessTimer(id, clock(), meterTTL);
+  }
+
+  @Override protected Gauge newGauge(Id id) {
+    return new StatelessGauge(id, clock(), meterTTL);
+  }
+
+  @Override protected Gauge newMaxGauge(Id id) {
+    return new StatelessMaxGauge(id, clock(), meterTTL);
+  }
+
+}

--- a/spectator-reg-stateless/src/main/java/com/netflix/spectator/stateless/StatelessTimer.java
+++ b/spectator-reg-stateless/src/main/java/com/netflix/spectator/stateless/StatelessTimer.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.stateless;
+
+import com.netflix.spectator.api.Clock;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.Statistic;
+import com.netflix.spectator.api.Timer;
+import com.netflix.spectator.impl.AtomicDouble;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongToDoubleFunction;
+
+/**
+ * Timer that keeps track of the deltas since the last time it was measured.
+ */
+class StatelessTimer extends StatelessMeter implements Timer {
+
+  private final AtomicLong count;
+  private final AtomicDouble totalTime;
+  private final AtomicDouble totalOfSquares;
+  private final AtomicDouble max;
+
+  private final Id[] stats;
+
+  /** Create a new instance. */
+  StatelessTimer(Id id, Clock clock, long ttl) {
+    super(id, clock, ttl);
+    count = new AtomicLong(0);
+    totalTime = new AtomicDouble(0);
+    totalOfSquares = new AtomicDouble(0.0);
+    max = new AtomicDouble(0);
+    stats = new Id[] {
+        id.withTags(Statistic.count),
+        id.withTags(Statistic.totalTime),
+        id.withTags(Statistic.totalOfSquares),
+        id.withTags(Statistic.max)
+    };
+  }
+
+  @Override public void record(long amount, TimeUnit unit) {
+    final double seconds = unit.toNanos(amount) / 1e9;
+    if (seconds >= 0.0) {
+      count.incrementAndGet();
+      totalTime.addAndGet(seconds);
+      totalOfSquares.addAndGet(seconds * seconds);
+      max.max(seconds);
+      updateLastModTime();
+    }
+  }
+
+  @Override public <T> T record(Callable<T> f) throws Exception {
+    final long start = clock.monotonicTime();
+    try {
+      return f.call();
+    } finally {
+      record(clock.monotonicTime() - start, TimeUnit.NANOSECONDS);
+    }
+  }
+
+  @Override public void record(Runnable f) {
+    final long start = clock.monotonicTime();
+    try {
+      f.run();
+    } finally {
+      record(clock.monotonicTime() - start, TimeUnit.NANOSECONDS);
+    }
+  }
+
+  @Override public long count() {
+    return count.get();
+  }
+
+  @Override public long totalTime() {
+    return (long) (totalTime.get() * 1e9);
+  }
+
+  @Override
+  public Iterable<Measurement> measure() {
+    if (count.get() == 0) {
+      return Collections.emptyList();
+    } else {
+      List<Measurement> ms = new ArrayList<>(4);
+      ms.add(newMeasurement(stats[0], count::getAndSet));
+      ms.add(newMeasurement(stats[1], totalTime::getAndSet));
+      ms.add(newMeasurement(stats[2], totalOfSquares::getAndSet));
+      ms.add(newMeasurement(stats[3], max::getAndSet));
+      return ms;
+    }
+  }
+
+  private Measurement newMeasurement(Id mid, LongToDoubleFunction getAndSet) {
+    double delta = getAndSet.applyAsDouble(0);
+    long timestamp = clock.wallTime();
+    return new Measurement(mid, timestamp, delta);
+  }
+}

--- a/spectator-reg-stateless/src/main/resources/META-INF/services/com.netflix.spectator.api.Registry
+++ b/spectator-reg-stateless/src/main/resources/META-INF/services/com.netflix.spectator.api.Registry
@@ -1,0 +1,1 @@
+com.netflix.spectator.stateless.StatelessRegistry

--- a/spectator-reg-stateless/src/test/java/com/netflix/spectator/stateless/JsonUtilsTest.java
+++ b/spectator-reg-stateless/src/test/java/com/netflix/spectator/stateless/JsonUtilsTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.stateless;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Statistic;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+@RunWith(JUnit4.class)
+public class JsonUtilsTest {
+
+  private static final JsonFactory FACTORY = new JsonFactory();
+
+  private final Registry registry = new DefaultRegistry();
+
+  private Measurement unknown(double delta, String name, String... tags) {
+    Id id = registry.createId(name).withTags(tags);
+    return new Measurement(id, 0L, delta);
+  }
+
+  private Measurement count(double delta, String name, String... tags) {
+    Id id = registry.createId(name).withTag(Statistic.count).withTags(tags);
+    return new Measurement(id, 0L, delta);
+  }
+
+  private Measurement max(double delta, String name, String... tags) {
+    Id id = registry.createId(name).withTag(Statistic.max).withTags(tags);
+    return new Measurement(id, 0L, delta);
+  }
+
+  @Test
+  public void encodeNoCommonTags() throws Exception {
+    List<Measurement> ms = new ArrayList<>();
+    ms.add(count(42.0, "test"));
+    Map<Id, Delta> values = decode(JsonUtils.encode(Collections.emptyMap(), ms));
+    Assert.assertEquals(1, values.size());
+    ms.forEach(m -> {
+      Assert.assertEquals(42.0, values.get(m.id()).value, 1e-12);
+    });
+  }
+
+  @Test
+  public void encodeCommonTags() throws Exception {
+    Map<String, String> commonTags = new HashMap<>();
+    commonTags.put("a", "1");
+    commonTags.put("b", "2");
+    List<Measurement> ms = new ArrayList<>();
+    ms.add(count(42.0, "test"));
+    Map<Id, Delta> values = decode(JsonUtils.encode(commonTags, ms));
+    Assert.assertEquals(1, values.size());
+    ms.forEach(m -> {
+      Id id = m.id().withTags(commonTags);
+      Assert.assertEquals(42.0, values.get(id).value, 1e-12);
+    });
+  }
+
+  @Test
+  public void encodeIgnoresNaN() throws Exception {
+    List<Measurement> ms = new ArrayList<>();
+    ms.add(count(Double.NaN, "test"));
+    Map<Id, Delta> values = decode(JsonUtils.encode(Collections.emptyMap(), ms));
+    Assert.assertEquals(0, values.size());
+  }
+
+  @Test
+  public void encodeIgnoresAdd0() throws Exception {
+    List<Measurement> ms = new ArrayList<>();
+    ms.add(count(0, "test"));
+    Map<Id, Delta> values = decode(JsonUtils.encode(Collections.emptyMap(), ms));
+    Assert.assertEquals(0, values.size());
+  }
+
+  @Test
+  public void encodeSendsMax0() throws Exception {
+    List<Measurement> ms = new ArrayList<>();
+    ms.add(max(0, "test"));
+    Map<Id, Delta> values = decode(JsonUtils.encode(Collections.emptyMap(), ms));
+    Assert.assertEquals(1, values.size());
+    ms.forEach(m -> {
+      Id id = m.id();
+      Assert.assertEquals(0.0, values.get(id).value, 1e-12);
+    });
+  }
+
+  @Test
+  public void encodeIgnoresInvalidStatistic() throws Exception {
+    List<Measurement> ms = new ArrayList<>();
+    ms.add(count(42, "test", "statistic", "foo"));
+    Map<Id, Delta> values = decode(JsonUtils.encode(Collections.emptyMap(), ms));
+    Assert.assertEquals(0, values.size());
+  }
+
+  @Test
+  public void encodeIgnoresNoStatistic() throws Exception {
+    List<Measurement> ms = new ArrayList<>();
+    ms.add(unknown(42, "test"));
+    Map<Id, Delta> values = decode(JsonUtils.encode(Collections.emptyMap(), ms));
+    Assert.assertEquals(0, values.size());
+  }
+
+  @Test
+  public void encodeSupportsKnownStats() throws Exception {
+    for (Statistic stat : Statistic.values()) {
+      List<Measurement> ms = new ArrayList<>();
+      ms.add(count(42, "test", "statistic", stat.value()));
+      Map<Id, Delta> values = decode(JsonUtils.encode(Collections.emptyMap(), ms));
+      Assert.assertEquals(1, values.size());
+      ms.forEach(m -> {
+        Id id = m.id();
+        Assert.assertEquals(42.0, values.get(id).value, 1e-12);
+      });
+    }
+  }
+
+
+
+  private Map<Id, Delta> decode(byte[] json) throws IOException {
+    Map<Id, Delta> values = new HashMap<>();
+    JsonParser parser = FACTORY.createParser(json);
+
+    // Array start
+    Assert.assertEquals(JsonToken.START_ARRAY, parser.nextToken());
+
+    // String table
+    String[] strings = new String[parser.nextIntValue(-1)];
+    for (int i = 0; i < strings.length; ++i) {
+      strings[i] = parser.nextTextValue();
+    }
+
+    // Read measurements
+    parser.nextToken();
+    while (parser.currentToken() != JsonToken.END_ARRAY) {
+      int n = parser.getIntValue();
+      Map<String, String> tags = new HashMap<>(n);
+      for (int i = 0; i < n; ++i) {
+        String k = strings[parser.nextIntValue(-1)];
+        String v = strings[parser.nextIntValue(-1)];
+        tags.put(k, v);
+      }
+      String name = tags.get("name");
+      tags.remove("name");
+      Id id = registry.createId(name).withTags(tags);
+      int op = parser.nextIntValue(-1);
+      parser.nextToken();
+      double value = parser.getDoubleValue();
+      values.put(id, new Delta(op, value));
+
+      parser.nextToken();
+    }
+
+    return values;
+  }
+
+  private static class Delta {
+    final int op;
+    final double value;
+
+    Delta(int op, double value) {
+      this.op = op;
+      this.value = value;
+    }
+
+    @Override public String toString() {
+      return (op == 0 ? "add(" : "max(") + value + ")";
+    }
+  }
+}

--- a/spectator-reg-stateless/src/test/java/com/netflix/spectator/stateless/StatelessConfigTest.java
+++ b/spectator-reg-stateless/src/test/java/com/netflix/spectator/stateless/StatelessConfigTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.stateless;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+
+@RunWith(JUnit4.class)
+public class StatelessConfigTest {
+
+  @Test
+  public void enabledByDefault() {
+    Map<String, String> props = Collections.emptyMap();
+    StatelessConfig config = props::get;
+    Assert.assertTrue(config.enabled());
+  }
+
+  @Test
+  public void explicitlyEnabled() {
+    Map<String, String> props = new HashMap<>();
+    props.put("stateless.enabled", "true");
+    StatelessConfig config = props::get;
+    Assert.assertTrue(config.enabled());
+  }
+
+  @Test
+  public void explicitlyDisabled() {
+    Map<String, String> props = new HashMap<>();
+    props.put("stateless.enabled", "false");
+    StatelessConfig config = props::get;
+    Assert.assertFalse(config.enabled());
+  }
+
+  @Test
+  public void enabledBadValue() {
+    Map<String, String> props = new HashMap<>();
+    props.put("stateless.enabled", "abc");
+    StatelessConfig config = props::get;
+    Assert.assertFalse(config.enabled());
+  }
+}

--- a/spectator-reg-stateless/src/test/java/com/netflix/spectator/stateless/StatelessRegistryTest.java
+++ b/spectator-reg-stateless/src/test/java/com/netflix/spectator/stateless/StatelessRegistryTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.stateless;
+
+import com.netflix.spectator.api.ManualClock;
+import com.netflix.spectator.api.Measurement;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+
+@RunWith(JUnit4.class)
+public class StatelessRegistryTest {
+
+  private ManualClock clock = new ManualClock();
+  private StatelessRegistry registry = new StatelessRegistry(clock, newConfig());
+
+  private StatelessConfig newConfig() {
+    ConcurrentHashMap<String, String> props = new ConcurrentHashMap<>();
+    props.put("stateless.frequency", "PT10S");
+    props.put("stateless.batchSize", "3");
+    return props::get;
+  }
+
+  @Test
+  public void measurementsEmpty() {
+    Assert.assertEquals(0, registry.getMeasurements().size());
+  }
+
+  @Test
+  public void measurementsWithCounter() {
+    registry.counter("test").increment();
+    Assert.assertEquals(1, registry.getMeasurements().size());
+  }
+
+  @Test
+  public void measurementsWithTimer() {
+    registry.timer("test").record(42, TimeUnit.NANOSECONDS);
+    Assert.assertEquals(4, registry.getMeasurements().size());
+  }
+
+  @Test
+  public void measurementsWithDistributionSummary() {
+    registry.distributionSummary("test").record(42);
+    Assert.assertEquals(4, registry.getMeasurements().size());
+  }
+
+  @Test
+  public void measurementsWithGauge() {
+    registry.gauge("test").set(4.0);
+    Assert.assertEquals(1, registry.getMeasurements().size());
+  }
+
+  @Test
+  public void measurementsWithMaxGauge() {
+    registry.maxGauge(registry.createId("test")).set(4.0);
+    Assert.assertEquals(1, registry.getMeasurements().size());
+  }
+
+  @Test
+  public void batchesEmpty() {
+    Assert.assertEquals(0, registry.getBatches().size());
+  }
+
+  @Test
+  public void batchesExact() {
+    for (int i = 0; i < 9; ++i) {
+      registry.counter("" + i).increment();
+    }
+    Assert.assertEquals(3, registry.getBatches().size());
+    for (List<Measurement> batch : registry.getBatches()) {
+      Assert.assertEquals(3, batch.size());
+    }
+  }
+
+  @Test
+  public void batchesLastPartial() {
+    for (int i = 0; i < 7; ++i) {
+      registry.counter("" + i).increment();
+    }
+    List<List<Measurement>> batches = registry.getBatches();
+    Assert.assertEquals(3, batches.size());
+    for (int i = 0; i < batches.size(); ++i) {
+      Assert.assertEquals((i < 2) ? 3 : 1, batches.get(i).size());
+    }
+  }
+
+  @Test
+  public void batchesExpiration() {
+    for (int i = 0; i < 9; ++i) {
+      registry.counter("" + i).increment();
+    }
+    Assert.assertEquals(3, registry.getBatches().size());
+    for (List<Measurement> batch : registry.getBatches()) {
+      Assert.assertEquals(3, batch.size());
+    }
+
+    clock.setWallTime(Duration.ofMinutes(15).toMillis() + 1);
+    Assert.assertEquals(0, registry.getBatches().size());
+  }
+
+}


### PR DESCRIPTION
Keeps track of basic delta and sends to an [aggregation service]
that can maintain the state for the step interval. This is the
similar to the implementation being used with the the thin
clients for various languages.

[aggregation service]: https://github.com/Netflix-Skunkworks/iep-apps/tree/master/atlas-aggregator

Fixes #432.