### PR TITLE
 no error reason for successful requests

### DIFF
--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcLogEntry.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcLogEntry.java
@@ -435,6 +435,9 @@ public final class IpcLogEntry {
     if (result == null) {
       withResult((status < 400) ? IpcResult.success : IpcResult.failure);
     }
+    if (errorReason == null && status >= 400 & status < 600) {
+      errorReason = "HTTP_" + status;
+    }
     if (errorGroup == null) {
       switch (status) {
         case 429:
@@ -573,8 +576,6 @@ public final class IpcLogEntry {
     if (isNullOrEmpty(errorReason)) {
       if (exception != null) {
         errorReason = exception.getClass().getSimpleName();
-      } else if (httpStatus > 0) {
-        errorReason = "HTTP_" + httpStatus;
       }
     }
     return errorReason;

--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcLogEntry.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcLogEntry.java
@@ -573,10 +573,8 @@ public final class IpcLogEntry {
   }
 
   private String getErrorReason() {
-    if (isNullOrEmpty(errorReason)) {
-      if (exception != null) {
-        errorReason = exception.getClass().getSimpleName();
-      }
+    if (isNullOrEmpty(errorReason) && exception != null) {
+      errorReason = exception.getClass().getSimpleName();
     }
     return errorReason;
   }

--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcMetric.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcMetric.java
@@ -185,15 +185,19 @@ public enum IpcMetric {
       assertTrue(value != null, "[%s] is missing required dimension %s", id, k.key());
     });
 
-    // Check that error group is only present for failed requests
+    // Check that error group and error reason are only present for failed requests
     if (requiredDimensions.contains(IpcTagKey.errorGroup)) {
       String result = Utils.getTagValue(id, IpcTagKey.result.key());
       String errorGroup = Utils.getTagValue(id, IpcTagKey.errorGroup.key());
+      String errorReason = Utils.getTagValue(id, IpcTagKey.errorReason.key());
       switch (result) {
         case "success":
           assertTrue(errorGroup == null,
               "[%s] %s should not be present on successful request",
               id, IpcTagKey.errorGroup.key());
+          assertTrue(errorReason == null,
+              "[%s] %s should not be present on successful request",
+              id, IpcTagKey.errorReason.key());
           break;
         case "failure":
           assertTrue(errorGroup != null,

--- a/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/IpcLogEntryTest.java
+++ b/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/IpcLogEntryTest.java
@@ -653,6 +653,21 @@ public class IpcLogEntryTest {
   }
 
   @Test
+  public void clientMetricsValidateHttpSuccess() {
+    Registry registry = new DefaultRegistry();
+    IpcLogger logger = new IpcLogger(registry, clock, LoggerFactory.getLogger(getClass()));
+
+    logger.createClientEntry()
+        .withOwner("test")
+        .markStart()
+        .markEnd()
+        .withHttpStatus(200)
+        .log();
+
+    IpcMetric.validate(registry);
+  }
+
+  @Test
   public void serverMetricsValidate() {
     Registry registry = new DefaultRegistry();
     IpcLogger logger = new IpcLogger(registry, clock, LoggerFactory.getLogger(getClass()));

--- a/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/IpcMetricTest.java
+++ b/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/IpcMetricTest.java
@@ -118,6 +118,18 @@ public class IpcMetricTest {
   }
 
   @Test(expected = IllegalArgumentException.class)
+  public void validateIdErrorReasonOnSuccess() {
+    Id id = registry.createId(IpcMetric.clientCall.metricName())
+        .withTag(IpcTagKey.owner.tag("test"))
+        .withTag(IpcResult.success)
+        .withTag(IpcErrorGroup.general)
+        .withTag(IpcTagKey.errorReason.tag("foo"))
+        .withTag(IpcAttempt.initial)
+        .withTag(IpcTagKey.attemptFinal.key(), true);
+    IpcMetric.clientCall.validate(id);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
   public void validateIdBadResultValue() {
     Id id = registry.createId(IpcMetric.clientCall.metricName())
         .withTag(IpcTagKey.owner.tag("test"))


### PR DESCRIPTION
Update validation to check that successful requests will
not get an error reason. The logger was setting to successful
http status codes.