### PR TITLE
add reset() method for DefaultRegistry

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/AbstractRegistry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/AbstractRegistry.java
@@ -243,4 +243,14 @@ public abstract class AbstractRegistry implements Registry {
     }
     logger.debug("removed {} expired meters out of {} total", expired, total);
   }
+
+  /**
+   * This can be called be sub-classes to reset all state for the registry. Typically this
+   * should only be exposed for test registries as most users should not be able to reset the
+   * state and interrupt metrics collection for the overall system.
+   */
+  protected void reset() {
+    meters.clear();
+    state.clear();
+  }
 }

--- a/spectator-api/src/main/java/com/netflix/spectator/api/DefaultRegistry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/DefaultRegistry.java
@@ -52,4 +52,16 @@ public final class DefaultRegistry extends AbstractRegistry {
   @Override protected Gauge newMaxGauge(Id id) {
     return new DefaultMaxGauge(clock(), id);
   }
+
+  /**
+   * Reset the state of this registry. All meters and other associated state will be lost.
+   * Though it is typically recommended to use a new instance for each test, if that is not
+   * possible for some reason, this method can be used to reset the state before a given
+   * unit test.
+   */
+  @SuppressWarnings("PMD.UselessOverridingMethod")
+  @Override public void reset() {
+    // Overridden to increase visibility from protected in base class to public
+    super.reset();
+  }
 }


### PR DESCRIPTION
The use-case is to allow for resetting the state between
test invocations when the registry instance needs to be
reused.

/cc @quidryan 