### PR TITLE
registry that delegates to Micrometer

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -16,6 +16,7 @@ include 'spectator-api',
         'spectator-ext-spark',
         'spectator-reg-atlas',
         'spectator-reg-metrics3',
+        'spectator-reg-micrometer',
         'spectator-reg-servo',
         'spectator-reg-stateless',
         'spectator-web-spring'

--- a/spectator-api/src/main/java/com/netflix/spectator/api/BasicTag.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/BasicTag.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 Netflix, Inc.
+/*
+ * Copyright 2014-2018 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spectator-api/src/main/java/com/netflix/spectator/api/Id.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/Id.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 Netflix, Inc.
+/*
+ * Copyright 2014-2018 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -128,5 +128,15 @@ public interface Id {
       tmp = tmp.withTag(entry.getKey(), entry.getValue());
     }
     return tmp;
+  }
+
+  /**
+   * Create an immutable Id with the provided name. In many cases it is preferable to use
+   * {@link Registry#createId(String)} instead so that the overhead for instrumentation can
+   * be mostly removed when choosing to use a NoopRegistry. Using this method directly the Id
+   * will always be created.
+   */
+  static Id create(String name) {
+    return new DefaultId(name);
   }
 }

--- a/spectator-api/src/main/java/com/netflix/spectator/api/Tag.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/Tag.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 Netflix, Inc.
+/*
+ * Copyright 2014-2018 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,4 +22,9 @@ public interface Tag {
 
   /** Value for the tag. */
   String value();
+
+  /** Create an immutable instance of a tag. */
+  static Tag of(String key, String value) {
+    return new BasicTag(key, value);
+  }
 }

--- a/spectator-reg-micrometer/build.gradle
+++ b/spectator-reg-micrometer/build.gradle
@@ -1,0 +1,12 @@
+dependencies {
+  compileApi project(':spectator-api')
+  compile 'io.micrometer:micrometer-core:1.1.0'
+}
+
+jar {
+  manifest {
+    attributes(
+      "Automatic-Module-Name": "com.netflix.spectator.micrometer"
+    )
+  }
+}

--- a/spectator-reg-micrometer/src/main/java/com/netflix/spectator/micrometer/MicrometerClock.java
+++ b/spectator-reg-micrometer/src/main/java/com/netflix/spectator/micrometer/MicrometerClock.java
@@ -1,0 +1,24 @@
+package com.netflix.spectator.micrometer;
+
+import com.netflix.spectator.api.Clock;
+
+/**
+ * Wraps a Micrometer Clock to make it conform to the Spectator API.
+ */
+class MicrometerClock implements Clock {
+
+  private final io.micrometer.core.instrument.Clock impl;
+
+  /** Create a new instance. */
+  MicrometerClock(io.micrometer.core.instrument.Clock impl) {
+    this.impl = impl;
+  }
+
+  @Override public long wallTime() {
+    return impl.wallTime();
+  }
+
+  @Override public long monotonicTime() {
+    return impl.monotonicTime();
+  }
+}

--- a/spectator-reg-micrometer/src/main/java/com/netflix/spectator/micrometer/MicrometerCounter.java
+++ b/spectator-reg-micrometer/src/main/java/com/netflix/spectator/micrometer/MicrometerCounter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.micrometer;
+
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Measurement;
+
+/**
+ * Wraps a Micrometer Counter to make it conform to the Spectator API.
+ */
+class MicrometerCounter extends MicrometerMeter implements Counter {
+
+  private final io.micrometer.core.instrument.Counter impl;
+
+  /** Create a new instance. */
+  MicrometerCounter(Id id, io.micrometer.core.instrument.Counter impl) {
+    super(id);
+    this.impl = impl;
+  }
+
+  @Override public Iterable<Measurement> measure() {
+    return convert(impl.measure());
+  }
+
+  @Override public void add(double amount) {
+    impl.increment(amount);
+  }
+
+  @Override public double actualCount() {
+    return impl.count();
+  }
+}

