### PR TITLE
ignore NaN values when publishing

### DIFF
--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasRegistryTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasRegistryTest.java
@@ -26,6 +26,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 
 @RunWith(JUnit4.class)
@@ -42,39 +43,49 @@ public class AtlasRegistryTest {
     return props::get;
   }
 
+  private List<Measurement> getMeasurements() {
+    return registry.getMeasurements().collect(Collectors.toList());
+  }
+
   @Test
   public void measurementsEmpty() {
-    Assert.assertEquals(0, registry.getMeasurements().size());
+    Assert.assertEquals(0, getMeasurements().size());
   }
 
   @Test
   public void measurementsWithCounter() {
     registry.counter("test").increment();
-    Assert.assertEquals(1, registry.getMeasurements().size());
+    Assert.assertEquals(1, getMeasurements().size());
   }
 
   @Test
   public void measurementsWithTimer() {
     registry.timer("test").record(42, TimeUnit.NANOSECONDS);
-    Assert.assertEquals(4, registry.getMeasurements().size());
+    Assert.assertEquals(4, getMeasurements().size());
   }
 
   @Test
   public void measurementsWithDistributionSummary() {
     registry.distributionSummary("test").record(42);
-    Assert.assertEquals(4, registry.getMeasurements().size());
+    Assert.assertEquals(4, getMeasurements().size());
   }
 
   @Test
   public void measurementsWithGauge() {
     registry.gauge("test").set(4.0);
-    Assert.assertEquals(1, registry.getMeasurements().size());
+    Assert.assertEquals(1, getMeasurements().size());
+  }
+
+  @Test
+  public void measurementsIgnoresNaN() {
+    registry.gauge("test").set(Double.NaN);
+    Assert.assertEquals(0, getMeasurements().size());
   }
 
   @Test
   public void measurementsWithMaxGauge() {
     registry.maxGauge(registry.createId("test")).set(4.0);
-    Assert.assertEquals(1, registry.getMeasurements().size());
+    Assert.assertEquals(1, getMeasurements().size());
   }
 
   @Test


### PR DESCRIPTION
Updates the Atlas registry to explicitly ignore the
measurements with a value of `NaN`. Before a gauge
that was explicitly set to `NaN` would get passed
through.