### PR TITLE
set spectator context for servo earlier

### DIFF
--- a/spectator-nflx-plugin/src/main/java/com/netflix/spectator/nflx/SpectatorModule.java
+++ b/spectator-nflx-plugin/src/main/java/com/netflix/spectator/nflx/SpectatorModule.java
@@ -22,7 +22,6 @@ import com.google.inject.name.Names;
 import com.netflix.archaius.api.Config;
 import com.netflix.servo.SpectatorContext;
 import com.netflix.spectator.api.Clock;
-import com.netflix.spectator.api.NoopRegistry;
 import com.netflix.spectator.atlas.AtlasConfig;
 import com.netflix.spectator.atlas.AtlasRegistry;
 

--- a/spectator-nflx-plugin/src/main/java/com/netflix/spectator/nflx/SpectatorModule.java
+++ b/spectator-nflx-plugin/src/main/java/com/netflix/spectator/nflx/SpectatorModule.java
@@ -73,6 +73,9 @@ import java.util.Map;
 public final class SpectatorModule extends AbstractModule {
 
   @Override protected void configure() {
+    // Servo is all based on static classes. The context for servo needs to be set as early
+    // as possible to avoid missing metrics because the context has not yet been set.
+    SpectatorContext.setRegistry(Spectator.globalRegistry());
     bind(Plugin.class).asEagerSingleton();
     bind(StaticManager.class).asEagerSingleton();
     bind(Config.class)
@@ -121,12 +124,10 @@ public final class SpectatorModule extends AbstractModule {
     StaticManager(Registry registry) {
       this.registry = registry;
       Spectator.globalRegistry().add(registry);
-      SpectatorContext.setRegistry(registry);
     }
 
     @Override public void close() {
       Spectator.globalRegistry().remove(registry);
-      SpectatorContext.setRegistry(new NoopRegistry());
     }
   }
 


### PR DESCRIPTION
Before many things could get initialized prior to the
context for Servo being set. This would result in those
metrics being missing.