### PR TITLE
use simple rollup limiter for ipc

### DIFF
--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcLogger.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcLogger.java
@@ -84,7 +84,7 @@ public class IpcLogger {
    * backend from a metrics explosion if some dimensions have a high cardinality.
    */
   Function<String, String> limiterForKey(String key) {
-    return Utils.computeIfAbsent(limiters, key, k -> CardinalityLimiters.mostFrequent(10));
+    return Utils.computeIfAbsent(limiters, key, k -> CardinalityLimiters.rollup(25));
   }
 
   private IpcLogEntry newEntry() {


### PR DESCRIPTION
The frequencies get a bit messy for use-cases that have
many clusters / ASGs reporting at a fixed rate. There is
a larger number with roughly the same frequency. This should
be a lot easier to reason about.