### PR TITLE
update to checkstyle 8.14

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,7 +101,7 @@ subprojects {
   }
   
   checkstyle {
-    toolVersion = '6.7'
+    toolVersion = '8.14'
     ignoreFailures = false 
     configFile = rootProject.file('codequality/checkstyle.xml')
     sourceSets = [sourceSets.main]

--- a/codequality/checkstyle.xml
+++ b/codequality/checkstyle.xml
@@ -169,20 +169,17 @@
         </module>
         <module name="UpperEll"/>
 
-        <module name="FileContentsHolder"/> <!-- Required by comment suppression filters -->
-
-    </module>
-
-    <!-- Enable suppression comments -->
-    <module name="SuppressionCommentFilter">
-      <property name="offCommentFormat" value="CHECKSTYLE IGNORE\s+(\S+)"/>
-      <property name="onCommentFormat" value="CHECKSTYLE END IGNORE\s+(\S+)"/>
-      <property name="checkFormat" value="$1"/>
-    </module>
-    <module name="SuppressWithNearbyCommentFilter">
-      <!-- Syntax is "SUPPRESS CHECKSTYLE name" -->
-      <property name="commentFormat" value="SUPPRESS CHECKSTYLE (\w+)"/>
-      <property name="checkFormat" value="$1"/>
-      <property name="influenceFormat" value="1"/>
+      <!-- Enable suppression comments -->
+      <module name="SuppressionCommentFilter">
+        <property name="offCommentFormat" value="CHECKSTYLE IGNORE\s+(\S+)"/>
+        <property name="onCommentFormat" value="CHECKSTYLE END IGNORE\s+(\S+)"/>
+        <property name="checkFormat" value="$1"/>
+      </module>
+      <module name="SuppressWithNearbyCommentFilter">
+        <!-- Syntax is "SUPPRESS CHECKSTYLE name" -->
+        <property name="commentFormat" value="SUPPRESS CHECKSTYLE (\w+)"/>
+        <property name="checkFormat" value="$1"/>
+        <property name="influenceFormat" value="1"/>
+      </module>
     </module>
 </module>

--- a/spectator-api/src/main/java/com/netflix/spectator/api/CompositeMeter.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/CompositeMeter.java
@@ -39,7 +39,7 @@ class CompositeMeter<T extends Meter> implements Meter {
    * @param meters
    *     Set of meters that make up the composite.
    */
-  public CompositeMeter(Id id, Collection<T> meters) {
+  CompositeMeter(Id id, Collection<T> meters) {
     this.id = id;
     this.meters = meters;
   }

--- a/spectator-api/src/main/java/com/netflix/spectator/api/DefaultId.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/DefaultId.java
@@ -29,7 +29,7 @@ final class DefaultId implements Id {
   private final ArrayTagSet tags;
 
   /** Create a new instance. */
-  public DefaultId(String name) {
+  DefaultId(String name) {
     this(name, ArrayTagSet.EMPTY);
   }
 

--- a/spectator-ext-aws/src/main/java/com/netflix/spectator/aws/SpectatorRequestMetricCollector.java
+++ b/spectator-ext-aws/src/main/java/com/netflix/spectator/aws/SpectatorRequestMetricCollector.java
@@ -196,21 +196,21 @@ public class SpectatorRequestMetricCollector extends RequestMetricCollector {
     private final String name;
     private final Function<Object, String> tagExtractor;
 
-    public TagField(Field field) {
+    TagField(Field field) {
       this(field, Object::toString);
     }
 
-    public TagField(Field field, Function<Object, String> tagExtractor) {
+    TagField(Field field, Function<Object, String> tagExtractor) {
       this.field = field;
       this.tagExtractor = tagExtractor;
       this.name = Introspector.decapitalize(field.name());
     }
 
-    public String getName() {
+    String getName() {
       return name;
     }
 
-    public Optional<String> getValue(AWSRequestMetrics metrics) {
+    Optional<String> getValue(AWSRequestMetrics metrics) {
       return firstValue(metrics.getProperty(field), tagExtractor);
     }
   }

--- a/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoId.java
+++ b/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoId.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 Netflix, Inc.
+/*
+ * Copyright 2014-2018 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ final class ServoId implements Id {
   private final MonitorConfig config;
 
   /** Create a new instance. */
-  public ServoId(MonitorConfig config) {
+  ServoId(MonitorConfig config) {
     this.config = config;
   }
 

--- a/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoTag.java
+++ b/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoTag.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 Netflix, Inc.
+/*
+ * Copyright 2014-2018 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ class ServoTag implements Tag {
   private final com.netflix.servo.tag.Tag tag;
 
   /** Create a new instance. */
-  public ServoTag(com.netflix.servo.tag.Tag tag) {
+  ServoTag(com.netflix.servo.tag.Tag tag) {
     this.tag = tag;
   }
 


### PR DESCRIPTION
Fixes incorrect flagging of javadoc on variables used inside
a lambda function (checkstyle/checkstyle#1254).