### PR TITLE
agent: support reloading changed configs

### DIFF
--- a/spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java
+++ b/spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java
@@ -21,6 +21,7 @@ import com.netflix.spectator.atlas.AtlasConfig;
 import com.netflix.spectator.atlas.AtlasRegistry;
 import com.netflix.spectator.gc.GcLogger;
 import com.netflix.spectator.jvm.Jmx;
+import com.netflix.spectator.jvm.JmxPoller;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import org.slf4j.Logger;
@@ -28,9 +29,16 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.lang.instrument.Instrumentation;
+import java.time.Duration;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 
 /**
  * Agent that can be added to JVM to get basic stats about GC, memory, and optionally
@@ -43,21 +51,44 @@ public final class Agent {
   private Agent() {
   }
 
-  /** Helper to load config files specified by the user. */
-  static Config loadConfig(String userResources) {
-    Config config = ConfigFactory.load("agent");
+  /** Parse the set of user resources. */
+  static List<Object> parseResourceList(String userResources) {
+    List<Object> resources = new ArrayList<>();
     if (userResources != null && !"".equals(userResources)) {
       for (String userResource : userResources.split("[,\\s]+")) {
         if (userResource.startsWith("file:")) {
           File file = new File(userResource.substring("file:".length()));
-          LOGGER.info("loading configuration from file: {}", file);
-          Config user = ConfigFactory.parseFile(file);
-          config = user.withFallback(config);
+          resources.add(file);
         } else {
-          LOGGER.info("loading configuration from resource: {}", userResource);
-          Config user = ConfigFactory.parseResourcesAnySyntax(userResource);
-          config = user.withFallback(config);
+          resources.add(userResource);
         }
+      }
+    }
+    return resources;
+  }
+
+  /** Check for changes to the configs on the file system. */
+  static List<File> findUpdatedConfigs(List<Object> resources, long timestamp) {
+    return resources.stream()
+        .filter(r -> r instanceof File && ((File) r).lastModified() > timestamp)
+        .map(r -> (File) r)
+        .collect(Collectors.toList());
+  }
+
+  /** Helper to load config files specified by the user. */
+  static Config loadConfig(List<Object> resources) {
+    Config config = ConfigFactory.load("agent");
+    for (Object r : resources) {
+      if (r instanceof File) {
+        File file = (File) r;
+        LOGGER.info("loading configuration from file: {}", file);
+        Config user = ConfigFactory.parseFile(file);
+        config = user.withFallback(config);
+      } else {
+        String userResource = (String) r;
+        LOGGER.info("loading configuration from resource: {}", userResource);
+        Config user = ConfigFactory.parseResourcesAnySyntax(userResource);
+        config = user.withFallback(config);
       }
     }
     return config.resolve().getConfig("netflix.spectator.agent");
@@ -81,7 +112,8 @@ public final class Agent {
   /** Entry point for the agent. */
   public static void premain(String arg, Instrumentation instrumentation) throws Exception {
     // Setup logging
-    Config config = loadConfig(arg);
+    final List<Object> resources = parseResourceList(arg);
+    Config config = loadConfig(resources);
     LOGGER.debug("loaded configuration: {}", config.root().render());
     createDependencyProperties(config);
 
@@ -104,9 +136,36 @@ public final class Agent {
 
     // Enable JMX query collection
     if (config.getBoolean("collection.jmx")) {
-      for (Config cfg : config.getConfigList("jmx.mappings")) {
-        Jmx.registerMappingsFromConfig(registry, cfg);
-      }
+      ScheduledExecutorService exec = Executors.newSingleThreadScheduledExecutor(r -> {
+        Thread t = new Thread(r, "spectator-agent-jmx");
+        t.setDaemon(true);
+        return t;
+      });
+
+      // Poll the JMX data at least once per step interval unless it is less than a second
+      // to avoid to much overhead
+      Duration step = Duration.parse(config.getString("atlas.step"));
+      long delay = Math.max(1000L, step.toMillis() / 2L);
+
+      // Keep track of last time the configs have been loaded
+      final AtomicLong lastUpdated = new AtomicLong(System.currentTimeMillis());
+      final JmxPoller poller = new JmxPoller(registry);
+      poller.updateConfigs(config.getConfigList("jmx.mappings"));
+
+      exec.scheduleWithFixedDelay(() -> {
+        try {
+          List<File> updatedConfigs = findUpdatedConfigs(resources, lastUpdated.get());
+          if (!updatedConfigs.isEmpty()) {
+            LOGGER.info("detected updated config files: {}", updatedConfigs);
+            lastUpdated.set(System.currentTimeMillis());
+            Config cfg = loadConfig(resources);
+            poller.updateConfigs(cfg.getConfigList("jmx.mappings"));
+          }
+        } catch (Exception e) {
+          LOGGER.warn("failed to update jmx config mappings, using previous config", e);
+        }
+        poller.poll();
+      }, delay, delay, TimeUnit.MILLISECONDS);
     }
 
     // Start collection for the registry

--- a/spectator-agent/src/main/resources/agent.conf
+++ b/spectator-agent/src/main/resources/agent.conf
@@ -7,7 +7,7 @@ netflix.spectator.agent {
   }
 
   atlas {
-    step = PT1M
+    step = PT10S
     uri = "http://localhost:7101/api/v1/publish"
 
     tags = []

--- a/spectator-agent/src/main/resources/agent.conf
+++ b/spectator-agent/src/main/resources/agent.conf
@@ -7,7 +7,7 @@ netflix.spectator.agent {
   }
 
   atlas {
-    step = PT10S
+    step = PT1M
     uri = "http://localhost:7101/api/v1/publish"
 
     tags = []

--- a/spectator-agent/src/test/java/com/netflix/spectator/agent/AgentTest.java
+++ b/spectator-agent/src/test/java/com/netflix/spectator/agent/AgentTest.java
@@ -27,14 +27,14 @@ public class AgentTest {
 
   @Test
   public void loadConfigA() {
-    Config config = Agent.loadConfig("a");
+    Config config = Agent.loadConfig(Agent.parseResourceList("a"));
     Assertions.assertEquals("a", config.getString("option"));
     Assertions.assertTrue(config.getBoolean("a"));
   }
 
   @Test
   public void loadConfigAB() {
-    Config config = Agent.loadConfig("a,b");
+    Config config = Agent.loadConfig(Agent.parseResourceList("a,b"));
     Assertions.assertEquals("b", config.getString("option"));
     Assertions.assertTrue(config.getBoolean("a"));
     Assertions.assertTrue(config.getBoolean("b"));
@@ -42,7 +42,7 @@ public class AgentTest {
 
   @Test
   public void loadConfigABC() {
-    Config config = Agent.loadConfig("a\tb, \nc");
+    Config config = Agent.loadConfig(Agent.parseResourceList("a\tb, \nc"));
     Assertions.assertEquals("c", config.getString("option"));
     Assertions.assertTrue(config.getBoolean("a"));
     Assertions.assertTrue(config.getBoolean("b"));
@@ -51,7 +51,7 @@ public class AgentTest {
 
   @Test
   public void loadConfigListsAppend() {
-    Config config = Agent.loadConfig("a,b,c");
+    Config config = Agent.loadConfig(Agent.parseResourceList("a,b,c"));
     List<String> items = config.getStringList("list");
     Collections.sort(items);
 

--- a/spectator-ext-jvm/src/main/java/com/netflix/spectator/jvm/JmxMeasurementConfig.java
+++ b/spectator-ext-jvm/src/main/java/com/netflix/spectator/jvm/JmxMeasurementConfig.java
@@ -16,13 +16,11 @@
 package com.netflix.spectator.jvm;
 
 import com.netflix.spectator.api.Id;
-import com.netflix.spectator.api.Measurement;
 import com.netflix.spectator.api.Registry;
 import com.typesafe.config.Config;
 
 import javax.management.ObjectName;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
@@ -77,7 +75,7 @@ final class JmxMeasurementConfig {
   /**
    * Fill in {@code ms} with measurements extracted from {@code data}.
    */
-  void measure(Registry registry, JmxData data, List<Measurement> ms) {
+  void measure(Registry registry, JmxData data) {
     Map<String, String> tags = tagMappings.entrySet().stream().collect(Collectors.toMap(
         Map.Entry::getKey,
         e -> MappingExpr.substitute(e.getValue(), data.getStringAttrs())
@@ -98,7 +96,7 @@ final class JmxMeasurementConfig {
       if (counter) {
         updateCounter(registry, id, v.longValue());
       } else {
-        ms.add(new Measurement(id, registry.clock().wallTime(), v));
+        registry.gauge(id).set(v);
       }
     }
   }

--- a/spectator-ext-jvm/src/main/java/com/netflix/spectator/jvm/JmxMeter.java
+++ b/spectator-ext-jvm/src/main/java/com/netflix/spectator/jvm/JmxMeter.java
@@ -22,8 +22,7 @@ import com.netflix.spectator.api.Registry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Collections;
 
 /** Meter based on a {@link JmxConfig}. */
 final class JmxMeter implements Meter {
@@ -47,18 +46,17 @@ final class JmxMeter implements Meter {
 
   @Override
   public Iterable<Measurement> measure() {
-
-    List<Measurement> ms = new ArrayList<>();
     try {
       for (JmxData data : JmxData.query(config.getQuery())) {
         for (JmxMeasurementConfig cfg : config.getMeasurements()) {
-          cfg.measure(registry, data, ms);
+          cfg.measure(registry, data);
         }
       }
     } catch (Exception e) {
       LOGGER.warn("failed to query jmx data: {}", config.getQuery().getCanonicalName(), e);
     }
-    return ms;
+    // The measure will update counter/gauge values in the registry directly
+    return Collections.emptyList();
   }
 
   @Override public boolean hasExpired() {

--- a/spectator-ext-jvm/src/main/java/com/netflix/spectator/jvm/JmxPoller.java
+++ b/spectator-ext-jvm/src/main/java/com/netflix/spectator/jvm/JmxPoller.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.jvm;
+
+import com.netflix.spectator.api.Registry;
+import com.typesafe.config.Config;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Helper to poll JMX data based on a config and update a registry.
+ *
+ * <p><b>This class is an internal implementation detail only intended for use by
+ * {@code spectator-agent}. It is subject to change without notice.</b></p>
+ */
+public class JmxPoller {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(JmxPoller.class);
+
+  private final Registry registry;
+  private List<JmxConfig> configs = Collections.emptyList();
+
+  /**
+   * Create a new instance.
+   *
+   * @param registry
+   *     Registry to update when polling the data.
+   */
+  public JmxPoller(Registry registry) {
+    this.registry = registry;
+  }
+
+  /**
+   * Update the set of configs for what to poll.
+   */
+  public void updateConfigs(List<? extends Config> configs) {
+    this.configs = configs.stream()
+        .map(JmxConfig::from)
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Poll the JMX data once and update the registry.
+   */
+  public void poll() {
+    for (JmxConfig config : configs) {
+      try {
+        for (JmxData data : JmxData.query(config.getQuery())) {
+          for (JmxMeasurementConfig cfg : config.getMeasurements()) {
+            cfg.measure(registry, data);
+          }
+        }
+      } catch (Exception e) {
+        LOGGER.warn("failed to query jmx data: {}", config.getQuery().getCanonicalName(), e);
+      }
+    }
+  }
+}

--- a/spectator-ext-jvm/src/test/java/com/netflix/spectator/jvm/CassandraTest.java
+++ b/spectator-ext-jvm/src/test/java/com/netflix/spectator/jvm/CassandraTest.java
@@ -30,6 +30,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 
 public class CassandraTest {
@@ -45,15 +47,16 @@ public class CassandraTest {
   }
 
   private List<Measurement> measure(Registry registry, List<JmxConfig> configs, JmxData data) {
-    List<Measurement> ms = new ArrayList<>();
     for (JmxConfig cfg : configs) {
       if (cfg.getQuery().apply(data.getName())) {
         for (JmxMeasurementConfig c : cfg.getMeasurements()) {
-          c.measure(registry, data, ms);
+          c.measure(registry, data);
         }
       }
     }
-    return ms;
+    return registry.stream()
+        .flatMap(m -> StreamSupport.stream(m.measure().spliterator(), false))
+        .collect(Collectors.toList());
   }
 
   private JmxData timer(String props, int i) throws Exception {


### PR DESCRIPTION
The agent will now check file based configs to see if they
have been modified and then reload the JMX mappings. This
allows the mappings to be updated without having to restart
the process.

Fixes #704.