### PR TITLE
Spring Boot 2 properties compatibility

### DIFF
--- a/spectator-web-spring/src/main/java/com/netflix/spectator/controllers/MetricsController.java
+++ b/spectator-web-spring/src/main/java/com/netflix/spectator/controllers/MetricsController.java
@@ -48,7 +48,7 @@ import java.util.HashMap;
  */
 @RequestMapping("/spectator/metrics")
 @RestController
-@ConditionalOnExpression("${spectator.webEndpoint.enabled:false}")
+@ConditionalOnExpression("${spectator.web-endpoint.enabled:false}")
 public class MetricsController {
   @Autowired
   private Registry registry;
@@ -58,13 +58,13 @@ public class MetricsController {
    */
   public static final Predicate<Measurement> ALL_MEASUREMENTS_FILTER = m -> true;
 
-  @Value("${spectator.applicationName:}")
+  @Value("${spectator.application-name:}")
   private String applicationName;
 
-  @Value("${spectator.applicationVersion:}")
+  @Value("${spectator.application-version:}")
   private String applicationVersion;
 
-  @Value("${spectator.webEndpoint.prototypeFilter.path:}")
+  @Value("${spectator.web-endpoint.prototype-filter.path:}")
   private String prototypeFilterPath;
 
   private final Map<Id, String> knownMeterKinds = new HashMap<>();


### PR DESCRIPTION
Updates the MetricsController spring properties to be compatible with Spring Boot 2. Boot 2 enforces convergence on kebab-case configurations within code. User-land configuration will continue to resolve correctly if kept as camelCase.

This is to support Spinnaker's upgrade to Spring Boot 2.