### PR TITLE
Relax valid charset for atlas to allow tilde

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasConfig.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasConfig.java
@@ -145,10 +145,10 @@ public interface AtlasConfig extends RegistryConfig {
   /**
    * Returns a pattern indicating the valid characters for a tag key or value. The character
    * set for tag values can be overridden for a particular tag key using
-   * {@link #validTagValueCharacters()}. The default is {@code -._A-Za-z0-9}.
+   * {@link #validTagValueCharacters()}. The default is {@code -._A-Za-z0-9~^}.
    */
   default String validTagCharacters() {
-    return "-._A-Za-z0-9~";
+    return "-._A-Za-z0-9~^";
   }
 
   /**

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasConfig.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasConfig.java
@@ -148,7 +148,7 @@ public interface AtlasConfig extends RegistryConfig {
    * {@link #validTagValueCharacters()}. The default is {@code -._A-Za-z0-9}.
    */
   default String validTagCharacters() {
-    return "-._A-Za-z0-9";
+    return "-._A-Za-z0-9~";
   }
 
   /**

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasConfigTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasConfigTest.java
@@ -89,7 +89,7 @@ public class AtlasConfigTest {
   }
 
   @Test
-  public void defaultValidCharsTilde() {
+  public void defaultValidChars() {
     Map<String, String> props = Collections.emptyMap();
     AtlasConfig config = props::get;
     AsciiSet set = AsciiSet.fromPattern(config.validTagCharacters());
@@ -98,6 +98,7 @@ public class AtlasConfigTest {
     Assertions.assertTrue(set.contains('c'));
     Assertions.assertTrue(set.contains('C'));
     Assertions.assertTrue(set.contains('~'));
+    Assertions.assertTrue(set.contains('^'));
     Assertions.assertTrue(set.contains('_'));
     Assertions.assertFalse(set.contains('!'));
     Assertions.assertFalse(set.contains('%'));

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasConfigTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasConfigTest.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.spectator.atlas;
 
+import com.netflix.spectator.impl.AsciiSet;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -85,5 +86,22 @@ public class AtlasConfigTest {
     props.put("atlas.lwc.enabled", "abc");
     AtlasConfig config = props::get;
     Assertions.assertFalse(config.lwcEnabled());
+  }
+
+  @Test
+  public void defaultValidCharsTilde() {
+    Map<String, String> props = Collections.emptyMap();
+    AtlasConfig config = props::get;
+    AsciiSet set = AsciiSet.fromPattern(config.validTagCharacters());
+    // quick sanity check of the allowed values
+    Assertions.assertTrue(set.contains('7'));
+    Assertions.assertTrue(set.contains('c'));
+    Assertions.assertTrue(set.contains('C'));
+    Assertions.assertTrue(set.contains('~'));
+    Assertions.assertTrue(set.contains('_'));
+    Assertions.assertFalse(set.contains('!'));
+    Assertions.assertFalse(set.contains('%'));
+    Assertions.assertFalse(set.contains('/'));
+    Assertions.assertFalse(set.contains(':'));
   }
 }


### PR DESCRIPTION
Allow the tilde `~` character in the tags we send to atlas. This is
needed because internally some server groups include that character in
their names