### PR TITLE
provide access to log entry from request builder

### DIFF
--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/http/HttpRequestBuilder.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/http/HttpRequestBuilder.java
@@ -35,6 +35,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.zip.Deflater;
 
 /**
@@ -205,6 +206,15 @@ public class HttpRequestBuilder {
   public HttpRequestBuilder withSSLSocketFactory(SSLSocketFactory factory) {
     requireHttps("ssl cannot be used with http, use https");
     this.sslFactory = factory;
+    return this;
+  }
+
+  /**
+   * Provides access to the {@link IpcLogEntry} object to make adjustments if needed. For
+   * most common usage the default should be fine.
+   */
+  public HttpRequestBuilder customizeLogging(Consumer<IpcLogEntry> f) {
+    f.accept(entry);
     return this;
   }
 


### PR DESCRIPTION
For some use-cases it can be useful to perform some minor
adjustments to the log entry for the request.

/cc @rnz0 