### PR TITLE
remove deprecation of `http.status`

### DIFF
--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcTagKey.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcTagKey.java
@@ -165,12 +165,10 @@ public enum IpcTagKey {
   serverPort("ipc.server.port"),
 
   /**
-   * HTTP status code.
-   *
-   * @deprecated Use {@link #statusDetail} instead. This value will be removed in
-   * January of 2019.
+   * HTTP status code. In most cases it is preferred to use {@link #statusDetail} instead.
+   * This tag key is optionally used to include the HTTP status code when the status detail
+   * is overridden with application specific values.
    */
-  @Deprecated
   httpStatus("http.status"),
 
   /**


### PR DESCRIPTION
Zuul team wants to be able to use this still so they can
have application specific details while retaining the actual
HTTP status code.