### PR TITLE
reduce allocs for lookups of Percentile types

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,7 +100,7 @@ subprojects {
     profilers = ['stack', 'gc']
     includeTests = false
     duplicateClassesStrategy = 'warn'
-    include = ['.*PatternMatching.*']
+    include = ['.*PercentileTimers.*']
   }
 
   checkstyle {

--- a/spectator-api/src/jmh/java/com/netflix/spectator/perf/PercentileTimers.java
+++ b/spectator-api/src/jmh/java/com/netflix/spectator/perf/PercentileTimers.java
@@ -16,6 +16,7 @@
 package com.netflix.spectator.perf;
 
 import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Timer;
 import com.netflix.spectator.api.histogram.PercentileTimer;
@@ -36,16 +37,30 @@ public class PercentileTimers {
   private final PercentileTimer percentileTimerCached =
       PercentileTimer.get(registry, registry.createId("percentile-cached"));
 
+  private final Id dfltId = registry.createId("default");
+
+  private final Id pctId = registry.createId("percentile");
+
   @Threads(1)
   @Benchmark
   public void defaultTimerGet() {
-    registry.timer("default").record(31, TimeUnit.MILLISECONDS);
+    registry.timer(dfltId).record(31, TimeUnit.MILLISECONDS);
   }
 
   @Threads(1)
   @Benchmark
   public void percentileTimerGet() {
-    PercentileTimer.get(registry, registry.createId("percentile")).record(31, TimeUnit.MILLISECONDS);
+    PercentileTimer.get(registry, pctId).record(31, TimeUnit.MILLISECONDS);
+  }
+
+  @Threads(1)
+  @Benchmark
+  public void percentileTimerBuilder() {
+    PercentileTimer.builder(registry)
+        .withId(pctId)
+        .withRange(10, 10000, TimeUnit.MILLISECONDS)
+        .build()
+        .record(31, TimeUnit.MILLISECONDS);
   }
 
   @Threads(1)

--- a/spectator-api/src/main/java/com/netflix/spectator/api/CompositeRegistry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/CompositeRegistry.java
@@ -105,6 +105,7 @@ public final class CompositeRegistry implements Registry {
       distSummaries.clear();
       timers.clear();
       gauges.clear();
+      state.clear();
     } finally {
       wlock.unlock();
     }

--- a/spectator-api/src/test/java/com/netflix/spectator/api/histogram/PercentileDistributionSummaryTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/histogram/PercentileDistributionSummaryTest.java
@@ -63,4 +63,34 @@ public class PercentileDistributionSummaryTest {
         .build();
     checkPercentiles(t, 25);
   }
+
+  private void checkValue(PercentileDistributionSummary t1, PercentileDistributionSummary t2, double expected) {
+    Assertions.assertEquals(expected, t1.percentile(99.0), expected / 5.0);
+    Assertions.assertEquals(expected, t2.percentile(99.0), expected / 5.0);
+  }
+
+  @Test
+  public void builderWithDifferentThresholds() {
+    Registry r = newRegistry();
+    PercentileDistributionSummary t1 = PercentileDistributionSummary.builder(r)
+        .withName("test")
+        .withRange(10, 50)
+        .build();
+    PercentileDistributionSummary t2 = PercentileDistributionSummary.builder(r)
+        .withName("test")
+        .withRange(100, 200)
+        .build();
+
+    t1.record(5);
+    checkValue(t1, t2, 10.0);
+
+    t1.record(500);
+    checkValue(t1, t2, 50.0);
+
+    t2.record(5);
+    checkValue(t1, t2, 100.0);
+
+    t2.record(500);
+    checkValue(t1, t2, 200.0);
+  }
 }

--- a/spectator-api/src/test/java/com/netflix/spectator/api/histogram/PercentileTimerTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/histogram/PercentileTimerTest.java
@@ -67,4 +67,34 @@ public class PercentileTimerTest {
         .build();
     checkPercentiles(t, 0);
   }
+
+  private void checkValue(PercentileTimer t1, PercentileTimer t2, double expected) {
+    Assertions.assertEquals(expected, t1.percentile(99.0), expected / 5.0);
+    Assertions.assertEquals(expected, t2.percentile(99.0), expected / 5.0);
+  }
+
+  @Test
+  public void builderWithDifferentThresholds() {
+    Registry r = newRegistry();
+    PercentileTimer t1 = PercentileTimer.builder(r)
+        .withName("test")
+        .withRange(10, 50, TimeUnit.SECONDS)
+        .build();
+    PercentileTimer t2 = PercentileTimer.builder(r)
+        .withName("test")
+        .withRange(100, 200, TimeUnit.SECONDS)
+        .build();
+
+    t1.record(5, TimeUnit.SECONDS);
+    checkValue(t1, t2, 10.0);
+
+    t1.record(500, TimeUnit.SECONDS);
+    checkValue(t1, t2, 50.0);
+
+    t2.record(5, TimeUnit.SECONDS);
+    checkValue(t1, t2, 100.0);
+
+    t2.record(500, TimeUnit.SECONDS);
+    checkValue(t1, t2, 200.0);
+  }
 }


### PR DESCRIPTION
For percentile approximations that are dynamically looked
up based on the the id, a new instance of the composite
was being created each time. The array used for keeping
track of the counters is about 1-2K (depending on pointer
size) leading to a lot of allocations if this was done in
a hotspot in the code.

This change will cache the results as part of the registry
state. JMH benchmarks show no degradation in the overhead
to record a value and much lower allocation rate:

**Before**

```
defaultTimerGet             16.012 ±       0.001    B/op
defaultTimerReuse            0.005 ±       0.001    B/op
percentileTimerBuilder    1424.163 ±       0.021    B/op
percentileTimerGet        1376.149 ±       0.007    B/op
percentileTimerReuse         0.012 ±       0.001    B/op
```

**After**

```
defaultTimerGet             16.012 ±       0.001    B/op
defaultTimerReuse            0.005 ±       0.001    B/op
percentileTimerBuilder      48.018 ±       0.001    B/op
percentileTimerGet           0.015 ±       0.001    B/op
percentileTimerReuse         0.013 ±       0.001    B/op
```

/cc @joshgord 