### PR TITLE
limit use of step clock to gauges

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasMaxGauge.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasMaxGauge.java
@@ -44,7 +44,7 @@ class AtlasMaxGauge extends AtlasMeter implements Gauge {
   }
 
   @Override public Iterable<Measurement> measure() {
-    final Measurement m = new Measurement(stat, clock.wallTime(), value());
+    final Measurement m = new Measurement(stat, value.timestamp(), value());
     return Collections.singletonList(m);
   }
 

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasRegistryTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 Netflix, Inc.
+ * Copyright 2014-2018 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,9 +23,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import java.time.Duration;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 


### PR DESCRIPTION
Some use-cases expect to access the clock from the registry
and it is confusing to have it be step aligned. This is only
really needed for the measurements read from gauges.