### PR TITLE
IpcLogger should default to registry clock

### DIFF
--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcLogger.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcLogger.java
@@ -66,12 +66,12 @@ public class IpcLogger {
 
   /** Create a new instance. */
   public IpcLogger(Registry registry, Logger logger) {
-    this(registry, Clock.SYSTEM, logger);
+    this(registry, registry.clock(), logger);
   }
 
   /** Create a new instance. */
   public IpcLogger(Registry registry) {
-    this(registry, Clock.SYSTEM, LoggerFactory.getLogger(IpcLogger.class));
+    this(registry, registry.clock(), LoggerFactory.getLogger(IpcLogger.class));
   }
 
   /** Return the number of inflight requests associated with the given id. */


### PR DESCRIPTION
This makes it easier to use for testing when the clock for
the registry is manually controlled.