### PR TITLE
Minor fix for gauge documentation

### DIFF
--- a/docs/intro/gauge.md
+++ b/docs/intro/gauge.md
@@ -80,7 +80,7 @@ assignment:
 ```java
 AtomicInteger size = PolledMeter.using(registry)
   .withName("queue.size")
-  .monitorValue(size);
+  .monitorValue(new AtomicInteger());
 ```
 
 Updates to the value are preformed by updating the number instance directly.


### PR DESCRIPTION
Fix the example of using a gauge with a `Number`