--- a/spectator-reg-micrometer/src/main/java/com/netflix/spectator/micrometer/MicrometerDistributionSummary.java
+++ b/spectator-reg-micrometer/src/main/java/com/netflix/spectator/micrometer/MicrometerDistributionSummary.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.micrometer;
+
+import com.netflix.spectator.api.DistributionSummary;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Measurement;
+
+/**
+ * Wraps a Micrometer DistributionSummary to make it conform to the Spectator API.
+ */
+class MicrometerDistributionSummary extends MicrometerMeter implements DistributionSummary {
+
+  private final io.micrometer.core.instrument.DistributionSummary impl;
+
+  /** Create a new instance. */
+  MicrometerDistributionSummary(Id id, io.micrometer.core.instrument.DistributionSummary impl) {
+    super(id);
+    this.impl = impl;
+  }
+
+  @Override public void record(long amount) {
+    impl.record(amount);
+  }
+
+  @Override public long count() {
+    return impl.count();
+  }
+
+  @Override public long totalAmount() {
+    return (long) impl.totalAmount();
+  }
+
+  @Override public Iterable<Measurement> measure() {
+    return convert(impl.measure());
+  }
+}

--- a/spectator-reg-micrometer/src/main/java/com/netflix/spectator/micrometer/MicrometerGauge.java
+++ b/spectator-reg-micrometer/src/main/java/com/netflix/spectator/micrometer/MicrometerGauge.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.micrometer;
+
+import com.netflix.spectator.api.Gauge;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Measurement;
+
+import java.util.function.DoubleConsumer;
+
+/**
+ * Wraps a Micrometer Gauge to make it conform to the Spectator API.
+ */
+class MicrometerGauge extends MicrometerMeter implements Gauge {
+
+  private final DoubleConsumer updateFunc;
+  private final io.micrometer.core.instrument.Gauge impl;
+
+  /** Create a new instance. */
+  MicrometerGauge(Id id, DoubleConsumer updateFunc, io.micrometer.core.instrument.Gauge impl) {
+    super(id);
+    this.updateFunc = updateFunc;
+    this.impl = impl;
+  }
+
+  @Override public void set(double v) {
+    updateFunc.accept(v);
+  }
+
+  @Override public double value() {
+    return impl.value();
+  }
+
+  @Override public Iterable<Measurement> measure() {
+    return convert(impl.measure());
+  }
+}

--- a/spectator-reg-micrometer/src/main/java/com/netflix/spectator/micrometer/MicrometerMeter.java
+++ b/spectator-reg-micrometer/src/main/java/com/netflix/spectator/micrometer/MicrometerMeter.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.micrometer;
+
+import com.netflix.spectator.api.Clock;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.Meter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Base class for core meter types used by {@link MicrometerRegistry}. */
+abstract class MicrometerMeter implements Meter {
+
+  /** Base identifier for all measurements supplied by this meter. */
+  private final Id id;
+
+  /** Create a new instance. */
+  MicrometerMeter(Id id) {
+    this.id = id;
+  }
+
+  @Override public Id id() {
+    return id;
+  }
+
+  @Override public boolean hasExpired() {
+    return false;
+  }
+
+  /** Helper for converting Micrometer measurements to Spectator measurements. */
+  Iterable<Measurement> convert(Iterable<io.micrometer.core.instrument.Measurement> ms) {
+    long now = Clock.SYSTEM.wallTime();
+    List<Measurement> measurements = new ArrayList<>();
+    for (io.micrometer.core.instrument.Measurement m : ms) {
+      Id measurementId = id.withTag("statistic", m.getStatistic().getTagValueRepresentation());
+      measurements.add(new Measurement(measurementId, now, m.getValue()));
+    }
+    return measurements;
+  }
+}

