### PR TITLE
avoid using provider for Registry binding

### DIFF
--- a/spectator-nflx-plugin/src/main/java/com/netflix/spectator/nflx/Plugin.java
+++ b/spectator-nflx-plugin/src/main/java/com/netflix/spectator/nflx/Plugin.java
@@ -23,6 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.inject.Singleton;
 
 /**
@@ -39,7 +40,7 @@ final class Plugin {
 
   /** Create a new instance. */
   @Inject
-  Plugin(Registry registry, Config config) {
+  Plugin(Registry registry, @Named("spectator") Config config) {
 
     final boolean enabled = config.getBoolean(ENABLED_PROP, true);
     if (enabled) {

--- a/spectator-nflx-plugin/src/test/java/com/netflix/spectator/nflx/SpectatorModuleTest.java
+++ b/spectator-nflx-plugin/src/test/java/com/netflix/spectator/nflx/SpectatorModuleTest.java
@@ -19,6 +19,7 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
+import com.google.inject.multibindings.OptionalBinder;
 import com.netflix.spectator.api.Clock;
 import com.netflix.spectator.api.ExtendedRegistry;
 import com.netflix.spectator.api.ManualClock;
@@ -48,7 +49,9 @@ public class SpectatorModuleTest {
     Injector injector = Guice.createInjector(
         new AbstractModule() {
           @Override protected void configure() {
-            bind(Clock.class).toInstance(clock);
+            OptionalBinder.newOptionalBinder(binder(), Clock.class)
+                .setBinding()
+                .toInstance(clock);
           }
         },
         new SpectatorModule());

--- a/spectator-reg-atlas/build.gradle
+++ b/spectator-reg-atlas/build.gradle
@@ -4,6 +4,7 @@ dependencies {
   compile 'com.fasterxml.jackson.core:jackson-core'
   compile 'com.fasterxml.jackson.core:jackson-databind'
   compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-smile'
+  compile 'javax.inject:javax.inject'
   jmh project(':spectator-api')
 }
 

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasConfig.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasConfig.java
@@ -52,6 +52,17 @@ public interface AtlasConfig extends RegistryConfig {
   }
 
   /**
+   * Returns true if the registry should automatically start the background reporting threads
+   * in the constructor. When using DI systems this can be used to automatically start the
+   * registry when it is constructed. Otherwise the {@code AtlasRegistry.start()} method will
+   * need to be called explicitly. Default is false.
+   */
+  default boolean autoStart() {
+    String v = get("atlas.autoStart");
+    return v != null && Boolean.valueOf(v);
+  }
+
+  /**
    * Returns the number of threads to use with the scheduler. The default is
    * 2 threads.
    */

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
@@ -39,6 +39,8 @@ import com.netflix.spectator.impl.Scheduler;
 import com.netflix.spectator.ipc.http.HttpClient;
 import com.netflix.spectator.ipc.http.HttpResponse;
 
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
@@ -55,7 +57,8 @@ import java.util.stream.StreamSupport;
 /**
  * Registry for reporting metrics to Atlas.
  */
-public final class AtlasRegistry extends AbstractRegistry {
+@Singleton
+public final class AtlasRegistry extends AbstractRegistry implements AutoCloseable {
 
   private static final String CLOCK_SKEW_TIMER = "spectator.atlas.clockSkew";
 
@@ -90,6 +93,7 @@ public final class AtlasRegistry extends AbstractRegistry {
   private final SubscriptionManager subManager;
 
   /** Create a new instance. */
+  @Inject
   public AtlasRegistry(Clock clock, AtlasConfig config) {
     super(clock, config);
     this.config = config;
@@ -121,6 +125,10 @@ public final class AtlasRegistry extends AbstractRegistry {
     this.client = HttpClient.create(this);
 
     this.subManager = new SubscriptionManager(jsonMapper, client, clock, config);
+
+    if (config.autoStart()) {
+      start();
+    }
   }
 
   /**
@@ -181,6 +189,15 @@ public final class AtlasRegistry extends AbstractRegistry {
     } else {
       logger.warn("registry stopped, but was never started");
     }
+  }
+
+  /**
+   * Stop the scheduler reporting Atlas data. This is the same as calling {@link #stop()} and
+   * is included to allow the registry to be stopped correctly when used with DI frameworks that
+   * support lifecycle management.
+   */
+  @Override public void close() {
+    stop();
   }
 
   /** Collect data and send to Atlas. */


### PR DESCRIPTION
Re-applying change from #699. This was rolled back in #703 
due to a memory leak in Governator that was fixed in 1.17.6.

In some internal use-cases where this gets used with Spring
via a Guice bridge, the provider can cause problems and avoid
the detection used to prevent interference with the Spring
bindings. While the underlying problem is some bug with the
Guice bridge used in the Spring apps, this change should help
reduce the probability that our library is in the middle of it
when users hit problems.