### PR TITLE
add travis build for jdk12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ matrix:
     env: GRADLE_PUBLISH=true
   - jdk: openjdk11
     env: GRADLE_PUBLISH=false
+  - jdk: openjdk12
+    env: GRADLE_PUBLISH=false
 sudo: false
 dist: trusty
 install: ./installViaTravis.sh


### PR DESCRIPTION
Current goal is to ensure the libraries work on jdk8, jdk11,
and latest.