### PR TITLE
add index for matching against a set of queries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,10 +93,10 @@ subprojects {
 
   jmh {
     jmhVersion = '1.21'
-    warmupIterations = 5
-    iterations = 10
+    warmupIterations = 2
+    iterations = 5
     fork = 1
-    threads = 1
+    //threads = 1
     profilers = ['stack', 'gc']
     includeTests = false
     duplicateClassesStrategy = 'warn'

--- a/spectator-api/build.gradle
+++ b/spectator-api/build.gradle
@@ -2,6 +2,7 @@
 dependencies {
   testCompile files("$projectDir/src/test/lib/compatibility-0.68.0.jar")
   jmh "com.google.re2j:re2j:1.2"
+  jmh "com.github.ben-manes.caffeine:caffeine:2.7.0"
 }
 
 javadoc {

--- a/spectator-api/src/jmh/java/com/netflix/spectator/perf/Caching.java
+++ b/spectator-api/src/jmh/java/com/netflix/spectator/perf/Caching.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.perf;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.netflix.spectator.api.NoopRegistry;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.impl.Cache;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * With NoopRegistry:
+ *
+ * <pre>
+ * </pre>
+ *
+ * With DefaultRegistry:
+ *
+ * <pre>
+ * </pre>
+ */
+public class Caching {
+
+  @State(Scope.Benchmark)
+  public static class AllMissesState {
+
+    private final Registry registry = new NoopRegistry();
+
+    final Cache<String, String> spectator = Cache.lfu(registry, "jmh", 200, 1000);
+
+    final LoadingCache<String, String> caffeine = Caffeine.newBuilder()
+        .recordStats()
+        .maximumSize(1000)
+        .build(String::toUpperCase);
+
+    private final String[] missData = createTestData(10000);
+    private AtomicInteger pos = new AtomicInteger();
+
+    private String[] createTestData(int n) {
+      String[] values = new String[n];
+      for (int i = 0; i < values.length; ++i) {
+        values[i] = UUID.randomUUID().toString();
+      }
+      return values;
+    }
+
+    public String next() {
+      int i = Integer.remainderUnsigned(pos.getAndIncrement(), missData.length);
+      return missData[i];
+    }
+  }
+
+  @State(Scope.Benchmark)
+  public static class TypicalState {
+
+    private final Registry registry = new NoopRegistry();
+
+    final Cache<String, String> spectator = Cache.lfu(registry, "jmh", 200, 1000);
+
+    final LoadingCache<String, String> caffeine = Caffeine.newBuilder()
+        .recordStats()
+        .maximumSize(1000)
+        .build(String::toUpperCase);
+
+    private final String[] data = createTestData();
+    private AtomicInteger pos = new AtomicInteger();
+
+    private String[] createTestData() {
+      int n = 10000;
+      String[] values = new String[n];
+
+      int i = 0;
+      int amount = 140;
+      while (i < n && amount > 0) {
+        String v = UUID.randomUUID().toString();
+        for (int j = 0; j < amount; ++j) {
+          values[i] = v;
+          ++i;
+        }
+        --amount;
+      }
+
+      for (; i < values.length; ++i) {
+        values[i] = UUID.randomUUID().toString();
+      }
+
+      List<String> list = Arrays.asList(values);
+      Collections.shuffle(list);
+
+      return list.toArray(new String[0]);
+    }
+
+    public String next() {
+      int i = Integer.remainderUnsigned(pos.getAndIncrement(), data.length);
+      return data[i];
+    }
+  }
+
+  @Threads(8)
+  @Benchmark
+  public void allMissesSpectator(Blackhole bh, AllMissesState state) {
+    String s = state.next();
+    bh.consume(state.spectator.computeIfAbsent(s, String::toUpperCase));
+  }
+
+  @Threads(8)
+  @Benchmark
+  public void allMissesCaffeine(Blackhole bh, AllMissesState state) {
+    String s = state.next();
+    bh.consume(state.caffeine.get(s));
+  }
+
+  @Threads(8)
+  @Benchmark
+  public void typicalSpectator(Blackhole bh, TypicalState state) {
+    String s = state.next();
+    bh.consume(state.spectator.computeIfAbsent(s, String::toUpperCase));
+  }
+
+  @Threads(8)
+  @Benchmark
+  public void typicalCaffeine(Blackhole bh, TypicalState state) {
+    String s = state.next();
+    bh.consume(state.caffeine.get(s));
+  }
+}

--- a/spectator-api/src/jmh/java/com/netflix/spectator/perf/Caching.java
+++ b/spectator-api/src/jmh/java/com/netflix/spectator/perf/Caching.java
@@ -33,15 +33,13 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * With NoopRegistry:
+ * Compare performance of simple caching implementation to Caffeine. In some cases we have
+ * see Caffeine/Guava implementations cause quite a bit of thread contention for concurrent
+ * access of a LoadingCache.
  *
- * <pre>
- * </pre>
- *
- * With DefaultRegistry:
- *
- * <pre>
- * </pre>
+ * Also the enabling the registry causes updating the hits/misses counters for each access.
+ * This can potentially be quite a bit of overhead compared to just the lookup, so enabling
+ * the monitoring may significantly reduce performance.
  */
 public class Caching {
 

--- a/spectator-api/src/main/java/com/netflix/spectator/api/TagList.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/TagList.java
@@ -46,7 +46,7 @@ public interface TagList extends Iterable<Tag> {
       consumer.accept(getKey(i), getValue(i));
     }
   }
-  
+
   @Override default Iterator<Tag> iterator() {
     final int length = size();
     return new Iterator<Tag>() {

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/Cache.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/Cache.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.impl;
+
+import com.netflix.spectator.api.Registry;
+
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Simple in-memory cache based on ConcurrentHashMap with minimal dependencies.
+ *
+ * <p><b>This class is an internal implementation detail only intended for use within spectator.
+ * It is subject to change without notice.</b></p>
+ */
+public interface Cache<K, V> {
+
+  /**
+   * Create a new cache instance that removes the least frequently used items when full.
+   *
+   * @param registry
+   *     Registry to use for tracking stats about the cache.
+   * @param id
+   *     Used with metrics to indentify a particular instance of the cache.
+   * @param baseSize
+   *     Number of items that should always be kept around in the cache.
+   * @param compactionSize
+   *     Maximum size of the underlying map for the cache.
+   * @return
+   *     Instance of an LFU cache.
+   */
+  static <K1, V1> Cache<K1, V1> lfu(Registry registry, String id, int baseSize, int compactionSize) {
+    return new LfuCache<>(registry, id, baseSize, compactionSize);
+  }
+
+  /**
+   * Returns the cached value associated with the key or null if none is found.
+   */
+  V get(K key);
+
+  /**
+   * Like {@link #get(Object)}, but does not update the access count.
+   */
+  V peek(K key);
+
+  /**
+   * Add or overwrite the cache entry for the key.
+   */
+  void put(K key, V value);
+
+  /**
+   * Returns the cached value associated with the key if present, otherwise computes a value
+   * using the provided function.
+   *
+   * @param key
+   *     Id to use for looking up a value in the cache.
+   * @param f
+   *     Function to compute a value based on the key. This function may get called multiple
+   *     times on a cache miss with some results getting discarded.
+   * @return
+   *     The value that was already cached or was just computed.
+   */
+  V computeIfAbsent(K key, Function<K, V> f);
+
+  /**
+   * Remove all entries from the cache.
+   */
+  void clear();
+
+  int size();
+
+  /**
+   * Returns a map containing a snapshot of the cache.
+   */
+  Map<K, V> asMap();
+}

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/LfuCache.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/LfuCache.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.impl;
+
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.Registry;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * LFU implementation of {@link Cache}.
+ */
+class LfuCache<K, V> implements Cache<K, V> {
+
+  private final Counter hits;
+  private final Counter misses;
+  private final Counter compactions;
+
+  private final ConcurrentHashMap<K, Pair<V>> data;
+  private final int baseSize;
+  private final int compactionSize;
+
+  private final AtomicInteger size;
+
+  private final Lock lock;
+
+  LfuCache(Registry registry, String id, int baseSize, int compactionSize) {
+    this.hits = registry.counter("spectator.cache.requests", "id", id, "result", "hit");
+    this.misses = registry.counter("spectator.cache.requests", "id", id, "result", "miss");
+    this.compactions = registry.counter("spectator.cache.compactions", "id", id);
+    data = new ConcurrentHashMap<>();
+    this.baseSize = baseSize;
+    this.compactionSize = compactionSize;
+    this.size = new AtomicInteger();
+    this.lock = new ReentrantLock();
+  }
+
+  private void compact() {
+    Map<K, Snapshot<V>> snapshot = new HashMap<>();
+    data.forEach((k, v) -> snapshot.put(k, v.snapshot()));
+
+    snapshot.entrySet()
+        .stream()
+        .sorted(Comparator.comparingLong(e -> e.getValue().negativeCount()))
+        .skip(baseSize)
+        .forEach(e -> data.remove(e.getKey()));
+
+    size.set(data.size());
+    compactions.increment();
+  }
+
+  private void tryCompact() {
+    if (lock.tryLock()) {
+      try {
+        compact();
+      } finally {
+        lock.unlock();
+      }
+    }
+  }
+
+  @Override
+  public V get(K key) {
+    Pair<V> value = data.get(key);
+    if (value == null) {
+      misses.increment();
+      return null;
+    } else {
+      hits.increment();
+      return value.get();
+    }
+  }
+
+  @Override public V peek(K key) {
+    Pair<V> value = data.get(key);
+    return value == null ? null : value.peek();
+  }
+
+  @Override public void put(K key, V value) {
+    Pair<V> prev = data.put(key, new Pair<>(value));
+    if (prev == null && size.incrementAndGet() > compactionSize) {
+      tryCompact();
+    }
+  }
+
+  @Override public V computeIfAbsent(K key, Function<K, V> f) {
+    Pair<V> value = data.get(key);
+    if (value == null) {
+      misses.increment();
+      Pair<V> tmp = new Pair<>(f.apply(key));
+      value = data.putIfAbsent(key, tmp);
+      if (value == null) {
+        value = tmp;
+        if (size.incrementAndGet() > compactionSize) {
+          tryCompact();
+        }
+      }
+    } else {
+      hits.increment();
+    }
+    return value.get();
+  }
+
+  @Override public void clear() {
+    size.set(0);
+    data.clear();
+  }
+
+  @Override public int size() {
+    return size.get();
+  }
+
+  @Override public Map<K, V> asMap() {
+    return data.entrySet()
+        .stream()
+        .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().peek()));
+  }
+
+  private static class Pair<V> {
+    private V value;
+    private LongAdder count;
+
+    Pair(V value) {
+      this.value = value;
+      this.count = new LongAdder();
+    }
+
+    V get() {
+      count.increment();
+      return value;
+    }
+
+    V peek() {
+      return value;
+    }
+
+    Snapshot<V> snapshot() {
+      return new Snapshot<>(value, count.sum());
+    }
+  }
+
+  private static class Snapshot<V> {
+    private V value;
+    private long count;
+
+    Snapshot(V value, long count) {
+      this.value = value;
+      this.count = count;
+    }
+
+    V get() {
+      return value;
+    }
+
+    long negativeCount() {
+      return -count;
+    }
+  }
+}

--- a/spectator-api/src/test/java/com/netflix/spectator/impl/LfuCacheTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/LfuCacheTest.java
@@ -1,0 +1,121 @@
+package com.netflix.spectator.impl;
+
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.Registry;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public class LfuCacheTest {
+
+  private Registry registry;
+
+  @BeforeEach
+  public void before() {
+    registry = new DefaultRegistry();
+  }
+
+  private long hits() {
+    return registry
+        .counter("spectator.cache.requests", "id", "test", "result", "hit")
+        .count();
+  }
+
+  private long misses() {
+    return registry
+        .counter("spectator.cache.requests", "id", "test", "result", "miss")
+        .count();
+  }
+
+  private long compactions() {
+    return registry
+        .counter("spectator.cache.compactions", "id", "test")
+        .count();
+  }
+
+  private Cache<String, String> create(int baseSize, int compactionSize) {
+    return Cache.lfu(registry, "test", baseSize, compactionSize);
+  }
+
+  private String[] createTestData() {
+    int n = 10000;
+    String[] values = new String[n];
+
+    int i = 0;
+    int amount = 140; // should have ~98% hit rate with base size > 140
+    while (i < n && amount > 0) {
+      String v = UUID.randomUUID().toString();
+      for (int j = 0; j < amount; ++j) {
+        values[i] = v;
+        ++i;
+      }
+      --amount;
+    }
+
+    for (; i < values.length; ++i) {
+      values[i] = UUID.randomUUID().toString();
+    }
+
+    List<String> list = Arrays.asList(values);
+    Collections.shuffle(list);
+
+    return list.toArray(new String[0]);
+  }
+
+  @Test
+  public void computeIfAbsent() {
+    Cache<String, String> cache = create(1, 2);
+    Assertions.assertEquals("A", cache.computeIfAbsent("a", String::toUpperCase));
+    Assertions.assertEquals(0, hits());
+    Assertions.assertEquals(1, misses());
+  }
+
+  @Test
+  public void computeIfAbsentRepeat() {
+    Cache<String, String> cache = create(1, 2);
+    Assertions.assertEquals("A", cache.computeIfAbsent("a", String::toUpperCase));
+    Assertions.assertEquals("A", cache.computeIfAbsent("a", s -> {
+      // Shouldn't get called since key is cached
+      throw new RuntimeException("fail");
+    }));
+    Assertions.assertEquals(1, hits());
+    Assertions.assertEquals(1, misses());
+  }
+
+  @Test
+  public void computeIfAbsentCompaction() {
+    Cache<String, String> cache = create(1, 2);
+    Assertions.assertEquals("A", cache.computeIfAbsent("a", String::toUpperCase));
+    Assertions.assertEquals("B", cache.computeIfAbsent("b", String::toUpperCase));
+    Assertions.assertEquals("B", cache.computeIfAbsent("b", String::toUpperCase));
+    Assertions.assertEquals(2, cache.size());
+
+    Assertions.assertEquals("C", cache.computeIfAbsent("c", String::toUpperCase));
+    Assertions.assertEquals(1, hits());
+    Assertions.assertEquals(3, misses());
+    Assertions.assertEquals(1, compactions());
+    Assertions.assertEquals(1, cache.size());
+
+    Map<String, String> expected = new HashMap<>();
+    expected.put("b", "B");
+    Assertions.assertEquals(expected, cache.asMap());
+  }
+
+  @Test
+  public void computeIfAbsentHitRate() {
+    Cache<String, String> cache = create(100, 1000);
+    for (String s : createTestData()) {
+      cache.computeIfAbsent(s, String::toUpperCase);
+    }
+    Assertions.assertEquals(9730, hits());
+    Assertions.assertEquals(270, misses());
+    Assertions.assertEquals(0, compactions());
+  }
+}

--- a/spectator-api/src/test/java/com/netflix/spectator/impl/LfuCacheTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/LfuCacheTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.spectator.impl;
 
 import com.netflix.spectator.api.DefaultRegistry;

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/QueryIndex.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/QueryIndex.java
@@ -28,7 +28,8 @@ import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Index that to efficiently match an {@link com.netflix.spectator.api.Id} against a set of
- * queries that are known in advance.
+ * queries that are known in advance. The index is thread safe for queries. Updates to the
+ * index should be done from a single thread at a time.
  */
 public final class QueryIndex<T> {
 
@@ -41,8 +42,8 @@ public final class QueryIndex<T> {
 
   /**
    * Return a new instance of an index that is empty and doesn't have an explicit key set.
-   * Used internally rather than {@link #newInstance(Registry)}. For external usage the
-   * {@link #newInstance(Registry)}
+   * Used internally rather than {@link #newInstance(Registry)} which sets the key to {@code name}
+   * so the root node will be correct for traversing the id.
    */
   private static <V> QueryIndex<V> empty(Registry registry) {
     return new QueryIndex<>(registry, null);

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/QueryIndex.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/QueryIndex.java
@@ -1,0 +1,322 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas.impl;
+
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.impl.Cache;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Index that to efficiently match an {@link com.netflix.spectator.api.Id} against a set of
+ * queries that are known in advance.
+ */
+public final class QueryIndex<T> {
+
+  /**
+   * Return a new instance of an index that is empty.
+   */
+  public static <V> QueryIndex<V> newInstance(Registry registry) {
+    return new QueryIndex<>(registry, "name");
+  }
+
+  /**
+   * Return a new instance of an index that is empty and doesn't have an explicit key set.
+   * Used internally rather than {@link #newInstance(Registry)}. For external usage the
+   * {@link #newInstance(Registry)}
+   */
+  private static <V> QueryIndex<V> empty(Registry registry) {
+    return new QueryIndex<>(registry, null);
+  }
+
+  /**
+   * Compare the strings and put {@code name} first and then normally sort the other keys.
+   * This allows the {@link Id} to be traversed in order while performing the lookup.
+   */
+  private static int compare(String k1, String k2) {
+    if ("name".equals(k1) && "name".equals(k2)) {
+      return 0;
+    } else if ("name".equals(k1)) {
+      return -1;
+    } else if ("name".equals(k2)) {
+      return 1;
+    } else {
+      return k1.compareTo(k2);
+    }
+  }
+
+  private final Registry registry;
+
+  private volatile String key;
+
+  private final ConcurrentHashMap<String, QueryIndex<T>> equalChecks;
+
+  private final ConcurrentHashMap<Query.KeyQuery, QueryIndex<T>> otherChecks;
+  private final Cache<String, List<QueryIndex<T>>> otherChecksCache;
+
+  private volatile QueryIndex<T> otherKeysIdx;
+
+  private final Set<T> matches;
+
+  /** Create a new instance. */
+  private QueryIndex(Registry registry, String key) {
+    this.registry = registry;
+    this.key = key;
+    this.equalChecks = new ConcurrentHashMap<>();
+    this.otherChecks = new ConcurrentHashMap<>();
+    this.otherChecksCache = Cache.lfu(registry, "QueryIndex", 100, 1000);
+    this.otherKeysIdx = null;
+    this.matches = ConcurrentHashMap.newKeySet();
+  }
+
+  private List<Query.KeyQuery> sort(Query query) {
+    List<Query.KeyQuery> result = new ArrayList<>();
+    for (Query q : query.andList()) {
+      result.add((Query.KeyQuery) q);
+    }
+    result.sort((q1, q2) -> compare(q1.key(), q2.key()));
+    return result;
+  }
+
+  /**
+   * Add a value that should match for the specified query.
+   *
+   * @param query
+   *     Query that corresponds to the value.
+   * @param value
+   *     Value to return for ids that match the query.
+   * @return
+   *     This index so it can be used in a fluent manner.
+   */
+  public QueryIndex<T> add(Query query, T value) {
+    for (Query q : query.dnfList()) {
+      add(sort(q), 0, value);
+    }
+    return this;
+  }
+
+  private void add(List<Query.KeyQuery> queries, int i, T value) {
+    if (i < queries.size()) {
+      Query.KeyQuery kq = queries.get(i);
+
+      // Check for additional queries based on the same key and combine into a
+      // composite if needed
+      Query.CompositeKeyQuery composite = null;
+      int j = i + 1;
+      while (j < queries.size()) {
+        Query.KeyQuery q = queries.get(j);
+        if (kq.key().equals(q.key())) {
+          if (composite == null) {
+            composite = new Query.CompositeKeyQuery(kq);
+            kq = composite;
+          }
+          composite.add(q);
+          ++j;
+        } else {
+          break;
+        }
+      }
+
+      if (key == null) {
+        key = kq.key();
+      }
+
+      if (key.equals(kq.key())) {
+        if (kq instanceof Query.Equal) {
+          String v = ((Query.Equal) kq).value();
+          QueryIndex<T> idx = equalChecks.computeIfAbsent(v, id -> QueryIndex.empty(registry));
+          idx.add(queries, j, value);
+        } else {
+          QueryIndex<T> idx = otherChecks.computeIfAbsent(kq, id -> QueryIndex.empty(registry));
+          idx.add(queries, j, value);
+          otherChecksCache.clear();
+        }
+      } else {
+        if (otherKeysIdx == null) {
+          otherKeysIdx = QueryIndex.empty(registry);
+        }
+        otherKeysIdx.add(queries, i, value);
+      }
+    } else {
+      matches.add(value);
+    }
+  }
+
+  private <K> boolean remove(ConcurrentHashMap<K, QueryIndex<T>> map, T value) {
+    boolean removed = false;
+    Iterator<Map.Entry<K, QueryIndex<T>>> it = map.entrySet().iterator();
+    while (it.hasNext()) {
+      Map.Entry<K, QueryIndex<T>> entry = it.next();
+      QueryIndex<T> idx = entry.getValue();
+      if (idx.remove(value)) {
+        removed = true;
+        if (idx.isEmpty()) {
+          it.remove();
+        }
+      }
+    }
+    return removed;
+  }
+
+  private boolean removeFromOtherChecks(T value) {
+    if (remove(otherChecks, value)) {
+      otherChecksCache.clear();
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  private boolean removeFromOtherKeysIdx(T value) {
+    if (otherKeysIdx != null && otherKeysIdx.remove(value)) {
+      if (otherKeysIdx.isEmpty()) {
+        otherKeysIdx = null;
+      }
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  /**
+   * Remove the specified value from the index. Returns true if a value was successfully
+   * removed.
+   */
+  public boolean remove(T value) {
+    return matches.remove(value)
+        || remove(equalChecks, value)
+        || removeFromOtherChecks(value)
+        || removeFromOtherKeysIdx(value);
+  }
+
+  /**
+   * Returns true if this index is empty and wouldn't match any ids.
+   */
+  public boolean isEmpty() {
+    return matches.isEmpty()
+        && equalChecks.values().stream().allMatch(QueryIndex::isEmpty)
+        && otherChecks.values().stream().allMatch(QueryIndex::isEmpty)
+        && (otherKeysIdx == null || otherKeysIdx.isEmpty());
+  }
+
+  /**
+   * Find all values where the corresponding queries match the specified id.
+   *
+   * @param id
+   *     Id to check against the queries.
+   * @return
+   *     List of all matching values for the id.
+   */
+  public List<T> findMatches(Id id) {
+    List<T> result = new ArrayList<>();
+    findMatches(result, id, 0);
+    return result;
+  }
+
+  private void findMatches(List<T> result, Id tags, int i) {
+    // Matches for this level
+    result.addAll(matches);
+
+    if (key != null) {
+
+      for (int j = i; j < tags.size(); ++j) {
+        String k = tags.getKey(j);
+        String v = tags.getValue(j);
+        int cmp = compare(k, key);
+        if (cmp == 0) {
+          // Find exact matches
+          QueryIndex<T> eqIdx = equalChecks.get(v);
+          if (eqIdx != null) {
+            eqIdx.findMatches(result, tags, i + 1);
+          }
+
+          // Scan for matches with other conditions
+          List<QueryIndex<T>> otherMatches = otherChecksCache.get(v);
+          if (otherMatches == null) {
+            List<QueryIndex<T>> tmp = new ArrayList<>();
+            otherChecks.forEach((kq, idx) -> {
+              if (kq.matches(v)) {
+                tmp.add(idx);
+                idx.findMatches(result, tags, i + 1);
+              }
+            });
+            otherChecksCache.put(v, tmp);
+          } else {
+            for (QueryIndex<T> idx : otherMatches) {
+              idx.findMatches(result, tags, i + 1);
+            }
+          }
+        } else if (cmp > 0) {
+          break;
+        }
+      }
+
+      // Check matches with other keys
+      if (otherKeysIdx != null) {
+        otherKeysIdx.findMatches(result, tags, i);
+      }
+    }
+  }
+
+  @Override public String toString() {
+    StringBuilder builder = new StringBuilder();
+    buildString(builder, 0);
+    return builder.toString();
+  }
+
+  private StringBuilder indent(StringBuilder builder, int n) {
+    for (int i = 0; i < n * 4; ++i) {
+      builder.append(' ');
+    }
+    return builder;
+  }
+
+  private void buildString(StringBuilder builder, int n) {
+    if (key != null) {
+      indent(builder, n).append("key: [").append(key).append("]\n");
+    }
+    if (!equalChecks.isEmpty()) {
+      indent(builder, n).append("equal checks:\n");
+      equalChecks.forEach((v, idx) -> {
+        indent(builder, n).append("- [").append(v).append("]\n");
+        idx.buildString(builder, n + 1);
+      });
+    }
+    if (!otherChecks.isEmpty()) {
+      indent(builder, n).append("other checks:\n");
+      otherChecks.forEach((kq, idx) -> {
+        indent(builder, n).append("- [").append(kq).append("]\n");
+        idx.buildString(builder, n + 1);
+      });
+    }
+    if (otherKeysIdx != null) {
+      indent(builder, n).append("other keys:\n");
+      otherKeysIdx.buildString(builder, n + 1);
+    }
+    if (!matches.isEmpty()) {
+      indent(builder, n).append("matches:\n");
+      for (T value : matches) {
+        indent(builder, n).append("- [").append(value).append("]\n");
+      }
+    }
+  }
+}

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/QueryIndexTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/QueryIndexTest.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas.impl;
+
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Registry;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+public class QueryIndexTest {
+
+  private final Registry registry = new DefaultRegistry();
+
+  private Id id(String name, String... tags) {
+    return registry.createId(name, tags);
+  }
+
+  private List<Query> list(Query... vs) {
+    return Arrays.asList(vs);
+  }
+
+  @Test
+  public void empty() {
+    QueryIndex<Integer> idx = QueryIndex.newInstance(registry);
+    Assertions.assertTrue(idx.findMatches(id("a")).isEmpty());
+  }
+
+  private static final Query SIMPLE_QUERY = Parser.parseQuery("name,a,:eq,key,b,:eq,:and");
+
+  private QueryIndex<Query> simpleIdx() {
+    return QueryIndex.<Query>newInstance(registry).add(SIMPLE_QUERY, SIMPLE_QUERY);
+  }
+
+  @Test
+  public void simpleMissingKey() {
+    Id id = id("a", "foo", "bar");
+    Assertions.assertTrue(simpleIdx().findMatches(id).isEmpty());
+  }
+
+  @Test
+  public void simpleMatches() {
+    Id id1 = id("a", "key", "b");
+    Id id2 = id("a", "foo", "bar", "key", "b");
+    Assertions.assertEquals(list(SIMPLE_QUERY), simpleIdx().findMatches(id1));
+    Assertions.assertEquals(list(SIMPLE_QUERY), simpleIdx().findMatches(id2));
+  }
+
+  @Test
+  public void simpleNameDoesNotMatch() {
+    Id id = id("b", "foo", "bar");
+    Assertions.assertTrue(simpleIdx().findMatches(id).isEmpty());
+  }
+
+  @Test
+  public void simpleRemoveValue() {
+    QueryIndex<Query> idx = simpleIdx();
+    Assertions.assertTrue(idx.remove(SIMPLE_QUERY));
+    Assertions.assertTrue(idx.isEmpty());
+
+    Id id = id("a", "key", "b");
+    Assertions.assertTrue(idx.findMatches(id).isEmpty());
+  }
+
+  private static final Query HASKEY_QUERY = Parser.parseQuery("name,a,:eq,key,b,:eq,:and,c,:has,:and");
+
+  private QueryIndex<Query> hasKeyIdx() {
+    return QueryIndex.<Query>newInstance(registry).add(HASKEY_QUERY, HASKEY_QUERY);
+  }
+
+  @Test
+  public void hasKeyMissingKey() {
+    Id id = id("a", "key", "b", "foo", "bar");
+    Assertions.assertTrue(hasKeyIdx().findMatches(id).isEmpty());
+  }
+
+  @Test
+  public void hasKeyMatches() {
+    Id id1 = id("a", "key", "b", "c", "12345");
+    Id id2 = id("a", "foo", "bar", "key", "b", "c", "foobar");
+    Assertions.assertEquals(list(HASKEY_QUERY), hasKeyIdx().findMatches(id1));
+    Assertions.assertEquals(list(HASKEY_QUERY), hasKeyIdx().findMatches(id2));
+  }
+
+  @Test
+  public void hasKeyRepeat() {
+    Id id1 = id("a", "key", "b", "c", "12345");
+    QueryIndex<Query> idx = hasKeyIdx();
+    for (int i = 0; i < 10; ++i) {
+      // Subsequent checks for :has operation should come from cache
+      Assertions.assertEquals(list(HASKEY_QUERY), idx.findMatches(id1));
+    }
+  }
+
+  private static final Query IN_QUERY = Parser.parseQuery("name,a,:eq,key,(,b,c,),:in,:and");
+
+  private QueryIndex<Query> inIdx() {
+    return QueryIndex.<Query>newInstance(registry).add(IN_QUERY, IN_QUERY);
+  }
+
+  @Test
+  public void inMissingKey() {
+    Id id = id("a", "key2", "b", "foo", "bar");
+    Assertions.assertTrue(inIdx().findMatches(id).isEmpty());
+  }
+
+  @Test
+  public void inMatches() {
+    Id id1 = id("a", "key", "b", "c", "12345");
+    Id id2 = id("a", "foo", "bar", "key", "c", "c", "foobar");
+    Assertions.assertEquals(list(IN_QUERY), inIdx().findMatches(id1));
+    Assertions.assertEquals(list(IN_QUERY), inIdx().findMatches(id2));
+  }
+
+  @Test
+  public void inValueNotInSet() {
+    Id id = id("a", "key", "d", "c", "12345");
+    Assertions.assertTrue(inIdx().findMatches(id).isEmpty());
+  }
+
+  @Test
+  public void removals() {
+    QueryIndex<Query> idx = QueryIndex.newInstance(registry);
+    idx.add(SIMPLE_QUERY, SIMPLE_QUERY);
+    idx.add(HASKEY_QUERY, HASKEY_QUERY);
+    idx.add(IN_QUERY, IN_QUERY);
+
+    Id id1 = id("a", "key", "b", "c", "12345");
+    Assertions.assertEquals(list(SIMPLE_QUERY, IN_QUERY, HASKEY_QUERY), idx.findMatches(id1));
+
+    Assertions.assertFalse(idx.remove(Parser.parseQuery("name,a,:eq")));
+    Assertions.assertEquals(list(SIMPLE_QUERY, IN_QUERY, HASKEY_QUERY), idx.findMatches(id1));
+
+    Assertions.assertTrue(idx.remove(IN_QUERY));
+    Assertions.assertEquals(list(SIMPLE_QUERY, HASKEY_QUERY), idx.findMatches(id1));
+
+    Assertions.assertTrue(idx.remove(SIMPLE_QUERY));
+    Assertions.assertEquals(list(HASKEY_QUERY), idx.findMatches(id1));
+
+    Assertions.assertTrue(idx.remove(HASKEY_QUERY));
+    Assertions.assertTrue(idx.isEmpty());
+    Assertions.assertTrue(idx.findMatches(id1).isEmpty());
+
+    idx.add(SIMPLE_QUERY, SIMPLE_QUERY);
+    Assertions.assertEquals(list(SIMPLE_QUERY), idx.findMatches(id1));
+  }
+
+  private Set<String> set(int n) {
+    Set<String> tmp = new LinkedHashSet<>();
+    for (int i = 0; i < n; ++i) {
+      tmp.add("" + i);
+    }
+    return tmp;
+  }
+
+  @Test
+  public void queryNormalization() {
+    Query q = Parser.parseQuery("name,a,:eq,name,b,:eq,:or,key,b,:eq,:and");
+    QueryIndex<Query> idx = QueryIndex.newInstance(registry);
+    idx.add(q, q);
+    Assertions.assertEquals(list(q), idx.findMatches(id("a", "key", "b")));
+    Assertions.assertEquals(list(q), idx.findMatches(id("b", "key", "b")));
+  }
+
+  @Test
+  public void inClauseExpansion() {
+    // If the :in clauses are fully expanded with a cross-product, then this will cause an OOM
+    // error because of the combinatorial explosion of simple queries (10k * 10k * 10k).
+    Query q1 = new Query.In("a", set(10000));
+    Query q2 = new Query.In("b", set(10000));
+    Query q3 = new Query.In("c", set(10000));
+    Query query = q1.and(q2).and(q3);
+    QueryIndex<Query> idx = QueryIndex.<Query>newInstance(registry).add(query, query);
+
+    Id id1 = id("cpu", "a", "1", "b", "9999", "c", "727");
+    Assertions.assertEquals(list(query), idx.findMatches(id1));
+  }
+
+  @Test
+  public void manyQueries() {
+    // CpuUsage for all instances
+    Query cpuUsage = Parser.parseQuery("name,cpuUsage,:eq");
+
+    // DiskUsage query per node
+    Query diskUsage = Parser.parseQuery("name,diskUsage,:eq");
+    List<Query> diskUsagePerNode = new ArrayList<>();
+    for (int i = 0; i < 100; ++i) {
+      String node = String.format("i-%05d", i);
+      Query q = new Query.And(new Query.Equal("nf.node", node), diskUsage);
+      diskUsagePerNode.add(q);
+    }
+
+    QueryIndex<Query> idx = QueryIndex.<Query>newInstance(registry)
+        .add(cpuUsage, cpuUsage)
+        .add(diskUsage, diskUsage);
+    for (Query q : diskUsagePerNode) {
+      idx.add(q, q);
+    }
+
+    // Matching
+    Assertions.assertEquals(
+        list(cpuUsage),
+        idx.findMatches(id("cpuUsage", "nf.node", "unknown")));
+    Assertions.assertEquals(
+        list(cpuUsage),
+        idx.findMatches(id("cpuUsage", "nf.node", "i-00099")));
+    Assertions.assertEquals(
+        list(diskUsage),
+        idx.findMatches(id("diskUsage", "nf.node", "unknown")));
+    Assertions.assertEquals(
+        list(diskUsage, diskUsagePerNode.get(diskUsagePerNode.size() - 1)),
+        idx.findMatches(id("diskUsage", "nf.node", "i-00099")));
+
+    // Shouldn't match
+    Assertions.assertTrue(
+        idx.findMatches(id("memoryUsage", "nf.node", "i-00099")).isEmpty());
+  }
+
+  @Test
+  public void multipleClausesForSameKey() {
+    Query q = Parser.parseQuery("name,abc.*,:re,name,.*def,:re,:and");
+    QueryIndex<Query> idx = QueryIndex.<Query>newInstance(registry).add(q, q);
+
+    // Doesn't match prefix check
+    Assertions.assertTrue(idx.findMatches(id("foodef")).isEmpty());
+
+    // Doesn't match suffix check
+    Assertions.assertTrue(idx.findMatches(id("abcbar")).isEmpty());
+
+    // Matches both
+    Assertions.assertFalse(idx.findMatches(id("abcdef")).isEmpty());
+    Assertions.assertFalse(idx.findMatches(id("abc def")).isEmpty());
+  }
+
+  @Test
+  public void toStringMethod() {
+    QueryIndex<Query> idx = QueryIndex.newInstance(registry);
+    idx.add(SIMPLE_QUERY, SIMPLE_QUERY);
+    idx.add(HASKEY_QUERY, HASKEY_QUERY);
+    idx.add(IN_QUERY, IN_QUERY);
+
+    String expected = "key: [name]\n" +
+        "equal checks:\n" +
+        "- [a]\n" +
+        "    key: [key]\n" +
+        "    equal checks:\n" +
+        "    - [b]\n" +
+        "        matches:\n" +
+        "        - [name,a,:eq,key,b,:eq,:and]\n" +
+        "    other checks:\n" +
+        "    - [key,(,b,c,),:in]\n" +
+        "        matches:\n" +
+        "        - [name,a,:eq,key,(,b,c,),:in,:and]\n" +
+        "    other keys:\n" +
+        "        key: [c]\n" +
+        "        other checks:\n" +
+        "        - [c,:has]\n" +
+        "            key: [key]\n" +
+        "            equal checks:\n" +
+        "            - [b]\n" +
+        "                matches:\n" +
+        "                - [name,a,:eq,key,b,:eq,:and,c,:has,:and]\n";
+
+    String actual = idx.toString();
+
+    Assertions.assertEquals(expected, actual);
+  }
+}


### PR DESCRIPTION
Adds a `QueryIndex` class that can be used to quickly check
and `Id` against a potentially large set of queries that are
known in advance.

This is similar to the structure in the Atlas backend, but
exploits the current structure of the Spectator `Id`. The tree
is setup to check the name first and then the tags in order.
To compensate for regex and other query types that would require
a linear scan of events a simple LFU cache is used. The scan
is only needed for the values that are not in the cache or after
the index is modified at that level.

Tests with real data shows it performs pretty well and allows us
to comfortably check ~450k distinct ids against ~50k alerting
queries in a fraction of a second.