### PR TITLE
update IPC metrics to use status and detail

### DIFF
--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcErrorGroup.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcErrorGroup.java
@@ -22,7 +22,11 @@ import com.netflix.spectator.api.Tag;
  * are the same for all implementations to make it easier to query across all
  * services and client implementations. An implementation specific failure can be
  * specified with {@link IpcTagKey#errorReason}.
+ *
+ * @deprecated Use {@link IpcStatus} instead. This value will be removed in
+ * January of 2019.
  */
+@Deprecated
 public enum IpcErrorGroup implements Tag {
 
   /** No error. */

--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcLogEntry.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcLogEntry.java
@@ -53,8 +53,8 @@ public final class IpcLogEntry {
 
   private String protocol;
 
-  private IpcErrorGroup errorGroup;
-  private String errorReason;
+  private IpcStatus status;
+  private String statusDetail;
   private Throwable exception;
 
   private IpcAttempt attempt;
@@ -203,11 +203,33 @@ public final class IpcLogEntry {
   }
 
   /**
-   * Set the high level cause for a request failure. See {@link IpcErrorGroup} for more
+   * Set the high level status for the request. See {@link IpcStatus} for more
    * information.
    */
+  public IpcLogEntry withStatus(IpcStatus status) {
+    this.status = status;
+    return this;
+  }
+
+  /**
+   * Set the detailed implementation specific status for the request. In most cases it
+   * is preferable to use {@link #withException(Throwable)} or {@link #withHttpStatus(int)}
+   * instead of calling this directly.
+   */
+  public IpcLogEntry withStatusDetail(String statusDetail) {
+    this.statusDetail = statusDetail;
+    return this;
+  }
+
+  /**
+   * Set the high level cause for a request failure. See {@link IpcErrorGroup} for more
+   * information.
+   *
+   * @deprecated Use {@link #withStatus(IpcStatus)} instead. This method will be removed in
+   * January of 2019.
+   */
+  @Deprecated
   public IpcLogEntry withErrorGroup(IpcErrorGroup errorGroup) {
-    this.errorGroup = errorGroup;
     return this;
   }
 
@@ -215,9 +237,12 @@ public final class IpcLogEntry {
    * Set the implementation specific reason for the request failure. In most cases it
    * is preferable to use {@link #withException(Throwable)} or {@link #withHttpStatus(int)}
    * instead of calling this directly.
+   *
+   * @deprecated Use {@link #withStatusDetail(String)} instead. This method will be removed in
+   * January of 2019.
    */
+  @Deprecated
   public IpcLogEntry withErrorReason(String errorReason) {
-    this.errorReason = errorReason;
     return this;
   }
 
@@ -227,8 +252,8 @@ public final class IpcLogEntry {
    */
   public IpcLogEntry withException(Throwable exception) {
     this.exception = exception;
-    if (errorReason == null) {
-      errorReason = exception.getClass().getSimpleName();
+    if (statusDetail == null) {
+      statusDetail = exception.getClass().getSimpleName();
     }
     return this;
   }
@@ -433,30 +458,16 @@ public final class IpcLogEntry {
    * Set the HTTP status code for this request. For the metrics this will be used to populate
    * the {@link #withErrorReason(String)}.
    */
-  public IpcLogEntry withHttpStatus(int status) {
-    this.httpStatus = status;
+  public IpcLogEntry withHttpStatus(int httpStatus) {
+    this.httpStatus = httpStatus;
+    if (statusDetail == null && httpStatus >= 100 & httpStatus < 600) {
+      statusDetail = "HTTP_" + httpStatus;
+    }
+    if (status == null) {
+      status = IpcStatus.forHttpStatus(httpStatus);
+    }
     if (result == null) {
-      withResult((status < 400) ? IpcResult.success : IpcResult.failure);
-    }
-    if (errorReason == null && status >= 400 & status < 600) {
-      errorReason = "HTTP_" + status;
-    }
-    if (errorGroup == null) {
-      switch (status) {
-        case 429:
-          errorGroup = IpcErrorGroup.client_throttled;
-          break;
-        case 503:
-          errorGroup = IpcErrorGroup.server_throttled;
-          break;
-        default:
-          if (status >= 400 && status < 500) {
-            errorGroup = IpcErrorGroup.client_error;
-          } else if (status >= 500) {
-            errorGroup = IpcErrorGroup.server_error;
-          }
-          break;
-      }
+      result = status.result();
     }
     return this;
   }
@@ -570,9 +581,16 @@ public final class IpcLogEntry {
 
   private IpcResult getResult() {
     if (result == null) {
-      result = errorGroup == null ? IpcResult.success : IpcResult.failure;
+      result = status == null ? IpcResult.success : status.result();
     }
     return result;
+  }
+
+  private IpcStatus getStatus() {
+    if (status == null) {
+      status = (result == IpcResult.success) ? IpcStatus.success : IpcStatus.unexpected_error;
+    }
+    return status;
   }
 
   private IpcAttempt getAttempt() {
@@ -605,7 +623,7 @@ public final class IpcLogEntry {
     // Required for both client and server
     putTag(tags, IpcTagKey.owner.key(), owner);
     putTag(tags, getResult());
-    putTag(tags, errorGroup);
+    putTag(tags, getStatus());
 
     if (isClient()) {
       // Required for client, should be null on server
@@ -631,11 +649,8 @@ public final class IpcLogEntry {
     putTag(tags, IpcTagKey.endpoint.key(), endpoint);
     putTag(tags, IpcTagKey.vip.key(), vip);
     putTag(tags, IpcTagKey.protocol.key(), protocol);
-    putTag(tags, IpcTagKey.errorReason.key(), errorReason);
+    putTag(tags, IpcTagKey.statusDetail.key(), statusDetail);
     putTag(tags, IpcTagKey.httpMethod.key(), httpMethod);
-    if (httpStatus >= 100 && httpStatus < 600) {
-      putTag(tags, IpcTagKey.httpStatus.key(), "" + httpStatus);
-    }
 
     return registry.createId(name, tags);
   }
@@ -783,8 +798,8 @@ public final class IpcLogEntry {
         .addField("attempt", attempt)
         .addField("attemptFinal", attemptFinal)
         .addField("result", result)
-        .addField("errorGroup", errorGroup)
-        .addField("errorReason", errorReason)
+        .addField("status", status)
+        .addField("statusDetail", statusDetail)
         .addField("exceptionClass", getExceptionClass())
         .addField("exceptionMessage", getExceptionMessage())
         .addField("httpMethod", httpMethod)
@@ -809,8 +824,8 @@ public final class IpcLogEntry {
     owner = null;
     result = null;
     protocol = null;
-    errorGroup = null;
-    errorReason = null;
+    status = null;
+    statusDetail = null;
     exception = null;
     attempt = null;
     attemptFinal = null;
@@ -850,8 +865,8 @@ public final class IpcLogEntry {
     startNanos = -1L;
     latency = -1L;
     result = null;
-    errorGroup = null;
-    errorReason = null;
+    status = null;
+    statusDetail = null;
     exception = null;
     attempt = null;
     attemptFinal = null;

--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcLogEntry.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcLogEntry.java
@@ -255,6 +255,9 @@ public final class IpcLogEntry {
     if (statusDetail == null) {
       statusDetail = exception.getClass().getSimpleName();
     }
+    if (status == null) {
+      status = IpcStatus.forException(exception);
+    }
     return this;
   }
 

--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcStatus.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcStatus.java
@@ -19,6 +19,8 @@ import com.netflix.spectator.api.Tag;
 
 import javax.net.ssl.SSLException;
 import java.io.IOException;
+import java.net.SocketTimeoutException;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Dimension indicating the high level status for the request.
@@ -145,6 +147,8 @@ public enum IpcStatus implements Tag {
     IpcStatus status;
     if (t instanceof SSLException) {
       status = access_denied;
+    } else if (t instanceof SocketTimeoutException || t instanceof TimeoutException) {
+      status = timeout;
     } else if (t instanceof IOException) {
       status = connection_error;
     } else if (t instanceof IllegalArgumentException || t instanceof IllegalStateException) {

--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcStatus.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcStatus.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.ipc;
+
+import com.netflix.spectator.api.Tag;
+
+import javax.net.ssl.SSLException;
+import java.io.IOException;
+
+/**
+ * Dimension indicating the high level status for the request.
+ *
+ * @see IpcTagKey#status
+ */
+public enum IpcStatus implements Tag {
+
+  /**
+   * The request was successfully processed and responded to, as far as the client or server
+   * know.
+   */
+  success,
+
+  /**
+   * There was a problem with the clients' request causing it not to be fulfilled.
+   */
+  bad_request,
+
+  /**
+   * The client or server encountered an unexpected error processing the request.
+   */
+  unexpected_error,
+
+  /**
+   * There was an error with the underlying network connection either during establishment
+   * or while in use.
+   */
+  connection_error,
+
+  /**
+   * There were no servers available to process the request.
+   */
+  unavailable,
+
+  /**
+   * The request was rejected due to the client or server considering the server to be
+   * above capacity.
+   */
+  throttled,
+
+  /**
+   * The request could not or would not be complete within the configured threshold (either
+   * on client or server).
+   */
+  timeout,
+
+  /**
+   * The client cancelled the request before it was completed.
+   */
+  cancelled,
+
+  /**
+   * The request was denied access for authentication or authorization reasons.
+   */
+  access_denied;
+
+  @Override public String key() {
+    return IpcTagKey.status.key();
+  }
+
+  @Override public String value() {
+    return name();
+  }
+
+  /**
+   * Return the corresponding IPC result.
+   */
+  public IpcResult result() {
+    return this == success ? IpcResult.success : IpcResult.failure;
+  }
+
+  /**
+   * Maps HTTP status codes to the appropriate status.
+   *
+   * @param httpStatus
+   *     HTTP status for the request.
+   * @return
+   *     Status value corresponding to the HTTP status code.
+   */
+  public static IpcStatus forHttpStatus(int httpStatus) {
+    IpcStatus status;
+    switch (httpStatus) {
+      case 200: status = success;       break; // OK
+      case 401: status = access_denied; break; // Unauthorized
+      case 402: status = access_denied; break; // Payment Required
+      case 403: status = access_denied; break; // Forbidden
+      case 404: status = success;       break; // Not Found
+      case 405: status = bad_request;   break; // Method Not Allowed
+      case 406: status = bad_request;   break; // Not Acceptable
+      case 407: status = access_denied; break; // Proxy Authentication Required
+      case 408: status = timeout;       break; // Request Timeout
+      case 429: status = throttled;     break; // Too Many Requests
+      case 503: status = unavailable;   break; // Unavailable
+      case 511: status = access_denied; break; // Network Authentication Required
+      default:
+        if (httpStatus < 100) {
+          // Shouldn't get here, but since the input value isn't validated it is a possibility
+          status = unexpected_error;
+        } else if (httpStatus < 400) {
+          // All 1xx, 2xx, and 3xx unless otherwise specified will be marked as a success
+          status = success;
+        } else if (httpStatus < 500) {
+          // All 4xx unless otherwise specified will be marked as a bad request
+          status = bad_request;
+        } else {
+          // Anything else is unexpected
+          status = unexpected_error;
+        }
+        break;
+    }
+    return status;
+  }
+
+  /**
+   * Maps common exceptions from the JDK to the appropriate status.
+   *
+   * @param t
+   *     Exception to map to a status.
+   * @return
+   *     Status corresponding to the passed in exception.
+   */
+  public static IpcStatus forException(Throwable t) {
+    IpcStatus status;
+    if (t instanceof SSLException) {
+      status = access_denied;
+    } else if (t instanceof IOException) {
+      status = connection_error;
+    } else if (t instanceof IllegalArgumentException || t instanceof IllegalStateException) {
+      status = bad_request;
+    } else {
+      status = unexpected_error;
+    }
+    return status;
+  }
+}

--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcTagKey.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcTagKey.java
@@ -33,16 +33,38 @@ public enum IpcTagKey {
   result("ipc.result"),
 
   /**
+   * Dimension indicating a high level status for the request. These values are the same
+   * for all implementations to make it easier to query across services. See {@link IpcStatus}
+   * for permitted values.
+   */
+  status("ipc.status"),
+
+  /**
+   * Optional dimension indicating a more detailed status. The values for this are
+   * implementation specific. For example with HTTP, the status code would be a likely
+   * value used here.
+   */
+  statusDetail("icp.status.detail"),
+
+  /**
    * Dimension indicating a high level cause for the request failure. These groups
    * are the same for all implementations to make it easier to query across all
    * services and client implementations. See {@link IpcErrorGroup} for permitted
    * values.
+   *
+   * @deprecated Use {@link #status} instead. This value will be removed in
+   * January of 2019.
    */
+  @Deprecated
   errorGroup("ipc.error.group"),
 
   /**
    * Implementation specific error code.
+   *
+   * @deprecated Use {@link #statusDetail} instead. This value will be removed in
+   * January of 2019.
    */
+  @Deprecated
   errorReason("ipc.error.reason"),
 
   /**
@@ -144,7 +166,11 @@ public enum IpcTagKey {
 
   /**
    * HTTP status code.
+   *
+   * @deprecated Use {@link #statusDetail} instead. This value will be removed in
+   * January of 2019.
    */
+  @Deprecated
   httpStatus("http.status"),
 
   /**

--- a/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/IpcLogEntryTest.java
+++ b/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/IpcLogEntryTest.java
@@ -136,22 +136,22 @@ public class IpcLogEntryTest {
   }
 
   @Test
-  public void errorGroup() {
-    String expected = IpcErrorGroup.cancelled.value();
+  public void status() {
+    String expected = IpcStatus.cancelled.value();
     String actual = (String) entry
-        .withErrorGroup(IpcErrorGroup.cancelled)
+        .withStatus(IpcStatus.cancelled)
         .convert(this::toMap)
-        .get("errorGroup");
+        .get("status");
     Assert.assertEquals(expected, actual);
   }
 
   @Test
-  public void errorReason() {
+  public void statusDetail() {
     String expected = "connection_failed";
     String actual = (String) entry
-        .withErrorReason(expected)
+        .withStatusDetail(expected)
         .convert(this::toMap)
-        .get("errorReason");
+        .get("statusDetail");
     Assert.assertEquals(expected, actual);
   }
 
@@ -466,8 +466,8 @@ public class IpcLogEntryTest {
     String actual = (String) entry
         .withHttpStatus(429)
         .convert(this::toMap)
-        .get("errorGroup");
-    Assert.assertEquals(IpcErrorGroup.client_throttled.value(), actual);
+        .get("status");
+    Assert.assertEquals(IpcStatus.throttled.value(), actual);
   }
 
   @Test
@@ -475,8 +475,8 @@ public class IpcLogEntryTest {
     String actual = (String) entry
         .withHttpStatus(503)
         .convert(this::toMap)
-        .get("errorGroup");
-    Assert.assertEquals(IpcErrorGroup.server_throttled.value(), actual);
+        .get("status");
+    Assert.assertEquals(IpcStatus.unavailable.value(), actual);
   }
 
   @Test
@@ -598,9 +598,9 @@ public class IpcLogEntryTest {
   public void stringEscape() {
     for (char c = 0; c < 65535; ++c) {
       String actual = (String) entry
-          .withErrorReason("" + c)
+          .withStatusDetail("" + c)
           .convert(this::toMap)
-          .get("errorReason");
+          .get("statusDetail");
       if (actual.length() == 0) {
         Assert.assertTrue(Character.isISOControl(c));
         Assert.assertEquals("", actual);

--- a/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/IpcMetricTest.java
+++ b/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/IpcMetricTest.java
@@ -41,6 +41,7 @@ public class IpcMetricTest {
     Id id = registry.createId(IpcMetric.clientCall.metricName())
         .withTag(IpcTagKey.owner.tag("test"))
         .withTag(IpcResult.success)
+        .withTag(IpcStatus.success)
         .withTag(IpcAttempt.initial)
         .withTag(IpcTagKey.attemptFinal.key(), true);
     IpcMetric.clientCall.validate(id);
@@ -51,6 +52,7 @@ public class IpcMetricTest {
     Id id = registry.createId(IpcMetric.clientCall.metricName())
         .withTag(IpcTagKey.owner.key(), "test")
         .withTag(IpcResult.success)
+        .withTag(IpcStatus.success)
         .withTag(IpcAttempt.initial)
         .withTag(IpcAttemptFinal.is_true);
     IpcMetric.clientCall.validate(id);
@@ -61,6 +63,7 @@ public class IpcMetricTest {
     Id id = registry.createId(IpcMetric.clientCall.metricName())
         .withTag(IpcTagKey.owner.key(), "test")
         .withTag(IpcResult.success)
+        .withTag(IpcStatus.success)
         .withTag(IpcAttempt.initial)
         .withTag(IpcAttemptFinal.is_false);
     IpcMetric.clientCall.validate(id);
@@ -71,6 +74,7 @@ public class IpcMetricTest {
     Id id = registry.createId("ipc.client-call")
         .withTag(IpcTagKey.owner.tag("test"))
         .withTag(IpcResult.success)
+        .withTag(IpcStatus.success)
         .withTag(IpcAttempt.initial)
         .withTag(IpcTagKey.attemptFinal.key(), true);
     IpcMetric.clientCall.validate(id);
@@ -80,17 +84,18 @@ public class IpcMetricTest {
   public void validateIdMissingResult() {
     Id id = registry.createId(IpcMetric.clientCall.metricName())
         .withTag(IpcTagKey.owner.tag("test"))
+        .withTag(IpcStatus.success)
         .withTag(IpcAttempt.initial)
         .withTag(IpcTagKey.attemptFinal.key(), true);
     IpcMetric.clientCall.validate(id);
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void validateIdErrorGroupOnSuccess() {
+  public void validateIdErrorStatusOnSuccess() {
     Id id = registry.createId(IpcMetric.clientCall.metricName())
         .withTag(IpcTagKey.owner.tag("test"))
         .withTag(IpcResult.success)
-        .withTag(IpcErrorGroup.general)
+        .withTag(IpcStatus.bad_request)
         .withTag(IpcAttempt.initial)
         .withTag(IpcTagKey.attemptFinal.key(), true);
     IpcMetric.clientCall.validate(id);
@@ -101,29 +106,29 @@ public class IpcMetricTest {
     Id id = registry.createId(IpcMetric.clientCall.metricName())
         .withTag(IpcTagKey.owner.tag("test"))
         .withTag(IpcResult.failure)
-        .withTag(IpcErrorGroup.general)
+        .withTag(IpcStatus.bad_request)
         .withTag(IpcAttempt.initial)
         .withTag(IpcTagKey.attemptFinal.key(), true);
     IpcMetric.clientCall.validate(id);
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void validateIdErrorGroupNotOnFailure() {
+  public void validateIdSuccessStatusOnFailure() {
     Id id = registry.createId(IpcMetric.clientCall.metricName())
         .withTag(IpcTagKey.owner.tag("test"))
         .withTag(IpcResult.failure)
+        .withTag(IpcStatus.success)
         .withTag(IpcAttempt.initial)
         .withTag(IpcTagKey.attemptFinal.key(), true);
     IpcMetric.clientCall.validate(id);
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void validateIdErrorReasonOnSuccess() {
+  public void validateIdStatusDetailOnSuccess() {
     Id id = registry.createId(IpcMetric.clientCall.metricName())
         .withTag(IpcTagKey.owner.tag("test"))
         .withTag(IpcResult.success)
-        .withTag(IpcErrorGroup.general)
-        .withTag(IpcTagKey.errorReason.tag("foo"))
+        .withTag(IpcStatus.success)
+        .withTag(IpcTagKey.statusDetail.tag("foo"))
         .withTag(IpcAttempt.initial)
         .withTag(IpcTagKey.attemptFinal.key(), true);
     IpcMetric.clientCall.validate(id);
@@ -134,6 +139,18 @@ public class IpcMetricTest {
     Id id = registry.createId(IpcMetric.clientCall.metricName())
         .withTag(IpcTagKey.owner.tag("test"))
         .withTag(IpcTagKey.result.tag("foo"))
+        .withTag(IpcStatus.success)
+        .withTag(IpcAttempt.initial)
+        .withTag(IpcTagKey.attemptFinal.key(), true);
+    IpcMetric.clientCall.validate(id);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void validateIdBadStatusValue() {
+    Id id = registry.createId(IpcMetric.clientCall.metricName())
+        .withTag(IpcTagKey.owner.tag("test"))
+        .withTag(IpcResult.success)
+        .withTag(IpcTagKey.status.tag("foo"))
         .withTag(IpcAttempt.initial)
         .withTag(IpcTagKey.attemptFinal.key(), true);
     IpcMetric.clientCall.validate(id);
@@ -154,6 +171,7 @@ public class IpcMetricTest {
     Id id = registry.createId(IpcMetric.clientCall.metricName())
         .withTag(IpcTagKey.owner.tag("test"))
         .withTag(IpcResult.success)
+        .withTag(IpcStatus.success)
         .withTag(IpcAttempt.initial)
         .withTag(IpcTagKey.attemptFinal.key(), true);
     registry.timer(id).record(Duration.ofSeconds(42));
@@ -165,6 +183,7 @@ public class IpcMetricTest {
     Id id = registry.createId(IpcMetric.clientCall.metricName())
         .withTag(IpcTagKey.owner.tag("test"))
         .withTag(IpcResult.success)
+        .withTag(IpcStatus.success)
         .withTag(IpcAttempt.initial)
         .withTag(IpcTagKey.attemptFinal.key(), true);
     registry.counter(id).increment();

--- a/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/IpcStatusTest.java
+++ b/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/IpcStatusTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.ipc;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import javax.net.ssl.SSLException;
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
+import java.util.concurrent.TimeoutException;
+
+@RunWith(JUnit4.class)
+public class IpcStatusTest {
+
+  @Test
+  public void forHttpStatusNegative() {
+    Assert.assertEquals(IpcStatus.unexpected_error, IpcStatus.forHttpStatus(-1));
+  }
+
+  @Test
+  public void forHttpStatus1xx() {
+    Assert.assertEquals(IpcStatus.success, IpcStatus.forHttpStatus(100));
+  }
+
+  @Test
+  public void forHttpStatus2xx() {
+    Assert.assertEquals(IpcStatus.success, IpcStatus.forHttpStatus(200));
+  }
+
+  @Test
+  public void forHttpStatus3xx() {
+    Assert.assertEquals(IpcStatus.success, IpcStatus.forHttpStatus(304));
+  }
+
+  @Test
+  public void forHttpStatus404() {
+    Assert.assertEquals(IpcStatus.success, IpcStatus.forHttpStatus(404));
+  }
+
+  @Test
+  public void forHttpStatus403() {
+    Assert.assertEquals(IpcStatus.access_denied, IpcStatus.forHttpStatus(403));
+  }
+
+  @Test
+  public void forHttpStatus429() {
+    Assert.assertEquals(IpcStatus.throttled, IpcStatus.forHttpStatus(429));
+  }
+
+  @Test
+  public void forHttpStatus4xx() {
+    Assert.assertEquals(IpcStatus.bad_request, IpcStatus.forHttpStatus(487));
+  }
+
+  @Test
+  public void forHttpStatus503() {
+    Assert.assertEquals(IpcStatus.unavailable, IpcStatus.forHttpStatus(503));
+  }
+
+  @Test
+  public void forHttpStatus5xx() {
+    Assert.assertEquals(IpcStatus.unexpected_error, IpcStatus.forHttpStatus(587));
+  }
+
+  @Test
+  public void forHttpStatusTooBig() {
+    Assert.assertEquals(IpcStatus.unexpected_error, IpcStatus.forHttpStatus(123456));
+  }
+
+  @Test
+  public void forExceptionIO() {
+    Throwable t = new IOException();
+    Assert.assertEquals(IpcStatus.connection_error, IpcStatus.forException(t));
+  }
+
+  @Test
+  public void forExceptionSocket() {
+    Throwable t = new SocketException();
+    Assert.assertEquals(IpcStatus.connection_error, IpcStatus.forException(t));
+  }
+
+  @Test
+  public void forExceptionUnknownHost() {
+    Throwable t = new UnknownHostException();
+    Assert.assertEquals(IpcStatus.connection_error, IpcStatus.forException(t));
+  }
+
+  @Test
+  public void forExceptionConnect() {
+    Throwable t = new ConnectException();
+    Assert.assertEquals(IpcStatus.connection_error, IpcStatus.forException(t));
+  }
+
+  @Test
+  public void forExceptionTimeout() {
+    Throwable t = new TimeoutException();
+    Assert.assertEquals(IpcStatus.timeout, IpcStatus.forException(t));
+  }
+
+  @Test
+  public void forExceptionSocketTimeout() {
+    Throwable t = new SocketTimeoutException();
+    Assert.assertEquals(IpcStatus.timeout, IpcStatus.forException(t));
+  }
+
+  @Test
+  public void forExceptionIllegalArgument() {
+    Throwable t = new IllegalArgumentException();
+    Assert.assertEquals(IpcStatus.bad_request, IpcStatus.forException(t));
+  }
+
+  @Test
+  public void forExceptionIllegalState() {
+    Throwable t = new IllegalStateException();
+    Assert.assertEquals(IpcStatus.bad_request, IpcStatus.forException(t));
+  }
+
+  @Test
+  public void forExceptionRuntime() {
+    Throwable t = new RuntimeException();
+    Assert.assertEquals(IpcStatus.unexpected_error, IpcStatus.forException(t));
+  }
+
+  @Test
+  public void forExceptionSSL() {
+    Throwable t = new SSLException("test");
+    Assert.assertEquals(IpcStatus.access_denied, IpcStatus.forException(t));
+  }
+}

--- a/spectator-ext-ipcservlet/src/test/java/com/netflix/spectator/ipcservlet/IpcServletFilterTest.java
+++ b/spectator-ext-ipcservlet/src/test/java/com/netflix/spectator/ipcservlet/IpcServletFilterTest.java
@@ -82,7 +82,6 @@ public class IpcServletFilterTest {
   public void validateIdTest() throws Exception {
     client.get(baseUri.resolve("/test/foo/12345?q=54321")).send();
     checkResult(registry, "success");
-    checkErrorReason(registry, null);
     checkStatus(registry, "200");
     checkMethod(registry, "GET");
     checkEndpoint(registry, "/test/foo");
@@ -120,7 +119,6 @@ public class IpcServletFilterTest {
     checkResult(registry, "failure");
     checkClientErrorReason(registry, "HTTP_500");
     checkServerErrorReason(registry, "RuntimeException");
-    checkStatus(registry, "500");
     checkMethod(registry, "GET");
     checkClientEndpoint(registry, null);
     checkServerEndpoint(registry, "/throw");
@@ -131,7 +129,6 @@ public class IpcServletFilterTest {
   public void validateIdCustom() throws Exception {
     client.delete(baseUri.resolve("/endpoint/foo/12345?q=54321")).send();
     checkResult(registry, "success");
-    checkErrorReason(registry, null);
     checkStatus(registry, "200");
     checkMethod(registry, "DELETE");
     checkEndpoint(registry, "/servlet"); // header set in the servlet

--- a/spectator-ext-ipcservlet/src/test/java/com/netflix/spectator/ipcservlet/TestUtils.java
+++ b/spectator-ext-ipcservlet/src/test/java/com/netflix/spectator/ipcservlet/TestUtils.java
@@ -64,8 +64,8 @@ final class TestUtils {
   }
 
   static void checkStatus(Id id, String expected) {
-    String endpoint = Utils.getTagValue(id, IpcTagKey.httpStatus.key());
-    Assert.assertEquals(expected, endpoint);
+    String endpoint = Utils.getTagValue(id, IpcTagKey.statusDetail.key());
+    Assert.assertEquals("HTTP_" + expected, endpoint);
   }
 
   static void checkClientStatus(Registry registry, String expected) {
@@ -104,7 +104,7 @@ final class TestUtils {
   }
 
   static void checkErrorReason(Id id, String expected) {
-    String endpoint = Utils.getTagValue(id, IpcTagKey.errorReason.key());
+    String endpoint = Utils.getTagValue(id, IpcTagKey.statusDetail.key());
     Assert.assertEquals(expected, endpoint);
   }
 


### PR DESCRIPTION
Updates the IPC metrics pattern based on recent internal
conversations. In particular, many found the errorGroup
and errorReason values to be confusing and these have been
replaced by status and statusDetail.