### PR TITLE
Revert "avoid using provider for Registry binding (#699)"

### DIFF
--- a/spectator-nflx-plugin/src/main/java/com/netflix/spectator/nflx/Plugin.java
+++ b/spectator-nflx-plugin/src/main/java/com/netflix/spectator/nflx/Plugin.java
@@ -23,7 +23,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 import javax.inject.Singleton;
 
 /**
@@ -40,7 +39,7 @@ final class Plugin {
 
   /** Create a new instance. */
   @Inject
-  Plugin(Registry registry, @Named("spectator") Config config) {
+  Plugin(Registry registry, Config config) {
 
     final boolean enabled = config.getBoolean(ENABLED_PROP, true);
     if (enabled) {

--- a/spectator-nflx-plugin/src/main/java/com/netflix/spectator/nflx/SpectatorModule.java
+++ b/spectator-nflx-plugin/src/main/java/com/netflix/spectator/nflx/SpectatorModule.java
@@ -18,15 +18,13 @@ package com.netflix.spectator.nflx;
 import com.google.inject.Inject;
 import com.google.inject.Scopes;
 import com.google.inject.multibindings.OptionalBinder;
-import com.google.inject.name.Names;
 import com.netflix.archaius.api.Config;
 import com.netflix.servo.SpectatorContext;
 import com.netflix.spectator.api.Clock;
-import com.netflix.spectator.api.NoopRegistry;
 import com.netflix.spectator.atlas.AtlasConfig;
 import com.netflix.spectator.atlas.AtlasRegistry;
 
-import javax.inject.Named;
+import javax.annotation.PreDestroy;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 
@@ -34,6 +32,8 @@ import com.google.inject.AbstractModule;
 import com.netflix.spectator.api.ExtendedRegistry;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Spectator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 
@@ -72,22 +72,17 @@ import java.util.Map;
  */
 public final class SpectatorModule extends AbstractModule {
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(SpectatorModule.class);
+
   @Override protected void configure() {
-    bind(Plugin.class).asEagerSingleton();
+    bind(Plugin.class).toProvider(PluginProvider.class).asEagerSingleton();
     bind(StaticManager.class).asEagerSingleton();
-    bind(Config.class)
-        .annotatedWith(Names.named("spectator"))
-        .toProvider(ConfigProvider.class);
-    bind(AtlasConfig.class).to(AtlasConfiguration.class);
     OptionalBinder.newOptionalBinder(binder(), ExtendedRegistry.class)
         .setDefault()
         .toInstance(Spectator.registry());
-    OptionalBinder.newOptionalBinder(binder(), Clock.class)
-        .setDefault()
-        .toInstance(Clock.SYSTEM);
     OptionalBinder.newOptionalBinder(binder(), Registry.class)
         .setDefault()
-        .to(AtlasRegistry.class)
+        .toProvider(RegistryProvider.class)
         .in(Scopes.SINGLETON);
   }
 
@@ -99,66 +94,94 @@ public final class SpectatorModule extends AbstractModule {
     return getClass().hashCode();
   }
 
-  @Singleton
-  private static class ConfigProvider implements Provider<Config> {
+  private static class PluginProvider implements Provider<Plugin> {
+    private final Plugin plugin;
+
+    @Inject
+    PluginProvider(Registry registry, OptionalInjections opts) {
+      plugin = new Plugin(registry, opts.config());
+    }
+
+    @Override public Plugin get() {
+      return plugin;
+    }
+  }
+
+  private static class OptionalInjections {
     @Inject(optional = true)
     private Config config;
 
     private Config atlasConfig;
 
-    @Override public Config get() {
+    @Inject(optional = true)
+    private Clock clock;
+
+    Config config() {
       if (atlasConfig == null) {
         atlasConfig = NetflixConfig.createConfig(config);
       }
+
       return atlasConfig;
+    }
+
+    Clock clock() {
+      return (clock == null) ? Clock.SYSTEM : clock;
     }
   }
 
-  private static class StaticManager implements AutoCloseable {
+  private static class StaticManager {
     private final Registry registry;
 
     @Inject
     StaticManager(Registry registry) {
       this.registry = registry;
       Spectator.globalRegistry().add(registry);
-      SpectatorContext.setRegistry(registry);
     }
 
-    @Override public void close() {
+    @PreDestroy
+    void onShutdown() {
       Spectator.globalRegistry().remove(registry);
-      SpectatorContext.setRegistry(new NoopRegistry());
     }
   }
 
   @Singleton
-  private static class AtlasConfiguration implements AtlasConfig {
+  private static class RegistryProvider implements Provider<Registry>, AutoCloseable {
 
-    private final Config cfg;
+    private final AtlasRegistry registry;
 
     @Inject
-    AtlasConfiguration(@Named("spectator") Config cfg) {
-      this.cfg = cfg;
+    RegistryProvider(OptionalInjections opts) {
+      final Config config = opts.config();
+      final Map<String, String> nflxCommonTags = NetflixConfig.commonTags();
+
+      LOGGER.info("using AtlasRegistry and delegating Servo operations to Spectator");
+      AtlasConfig cfg = new AtlasConfig() {
+        @Override public String get(String k) {
+          final String prop = "netflix.spectator.registry." + k;
+          return config.getString(prop, null);
+        }
+
+        @Override public boolean enabled() {
+          String v = get("atlas.enabled");
+          return v != null && Boolean.valueOf(v);
+        }
+
+        @Override
+        public Map<String, String> commonTags() {
+          return nflxCommonTags;
+        }
+      };
+      registry = new AtlasRegistry(opts.clock(), cfg);
+      registry.start();
+      SpectatorContext.setRegistry(registry);
     }
 
-    private final Map<String, String> nflxCommonTags = NetflixConfig.commonTags();
-
-    @Override public String get(String k) {
-      final String prop = "netflix.spectator.registry." + k;
-      return cfg.getString(prop, null);
+    @Override public void close() {
+      registry.stop();
     }
 
-    @Override public boolean enabled() {
-      String v = get("atlas.enabled");
-      return v != null && Boolean.valueOf(v);
-    }
-
-    @Override public boolean autoStart() {
-      return true;
-    }
-
-    @Override
-    public Map<String, String> commonTags() {
-      return nflxCommonTags;
+    @Override public Registry get() {
+      return registry;
     }
   }
 }

--- a/spectator-nflx-plugin/src/test/java/com/netflix/spectator/nflx/SpectatorModuleTest.java
+++ b/spectator-nflx-plugin/src/test/java/com/netflix/spectator/nflx/SpectatorModuleTest.java
@@ -19,7 +19,6 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
-import com.google.inject.multibindings.OptionalBinder;
 import com.netflix.spectator.api.Clock;
 import com.netflix.spectator.api.ExtendedRegistry;
 import com.netflix.spectator.api.ManualClock;
@@ -49,9 +48,7 @@ public class SpectatorModuleTest {
     Injector injector = Guice.createInjector(
         new AbstractModule() {
           @Override protected void configure() {
-            OptionalBinder.newOptionalBinder(binder(), Clock.class)
-                .setBinding()
-                .toInstance(clock);
+            bind(Clock.class).toInstance(clock);
           }
         },
         new SpectatorModule());

--- a/spectator-reg-atlas/build.gradle
+++ b/spectator-reg-atlas/build.gradle
@@ -4,7 +4,6 @@ dependencies {
   compile 'com.fasterxml.jackson.core:jackson-core'
   compile 'com.fasterxml.jackson.core:jackson-databind'
   compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-smile'
-  compile 'javax.inject:javax.inject'
   jmh project(':spectator-api')
 }
 

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasConfig.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasConfig.java
@@ -52,17 +52,6 @@ public interface AtlasConfig extends RegistryConfig {
   }
 
   /**
-   * Returns true if the registry should automatically start the background reporting threads
-   * in the constructor. When using DI systems this can be used to automatically start the
-   * registry when it is constructed. Otherwise the {@code AtlasRegistry.start()} method will
-   * need to be called explicitly. Default is false.
-   */
-  default boolean autoStart() {
-    String v = get("atlas.autoStart");
-    return v != null && Boolean.valueOf(v);
-  }
-
-  /**
    * Returns the number of threads to use with the scheduler. The default is
    * 2 threads.
    */

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
@@ -39,8 +39,6 @@ import com.netflix.spectator.impl.Scheduler;
 import com.netflix.spectator.ipc.http.HttpClient;
 import com.netflix.spectator.ipc.http.HttpResponse;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
 import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
@@ -57,8 +55,7 @@ import java.util.stream.StreamSupport;
 /**
  * Registry for reporting metrics to Atlas.
  */
-@Singleton
-public final class AtlasRegistry extends AbstractRegistry implements AutoCloseable {
+public final class AtlasRegistry extends AbstractRegistry {
 
   private static final String CLOCK_SKEW_TIMER = "spectator.atlas.clockSkew";
 
@@ -93,7 +90,6 @@ public final class AtlasRegistry extends AbstractRegistry implements AutoCloseab
   private final SubscriptionManager subManager;
 
   /** Create a new instance. */
-  @Inject
   public AtlasRegistry(Clock clock, AtlasConfig config) {
     super(clock, config);
     this.config = config;
@@ -125,10 +121,6 @@ public final class AtlasRegistry extends AbstractRegistry implements AutoCloseab
     this.client = HttpClient.create(this);
 
     this.subManager = new SubscriptionManager(jsonMapper, client, clock, config);
-
-    if (config.autoStart()) {
-      start();
-    }
   }
 
   /**
@@ -189,15 +181,6 @@ public final class AtlasRegistry extends AbstractRegistry implements AutoCloseab
     } else {
       logger.warn("registry stopped, but was never started");
     }
-  }
-
-  /**
-   * Stop the scheduler reporting Atlas data. This is the same as calling {@link #stop()} and
-   * is included to allow the registry to be stopped correctly when used with DI frameworks that
-   * support lifecycle management.
-   */
-  @Override public void close() {
-    stop();
   }
 
   /** Collect data and send to Atlas. */


### PR DESCRIPTION
This reverts commit 90b78aea00d0837b9a9332a853dfdc62135fdfd9.

Due to a bug in governator that can cause a memory leak
(see Netflix/governator#392) we are going to revert this
change.

Note, if we do roll forward there is also an intialization
order issue because the SpectatorContext may not be set until
much later. That issue can be worked around by setting it to
the global registry when configured.