### PR TITLE
fix AbstractMethodError on older servlet-api

### DIFF
--- a/spectator-ext-ipcservlet/build.gradle
+++ b/spectator-ext-ipcservlet/build.gradle
@@ -3,7 +3,6 @@ dependencies {
   compileApi project(':spectator-ext-ipc')
   compile 'javax.inject:javax.inject:1'
   compileOnly 'javax.servlet:javax.servlet-api:4.0.1'
-  testCompile 'javax.servlet:javax.servlet-api:4.0.1' // compileOnly is not included for tests
   testCompile 'org.eclipse.jetty:jetty-servlet:9.4.11.v20180605'
   testCompile 'org.eclipse.jetty:jetty-webapp:9.4.11.v20180605'
   testCompile 'com.google.inject.extensions:guice-servlet:4.1.0'

--- a/spectator-ext-ipcservlet/src/main/java/com/netflix/spectator/ipcservlet/IpcServletFilter.java
+++ b/spectator-ext-ipcservlet/src/main/java/com/netflix/spectator/ipcservlet/IpcServletFilter.java
@@ -29,6 +29,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
@@ -141,5 +142,17 @@ public class IpcServletFilter implements Filter {
         entry.addResponseHeader(header, value);
       }
     }
+  }
+
+  //
+  // In the servlet-api 4.x versions there are default implementations of the methods
+  // below. To avoid AbstractMethodErrors when running on older versions, we explicitly
+  // override them with empty implementations.
+  //
+
+  @Override public void init(FilterConfig filterConfig) throws ServletException {
+  }
+
+  @Override public void destroy() {
   }
 }


### PR DESCRIPTION
The `init` and `destroy` methods have default implementations
on 4.x, for older versions they do not.