### PR TITLE
fix ipc validation for percentile counters

### DIFF
--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcMetric.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcMetric.java
@@ -115,10 +115,15 @@ public enum IpcMetric {
     return cls.getSimpleName();
   }
 
+  private static boolean isPercentile(Id id) {
+    final String stat = Utils.getTagValue(id, "statistic");
+    return "percentile".equals(stat);
+  }
+
   private static void validateIpcMeter(Registry registry, IpcMetric metric, Class<?> type) {
     final String name = metric.metricName();
     registry.stream()
-        .filter(m -> name.equals(m.id().name()))
+        .filter(m -> name.equals(m.id().name()) && !isPercentile(m.id()))
         .forEach(m -> {
           assertTrue(type.isAssignableFrom(m.getClass()),
               "[%s] has the wrong type, expected %s but found %s",

--- a/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/IpcLogEntryTest.java
+++ b/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/IpcLogEntryTest.java
@@ -637,4 +637,32 @@ public class IpcLogEntryTest {
     Assert.assertEquals((10 * 11) / 2, summary.totalAmount());
     Assert.assertEquals(10L, summary.count());
   }
+
+  @Test
+  public void clientMetricsValidate() {
+    Registry registry = new DefaultRegistry();
+    IpcLogger logger = new IpcLogger(registry, clock, LoggerFactory.getLogger(getClass()));
+
+    logger.createClientEntry()
+        .withOwner("test")
+        .markStart()
+        .markEnd()
+        .log();
+
+    IpcMetric.validate(registry);
+  }
+
+  @Test
+  public void serverMetricsValidate() {
+    Registry registry = new DefaultRegistry();
+    IpcLogger logger = new IpcLogger(registry, clock, LoggerFactory.getLogger(getClass()));
+
+    logger.createServerEntry()
+        .withOwner("test")
+        .markStart()
+        .markEnd()
+        .log();
+
+    IpcMetric.validate(registry);
+  }
 }


### PR DESCRIPTION
The percentile approximations are counters, the validation
was rejecting these as having an invalid type.