### PR TITLE
Utility function to accept Enum as tag value, using Enum::name()

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/Id.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/Id.java
@@ -47,6 +47,19 @@ public interface Id {
   }
 
   /**
+   * Return a new id with an additional tag value using {@link Enum#name()} to
+   * convert the Enum to a string representation. This is merely a convenience function
+   * for:
+   *
+   * <pre>
+   *   id.withTag("key", myEnum.name())
+   * </pre>
+   */
+  default <E extends Enum<E>> Id withTag(String k, Enum<E> v) {
+    return withTag(k, v.name());
+  }
+
+  /**
    * Return a new id with additional tag values. This overload is to avoid allocating a
    * parameters array for the more generic varargs method {@link #withTags(String...)}.
    */

--- a/spectator-api/src/test/java/com/netflix/spectator/api/DefaultIdTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/DefaultIdTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import java.nio.file.AccessMode;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -190,6 +191,19 @@ public class DefaultIdTest {
   public void withTagBooleanObjNull() {
     Boolean value = null;
     new DefaultId("test").withTag("bool", value);
+  }
+  
+  @Test
+  public void withTagEnum() {
+    Id id = new DefaultId("test").withTag("enum", AccessMode.WRITE);
+    Assert.assertEquals("test:enum=WRITE", id.toString());
+    Assert.assertEquals(new DefaultId("test").withTag("enum", "WRITE"), id);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void withTagEnumNull() {
+    Enum value = null;
+    new DefaultId("test").withTag("enum", value);
   }
 
   @Test


### PR DESCRIPTION
Leveraging a canonical String representation of an enum. Enum's given their nature, are a fixed cardinality and typical low-cardinality, which makes it safe to use as a tag.