### PR TITLE
support traversal of ids without allocations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,7 +100,7 @@ subprojects {
     profilers = ['stack', 'gc']
     includeTests = false
     duplicateClassesStrategy = 'warn'
-    include = ['.*PercentileTimers.*']
+    include = ['.*IdTraversal.*']
   }
 
   checkstyle {

--- a/spectator-api/src/jmh/java/com/netflix/spectator/perf/IdTraversal.java
+++ b/spectator-api/src/jmh/java/com/netflix/spectator/perf/IdTraversal.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.perf;
+
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Tag;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * <pre>
+ * Benchmark                             Mode  Cnt        Score        Error   Units
+ * IdTraversal.forEach                  thrpt   10  9804067.543 ±  70757.222   ops/s
+ * IdTraversal.iterator                 thrpt   10  6431905.789 ± 814667.475   ops/s
+ * </pre>
+ *
+ * In an actual app we measured a big difference in allocations for the Tag objects. For
+ * this test hotspot seems to be able to avoid most of them:
+ *
+ * https://shipilev.net/jvm/anatomy-quarks/18-scalar-replacement/
+ *
+ * <pre>
+ * Benchmark                             Mode  Cnt        Score        Error   Units
+ * IdTraversal.forEach     gc.alloc.rate.norm   10        0.039 ±      0.001    B/op
+ * IdTraversal.iterator    gc.alloc.rate.norm   10        0.059 ±      0.006    B/op
+ * </pre>
+ */
+@State(Scope.Thread)
+public class IdTraversal {
+
+  private final Id baseId = Id.create("http.req.complete")
+      .withTag(    "nf.app", "test_app")
+      .withTag("nf.cluster", "test_app-main")
+      .withTag(    "nf.asg", "test_app-main-v042")
+      .withTag(  "nf.stack", "main")
+      .withTag(    "nf.ami", "ami-0987654321")
+      .withTag( "nf.region", "us-east-1")
+      .withTag(   "nf.zone", "us-east-1e")
+      .withTag(   "nf.node", "i-1234567890")
+      .withTag(   "country", "US")
+      .withTag(    "device", "xbox")
+      .withTag(    "status", "200")
+      .withTag(    "client", "ab");
+
+  @Benchmark
+  public void iterator(Blackhole bh) {
+    for (Tag t : baseId) {
+      bh.consume(t.key());
+      bh.consume(t.value());
+    }
+  }
+
+  @Benchmark
+  public void forEach(Blackhole bh) {
+    baseId.forEach((k, v) -> {
+      bh.consume(k);
+      bh.consume(v);
+    });
+  }
+}

--- a/spectator-api/src/main/java/com/netflix/spectator/api/ArrayTagSet.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/ArrayTagSet.java
@@ -19,15 +19,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
 
 /**
  * An immutable set of tags sorted by the tag key.
  */
-final class ArrayTagSet implements Iterable<Tag> {
+final class ArrayTagSet implements TagList {
 
   private static final Comparator<Tag> TAG_COMPARATOR = (t1, t2) -> t1.key().compareTo(t2.key());
 
@@ -73,25 +71,6 @@ final class ArrayTagSet implements Iterable<Tag> {
     this.tags = tags;
     this.length = length;
     this.cachedHashCode = 0;
-  }
-
-  @Override public Iterator<Tag> iterator() {
-    return new Iterator<Tag>() {
-      private int i = 0;
-
-      @Override public boolean hasNext() {
-        return i < length;
-      }
-
-      @Override public Tag next() {
-        if (i >= length) {
-          throw new NoSuchElementException("next called after end of iterator");
-        }
-        final String k = tags[i++];
-        final String v = tags[i++];
-        return new BasicTag(k, v);
-      }
-    };
   }
 
   /** Check if this set is empty. */
@@ -321,8 +300,18 @@ final class ArrayTagSet implements Iterable<Tag> {
     }
   }
 
+  /** Return the key at the specified position. */
+  @Override public String getKey(int i) {
+    return tags[i * 2];
+  }
+
+  /** Return the value at the specified position. */
+  @Override public String getValue(int i) {
+    return tags[i * 2 + 1];
+  }
+
   /** Return the current size of this tag set. */
-  public int size() {
+  @Override public int size() {
     return length / 2;
   }
 

--- a/spectator-api/src/main/java/com/netflix/spectator/api/DefaultId.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/DefaultId.java
@@ -71,6 +71,18 @@ final class DefaultId implements Id {
     return new DefaultId(name, tags.addAll(ts));
   }
 
+  @Override public String getKey(int i) {
+    return i == 0 ? "name" : tags.getKey(i - 1);
+  }
+
+  @Override public String getValue(int i) {
+    return i == 0 ? name : tags.getValue(i - 1);
+  }
+
+  @Override public int size() {
+    return tags.size() + 1;
+  }
+
   /**
    * Returns a new id with the tag list sorted by key and with no duplicate keys.  This is equivalent to
    * {@code rollup(Collections.<String>emptySet(), false)}.

--- a/spectator-api/src/main/java/com/netflix/spectator/api/Id.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/Id.java
@@ -20,7 +20,8 @@ import java.util.Map;
 /**
  * Identifier for a meter or measurement.
  */
-public interface Id {
+public interface Id extends TagList {
+
   /** Description of the measurement that is being collected. */
   String name();
 

--- a/spectator-api/src/main/java/com/netflix/spectator/api/NoopId.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/NoopId.java
@@ -53,4 +53,16 @@ final class NoopId implements Id {
   @Override public String toString() {
     return name();
   }
+
+  @Override public String getKey(int i) {
+    return "name";
+  }
+
+  @Override public String getValue(int i) {
+    return name();
+  }
+
+  @Override public int size() {
+    return 1;
+  }
 }

--- a/spectator-api/src/main/java/com/netflix/spectator/api/TagList.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/TagList.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.api;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.function.BiConsumer;
+
+/**
+ * Base type for a collection of tags. Allows access to the keys and values without allocations
+ * if the underlying implementation does not store them as Tag objects.
+ */
+public interface TagList extends Iterable<Tag> {
+
+  /** Return the key at the specified index. */
+  String getKey(int i);
+
+  /** Return the value at the specified index. */
+  String getValue(int i);
+
+  /** Return the number of tags in the list. */
+  int size();
+
+  /** Return the tag at the specified index. */
+  default Tag getTag(int i) {
+    return Tag.of(getKey(i), getValue(i));
+  }
+
+  /** Apply the consumer function for each tag in the list. */
+  default void forEach(BiConsumer<String, String> consumer) {
+    final int n = size();
+    for (int i = 0; i < n; ++i) {
+      consumer.accept(getKey(i), getValue(i));
+    }
+  }
+  
+  @Override default Iterator<Tag> iterator() {
+    final int length = size();
+    return new Iterator<Tag>() {
+      private int i = 0;
+
+      @Override public boolean hasNext() {
+        return i < length;
+      }
+
+      @Override public Tag next() {
+        if (i >= length) {
+          throw new NoSuchElementException("next called after end of iterator");
+        }
+        return getTag(i++);
+      }
+    };
+  }
+}

--- a/spectator-api/src/test/java/com/netflix/spectator/api/ArrayTagSetTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/ArrayTagSetTest.java
@@ -338,4 +338,24 @@ public class ArrayTagSetTest {
         .add(new BasicTag("b", "1"));
     Assertions.assertEquals(expected, ts);
   }
+
+  @Test
+  public void tagListIterate() {
+    ArrayTagSet expected = ArrayTagSet.create("a", "1", "b", "2", "c", "3", "d", "4", "e", "5");
+    ArrayTagSet actual = ArrayTagSet.EMPTY;
+    for (Tag t : expected) {
+      actual = actual.add(t);
+    }
+    Assertions.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void tagListForEach() {
+    ArrayTagSet expected = ArrayTagSet.create("a", "1", "b", "2", "c", "3", "d", "4", "e", "5");
+    List<Tag> tmp = new ArrayList<>();
+    expected.forEach((k, v) -> {
+      tmp.add(Tag.of(k, v));
+    });
+    Assertions.assertEquals(expected, ArrayTagSet.create(tmp));
+  }
 }

--- a/spectator-api/src/test/java/com/netflix/spectator/api/DefaultIdTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/DefaultIdTest.java
@@ -21,8 +21,10 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.nio.file.AccessMode;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -249,5 +251,37 @@ public class DefaultIdTest {
 
     Assertions.assertEquals(id1.hashCode(), id2.hashCode());
     Assertions.assertEquals(id1, id2);
+  }
+
+  @Test
+  public void tagListIterator() {
+    List<Tag> expected = new ArrayList<>();
+    expected.add(Tag.of("name", "foo"));
+    expected.add(Tag.of("k1", "v1"));
+    expected.add(Tag.of("k2", "v2"));
+
+    DefaultId id = (new DefaultId("foo")).withTag("k1", "v1").withTag("k2", "v2");
+    List<Tag> actual = new ArrayList<>();
+    for (Tag t : id) {
+      actual.add(t);
+    }
+
+    Assertions.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void tagListForEach() {
+    List<Tag> expected = new ArrayList<>();
+    expected.add(Tag.of("name", "foo"));
+    expected.add(Tag.of("k1", "v1"));
+    expected.add(Tag.of("k2", "v2"));
+
+    DefaultId id = (new DefaultId("foo")).withTag("k1", "v1").withTag("k2", "v2");
+    List<Tag> actual = new ArrayList<>();
+    id.forEach((k, v) -> {
+      actual.add(Tag.of(k, v));
+    });
+
+    Assertions.assertEquals(expected, actual);
   }
 }


### PR DESCRIPTION
Adds a base interface for Id that allows it to be treated
consistently as a collection of tags, i.e., name is not
special other than being the first entry. It also allows
the tag keys and values to be accessed without allocating
a Tag object.