--- a/spectator-reg-micrometer/src/main/java/com/netflix/spectator/micrometer/MicrometerRegistry.java
+++ b/spectator-reg-micrometer/src/main/java/com/netflix/spectator/micrometer/MicrometerRegistry.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.micrometer;
+
+import com.netflix.spectator.api.Clock;
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.DistributionSummary;
+import com.netflix.spectator.api.Gauge;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Meter;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Tag;
+import com.netflix.spectator.api.Timer;
+import com.netflix.spectator.api.patterns.PolledMeter;
+import com.netflix.spectator.impl.AtomicDouble;
+import com.netflix.spectator.impl.StepDouble;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.search.MeterNotFoundException;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
+
+/**
+ * Wraps a Micrometer MeterRegistry to make it conform to the Spectator API.
+ */
+public final class MicrometerRegistry implements Registry {
+
+  private final MeterRegistry impl;
+
+  private final ConcurrentHashMap<Id, Object> state = new ConcurrentHashMap<>();
+
+  /** Create a new instance. */
+  public MicrometerRegistry(MeterRegistry impl) {
+    this.impl = impl;
+  }
+
+  private io.micrometer.core.instrument.Tag convert(Tag t) {
+    return io.micrometer.core.instrument.Tag.of(t.key(), t.value());
+  }
+
+  private Iterable<io.micrometer.core.instrument.Tag> convert(Iterable<Tag> tags) {
+    List<io.micrometer.core.instrument.Tag> micrometerTags = new ArrayList<>();
+    for (Tag t : tags) {
+      micrometerTags.add(convert(t));
+    }
+    return micrometerTags;
+  }
+
+  private Id convert(io.micrometer.core.instrument.Meter.Id id) {
+    List<Tag> tags = id.getTags()
+        .stream()
+        .map(t -> Tag.of(t.getKey(), t.getValue()))
+        .collect(Collectors.toList());
+    return Id.create(id.getName()).withTags(tags);
+  }
+
+  private Meter convert(io.micrometer.core.instrument.Meter meter) {
+    Id id = convert(meter.getId());
+    switch (meter.getId().getType()) {
+      case COUNTER:              return counter(id);
+      case TIMER:                return timer(id);
+      case DISTRIBUTION_SUMMARY: return distributionSummary(id);
+      case GAUGE:                return gauge(id);
+      default:                   return null;
+    }
+  }
+
+  @Override public Clock clock() {
+    return new MicrometerClock(impl.config().clock());
+  }
+
+  @Override public Id createId(String name) {
+    return Id.create(name);
+  }
+
+  @Override public Id createId(String name, Iterable<Tag> tags) {
+    return createId(name).withTags(tags);
+  }
+
+  @Override public void register(Meter meter) {
+    PolledMeter.monitorMeter(this, meter);
+  }
+
+  @Override public ConcurrentMap<Id, Object> state() {
+    return state;
+  }
+
+  @Override public Counter counter(Id id) {
+    return new MicrometerCounter(id, impl.counter(id.name(), convert(id.tags())));
+  }
+
+  @Override public DistributionSummary distributionSummary(Id id) {
+    return new MicrometerDistributionSummary(id, impl.summary(id.name(), convert(id.tags())));
+  }
+
+  @Override public Timer timer(Id id) {
+    return new MicrometerTimer(id, impl.timer(id.name(), convert(id.tags())));
+  }
+
+  @Override public Gauge gauge(Id id) {
+    AtomicDouble value = new AtomicDouble(Double.NaN);
+    io.micrometer.core.instrument.Gauge gauge = io.micrometer.core.instrument.Gauge
+        .builder(id.name(), value, AtomicDouble::get)
+        .tags(convert(id.tags()))
+        .register(impl);
+    return new MicrometerGauge(id, value::set, gauge);
+  }
+
+  @Override public Gauge maxGauge(Id id) {
+    // Note: micrometer doesn't support this type directly so it uses an arbitrary
+    // window of 1m
+    StepDouble value = new StepDouble(Double.NaN, clock(), 60000L);
+    io.micrometer.core.instrument.Gauge gauge = io.micrometer.core.instrument.Gauge
+        .builder(id.name(), value, StepDouble::poll)
+        .tags(convert(id.tags()))
+        .register(impl);
+    return new MicrometerGauge(id, v -> value.getCurrent().max(v), gauge);
+  }
+
+  @Override public Meter get(Id id) {
+    try {
+      return impl.get(id.name())
+          .tags(convert(id.tags()))
+          .meters()
+          .stream()
+          .filter(m -> id.equals(convert(m.getId())))
+          .map(this::convert)
+          .filter(Objects::nonNull)
+          .findFirst()
+          .orElse(null);
+    } catch (MeterNotFoundException e) {
+      return null;
+    }
+  }
+
+  @Override public Iterator<Meter> iterator() {
+    return impl.getMeters()
+        .stream()
+        .map(this::convert)
+        .filter(Objects::nonNull)
+        .iterator();
+  }
+}

