### PR TITLE
configurable debug registry for AtlasRegistry

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasConfig.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasConfig.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.spectator.atlas;
 
+import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.RegistryConfig;
 
 import java.time.Duration;
@@ -168,5 +169,15 @@ public interface AtlasConfig extends RegistryConfig {
    */
   default Map<String, String> validTagValueCharacters() {
     return Collections.emptyMap();
+  }
+
+  /**
+   * Returns a registry to use for recording metrics about the behavior of the AtlasRegistry.
+   * By default it will return null and the metrics will be reported to itself. In some cases
+   * it is useful to customize this for debugging so that the metrics for the behavior of
+   * AtlasRegistry will have a different failure mode than AtlasRegistry.
+   */
+  default Registry debugRegistry() {
+    return null;
   }
 }

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasRegistryTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasRegistryTest.java
@@ -17,12 +17,15 @@ package com.netflix.spectator.atlas;
 
 import com.netflix.spectator.api.ManualClock;
 import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.NoopRegistry;
+import com.netflix.spectator.api.Registry;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -33,11 +36,20 @@ public class AtlasRegistryTest {
   private AtlasRegistry registry = new AtlasRegistry(clock, newConfig());
 
   private AtlasConfig newConfig() {
-    ConcurrentHashMap<String, String> props = new ConcurrentHashMap<>();
+    Map<String, String> props = new LinkedHashMap<>();
     props.put("atlas.enabled", "false");
     props.put("atlas.step", "PT10S");
     props.put("atlas.batchSize", "3");
-    return props::get;
+
+    return new AtlasConfig() {
+      @Override public String get(String k) {
+        return props.get(k);
+      }
+
+      @Override public Registry debugRegistry() {
+        return new NoopRegistry();
+      }
+    };
   }
 
   private List<Measurement> getMeasurements() {


### PR DESCRIPTION
This allows the metrics for the registry itself to be reported
separately with a different failure mode. This can be useful for
debugging or cases where the AtlasRegistry is being used as a
service and forwarding data on behalf of other apps.