### PR TITLE
fix measured timestamp for Atlas max gauge

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasMaxGauge.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasMaxGauge.java
@@ -44,7 +44,11 @@ class AtlasMaxGauge extends AtlasMeter implements Gauge {
   }
 
   @Override public Iterable<Measurement> measure() {
-    final Measurement m = new Measurement(stat, value.timestamp(), value());
+    // poll needs to be called before accessing the timestamp to ensure
+    // the counters have been rotated if there was no activity in the
+    // current interval.
+    double v = value.poll();
+    final Measurement m = new Measurement(stat, value.timestamp(), v);
     return Collections.singletonList(m);
   }
 

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasMaxGaugeTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasMaxGaugeTest.java
@@ -93,4 +93,14 @@ public class AtlasMaxGaugeTest {
     gauge.set(1);
     Assert.assertFalse(gauge.hasExpired());
   }
+
+  @Test
+  public void measureTimestamp() {
+    long start = clock.wallTime();
+
+    clock.setWallTime(start + step);
+    Assert.assertEquals(start + step, gauge.measure().iterator().next().timestamp());
+    clock.setWallTime(start + step * 2);
+    Assert.assertEquals(start + step * 2, gauge.measure().iterator().next().timestamp());
+  }
 }


### PR DESCRIPTION
Polls the step double before accessing the timestamp to ensure
that it has been rotated. Otherwise the timestamp used for the
measurement may not have been advanced and still reflect the
previous interval.