### PR TITLE
Update link to live data size

### DIFF
--- a/docs/ext/jvm-memory-pools.md
+++ b/docs/ext/jvm-memory-pools.md
@@ -23,7 +23,7 @@ Jmx.registerStandardMXBeans(Spectator.registry());
 
 Gauge reporting the current amount of memory used. For the young and old gen pools this
 metric will typically have a sawtooth pattern. For alerting or detecting memory pressure
-the [live data size](https://github.com/Netflix/spectator/wiki/Garbage-Collection#jvmgclivedatasize)
+the [live data size](http://netflix.github.io/spectator/en/latest/ext/jvm-gc/#jvmgclivedatasize)
 is probably a better option.
 
 **Unit:** bytes


### PR DESCRIPTION
This seems to be the only link to the old wiki.