### PR TITLE
ipc: support mapping 503 to throttled

### DIFF
--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcStatus.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcStatus.java
@@ -94,7 +94,11 @@ public enum IpcStatus implements Tag {
   }
 
   /**
-   * Maps HTTP status codes to the appropriate status.
+   * Maps HTTP status codes to the appropriate status. Note, this method follows the historical
+   * convention in Netflix where services would use the service unavailable,
+   * <a href="https://tools.ietf.org/html/rfc7231#section-6.6.4">503</a> status code, to indicate
+   * throttling. To get behavior inline with the RFCs use {@link #forHttpStatusStandard(int)}
+   * instead.
    *
    * @param httpStatus
    *     HTTP status for the request.
@@ -102,6 +106,21 @@ public enum IpcStatus implements Tag {
    *     Status value corresponding to the HTTP status code.
    */
   public static IpcStatus forHttpStatus(int httpStatus) {
+    return forHttpStatusStandard(httpStatus == 503 ? 429 : httpStatus);
+  }
+
+  /**
+   * Maps HTTP status codes to the appropriate status based on the standard RFC definitions.
+   * In particular, <a href="https://tools.ietf.org/html/rfc7231#section-6.6.4">503</a> maps
+   * to {@link #unavailable} and <a href="https://tools.ietf.org/html/rfc6585#section-4">429</a>
+   * maps to {@link #throttled}.
+   *
+   * @param httpStatus
+   *     HTTP status for the request.
+   * @return
+   *     Status value corresponding to the HTTP status code.
+   */
+  public static IpcStatus forHttpStatusStandard(int httpStatus) {
     IpcStatus status;
     switch (httpStatus) {
       case 200: status = success;       break; // OK

--- a/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/IpcLogEntryTest.java
+++ b/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/IpcLogEntryTest.java
@@ -474,7 +474,7 @@ public class IpcLogEntryTest {
         .withHttpStatus(503)
         .convert(this::toMap)
         .get("status");
-    Assertions.assertEquals(IpcStatus.unavailable.value(), actual);
+    Assertions.assertEquals(IpcStatus.throttled.value(), actual);
   }
 
   @Test

--- a/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/IpcStatusTest.java
+++ b/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/IpcStatusTest.java
@@ -70,7 +70,12 @@ public class IpcStatusTest {
 
   @Test
   public void forHttpStatus503() {
-    Assertions.assertEquals(IpcStatus.unavailable, IpcStatus.forHttpStatus(503));
+    Assertions.assertEquals(IpcStatus.throttled, IpcStatus.forHttpStatus(503));
+  }
+
+  @Test
+  public void forHttpStatusStandard503() {
+    Assertions.assertEquals(IpcStatus.unavailable, IpcStatus.forHttpStatusStandard(503));
   }
 
   @Test


### PR DESCRIPTION
For many historical uses at Netflix, the 503 status code
is used to indicate throttling to the client. The `IpcStatus`
helper now maps `503` to `throttled` by default. A new
method `withHttpStatusStandard` that follows the RFC more
closely.