### PR TITLE
update to nebula 7.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
   dependencies {
     classpath 'com.github.ben-manes:gradle-versions-plugin:0.17.0'
     classpath 'com.netflix.nebula:nebula-dependency-recommender:6.1.1'
-    classpath 'com.netflix.nebula:gradle-netflixoss-project-plugin:7.0.0'
+    classpath 'com.netflix.nebula:gradle-netflixoss-project-plugin:7.1.0'
 
     // This is a workaround for getting the shadow plugin to work correctly
     // for some sub-projects. For more details see:


### PR DESCRIPTION
See if it fixes build error for publishing:

```
A problem occurred evaluating root project 'spectator'.
> Failed to apply plugin [class 'nebula.plugin.bintray.NebulaBintrayPublishingPlugin']
   > Cannot get property 'release.stage' on extra properties extension as it does not exist
```