### PR TITLE
improve churn resistance for mostFrequent limiter

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/CompositeMeter.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/CompositeMeter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 Netflix, Inc.
+ * Copyright 2014-2018 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spectator-api/src/main/java/com/netflix/spectator/api/DefaultId.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/DefaultId.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 Netflix, Inc.
+/*
+ * Copyright 2014-2018 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcLogger.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcLogger.java
@@ -84,7 +84,7 @@ public class IpcLogger {
    * backend from a metrics explosion if some dimensions have a high cardinality.
    */
   Function<String, String> limiterForKey(String key) {
-    return Utils.computeIfAbsent(limiters, key, k -> CardinalityLimiters.mostFrequent(25));
+    return Utils.computeIfAbsent(limiters, key, k -> CardinalityLimiters.mostFrequent(10));
   }
 
   private IpcLogEntry newEntry() {


### PR DESCRIPTION
Updates the most frequent cardinality limiter to better
handle cases where there is a long tail with a lot of
churn. It should now detect a baseline frequency that
is higher than the frequncy of values with a lot of
churn over time. This may limit the number of values
emitted to be smaller than the limit specified by the
user.