--- a/spectator-reg-micrometer/src/main/java/com/netflix/spectator/micrometer/MicrometerTimer.java
+++ b/spectator-reg-micrometer/src/main/java/com/netflix/spectator/micrometer/MicrometerTimer.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.micrometer;
+
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.Timer;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Wraps a Micrometer Timer to make it conform to the Spectator API.
+ */
+class MicrometerTimer extends MicrometerMeter implements Timer {
+
+  private final io.micrometer.core.instrument.Timer impl;
+
+  /** Create a new instance. */
+  MicrometerTimer(Id id, io.micrometer.core.instrument.Timer impl) {
+    super(id);
+    this.impl = impl;
+  }
+
+  @Override public void record(long amount, TimeUnit unit) {
+    impl.record(amount, unit);
+  }
+
+  @Override public <T> T record(Callable<T> f) throws Exception {
+    return impl.recordCallable(f);
+  }
+
+  @Override public void record(Runnable f) {
+    impl.record(f);
+  }
+
+  @Override public long count() {
+    return impl.count();
+  }
+
+  @Override public long totalTime() {
+    return (long) impl.totalTime(TimeUnit.NANOSECONDS);
+  }
+
+  @Override
+  public Iterable<Measurement> measure() {
+    return convert(impl.measure());
+  }
+}

--- a/spectator-reg-micrometer/src/main/resources/META-INF/services/com.netflix.spectator.api.Registry
+++ b/spectator-reg-micrometer/src/main/resources/META-INF/services/com.netflix.spectator.api.Registry
@@ -1,0 +1,1 @@
+com.netflix.spectator.micrometer.MicrometerRegistry

