### PR TITLE
remove bogus test case

### DIFF
--- a/spectator-api/src/test/java/com/netflix/spectator/api/histogram/PercentileBucketsTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/histogram/PercentileBucketsTest.java
@@ -127,11 +127,4 @@ public class PercentileBucketsTest {
       Assertions.assertEquals(expected, PercentileBuckets.percentile(counts, pcts[i]), threshold);
     }
   }
-
-  @Test
-  public void foo() {
-    int start = PercentileBuckets.indexOf(TimeUnit.MILLISECONDS.toNanos(10));
-    int end = PercentileBuckets.indexOf(TimeUnit.SECONDS.toNanos(60));
-    System.out.println("start = " + start + ", end = " + end + ", delta = " + (end - start + 1));
-  }
 }


### PR DESCRIPTION
It was used for some debugging and shouldn't have been
committed.