### PR TITLE
update javadoc link to javadoc.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Simple library for instrumenting code to record dimensional time series.
 ## Documentation
 
 * [Wiki](http://netflix.github.io/spectator/en/latest/)
-* [Javadoc](http://netflix.github.io/spectator/en/latest/javadoc/spectator-api/)
+* [Javadoc](https://www.javadoc.io/doc/com.netflix.spectator/spectator-api/)
 * [![Build Status](https://travis-ci.org/Netflix/spectator.svg)](https://travis-ci.org/Netflix/spectator/builds)
 
 ## Dependencies


### PR DESCRIPTION
This will automatically get updated to point to latest
version of javadocs that are available in maven central.