### PR TITLE
add rollup policy for AtlasRegistry

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasConfig.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasConfig.java
@@ -180,4 +180,13 @@ public interface AtlasConfig extends RegistryConfig {
   default Registry debugRegistry() {
     return null;
   }
+
+  /**
+   * Returns a rollup policy that will be applied to the measurements before sending to Atlas.
+   * The policy will not be applied to data going to the streaming path. Default is a no-op
+   * policy.
+   */
+  default RollupPolicy rollupPolicy() {
+    return RollupPolicy.noop();
+  }
 }

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/RollupPolicy.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/RollupPolicy.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Measurement;
+
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Policy for performing a rollup on a set of measurements. This typically involves
+ * removing some dimensions from the ids and combining the results into an aggregate
+ * measurement.
+ */
+public interface RollupPolicy extends Function<List<Measurement>, List<Measurement>> {
+
+  /** Does nothing, returns the input list without modification. */
+  static RollupPolicy noop() {
+    return ms -> ms;
+  }
+
+  /**
+   * Create a new policy that will aggregate ids based on the statistic tag. Counter types
+   * will use a sum aggregation and gauges will use max.
+   *
+   * @param idMapper
+   *     Map an id to a new identifier that will be used for the resulting aggregate measurement.
+   * @return
+   *     A rollup policy that will apply the mapping function to the ids of input measurements
+   *     and aggregate the results.
+   */
+  static RollupPolicy fromIdMapper(Function<Id, Id> idMapper) {
+    return ms -> Rollups.aggregate(idMapper, ms);
+  }
+}

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/Rollups.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/Rollups.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.Utils;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.DoubleBinaryOperator;
+import java.util.function.Function;
+
+/**
+ * Helper functions for performing rollups.
+ */
+final class Rollups {
+
+  private Rollups() {
+  }
+
+  /**
+   * Aggregate the measurements after appling the mapping function to the ids. Counters types
+   * will use a sum aggregation and gauges will use a max aggregation.
+   *
+   * @param idMapper
+   *     Map an id to a new identifier that will be used for the resulting aggregate measurement.
+   * @param measurements
+   *     Set of input measurements to aggregate.
+   * @return
+   *     Aggregated set of measurements.
+   */
+  static List<Measurement> aggregate(Function<Id, Id> idMapper, List<Measurement> measurements) {
+    Map<Id, Aggregator> aggregates = new HashMap<>();
+    for (Measurement m : measurements) {
+      Id id = idMapper.apply(m.id());
+      if (id != null) {
+        Aggregator aggregator = aggregates.get(id);
+        if (aggregator == null) {
+          aggregator = newAggregator(id, m);
+          aggregates.put(id, aggregator);
+        } else {
+          aggregator.update(m);
+        }
+      }
+    }
+
+    List<Measurement> result = new ArrayList<>(aggregates.size());
+    for (Aggregator aggregator : aggregates.values()) {
+      result.add(aggregator.toMeasurement());
+    }
+    return result;
+  }
+
+  private static final Set<String> SUM_STATS = new LinkedHashSet<>();
+  static {
+    SUM_STATS.add("count");
+    SUM_STATS.add("totalAmount");
+    SUM_STATS.add("totalTime");
+    SUM_STATS.add("totalOfSquares");
+    SUM_STATS.add("percentile");
+  }
+
+  private static final DoubleBinaryOperator SUM = nanAwareOp((a, b) -> a + b);
+  private static final DoubleBinaryOperator MAX = nanAwareOp((a, b) -> a > b ? a : b);
+
+  private static DoubleBinaryOperator nanAwareOp(DoubleBinaryOperator op) {
+    return (a, b) -> Double.isNaN(a) ? b : Double.isNaN(b) ? a : op.applyAsDouble(a, b);
+  }
+
+  private static Aggregator newAggregator(Id id, Measurement m) {
+    DoubleBinaryOperator af = MAX;
+    String statistic = Utils.getTagValue(id, "statistic");
+    if (statistic != null && SUM_STATS.contains(statistic)) {
+      af = SUM;
+    }
+    return new Aggregator(id, m.timestamp(), af, m.value());
+  }
+
+  private static class Aggregator {
+    private final Id id;
+    private final long timestamp;
+    private final DoubleBinaryOperator af;
+    private double value;
+
+    Aggregator(Id id, long timestamp, DoubleBinaryOperator af, double init) {
+      this.id = id;
+      this.timestamp = timestamp;
+      this.af = af;
+      this.value = init;
+    }
+
+    void update(Measurement m) {
+      value = af.applyAsDouble(value, m.value());
+    }
+
+    Measurement toMeasurement() {
+      return new Measurement(id, timestamp, value);
+    }
+  }
+}

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/RollupsTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/RollupsTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.ManualClock;
+import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.Statistic;
+import com.netflix.spectator.api.Tag;
+import com.netflix.spectator.api.Utils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+public class RollupsTest {
+
+  private ManualClock clock;
+  private AtlasRegistry registry;
+
+  @BeforeEach
+  public void before() {
+    clock = new ManualClock();
+    registry = new AtlasRegistry(clock, k -> null);
+  }
+
+  private Id removeIdxTag(Id id) {
+    List<Tag> filtered = new ArrayList<>();
+    for (Tag t : id.tags()) {
+      if (!"i".equals(t.key())) {
+        filtered.add(t);
+      }
+    }
+    return registry.createId(id.name()).withTags(filtered);
+  }
+
+  @Test
+  public void aggregateCounters() {
+    for (int i = 0; i < 10; ++i) {
+      registry.counter("test", "i", "" + i).increment();
+    }
+    clock.setWallTime(60000);
+    List<Measurement> input = registry.getMeasurements().collect(Collectors.toList());
+    List<Measurement> aggr = Rollups.aggregate(this::removeIdxTag, input);
+    Assertions.assertEquals(1, aggr.size());
+
+    Measurement m = aggr.get(0);
+    Id id = registry.createId("test")
+        .withTag("atlas.dstype", "rate")
+        .withTag(Statistic.count);
+    Assertions.assertEquals(id, m.id());
+    Assertions.assertEquals(10.0 / 60.0, m.value(), 1e-12);
+  }
+
+  @Test
+  public void aggregateGauges() {
+    for (int i = 0; i < 10; ++i) {
+      registry.gauge("test", "i", "" + i).set(2.0);
+    }
+    clock.setWallTime(60000);
+    List<Measurement> input = registry.getMeasurements().collect(Collectors.toList());
+    List<Measurement> aggr = Rollups.aggregate(this::removeIdxTag, input);
+    Assertions.assertEquals(1, aggr.size());
+
+    Measurement m = aggr.get(0);
+    Id id = registry.createId("test")
+        .withTag("atlas.dstype", "gauge")
+        .withTag(Statistic.gauge);
+    Assertions.assertEquals(id, m.id());
+    Assertions.assertEquals(2.0, m.value(), 1e-12);
+  }
+
+  @Test
+  public void aggregateGaugesWithNaN() {
+    for (int i = 0; i < 10; ++i) {
+      double v = (i % 2 == 0) ? i : Double.NaN;
+      registry.gauge("test", "i", "" + i).set(v);
+    }
+    clock.setWallTime(60000);
+    List<Measurement> input = registry.getMeasurements().collect(Collectors.toList());
+    List<Measurement> aggr = Rollups.aggregate(this::removeIdxTag, input);
+    Assertions.assertEquals(1, aggr.size());
+
+    Measurement m = aggr.get(0);
+    Id id = registry.createId("test")
+        .withTag("atlas.dstype", "gauge")
+        .withTag(Statistic.gauge);
+    Assertions.assertEquals(id, m.id());
+    Assertions.assertEquals(8.0, m.value(), 1e-12);
+  }
+
+  @Test
+  public void aggregateTimers() {
+    for (int i = 0; i < 10; ++i) {
+      registry.timer("test", "i", "" + i).record(i, TimeUnit.SECONDS);
+    }
+    clock.setWallTime(60000);
+    List<Measurement> input = registry.getMeasurements().collect(Collectors.toList());
+    List<Measurement> aggr = Rollups.aggregate(this::removeIdxTag, input);
+    Assertions.assertEquals(4, aggr.size());
+
+    for (Measurement m : aggr) {
+      Id id = registry.createId("test");
+      switch (Utils.getTagValue(m.id(), "statistic")) {
+        case "count":
+          id = id.withTag("atlas.dstype", "rate").withTag(Statistic.count);
+          Assertions.assertEquals(id, m.id());
+          Assertions.assertEquals(10.0 / 60.0, m.value(), 1e-12);
+          break;
+        case "totalTime":
+          id = id.withTag("atlas.dstype", "rate").withTag(Statistic.totalTime);
+          Assertions.assertEquals(id, m.id());
+          Assertions.assertEquals(45.0 / 60.0, m.value(), 1e-12);
+          break;
+        case "totalOfSquares":
+          id = id.withTag("atlas.dstype", "rate").withTag(Statistic.totalOfSquares);
+          Assertions.assertEquals(id, m.id());
+          Assertions.assertEquals(285.0 / 60.0, m.value(), 1e-12);
+          break;
+        case "max":
+          id = id.withTag("atlas.dstype", "gauge").withTag(Statistic.max);
+          Assertions.assertEquals(id, m.id());
+          Assertions.assertEquals(9.0, m.value(), 1e-12);
+          break;
+        default:
+          Assertions.fail("unexpected id: " + m.id());
+          break;
+      }
+    }
+  }
+
+  @Test
+  public void aggregateDistributionSummaries() {
+    for (int i = 0; i < 10; ++i) {
+      registry.distributionSummary("test", "i", "" + i).record(i);
+    }
+    clock.setWallTime(60000);
+    List<Measurement> input = registry.getMeasurements().collect(Collectors.toList());
+    List<Measurement> aggr = Rollups.aggregate(this::removeIdxTag, input);
+    Assertions.assertEquals(4, aggr.size());
+
+    for (Measurement m : aggr) {
+      Id id = registry.createId("test");
+      switch (Utils.getTagValue(m.id(), "statistic")) {
+        case "count":
+          id = id.withTag("atlas.dstype", "rate").withTag(Statistic.count);
+          Assertions.assertEquals(id, m.id());
+          Assertions.assertEquals(10.0 / 60.0, m.value(), 1e-12);
+          break;
+        case "totalAmount":
+          id = id.withTag("atlas.dstype", "rate").withTag(Statistic.totalAmount);
+          Assertions.assertEquals(id, m.id());
+          Assertions.assertEquals(45.0 / 60.0, m.value(), 1e-12);
+          break;
+        case "totalOfSquares":
+          id = id.withTag("atlas.dstype", "rate").withTag(Statistic.totalOfSquares);
+          Assertions.assertEquals(id, m.id());
+          Assertions.assertEquals(285.0 / 60.0, m.value(), 1e-12);
+          break;
+        case "max":
+          id = id.withTag("atlas.dstype", "gauge").withTag(Statistic.max);
+          Assertions.assertEquals(id, m.id());
+          Assertions.assertEquals(9.0, m.value(), 1e-12);
+          break;
+        default:
+          Assertions.fail("unexpected id: " + m.id());
+          break;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds a setting for a RollupPolicy that will get applied to
the set of measurements before sending to Atlas. This can
be used to perform automatic cardinality limiting or other
sanity checks prior to sending to the storage layer.

The policy is not applied for the streaming path so that
full data can be accessed on demand when needed.