### PR TITLE
use ETag for refreshing lwc subscriptions

### DIFF
--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/http/HttpRequestBuilder.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/http/HttpRequestBuilder.java
@@ -65,7 +65,7 @@ public class HttpRequestBuilder {
   private SSLSocketFactory sslFactory = null;
 
   /** Create a new instance for the specified URI. */
-  HttpRequestBuilder(IpcLogger logger, URI uri) {
+  public HttpRequestBuilder(IpcLogger logger, URI uri) {
     this.uri = uri;
     this.entry = logger.createClientEntry()
         .withOwner("spectator")
@@ -83,10 +83,13 @@ public class HttpRequestBuilder {
 
   /**
    * Add a header to the request. Note the content type will be set automatically
-   * when providing the content payload and should not be set here.
+   * when providing the content payload and should not be set here. If the value
+   * is null, then the header will get ignored.
    */
   public HttpRequestBuilder addHeader(String name, String value) {
-    reqHeaders.put(name, value);
+    if (value != null) {
+      reqHeaders.put(name, value);
+    }
     return this;
   }
 

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
@@ -33,7 +33,6 @@ import com.netflix.spectator.atlas.impl.Evaluator;
 import com.netflix.spectator.atlas.impl.MeasurementSerializer;
 import com.netflix.spectator.atlas.impl.PublishPayload;
 import com.netflix.spectator.atlas.impl.Subscription;
-import com.netflix.spectator.atlas.impl.Subscriptions;
 import com.netflix.spectator.atlas.impl.TagsValuePair;
 import com.netflix.spectator.impl.AsciiSet;
 import com.netflix.spectator.impl.Scheduler;

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
@@ -262,15 +262,6 @@ public final class AtlasRegistry extends AbstractRegistry {
     subManager.refresh();
   }
 
-  private Subscriptions filterByStep(Subscriptions subs) {
-    List<Subscription> subscriptions = subs
-        .getExpressions()
-        .stream()
-        .filter(s -> s.getFrequency() == stepMillis)
-        .collect(Collectors.toList());
-    return new Subscriptions().withExpressions(subscriptions);
-  }
-
   /**
    * Record the difference between the date response time and the local time on the server.
    * This is used to get a rough idea of the amount of skew in the environment. Ideally it

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/SubscriptionManager.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/SubscriptionManager.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spectator.api.Clock;
+import com.netflix.spectator.atlas.impl.Subscription;
+import com.netflix.spectator.atlas.impl.Subscriptions;
+import com.netflix.spectator.ipc.http.HttpClient;
+import com.netflix.spectator.ipc.http.HttpResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+/**
+ * Helper for managing the set of LWC subscriptions.
+ */
+class SubscriptionManager {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SubscriptionManager.class);
+
+  private final ObjectMapper mapper;
+  private final HttpClient client;
+  private final Clock clock;
+  private final URI uri;
+  private final int connectTimeout;
+  private final int readTimeout;
+  private final long stepMillis;
+
+  private final long configTTL;
+
+  private final Map<Subscription, Long> subscriptions = new ConcurrentHashMap<>();
+
+  private Subscriptions payload;
+  private String etag;
+
+  /** Create a new instance. */
+  SubscriptionManager(ObjectMapper mapper, HttpClient client, Clock clock, AtlasConfig config) {
+    this.mapper = mapper;
+    this.client = client;
+    this.clock = clock;
+    this.uri = URI.create(config.configUri());
+    this.connectTimeout = (int) config.connectTimeout().toMillis();
+    this.readTimeout = (int) config.readTimeout().toMillis();
+    this.stepMillis = config.step().toMillis();
+    this.configTTL = config.configTTL().toMillis();
+  }
+
+  /** Returns the current set of active subscriptions. */
+  List<Subscription> subscriptions() {
+    return new ArrayList<>(subscriptions.keySet());
+  }
+
+  /** Refresh the subscriptions from the server. */
+  void refresh() {
+    // Request latest expressions from the server
+    try {
+      HttpResponse res = client.get(uri)
+          .withConnectTimeout(connectTimeout)
+          .withReadTimeout(readTimeout)
+          .addHeader("If-None-Match", etag)
+          .send()
+          .decompress();
+      if (res.status() == 304) {
+        LOGGER.debug("no modification to subscriptions");
+      } else if (res.status() != 200) {
+        LOGGER.warn("failed to update subscriptions, received status {}", res.status());
+      } else {
+        etag = res.header("ETag");
+        payload = filterByStep(mapper.readValue(res.entity(), Subscriptions.class));
+      }
+    } catch (Exception e) {
+      LOGGER.warn("failed to update subscriptions", e);
+    }
+
+    // Update with the current payload, it will be null if there hasn't been a single
+    // successful request
+    if (payload != null) {
+      long now = clock.wallTime();
+      payload.update(subscriptions, now, now + configTTL);
+    }
+  }
+
+  private Subscriptions filterByStep(Subscriptions subs) {
+    List<Subscription> subscriptions = subs
+        .getExpressions()
+        .stream()
+        .filter(s -> s.getFrequency() == stepMillis)
+        .collect(Collectors.toList());
+    return new Subscriptions().withExpressions(subscriptions);
+  }
+}

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/SubscriptionManagerTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/SubscriptionManagerTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.netflix.spectator.api.ManualClock;
+import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.atlas.impl.MeasurementSerializer;
+import com.netflix.spectator.atlas.impl.Subscription;
+import com.netflix.spectator.atlas.impl.Subscriptions;
+import com.netflix.spectator.impl.AsciiSet;
+import com.netflix.spectator.ipc.http.HttpClient;
+import com.netflix.spectator.ipc.http.HttpRequestBuilder;
+import com.netflix.spectator.ipc.http.HttpResponse;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+
+@RunWith(JUnit4.class)
+public class SubscriptionManagerTest {
+
+  private SimpleModule module = new SimpleModule()
+      .addSerializer(
+          Measurement.class,
+          new MeasurementSerializer(AsciiSet.fromPattern("a-z"), Collections.emptyMap()));
+
+  private ObjectMapper mapper = new ObjectMapper(new JsonFactory()).registerModule(module);
+
+  private SubscriptionManager newInstance(ManualClock clock, HttpResponse... responses) {
+    final AtomicInteger pos = new AtomicInteger();
+    HttpClient client = uri -> new HttpRequestBuilder(HttpClient.DEFAULT_LOGGER, uri) {
+      @Override public HttpResponse send() {
+        return responses[pos.getAndIncrement()];
+      }
+    };
+    return new SubscriptionManager(mapper, client, clock, v -> null);
+  }
+
+  private Set<Subscription> set(Subscription... subs) {
+    return new HashSet<>(Arrays.asList(subs));
+  }
+
+  private byte[] json(Subscription... subs) throws Exception {
+    Subscriptions payload = new Subscriptions().withExpressions(Arrays.asList(subs));
+    return mapper.writeValueAsBytes(payload);
+  }
+
+  private Subscription sub(int i) {
+    return new Subscription()
+        .withId("" + i)
+        .withExpression("name," + i + ",:eq,:sum")
+        .withFrequency(60000);
+  }
+
+  private HttpResponse ok(byte[] data) {
+    return new HttpResponse(200, Collections.emptyMap(), data);
+  }
+
+  @Test
+  public void emptyExpressionList() {
+    ManualClock clock = new ManualClock();
+    byte[] data = "{\"expressions\":[]}".getBytes(StandardCharsets.UTF_8);
+    SubscriptionManager mgr = newInstance(clock, ok(data));
+    mgr.refresh();
+    Assert.assertTrue(mgr.subscriptions().isEmpty());
+  }
+
+  @Test
+  public void singleExpression() throws Exception {
+    ManualClock clock = new ManualClock();
+    byte[] data = json(sub(1));
+    SubscriptionManager mgr = newInstance(clock, ok(data));
+    mgr.refresh();
+    Assert.assertEquals(set(sub(1)), new HashSet<>(mgr.subscriptions()));
+  }
+
+  @Test
+  public void expiration() throws Exception {
+    ManualClock clock = new ManualClock();
+
+    byte[] data1 = json(sub(1), sub(2)); // Initial set of 2 expressions
+    byte[] data2 = json(sub(2));            // Final set with only expression 2
+
+    SubscriptionManager mgr = newInstance(clock, ok(data1), ok(data2), ok(data2));
+
+    mgr.refresh();
+    Assert.assertEquals(set(sub(1), sub(2)), new HashSet<>(mgr.subscriptions()));
+
+    // Should still contain 1 because it hasn't expired
+    mgr.refresh();
+    Assert.assertEquals(set(sub(1), sub(2)), new HashSet<>(mgr.subscriptions()));
+
+    // Should have removed 1 because it has expired
+    clock.setWallTime(Duration.ofMinutes(20).toMillis());
+    mgr.refresh();
+    Assert.assertEquals(set(sub(2)), new HashSet<>(mgr.subscriptions()));
+  }
+
+  @Test
+  public void startsFailing() throws Exception {
+    ManualClock clock = new ManualClock();
+    byte[] data = json(sub(1));
+
+    HttpResponse ok = new HttpResponse(200, Collections.emptyMap(), data);
+    HttpResponse error = new HttpResponse(500, Collections.emptyMap(), new byte[0]);
+
+    SubscriptionManager mgr = newInstance(clock, ok, error);
+    mgr.refresh();
+    Assert.assertEquals(set(sub(1)), new HashSet<>(mgr.subscriptions()));
+
+    // Double check it is not expired
+    clock.setWallTime(Duration.ofMinutes(20).toMillis());
+    mgr.refresh();
+    Assert.assertEquals(set(sub(1)), new HashSet<>(mgr.subscriptions()));
+  }
+
+  @Test
+  public void alwaysFailing() throws Exception {
+    ManualClock clock = new ManualClock();
+    byte[] data = json(sub(1));
+
+    HttpResponse error = new HttpResponse(500, Collections.emptyMap(), new byte[0]);
+
+    SubscriptionManager mgr = newInstance(clock, error, error);
+    mgr.refresh();
+    Assert.assertTrue(mgr.subscriptions().isEmpty());
+
+    // Double check it is not expired
+    clock.setWallTime(Duration.ofMinutes(20).toMillis());
+    mgr.refresh();
+    Assert.assertTrue(mgr.subscriptions().isEmpty());
+  }
+
+  @Test
+  public void notModified() throws Exception {
+    ManualClock clock = new ManualClock();
+    byte[] data = json(sub(1));
+
+    Map<String, List<String>> headers =
+        Collections.singletonMap("ETag", Collections.singletonList("12345"));
+    HttpResponse ok = new HttpResponse(200, headers, data);
+    HttpResponse notModified = new HttpResponse(304, Collections.emptyMap(), new byte[0]);
+
+    SubscriptionManager mgr = newInstance(clock, ok, notModified);
+    mgr.refresh();
+    Assert.assertEquals(set(sub(1)), new HashSet<>(mgr.subscriptions()));
+
+    // Double check it is not expired
+    clock.setWallTime(Duration.ofMinutes(20).toMillis());
+    mgr.refresh();
+    Assert.assertEquals(set(sub(1)), new HashSet<>(mgr.subscriptions()));
+  }
+
+  @Test
+  public void invalidPayload() {
+    ManualClock clock = new ManualClock();
+    byte[] data = "[]".getBytes(StandardCharsets.UTF_8);
+    SubscriptionManager mgr = newInstance(clock, ok(data));
+    mgr.refresh();
+    Assert.assertTrue(mgr.subscriptions().isEmpty());
+  }
+}


### PR DESCRIPTION
Take advantage of the ETag header and only update
the expression list if they have changed.