### PR TITLE
remove incorrect comment

### DIFF
--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/ServerGroup.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/ServerGroup.java
@@ -56,11 +56,6 @@ public class ServerGroup {
     return true;
   }
 
-  /**
-   * The substring method will create a copy of the substring in JDK 8 and probably newer
-   * versions. To reduce the number of allocations we use a char buffer to return a view
-   * with just that subset.
-   */
   private static String substr(String str, int s, int e) {
     return (s >= e) ? null : str.substring(s, e);
   }


### PR DESCRIPTION
This comment about copies is no longer true since we
switched to using String instead of CharSequence in #569.