### PR TITLE
update QueryIndex to handle true/false

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/QueryIndex.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/QueryIndex.java
@@ -111,7 +111,13 @@ public final class QueryIndex<T> {
    */
   public QueryIndex<T> add(Query query, T value) {
     for (Query q : query.dnfList()) {
-      add(sort(q), 0, value);
+      if (q == Query.TRUE) {
+        matches.add(value);
+      } else if (q == Query.FALSE) {
+        break;
+      } else {
+        add(sort(q), 0, value);
+      }
     }
     return this;
   }

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/QueryIndexTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/QueryIndexTest.java
@@ -138,6 +138,21 @@ public class QueryIndexTest {
   }
 
   @Test
+  public void trueMatches() {
+    QueryIndex<Query> idx = QueryIndex.<Query>newInstance(registry).add(Query.TRUE, Query.TRUE);
+    Id id1 = id("a", "key", "b", "c", "12345");
+    Id id2 = id("a", "foo", "bar", "key", "b", "c", "foobar");
+    Assertions.assertEquals(list(Query.TRUE), idx.findMatches(id1));
+    Assertions.assertEquals(list(Query.TRUE), idx.findMatches(id2));
+  }
+
+  @Test
+  public void falseDoesNotMatch() {
+    QueryIndex<Query> idx = QueryIndex.<Query>newInstance(registry).add(Query.FALSE, Query.FALSE);
+    Assertions.assertTrue(idx.isEmpty());
+  }
+
+  @Test
   public void removals() {
     QueryIndex<Query> idx = QueryIndex.newInstance(registry);
     idx.add(SIMPLE_QUERY, SIMPLE_QUERY);


### PR DESCRIPTION
Before this would cause a ClassCastException because they
were not a KeyQuery.