### PR TITLE
Make decimal buckets use 4 digits as needed

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/histogram/BucketFunctions.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/histogram/BucketFunctions.java
@@ -85,9 +85,10 @@ public final class BucketFunctions {
     final String[] decimalUnits = {"", "_k", "_M", "_G", "_T", "_P"};
     for (int i = 0; i < decimalUnits.length; ++i) {
       final int pow = i * 3;
-      DECIMAL_FORMATTERS.add(dec(10,   pow, 1, decimalUnits[i]));
-      DECIMAL_FORMATTERS.add(dec(100,  pow, 2, decimalUnits[i]));
-      DECIMAL_FORMATTERS.add(dec(1000, pow, 3, decimalUnits[i]));
+      DECIMAL_FORMATTERS.add(dec(10,    pow, 1, decimalUnits[i]));
+      DECIMAL_FORMATTERS.add(dec(100,   pow, 2, decimalUnits[i]));
+      DECIMAL_FORMATTERS.add(dec(1000,  pow, 3, decimalUnits[i]));
+      DECIMAL_FORMATTERS.add(dec(10000, pow, 4, decimalUnits[i]));
     }
     DECIMAL_FORMATTERS.add(new ValueFormatter(Long.MAX_VALUE, 1, "_E", v -> v / pow10(1, 18)));
   }

--- a/spectator-api/src/main/java/com/netflix/spectator/api/histogram/PercentileDistributionSummary.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/histogram/PercentileDistributionSummary.java
@@ -59,8 +59,8 @@ public class PercentileDistributionSummary implements DistributionSummary {
 
   /**
    * Creates a distribution summary object that can be used for estimating percentiles.
-   * <b>Percentile timers are expensive compared to basic distribution summaries from the
-   * registry.</b> Be diligent with ensuring that any additional dimensions have a small
+   * <b>Percentile distribution summaries are expensive compared to basic distribution summaries
+   * from the registry.</b> Be diligent with ensuring that any additional dimensions have a small
    * bounded cardinality. It is also highly recommended to explicitly set the threshold
    * (see {@link Builder#withRange(long, long)}) whenever possible.
    *
@@ -174,7 +174,7 @@ public class PercentileDistributionSummary implements DistributionSummary {
 
   // Lazily load the counter for a given bucket. This avoids the allocation for
   // creating the id and the map lookup after the first time a given bucket is
-  // accessed for a timer.
+  // accessed for a distribution summary.
   private Counter counterFor(int i) {
     Counter c = counters.get(i);
     if (c == null) {

--- a/spectator-api/src/test/java/com/netflix/spectator/api/histogram/BucketFunctionsTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/histogram/BucketFunctionsTest.java
@@ -154,6 +154,16 @@ public class BucketFunctionsTest {
   }
 
   @Test
+  public void bytes2M() {
+    LongFunction<String> f = BucketFunctions.bytes(2 * 1024 * 1024);
+    Assert.assertEquals("negative", f.apply(-1L));
+    Assert.assertEquals("0256_KiB", f.apply(761));
+    Assert.assertEquals("0512_KiB", f.apply(400_000));
+    Assert.assertEquals("1024_KiB", f.apply(512 * 1024 + 1));
+    Assert.assertEquals("large", f.apply(2 * 1024 * 1024 + 1));
+  }
+
+  @Test
   public void bytesMaxValue() {
     LongFunction<String> f = BucketFunctions.bytes(Long.MAX_VALUE);
     Assert.assertEquals("negative", f.apply(-1L));
@@ -171,6 +181,16 @@ public class BucketFunctionsTest {
     Assert.assertEquals("05_k", f.apply(4567));
     Assert.assertEquals("20_k", f.apply(15761));
     Assert.assertEquals("large", f.apply(20001));
+  }
+
+  @Test
+  public void decimal2M() {
+    LongFunction<String> f = BucketFunctions.decimal(2_000_000);
+    Assert.assertEquals("negative", f.apply(-1L));
+    Assert.assertEquals("0250_k", f.apply(761));
+    Assert.assertEquals("0500_k", f.apply(456_000));
+    Assert.assertEquals("1000_k", f.apply(576_100));
+    Assert.assertEquals("large", f.apply(2_000_001));
   }
 
   @Test


### PR DESCRIPTION
Previous to this change using something like
`BucketFunctions.decimal(2_000_000)` produced the following buckets:
`[negative, 0M, 0M, 1M, 2M]`

This change puts it in line with the other functions that will use 4
digits for the bucket boundaries when needed. This means we will
generate buckets: `[negative, 0250k, 0500k, 1000k]` for the above call.