### PR TITLE
use step clock for lwc eval payload

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
@@ -243,7 +243,7 @@ public final class AtlasRegistry extends AbstractRegistry {
           .map(this::newTagsValuePair)
           .collect(Collectors.toList());
       Evaluator evaluator = new Evaluator().addGroupSubscriptions("local", subs);
-      EvalPayload payload = evaluator.eval("local", clock().wallTime(), ms);
+      EvalPayload payload = evaluator.eval("local", stepClock.wallTime(), ms);
       try {
         String json = jsonMapper.writeValueAsString(payload);
         HttpClient.DEFAULT.newRequest("spectator-lwc-eval", evalUri)


### PR DESCRIPTION
This was inadvertently changed in #600. The timestamp sent
to the eval payload of lwc should always be step aligned.