### PR TITLE
collect HttpClientGetConnectionTime for AWS SDK

### DIFF
--- a/spectator-ext-aws/src/main/java/com/netflix/spectator/aws/SpectatorMetricCollector.java
+++ b/spectator-ext-aws/src/main/java/com/netflix/spectator/aws/SpectatorMetricCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2014-2018 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.netflix.spectator.aws;
 
 import com.amazonaws.metrics.MetricCollector;
@@ -27,6 +26,7 @@ import com.netflix.spectator.impl.Preconditions;
  */
 public class SpectatorMetricCollector extends MetricCollector {
     private final RequestMetricCollector requestMetricCollector;
+    private final ServiceMetricCollector serviceMetricCollector;
 
     /**
      * Constructs a new instance.
@@ -36,6 +36,7 @@ public class SpectatorMetricCollector extends MetricCollector {
         Preconditions.checkNotNull(registry, "registry");
 
         this.requestMetricCollector = new SpectatorRequestMetricCollector(registry);
+        this.serviceMetricCollector = new SpectatorServiceMetricCollector(registry);
     }
 
     @Override public boolean start() {
@@ -55,6 +56,6 @@ public class SpectatorMetricCollector extends MetricCollector {
     }
 
     @Override public ServiceMetricCollector getServiceMetricCollector() {
-        return ServiceMetricCollector.NONE;
+        return serviceMetricCollector;
     }
 }

--- a/spectator-ext-aws/src/main/java/com/netflix/spectator/aws/SpectatorServiceMetricCollector.java
+++ b/spectator-ext-aws/src/main/java/com/netflix/spectator/aws/SpectatorServiceMetricCollector.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.aws;
+
+import com.amazonaws.metrics.ByteThroughputProvider;
+import com.amazonaws.metrics.ServiceLatencyProvider;
+import com.amazonaws.metrics.ServiceMetricCollector;
+import com.amazonaws.util.AWSServiceMetrics;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Timer;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A {@link ServiceMetricCollector} that captures the time it takes to get a connection
+ * from the pool.
+ */
+class SpectatorServiceMetricCollector extends ServiceMetricCollector {
+
+  private final Timer clientGetConnectionTime;
+
+  /** Create a new instance. */
+  SpectatorServiceMetricCollector(Registry registry) {
+    super();
+    this.clientGetConnectionTime = registry.timer("aws.request.httpClientGetConnectionTime");
+  }
+
+  @Override
+  public void collectByteThroughput(ByteThroughputProvider provider) {
+  }
+
+  @Override
+  public void collectLatency(ServiceLatencyProvider provider) {
+    if (provider.getServiceMetricType() == AWSServiceMetrics.HttpClientGetConnectionTime) {
+      long nanos = (long) (provider.getDurationMilli() * 1e6);
+      clientGetConnectionTime.record(nanos, TimeUnit.NANOSECONDS);
+    }
+  }
+}


### PR DESCRIPTION
Update the SpectatorMetricCollector to get the time it takes
to retrieve a connection from the underlying connection pool.

/cc @okigan