--- a/spectator-reg-micrometer/src/test/java/com/netflix/spectator/micrometer/MicrometerRegistryTest.java
+++ b/spectator-reg-micrometer/src/test/java/com/netflix/spectator/micrometer/MicrometerRegistryTest.java
@@ -1,0 +1,322 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.micrometer;
+
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.DistributionSummary;
+import com.netflix.spectator.api.Gauge;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.Meter;
+import com.netflix.spectator.api.Statistic;
+import com.netflix.spectator.api.Tag;
+import com.netflix.spectator.api.Timer;
+import com.netflix.spectator.api.Utils;
+import com.netflix.spectator.api.patterns.LongTaskTimer;
+import com.netflix.spectator.api.patterns.PolledMeter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.MockClock;
+import io.micrometer.core.instrument.simple.SimpleConfig;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+
+@RunWith(JUnit4.class)
+public class MicrometerRegistryTest {
+
+  private MockClock clock;
+  private MeterRegistry meterRegistry;
+  private MicrometerRegistry registry;
+
+  @Before
+  public void before() {
+    clock = new MockClock();
+    meterRegistry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, clock);
+    registry = new MicrometerRegistry(meterRegistry);
+  }
+
+  @Test
+  public void createIdName() {
+    Id id = registry.createId("foo");
+    Assert.assertEquals("foo", id.name());
+    Assert.assertFalse(id.tags().iterator().hasNext());
+  }
+
+  @Test
+  public void createIdNameAndTags() {
+    Id id = registry.createId("foo", "a", "1", "b", "2");
+    Assert.assertEquals("foo", id.name());
+
+    Map<String, String> tags = new HashMap<>();
+    tags.put("a", "1");
+    tags.put("b", "2");
+
+    for (Tag t : id.tags()) {
+      Assert.assertEquals(tags.remove(t.key()), t.value());
+    }
+    Assert.assertTrue(tags.isEmpty());
+  }
+
+  @Test
+  public void notPresentGet() {
+    Assert.assertNull(registry.get(registry.createId("foo")));
+  }
+
+  @Test
+  public void counterIncrement() {
+    Counter c = registry.counter("foo");
+    Assert.assertEquals(0, c.count());
+    c.increment();
+    Assert.assertEquals(1, c.count());
+  }
+
+  @Test
+  public void counterAdd() {
+    Counter c = registry.counter("foo");
+    Assert.assertEquals(0.0, c.actualCount(), 1e-12);
+    c.add(1.5);
+    Assert.assertEquals(1.5, c.actualCount(), 1e-12);
+  }
+
+  @Test
+  public void counterMeasure() {
+    Counter c = registry.counter("foo");
+    c.increment();
+    int i = 0;
+    for (Measurement m : c.measure()) {
+      ++i;
+      Assert.assertEquals("foo", m.id().name());
+      Assert.assertEquals(1.0, m.value(), 1e-12);
+    }
+    Assert.assertEquals(1, i);
+  }
+
+  @Test
+  public void counterWithTags() {
+    Counter c1 = registry.counter("foo", "a", "1", "b", "2");
+    c1.increment();
+
+    Counter c2 = registry.counter(registry.createId("foo", "a", "1", "b", "2"));
+    Assert.assertEquals(1, c2.count());
+  }
+
+  @Test
+  public void counterGet() {
+    Counter c1 = registry.counter("foo");
+    c1.increment();
+
+    Counter c2 = (Counter) registry.get(registry.createId("foo"));
+    Assert.assertEquals(1, c2.count());
+  }
+
+  @Test
+  public void timerRecord() {
+    Timer t = registry.timer("foo");
+    Assert.assertEquals(0, t.count());
+    Assert.assertEquals(0, t.totalTime());
+    t.record(42, TimeUnit.SECONDS);
+    Assert.assertEquals(1, t.count());
+    Assert.assertEquals(TimeUnit.SECONDS.toNanos(42), t.totalTime());
+  }
+
+  @Test
+  public void timerRecordRunnable() {
+    Timer t = registry.timer("foo");
+    t.record((Runnable) () -> clock.add(42, TimeUnit.SECONDS));
+    Assert.assertEquals(1, t.count());
+    Assert.assertEquals(TimeUnit.SECONDS.toNanos(42), t.totalTime());
+  }
+
+  @Test
+  public void timerRecordCallable() throws Exception {
+    Timer t = registry.timer("foo");
+    t.record(() -> clock.add(42, TimeUnit.SECONDS));
+    Assert.assertEquals(1, t.count());
+    Assert.assertEquals(TimeUnit.SECONDS.toNanos(42), t.totalTime());
+  }
+
+  @Test
+  public void timerMeasure() {
+    Timer t = registry.timer("foo");
+    t.record(42, TimeUnit.SECONDS);
+    int i = 0;
+    for (Measurement m : t.measure()) {
+      ++i;
+      Assert.assertEquals("foo", m.id().name());
+      switch (Utils.getTagValue(m.id(), "statistic")) {
+        case "count":
+          Assert.assertEquals(1.0, m.value(), 1e-12);
+          break;
+        case "total":
+          Assert.assertEquals(42.0, m.value(), 1e-12);
+          break;
+        case "max":
+          Assert.assertEquals(42.0, m.value(), 1e-12);
+          break;
+        default:
+          Assert.fail("invalid statistic for measurment: " + m);
+      }
+    }
+    Assert.assertEquals(3, i);
+  }
+
+  @Test
+  public void timerGet() {
+    Timer t1 = registry.timer("foo");
+    t1.record(1, TimeUnit.SECONDS);
+
+    Timer t2 = (Timer) registry.get(registry.createId("foo"));
+    Assert.assertEquals(1, t2.count());
+  }
+
+  @Test
+  public void summaryRecord() {
+    DistributionSummary s = registry.distributionSummary("foo");
+    Assert.assertEquals(0, s.count());
+    Assert.assertEquals(0, s.totalAmount());
+    s.record(42);
+    Assert.assertEquals(1, s.count());
+    Assert.assertEquals(42, s.totalAmount());
+  }
+
+  @Test
+  public void summaryMeasure() {
+    DistributionSummary s = registry.distributionSummary("foo");
+    s.record(42);
+    int i = 0;
+    for (Measurement m : s.measure()) {
+      ++i;
+      Assert.assertEquals("foo", m.id().name());
+      switch (Utils.getTagValue(m.id(), "statistic")) {
+        case "count":
+          Assert.assertEquals(1.0, m.value(), 1e-12);
+          break;
+        case "total":
+          Assert.assertEquals(42.0, m.value(), 1e-12);
+          break;
+        case "max":
+          Assert.assertEquals(42.0, m.value(), 1e-12);
+          break;
+        default:
+          Assert.fail("invalid statistic for measurment: " + m);
+      }
+    }
+    Assert.assertEquals(3, i);
+  }
+
+  @Test
+  public void summaryGet() {
+    DistributionSummary s1 = registry.distributionSummary("foo");
+    s1.record(1);
+
+    DistributionSummary s2 = (DistributionSummary) registry.get(registry.createId("foo"));
+    Assert.assertEquals(1, s2.count());
+  }
+
+  @Test
+  public void gaugeSet() {
+    Gauge g = registry.gauge("foo");
+    Assert.assertTrue(Double.isNaN(g.value()));
+    g.set(42.0);
+    Assert.assertEquals(42.0, g.value(), 1e-12);
+    g.set(20.0);
+    Assert.assertEquals(20.0, g.value(), 1e-12);
+  }
+
+  @Test
+  public void gaugeMeasure() {
+    Gauge g = registry.gauge("foo");
+    g.set(42.0);
+    int i = 0;
+    for (Measurement m : g.measure()) {
+      ++i;
+      Assert.assertEquals("foo", m.id().name());
+      Assert.assertEquals(42.0, m.value(), 1e-12);
+    }
+    Assert.assertEquals(1, i);
+  }
+
+  @Test
+  public void gaugeGet() {
+    Gauge g1 = registry.gauge("foo");
+    g1.set(1.0);
+
+    Gauge g2 = (Gauge) registry.get(registry.createId("foo"));
+    Assert.assertEquals(1.0, g2.value(), 1e-12);
+  }
+
+  @Test
+  public void maxGaugeSet() {
+    Gauge g = registry.maxGauge("foo");
+    Assert.assertTrue(Double.isNaN(g.value()));
+    g.set(42.0);
+    g.set(20.0);
+    clock.addSeconds(60);
+    Assert.assertEquals(42.0, g.value(), 1e-12);
+  }
+
+  @Test
+  public void unknownGet() {
+    meterRegistry.more().longTaskTimer("foo").record(() -> clock.addSeconds(60));
+    Assert.assertNull(registry.get(registry.createId("foo")));
+  }
+
+  @Test
+  public void iterator() {
+    registry.counter("c");
+    registry.timer("t");
+    registry.distributionSummary("s");
+    registry.gauge("g");
+
+    Set<String> actual = new HashSet<>();
+    for (Meter m : registry) {
+      Assert.assertFalse(m.hasExpired());
+      actual.add(m.id().name());
+    }
+
+    Set<String> expected = new HashSet<>();
+    expected.add("c");
+    expected.add("t");
+    expected.add("s");
+    expected.add("g");
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void patternUsingState() {
+    LongTaskTimer t = LongTaskTimer.get(registry, registry.createId("foo"));
+    long tid = t.start();
+    clock.addSeconds(60);
+    PolledMeter.update(registry);
+
+    Gauge g = registry.gauge(registry.createId("foo").withTag(Statistic.duration));
+    Assert.assertEquals(60.0, g.value(), 1e-12);
+
+    t.stop(tid);
+    PolledMeter.update(registry);
+    Assert.assertEquals(0.0, g.value(), 1e-12);
+  }
+}


### PR DESCRIPTION
Wraps the Micrometer MeterRegistry interface so that code
instrumented using the Spectator API can use Micrometer
registry implementations. Micrometer API borrowed a lot
from Spectator so most of the concepts translate directly.

/cc @ewiseblatt @jkschneider 