### PR TITLE
StatelessRegistry should remove expired meters

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/AbstractRegistry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/AbstractRegistry.java
@@ -229,13 +229,18 @@ public abstract class AbstractRegistry implements Registry {
    * The SwapMeter types that are returned will lookup a new copy on the next access.
    */
   protected void removeExpiredMeters() {
+    int total = 0;
+    int expired = 0;
     Iterator<Map.Entry<Id, Meter>> it = meters.entrySet().iterator();
     while (it.hasNext()) {
+      ++total;
       Map.Entry<Id, Meter> entry = it.next();
       Meter m = entry.getValue();
       if (m.hasExpired()) {
+        ++expired;
         it.remove();
       }
     }
+    logger.debug("removed {} expired meters out of {} total", expired, total);
   }
 }

--- a/spectator-reg-stateless/src/main/java/com/netflix/spectator/stateless/StatelessRegistry.java
+++ b/spectator-reg-stateless/src/main/java/com/netflix/spectator/stateless/StatelessRegistry.java
@@ -124,6 +124,7 @@ public final class StatelessRegistry extends AbstractRegistry {
           logger.warn("failed to send metrics, status {}: {}", res.status(), res.entityAsString());
         }
       }
+      removeExpiredMeters();
     } catch (Exception e) {
       logger.warn("failed to send metrics", e);
     }


### PR DESCRIPTION
It will now do a cleanup check after sending data for a
given iteration.