### PR TITLE
set endpoint to unknown if not specified

### DIFF
--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcLogEntry.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcLogEntry.java
@@ -610,6 +610,10 @@ public final class IpcLogEntry {
     return attemptFinal;
   }
 
+  private String getEndpoint() {
+    return (endpoint == null) ? "unknown" : endpoint;
+  }
+
   private boolean isClient() {
     return marker != null && "ipc-client".equals(marker.getName());
   }
@@ -649,7 +653,7 @@ public final class IpcLogEntry {
     }
 
     // Optional for both client and server
-    putTag(tags, IpcTagKey.endpoint.key(), endpoint);
+    putTag(tags, IpcTagKey.endpoint.key(), getEndpoint());
     putTag(tags, IpcTagKey.vip.key(), vip);
     putTag(tags, IpcTagKey.protocol.key(), protocol);
     putTag(tags, IpcTagKey.statusDetail.key(), statusDetail);

--- a/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/IpcLogEntryTest.java
+++ b/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/IpcLogEntryTest.java
@@ -21,6 +21,7 @@ import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.DistributionSummary;
 import com.netflix.spectator.api.ManualClock;
 import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Utils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -679,5 +680,21 @@ public class IpcLogEntryTest {
         .log();
 
     IpcMetric.validate(registry);
+  }
+
+  @Test
+  public void endpointUnknownIfNotSet() {
+    Registry registry = new DefaultRegistry();
+    IpcLogger logger = new IpcLogger(registry, clock, LoggerFactory.getLogger(getClass()));
+
+    logger.createServerEntry()
+        .withOwner("test")
+        .markStart()
+        .markEnd()
+        .log();
+
+    registry.counters().forEach(c -> {
+      Assert.assertEquals("unknown", Utils.getTagValue(c.id(), "ipc.endpoint"));
+    });
   }
 }


### PR DESCRIPTION
For some dashboard use-cases the view is based on a foreach
of the endpoint values. If the endpoint is not set, then
those requests are missing.