### PR TITLE
update eval payload to support messages

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/EvalPayload.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/EvalPayload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 Netflix, Inc.
+ * Copyright 2014-2018 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package com.netflix.spectator.atlas.impl;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -29,11 +30,18 @@ public final class EvalPayload {
 
   private final long timestamp;
   private final List<Metric> metrics;
+  private final List<Message> messages;
+
+  /** Create a new instance. */
+  public EvalPayload(long timestamp, List<Metric> metrics, List<Message> messages) {
+    this.timestamp = timestamp;
+    this.metrics = metrics;
+    this.messages = messages;
+  }
 
   /** Create a new instance. */
   public EvalPayload(long timestamp, List<Metric> metrics) {
-    this.timestamp = timestamp;
-    this.metrics = metrics;
+    this(timestamp, metrics, Collections.emptyList());
   }
 
   /** Return the timestamp for metrics in this payload. */
@@ -41,26 +49,36 @@ public final class EvalPayload {
     return timestamp;
   }
 
-  /** Return the metric values for the data for this payload. */
+  /** Return the metric values for the data in this payload. */
   public List<Metric> getMetrics() {
     return metrics;
+  }
+
+  /** Return any diagnostic messages that should be sent back to the user. */
+  public List<Message> getMessages() {
+    return messages;
   }
 
   @Override public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     EvalPayload payload = (EvalPayload) o;
-    return timestamp == payload.timestamp && metrics.equals(payload.metrics);
+    return timestamp == payload.timestamp
+        && metrics.equals(payload.metrics)
+        && messages.equals(payload.messages);
   }
 
   @Override public int hashCode() {
     int result = (int) (timestamp ^ (timestamp >>> 32));
     result = 31 * result + metrics.hashCode();
+    result = 31 * result + messages.hashCode();
     return result;
   }
 
   @Override public String toString() {
-    return "EvalPayload(timestamp=" + timestamp + ", metrics=" + metrics + ")";
+    return "EvalPayload(timestamp=" + timestamp
+        + ", metrics=" + metrics
+        + ", messages=" + messages + ")";
   }
 
   /** Metric value. */
@@ -113,5 +131,105 @@ public final class EvalPayload {
     @Override public String toString() {
       return "Metric(id=" + id + ", tags=" + tags + ", value=" + value + ")";
     }
+  }
+
+  /** Message. */
+  @SuppressWarnings("PMD.AvoidFieldNameMatchingTypeName")
+  public static final class Message {
+    private final String id;
+    private final DiagnosticMessage message;
+
+    /** Create a new instance. */
+    public Message(String id, DiagnosticMessage message) {
+      this.id = id;
+      this.message = message;
+    }
+
+    /** Id for the expression that resulted in this message. */
+    public String getId() {
+      return id;
+    }
+
+    /** Message to send back to the user. */
+    public DiagnosticMessage getMessage() {
+      return message;
+    }
+
+    @Override public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      Message msg = (Message) o;
+      return id.equals(msg.id) && message.equals(msg.message);
+    }
+
+    @Override public int hashCode() {
+      int result;
+      result = id.hashCode();
+      result = 31 * result + message.hashCode();
+      return result;
+    }
+
+    @Override public String toString() {
+      return "Message(id=" + id + ", message=" + message + ")";
+    }
+  }
+
+  /** Diagnostic message. */
+  public static final class DiagnosticMessage {
+    private final MessageType type;
+    private final String message;
+
+    /** Create a new instance. */
+    public DiagnosticMessage(MessageType type, String message) {
+      this.type = type;
+      this.message = message;
+    }
+
+    /**
+     * Type of the message. Indicates whether it is purely informational or if there was
+     * a problem the user needs to handle.
+     */
+    public MessageType getType() {
+      return type;
+    }
+
+    /** Description of the problem. */
+    public String getMessage() {
+      return message;
+    }
+
+    @Override public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      DiagnosticMessage msg = (DiagnosticMessage) o;
+      return type == msg.type && message.equals(msg.message);
+    }
+
+    @Override public int hashCode() {
+      int result;
+      result = type.hashCode();
+      result = 31 * result + message.hashCode();
+      return result;
+    }
+
+    @Override public String toString() {
+      return "DiagnosticMessage(type=" + type + ", message=" + message + ")";
+    }
+  }
+
+  /** Message type. */
+  public enum MessageType {
+
+    /** Informational notices that are primarily to aide in debugging. */
+    info,
+
+    /**
+     * Notifies the user of something that went wrong or that they should change, but that
+     * is not causing an immediate problem.
+     */
+    warn,
+
+    /** Expression cannot be handled will be rejected. */
+    error;
   }
 }

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/EvalPayloadTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/EvalPayloadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 Netflix, Inc.
+ * Copyright 2014-2018 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,25 +15,11 @@
  */
 package com.netflix.spectator.atlas.impl;
 
-import com.netflix.spectator.api.DefaultRegistry;
-import com.netflix.spectator.api.ManualClock;
-import com.netflix.spectator.api.Measurement;
-import com.netflix.spectator.api.Registry;
-import com.netflix.spectator.api.Tag;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 
 @RunWith(JUnit4.class)
@@ -42,6 +28,20 @@ public class EvalPayloadTest {
   @Test
   public void metricEquals() {
     EqualsVerifier.forClass(EvalPayload.Metric.class)
+        .suppress(Warning.NULL_FIELDS)
+        .verify();
+  }
+
+  @Test
+  public void messageEquals() {
+    EqualsVerifier.forClass(EvalPayload.Message.class)
+        .suppress(Warning.NULL_FIELDS)
+        .verify();
+  }
+
+  @Test
+  public void diagnosticMessageEquals() {
+    EqualsVerifier.forClass(EvalPayload.DiagnosticMessage.class)
         .suppress(Warning.NULL_FIELDS)
         .verify();
   }


### PR DESCRIPTION
Updates the eval payload to include passing diagnostic
messages back to the server (Netflix/atlas#925).