### PR TITLE
enable CI build for jdk11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: java
 matrix:
   include:
-  - jdk: oraclejdk8
+  - jdk: openjdk8
     env: GRADLE_PUBLISH=true
-  - jdk: openjdk10
+  - jdk: openjdk11
     env: GRADLE_PUBLISH=false
 sudo: false
 dist: trusty


### PR DESCRIPTION
Now that there is an updated spotbugs release we should
be able to build on jdk11. Dropping jdk10 as it will no
longer be supported soon.