### PR TITLE
avoid second map lookup for subscription

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Subscriptions.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Subscriptions.java
@@ -56,10 +56,9 @@ public final class Subscriptions {
   public void update(Map<Subscription, Long> subs, long currentTime, long expirationTime) {
     // Update expiration time for existing subs and log new ones
     for (Subscription sub : expressions) {
-      if (!subs.containsKey(sub)) {
+      if (subs.put(sub, expirationTime) == null) {
         LOGGER.info("new subscription: {}", sub);
       }
-      subs.put(sub, expirationTime);
     }
 
     // Remove any expired entries


### PR DESCRIPTION
Minor optimization, the return value of put can be used
to determine if the key was already present so we can
avoid doing a secondary lookup for the log condition.