### PR TITLE
add trace logging of raw payload

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
@@ -201,6 +201,9 @@ public final class AtlasRegistry extends AbstractRegistry {
       try {
         for (List<Measurement> batch : getBatches()) {
           PublishPayload p = new PublishPayload(commonTags, batch);
+          if (logger.isTraceEnabled()) {
+            logger.trace("publish payload: {}", jsonMapper.writeValueAsString(p));
+          }
           HttpResponse res = client.post(uri)
               .withConnectTimeout(connectTimeout)
               .withReadTimeout(readTimeout)
@@ -210,7 +213,7 @@ public final class AtlasRegistry extends AbstractRegistry {
           recordClockSkew((date == null) ? 0L : date.toEpochMilli());
         }
       } catch (Exception e) {
-        logger.warn("failed to send metrics", e);
+        logger.warn("failed to send metrics (uri={})", uri, e);
       }
     } else {
       logger.debug("publishing is disabled, skipping collection");
@@ -241,6 +244,9 @@ public final class AtlasRegistry extends AbstractRegistry {
       EvalPayload payload = evaluator.eval("local", stepClock.wallTime(), ms);
       try {
         String json = jsonMapper.writeValueAsString(payload);
+        if (logger.isTraceEnabled()) {
+          logger.trace("eval payload: {}", json);
+        }
         client.post(evalUri)
             .withConnectTimeout(connectTimeout)
             .withReadTimeout(readTimeout)
@@ -248,7 +254,7 @@ public final class AtlasRegistry extends AbstractRegistry {
             .send()
             .decompress();
       } catch (Exception e) {
-        logger.warn("failed to send metrics for subscriptions", e);
+        logger.warn("failed to send metrics for subscriptions (uri={})", evalUri, e);
       }
     }
   }

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/SubscriptionManager.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/SubscriptionManager.java
@@ -89,7 +89,7 @@ class SubscriptionManager {
         payload = filterByStep(mapper.readValue(res.entity(), Subscriptions.class));
       }
     } catch (Exception e) {
-      LOGGER.warn("failed to update subscriptions", e);
+      LOGGER.warn("failed to update subscriptions (uri={})", uri, e);
     }
 
     // Update with the current payload, it will be null if there hasn't been a single


### PR DESCRIPTION
For the main publish payload this will be JSON instead
of the binary format over the wire.

Also explicitly adds the URI to failure warning logs as
a number of the default network exceptions do not include
it. The URI and exception is available via the IPC access
logging, but that is debug level and not on by default for
most apps.