### PR TITLE
cleanup excludes in the build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,9 +92,6 @@ subprojects {
     configFile = rootProject.file('codequality/checkstyle.xml')
     sourceSets = [sourceSets.main]
   }
-  tasks.withType(Checkstyle) {
-    exclude '**/tdunning/**'
-  }
   
   spotbugs {
     toolVersion = '3.1.10'
@@ -115,9 +112,6 @@ subprojects {
     sourceSets = [sourceSets.main]
     ruleSets = []
     ruleSetFiles = rootProject.files("codequality/pmd.xml")
-  }
-  tasks.withType(Pmd) {
-    exclude '**/tdunning/**'
   }
 }
 


### PR DESCRIPTION
These are no longer needed because we no longer inline
the tdigest library.