### PR TITLE
make PatternMatcher serializable

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/impl/AsciiSet.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/AsciiSet.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.spectator.impl;
 
+import java.io.Serializable;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Constructor;
@@ -30,7 +31,9 @@ import java.util.Optional;
  * <p><b>This class is an internal implementation detail only intended for use within spectator.
  * It is subject to change without notice.</b></p>
  */
-public final class AsciiSet {
+public final class AsciiSet implements Serializable {
+
+  private static final long serialVersionUID = 1L;
 
   private static boolean isJava8() {
     String version = System.getProperty("java.version", "1.8");

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/CharClassMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/CharClassMatcher.java
@@ -17,10 +17,13 @@ package com.netflix.spectator.impl.matcher;
 
 import com.netflix.spectator.impl.AsciiSet;
 
+import java.io.Serializable;
 import java.util.Objects;
 
 /** Matcher that matches any character from a specified set. */
-final class CharClassMatcher implements Matcher {
+final class CharClassMatcher implements Matcher, Serializable {
+
+  private static final long serialVersionUID = 1L;
 
   private final AsciiSet set;
   private final boolean ignoreCase;

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/CharSeqMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/CharSeqMatcher.java
@@ -15,10 +15,13 @@
  */
 package com.netflix.spectator.impl.matcher;
 
+import java.io.Serializable;
 import java.util.Objects;
 
 /** Matcher that checks for a sequence of characters. */
-final class CharSeqMatcher implements Matcher {
+final class CharSeqMatcher implements Matcher, Serializable {
+
+  private static final long serialVersionUID = 1L;
 
   private final String pattern;
   private final boolean ignoreCase;

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/IgnoreCaseMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/IgnoreCaseMatcher.java
@@ -17,10 +17,13 @@ package com.netflix.spectator.impl.matcher;
 
 import com.netflix.spectator.impl.PatternMatcher;
 
+import java.io.Serializable;
 import java.util.Objects;
 
 /** Matcher that ignores the case when checking against the input string. */
-final class IgnoreCaseMatcher implements PatternMatcher {
+final class IgnoreCaseMatcher implements PatternMatcher, Serializable {
+
+  private static final long serialVersionUID = 1L;
 
   private final PatternMatcher matcher;
 

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/IndexOfMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/IndexOfMatcher.java
@@ -15,13 +15,16 @@
  */
 package com.netflix.spectator.impl.matcher;
 
+import java.io.Serializable;
 import java.util.Objects;
 import java.util.function.Function;
 
 /**
  * Matcher that looks for a given substring within the string being matched.
  */
-final class IndexOfMatcher implements GreedyMatcher {
+final class IndexOfMatcher implements GreedyMatcher, Serializable {
+
+  private static final long serialVersionUID = 1L;
 
   private final String pattern;
   private final Matcher next;

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/NegativeLookaheadMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/NegativeLookaheadMatcher.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.spectator.impl.matcher;
 
+import java.io.Serializable;
 import java.util.Objects;
 import java.util.function.Function;
 
@@ -22,7 +23,9 @@ import java.util.function.Function;
  * Matcher that does a negative lookahead. If the sub-matcher matches, then it will return
  * no match, otherwise it will return the starting the position.
  */
-final class NegativeLookaheadMatcher implements Matcher {
+final class NegativeLookaheadMatcher implements Matcher, Serializable {
+
+  private static final long serialVersionUID = 1L;
 
   private final Matcher matcher;
 

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/OrMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/OrMatcher.java
@@ -17,6 +17,7 @@ package com.netflix.spectator.impl.matcher;
 
 import com.netflix.spectator.impl.PatternMatcher;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -24,7 +25,9 @@ import java.util.Objects;
 import java.util.function.Function;
 
 /** Matcher that checks if any of the sub-matchers matchers the string. */
-final class OrMatcher implements GreedyMatcher {
+final class OrMatcher implements GreedyMatcher, Serializable {
+
+  private static final long serialVersionUID = 1L;
 
   /** Create a new instance. */
   static Matcher create(List<Matcher> matchers) {

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/PositiveLookaheadMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/PositiveLookaheadMatcher.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.spectator.impl.matcher;
 
+import java.io.Serializable;
 import java.util.Objects;
 import java.util.function.Function;
 
@@ -22,7 +23,9 @@ import java.util.function.Function;
  * Matcher that does a positive lookahead. If the sub-matcher matches, then it will return
  * a match, but will not advance the position.
  */
-final class PositiveLookaheadMatcher implements Matcher {
+final class PositiveLookaheadMatcher implements Matcher, Serializable {
+
+  private static final long serialVersionUID = 1L;
 
   private final Matcher matcher;
 

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/RepeatMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/RepeatMatcher.java
@@ -15,11 +15,14 @@
  */
 package com.netflix.spectator.impl.matcher;
 
+import java.io.Serializable;
 import java.util.Objects;
 import java.util.function.Function;
 
 /** Matcher that looks for a fixed number of repetitions. */
-final class RepeatMatcher implements Matcher {
+final class RepeatMatcher implements Matcher, Serializable {
+
+  private static final long serialVersionUID = 1L;
 
   private final Matcher repeated;
   private final int min;

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/SeqMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/SeqMatcher.java
@@ -17,6 +17,7 @@ package com.netflix.spectator.impl.matcher;
 
 import com.netflix.spectator.impl.PatternMatcher;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -26,7 +27,9 @@ import java.util.function.Function;
 /**
  * Matcher that checks a sequence of sub-matchers.
  */
-final class SeqMatcher implements Matcher {
+final class SeqMatcher implements Matcher, Serializable {
+
+  private static final long serialVersionUID = 1L;
 
   /** Create a new instance. */
   static Matcher create(List<Matcher> matchers) {

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/StartsWithMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/StartsWithMatcher.java
@@ -15,12 +15,15 @@
  */
 package com.netflix.spectator.impl.matcher;
 
+import java.io.Serializable;
 import java.util.Objects;
 
 /**
  * Matcher that checks if the string starts with a given character sequence.
  */
-final class StartsWithMatcher implements Matcher {
+final class StartsWithMatcher implements Matcher, Serializable {
+
+  private static final long serialVersionUID = 1L;
 
   private final String pattern;
   private final boolean ignoreCase;

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/ZeroOrMoreMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/ZeroOrMoreMatcher.java
@@ -17,13 +17,16 @@ package com.netflix.spectator.impl.matcher;
 
 import com.netflix.spectator.impl.Preconditions;
 
+import java.io.Serializable;
 import java.util.Objects;
 import java.util.function.Function;
 
 /**
  * Matcher that looks for a pattern zero or more times followed by another pattern.
  */
-final class ZeroOrMoreMatcher implements GreedyMatcher {
+final class ZeroOrMoreMatcher implements GreedyMatcher, Serializable {
+
+  private static final long serialVersionUID = 1L;
 
   private final Matcher repeated;
   private final Matcher next;

--- a/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/MatcherSerializationTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/MatcherSerializationTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.impl.matcher;
+
+import com.netflix.spectator.impl.AsciiSet;
+import com.netflix.spectator.impl.PatternMatcher;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+public class MatcherSerializationTest {
+
+  static void checkSerde(PatternMatcher matcher) {
+    try {
+      ByteArrayOutputStream baos = new ByteArrayOutputStream();
+      try (ObjectOutputStream out = new ObjectOutputStream(baos)) {
+        out.writeObject(matcher);
+      }
+
+      ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+      try (ObjectInputStream in = new ObjectInputStream(bais)) {
+        PatternMatcher deserialized = (PatternMatcher) in.readObject();
+        Assertions.assertEquals(matcher, deserialized);
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Test
+  public void any() {
+    checkSerde(AnyMatcher.INSTANCE);
+  }
+
+  @Test
+  public void charClass() {
+    checkSerde(new CharClassMatcher(AsciiSet.fromPattern("abc")));
+  }
+
+  @Test
+  public void charSeq() {
+    checkSerde(new CharSeqMatcher("abc"));
+  }
+
+  @Test
+  public void end() {
+    checkSerde(EndMatcher.INSTANCE);
+  }
+
+  @Test
+  public void falseMatcher() {
+    checkSerde(FalseMatcher.INSTANCE);
+  }
+
+  @Test
+  public void ignoreCase() {
+    checkSerde(new IgnoreCaseMatcher(EndMatcher.INSTANCE));
+  }
+
+  @Test
+  public void indexOf() {
+    checkSerde(new IndexOfMatcher("abc", EndMatcher.INSTANCE));
+  }
+
+  @Test
+  public void negativeLookahead() {
+    checkSerde(new NegativeLookaheadMatcher(AnyMatcher.INSTANCE));
+  }
+
+  @Test
+  public void or() {
+    checkSerde(OrMatcher.create(AnyMatcher.INSTANCE, EndMatcher.INSTANCE));
+  }
+
+  @Test
+  public void positiveLookahead() {
+    checkSerde(new PositiveLookaheadMatcher(AnyMatcher.INSTANCE));
+  }
+
+  @Test
+  public void repeat() {
+    checkSerde(new RepeatMatcher(AnyMatcher.INSTANCE, 0, 3));
+  }
+
+  @Test
+  public void seq() {
+    checkSerde(SeqMatcher.create(AnyMatcher.INSTANCE, AnyMatcher.INSTANCE));
+  }
+
+  @Test
+  public void start() {
+    checkSerde(StartMatcher.INSTANCE);
+  }
+
+  @Test
+  public void startsWith() {
+    checkSerde(new StartsWithMatcher("abc"));
+  }
+
+  @Test
+  public void trueMatcher() {
+    checkSerde(TrueMatcher.INSTANCE);
+  }
+
+  @Test
+  public void zeroOrMore() {
+    checkSerde(new ZeroOrMoreMatcher(AnyMatcher.INSTANCE, EndMatcher.INSTANCE));
+  }
+}

--- a/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/PatternMatcherTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/PatternMatcherTest.java
@@ -35,5 +35,8 @@ public class PatternMatcherTest extends AbstractPatternMatcherTest {
     // Check pattern can be recreated from toString
     PatternMatcher actual = PatternMatcher.compile(matcher.toString());
     Assertions.assertEquals(matcher, actual);
+
+    // Check we can serialize and deserialize the matchers
+    MatcherSerializationTest.checkSerde(matcher);
   }
 }


### PR DESCRIPTION
This is needed for some Spark use-cases.