### PR TITLE
support multiple step sizes for LWC

### DIFF
--- a/spectator-nflx-plugin/src/test/java/com/netflix/spectator/nflx/SpectatorModuleTest.java
+++ b/spectator-nflx-plugin/src/test/java/com/netflix/spectator/nflx/SpectatorModuleTest.java
@@ -57,7 +57,7 @@ public class SpectatorModuleTest {
         new SpectatorModule());
     Registry registry = injector.getInstance(Registry.class);
     Spectator.globalRegistry().counter("test").increment();
-    clock.setWallTime(60000);
+    clock.setWallTime(5000);
     Assertions.assertEquals(1, registry.counter("test").count());
   }
 

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasConfig.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasConfig.java
@@ -82,6 +82,17 @@ public interface AtlasConfig extends RegistryConfig {
   }
 
   /**
+   * Returns the step size (reporting frequency) to use for streaming to Atlas LWC.
+   * The default is 5s. This is the highest resolution that would be supported for getting
+   * an on-demand stream of the data. It must be less than or equal to the Atlas step
+   * ({@link #step()}) and the Atlas step should be an even multiple of this value.
+   */
+  default Duration lwcStep() {
+    String v = get("atlas.lwc.step");
+    return (v == null) ? Duration.ofSeconds(5) : Duration.parse(v);
+  }
+
+  /**
    * Returns true if streaming to Atlas LWC is enabled. Default is false.
    */
   default boolean lwcEnabled() {

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Consolidator.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Consolidator.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas.impl;
+
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.Statistic;
+import com.netflix.spectator.api.Utils;
+import com.netflix.spectator.impl.Preconditions;
+
+/**
+ * Consolidates a set of measurements collected at a smaller step size to a set a measurement
+ * at a larger step size that is an even multiple of the primary.
+ */
+public interface Consolidator {
+
+  /**
+   * Update the state with a new primary datapoint.
+   *
+   * @param t
+   *     Timestamp for the new value.
+   * @param v
+   *     Value to include in the consolidated aggregate. If there is no new measurement, then
+   *     {@code NaN} can be used to force the completion of the consolidated value.
+   */
+  void update(long t, double v);
+
+  /**
+   * Update the state with a new primary datapoint. See {@link #update(long, double)} for more
+   * details.
+   */
+  default void update(Measurement m) {
+    update(m.timestamp(), m.value());
+  }
+
+  /**
+   * Return the consolidated value for the specified timestamp. The timestamp should be for the
+   * last completed interval.
+   */
+  double value(long t);
+
+  /**
+   * Returns true if the state is the same as it would be if a new instance of the consolidator
+   * was created. This can be used to check if the current instance can be garbage collected.
+   */
+  boolean isEmpty();
+
+  /**
+   * Create a new consolidator instance based on the statistic in the id. If not statistic tag
+   * is present, then it will be treated as a gauge.
+   *
+   * @param id
+   *     Id for the measurement to consolidate.
+   * @param step
+   *     Consolidated step size.
+   * @param multiple
+   *     Multiple for the consolidate step size. The primary step is {@code step / multiple}.
+   * @return
+   *     A new consolidator instance.
+   */
+  static Consolidator create(Id id, long step, int multiple) {
+    return create(Utils.getTagValue(id, "statistic"), step, multiple);
+  }
+
+  /**
+   * Create a new consolidator instance based on the specified statistic.
+   *
+   * @param statistic
+   *     Statistic used to determine which consolidation function to use.
+   * @param step
+   *     Consolidated step size.
+   * @param multiple
+   *     Multiple for the consolidate step size. The primary step is {@code step / multiple}.
+   * @return
+   *     A new consolidator instance.
+   */
+  static Consolidator create(Statistic statistic, long step, int multiple) {
+    return create(statistic.name(), step, multiple);
+  }
+
+  /**
+   * Create a new consolidator instance based on the specified statistic.
+   *
+   * @param statistic
+   *     Statistic used to determine which consolidation function to use. If the statistic is
+   *     null or unknown, the it will be treated as a gauge.
+   * @param step
+   *     Consolidated step size.
+   * @param multiple
+   *     Multiple for the consolidate step size. The primary step is {@code step / multiple}.
+   * @return
+   *     A new consolidator instance.
+   */
+  static Consolidator create(String statistic, long step, int multiple) {
+    if (multiple == 1) {
+      return new None();
+    }
+    Consolidator consolidator;
+    switch (statistic == null ? "gauge" : statistic) {
+      case "count":
+      case "totalAmount":
+      case "totalTime":
+      case "totalOfSquares":
+      case "percentile":
+        consolidator = new Avg(step, multiple);
+        break;
+      case "max":
+      case "duration":
+      case "activeTasks":
+        consolidator = new Max(step, multiple);
+        break;
+      default:
+        consolidator = new Last(step, multiple);
+        break;
+    }
+    return consolidator;
+  }
+
+  /**
+   * Placeholder implementation used when the the primary and consolidated step sizes are
+   * the same.
+   */
+  final class None implements Consolidator {
+
+    private long timestamp;
+    private double value;
+
+    None() {
+      this.timestamp = -1L;
+      this.value = Double.NaN;
+    }
+
+    @Override public void update(long t, double v) {
+      if (t > timestamp) {
+        timestamp = t;
+        value = v;
+      }
+    }
+
+    @Override public double value(long t) {
+      return timestamp == t ? value : Double.NaN;
+    }
+
+    @Override public boolean isEmpty() {
+      return Double.isNaN(value);
+    }
+  }
+
+  /** Base class for consolidator implementations. */
+  abstract class AbstractConsolidator implements Consolidator {
+    /** Consolidated step size. */
+    protected final long step;
+
+    /** Multiple from primary to consolidated step. */
+    protected final int multiple;
+
+    private long timestamp;
+
+    private double current;
+    private double previous;
+
+    AbstractConsolidator(long step, int multiple) {
+      Preconditions.checkArg(step > 0L, "step must be > 0");
+      Preconditions.checkArg(multiple > 0L, "multiple must be > 0");
+      this.step = step;
+      this.multiple = multiple;
+      this.timestamp = -1L;
+      this.current = Double.NaN;
+      this.previous = Double.NaN;
+    }
+
+    private long roundToConsolidatedStep(long t) {
+      return (t % step == 0L) ? t : t / step * step + step;
+    }
+
+    /** Combines two values to create an aggregate used as the consolidated value. */
+    protected abstract double aggregate(double v1, double v2);
+
+    /** Performs any final computation on the aggregated value. */
+    protected abstract double complete(double v);
+
+    @Override public void update(long rawTimestamp, double value) {
+      long t = roundToConsolidatedStep(rawTimestamp);
+      if (timestamp < 0) {
+        timestamp = t;
+      }
+      if (t == timestamp) {
+        // Updating the same datapoint, just apply the update
+        current = aggregate(current, value);
+        if (rawTimestamp == timestamp) {
+          // On the boundary, roll the value
+          previous = complete(current);
+          current = Double.NaN;
+          timestamp = t + step;
+        }
+      } else if (t > timestamp) {
+        if (t - timestamp == step) {
+          // Previous time interval
+          previous = complete(current);
+        } else {
+          // Gap in the data, clear out the previous sample
+          previous = Double.NaN;
+        }
+        current = value;
+        timestamp = t;
+      }
+    }
+
+    @Override public double value(long t) {
+      return (timestamp - t == step) ? previous : Double.NaN;
+    }
+
+    @Override public boolean isEmpty() {
+      return Double.isNaN(previous) && Double.isNaN(current);
+    }
+  }
+
+  /**
+   * Averages the raw values. The denominator will always be the multiple so missing data
+   * for some intervals will be treated as a zero. For counters this should give an accurate
+   * average rate per second across the consolidated interval.
+   */
+  final class Avg extends AbstractConsolidator {
+
+    Avg(long step, int multiple) {
+      super(step, multiple);
+    }
+
+    @Override protected double aggregate(double v1, double v2) {
+      return Double.isNaN(v1) ? v2 : Double.isNaN(v2) ? v1 : v1 + v2;
+    }
+
+    @Override protected double complete(double v) {
+      return v / multiple;
+    }
+  }
+
+  /**
+   * Selects the maximum value that is reported. Used for max gauges and similar types to
+   * preserve the overall max.
+   */
+  final class Max extends AbstractConsolidator {
+
+    Max(long step, int multiple) {
+      super(step, multiple);
+    }
+
+    @Override protected double aggregate(double v1, double v2) {
+      return Double.isNaN(v1) ? v2 : Double.isNaN(v2) ? v1 : Math.max(v1, v2);
+    }
+
+    @Override protected double complete(double v) {
+      return v;
+    }
+  }
+
+  /**
+   * Selects the last value that is reported. This is used for normal gauges to preserve the
+   * local behavior of a normal gauge collected with the consolidated step.
+   */
+  final class Last extends AbstractConsolidator {
+
+    Last(long step, int multiple) {
+      super(step, multiple);
+    }
+
+    @Override protected double aggregate(double v1, double v2) {
+      return Double.isNaN(v2) ? v1 : v2;
+    }
+
+    @Override protected double complete(double v) {
+      return v;
+    }
+  }
+}

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Subscriptions.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Subscriptions.java
@@ -57,7 +57,7 @@ public final class Subscriptions {
     // Update expiration time for existing subs and log new ones
     for (Subscription sub : expressions) {
       if (subs.put(sub, expirationTime) == null) {
-        LOGGER.info("new subscription: {}", sub);
+        LOGGER.debug("new subscription: {}", sub);
       }
     }
 
@@ -66,7 +66,7 @@ public final class Subscriptions {
     while (it.hasNext()) {
       Map.Entry<Subscription, Long> entry = it.next();
       if (entry.getValue() < currentTime) {
-        LOGGER.info("expired: {}", entry.getKey());
+        LOGGER.debug("expired: {}", entry.getKey());
         it.remove();
       }
     }

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/RollupsTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/RollupsTest.java
@@ -56,7 +56,7 @@ public class RollupsTest {
     for (int i = 0; i < 10; ++i) {
       registry.counter("test", "i", "" + i).increment();
     }
-    clock.setWallTime(60000);
+    clock.setWallTime(5000);
     List<Measurement> input = registry.getMeasurements().collect(Collectors.toList());
     List<Measurement> aggr = Rollups.aggregate(this::removeIdxTag, input);
     Assertions.assertEquals(1, aggr.size());
@@ -66,7 +66,7 @@ public class RollupsTest {
         .withTag("atlas.dstype", "rate")
         .withTag(Statistic.count);
     Assertions.assertEquals(id, m.id());
-    Assertions.assertEquals(10.0 / 60.0, m.value(), 1e-12);
+    Assertions.assertEquals(10.0 / 5.0, m.value(), 1e-12);
   }
 
   @Test
@@ -74,7 +74,7 @@ public class RollupsTest {
     for (int i = 0; i < 10; ++i) {
       registry.gauge("test", "i", "" + i).set(2.0);
     }
-    clock.setWallTime(60000);
+    clock.setWallTime(5000);
     List<Measurement> input = registry.getMeasurements().collect(Collectors.toList());
     List<Measurement> aggr = Rollups.aggregate(this::removeIdxTag, input);
     Assertions.assertEquals(1, aggr.size());
@@ -93,7 +93,7 @@ public class RollupsTest {
       double v = (i % 2 == 0) ? i : Double.NaN;
       registry.gauge("test", "i", "" + i).set(v);
     }
-    clock.setWallTime(60000);
+    clock.setWallTime(5000);
     List<Measurement> input = registry.getMeasurements().collect(Collectors.toList());
     List<Measurement> aggr = Rollups.aggregate(this::removeIdxTag, input);
     Assertions.assertEquals(1, aggr.size());
@@ -111,7 +111,7 @@ public class RollupsTest {
     for (int i = 0; i < 10; ++i) {
       registry.timer("test", "i", "" + i).record(i, TimeUnit.SECONDS);
     }
-    clock.setWallTime(60000);
+    clock.setWallTime(5000);
     List<Measurement> input = registry.getMeasurements().collect(Collectors.toList());
     List<Measurement> aggr = Rollups.aggregate(this::removeIdxTag, input);
     Assertions.assertEquals(4, aggr.size());
@@ -122,17 +122,17 @@ public class RollupsTest {
         case "count":
           id = id.withTag("atlas.dstype", "rate").withTag(Statistic.count);
           Assertions.assertEquals(id, m.id());
-          Assertions.assertEquals(10.0 / 60.0, m.value(), 1e-12);
+          Assertions.assertEquals(10.0 / 5.0, m.value(), 1e-12);
           break;
         case "totalTime":
           id = id.withTag("atlas.dstype", "rate").withTag(Statistic.totalTime);
           Assertions.assertEquals(id, m.id());
-          Assertions.assertEquals(45.0 / 60.0, m.value(), 1e-12);
+          Assertions.assertEquals(45.0 / 5.0, m.value(), 1e-12);
           break;
         case "totalOfSquares":
           id = id.withTag("atlas.dstype", "rate").withTag(Statistic.totalOfSquares);
           Assertions.assertEquals(id, m.id());
-          Assertions.assertEquals(285.0 / 60.0, m.value(), 1e-12);
+          Assertions.assertEquals(285.0 / 5.0, m.value(), 1e-12);
           break;
         case "max":
           id = id.withTag("atlas.dstype", "gauge").withTag(Statistic.max);
@@ -151,7 +151,7 @@ public class RollupsTest {
     for (int i = 0; i < 10; ++i) {
       registry.distributionSummary("test", "i", "" + i).record(i);
     }
-    clock.setWallTime(60000);
+    clock.setWallTime(5000);
     List<Measurement> input = registry.getMeasurements().collect(Collectors.toList());
     List<Measurement> aggr = Rollups.aggregate(this::removeIdxTag, input);
     Assertions.assertEquals(4, aggr.size());
@@ -162,17 +162,17 @@ public class RollupsTest {
         case "count":
           id = id.withTag("atlas.dstype", "rate").withTag(Statistic.count);
           Assertions.assertEquals(id, m.id());
-          Assertions.assertEquals(10.0 / 60.0, m.value(), 1e-12);
+          Assertions.assertEquals(10.0 / 5.0, m.value(), 1e-12);
           break;
         case "totalAmount":
           id = id.withTag("atlas.dstype", "rate").withTag(Statistic.totalAmount);
           Assertions.assertEquals(id, m.id());
-          Assertions.assertEquals(45.0 / 60.0, m.value(), 1e-12);
+          Assertions.assertEquals(45.0 / 5.0, m.value(), 1e-12);
           break;
         case "totalOfSquares":
           id = id.withTag("atlas.dstype", "rate").withTag(Statistic.totalOfSquares);
           Assertions.assertEquals(id, m.id());
-          Assertions.assertEquals(285.0 / 60.0, m.value(), 1e-12);
+          Assertions.assertEquals(285.0 / 5.0, m.value(), 1e-12);
           break;
         case "max":
           id = id.withTag("atlas.dstype", "gauge").withTag(Statistic.max);

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/ConsolidatorTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/ConsolidatorTest.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas.impl;
+
+import com.netflix.spectator.api.Clock;
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.Gauge;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.ManualClock;
+import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.Statistic;
+import com.netflix.spectator.atlas.AtlasRegistry;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import java.util.function.DoubleConsumer;
+import java.util.function.Supplier;
+
+public class ConsolidatorTest {
+
+  private static final long TTL = 15L * 60L * 1000L;
+  private static final long PRIMARY_STEP = 5L * 1000L;
+  private static final long CONSOLIDATED_STEP = 60L * 1000L;
+  private static final int MULTIPLE = (int) (CONSOLIDATED_STEP / PRIMARY_STEP);
+
+  private AtlasRegistry registry(Clock clock, long step) {
+    Map<String, String> config = new HashMap<>();
+    config.put("atlas.meterTTL", Duration.ofMillis(TTL).toString());
+    config.put("atlas.step", Duration.ofMillis(step).toString());
+    config.put("atlas.lwc.step", Duration.ofMillis(step).toString());
+    return new AtlasRegistry(clock, config::get);
+  }
+
+  @Test
+  public void avgNormalOperation() {
+    Consolidator consolidator = new Consolidator.Avg(CONSOLIDATED_STEP, MULTIPLE);
+    for (int i = 0; i < 10; ++i) {
+      long baseTimestamp = i * CONSOLIDATED_STEP;
+      for (int j = 0; j < MULTIPLE; ++j) {
+        consolidator.update(baseTimestamp + j * PRIMARY_STEP, j);
+      }
+      Assertions.assertEquals(i == 0 ? 0.0 : 5.5, consolidator.value(baseTimestamp), 1e-8);
+    }
+  }
+
+  @Test
+  public void avgMissingPrimaryValues() {
+    Consolidator consolidator = new Consolidator.Avg(CONSOLIDATED_STEP, MULTIPLE);
+    consolidator.update(30000, 12.0);
+    consolidator.update(60000, Double.NaN);
+    Assertions.assertEquals(1.0, consolidator.value(60000));
+  }
+
+  @Test
+  public void avgSingleStepGap() {
+    Consolidator consolidator = new Consolidator.Avg(CONSOLIDATED_STEP, MULTIPLE);
+    consolidator.update(30000, 12.0);
+    consolidator.update(110000, 12.0);
+    Assertions.assertEquals(1.0, consolidator.value(60000));
+    consolidator.update(120000, Double.NaN);
+    Assertions.assertEquals(1.0, consolidator.value(120000));
+  }
+
+  @Test
+  public void avgManyStepGap() {
+    Consolidator consolidator = new Consolidator.Avg(CONSOLIDATED_STEP, MULTIPLE);
+    consolidator.update(30000, 12.0);
+    consolidator.update(360000, 12.0);
+    Assertions.assertTrue(Double.isNaN(consolidator.value(60000)));
+    Assertions.assertTrue(Double.isNaN(consolidator.value(360000)));
+  }
+
+  @Test
+  public void avgBackInTime() {
+    Consolidator consolidator = new Consolidator.Avg(CONSOLIDATED_STEP, MULTIPLE);
+    consolidator.update(360000, 12.0);
+    consolidator.update(350000, 12.0);
+    Assertions.assertEquals(1.0, consolidator.value(360000), 1e-8);
+  }
+
+  @Test
+  public void avgEmpty() {
+    Consolidator consolidator = new Consolidator.Avg(CONSOLIDATED_STEP, MULTIPLE);
+    Assertions.assertTrue(consolidator.isEmpty());
+    consolidator.update(30000, 12.0);
+    Assertions.assertFalse(consolidator.isEmpty());
+    consolidator.update(150000, Double.NaN);
+    Assertions.assertTrue(consolidator.isEmpty());
+  }
+
+  @Test
+  public void noneEmpty() {
+    Consolidator consolidator = new Consolidator.None();
+    Assertions.assertTrue(consolidator.isEmpty());
+    consolidator.update(30000, 12.0);
+    Assertions.assertFalse(consolidator.isEmpty());
+    consolidator.update(150000, Double.NaN);
+    Assertions.assertTrue(consolidator.isEmpty());
+  }
+
+  private void consolidateRandomData(
+      Id id,
+      Id measurementId,
+      ManualClock clock,
+      Consolidator consolidator,
+      DoubleConsumer primary,
+      DoubleConsumer consolidated,
+      Supplier<Iterable<Measurement>> primaryMeasure,
+      Supplier<Iterable<Measurement>> consolidatedMeasure) {
+
+    Random r = new Random(42);
+
+    for (int i = 0; i < 3600; ++i) {
+      long t = i * 1000L;
+      clock.setWallTime(t);
+      int v = r.nextInt(10_000);
+      primary.accept(v);
+      consolidated.accept(v);
+      if (t % PRIMARY_STEP == 0L) {
+        for (Measurement m : primaryMeasure.get()) {
+          consolidator.update(m);
+        }
+      }
+      if (t % CONSOLIDATED_STEP == 0L) {
+        Measurement actual = new Measurement(measurementId, t, consolidator.value(t));
+        for (Measurement m : consolidatedMeasure.get()) {
+          Assertions.assertEquals(m.id(), actual.id());
+          Assertions.assertEquals(m.timestamp(), actual.timestamp());
+          Assertions.assertEquals(m.value(), actual.value(), 1e-8);
+        }
+      }
+
+      // Simulate a gap
+      if (i == 968) {
+        i += 360;
+      }
+    }
+  }
+
+  @Test
+  public void avgRandom() {
+    Id id = Id.create("test");
+    Id measurementId = id.withTag("atlas.dstype", "rate").withTag(Statistic.count);
+    ManualClock clock = new ManualClock();
+
+    Counter primary = registry(clock, PRIMARY_STEP).counter(id);
+    Counter consolidated = registry(clock, CONSOLIDATED_STEP).counter(id);
+
+    Consolidator consolidator = new Consolidator.Avg(CONSOLIDATED_STEP, MULTIPLE);
+
+    consolidateRandomData(
+        id,
+        measurementId,
+        clock,
+        consolidator,
+        primary::add,
+        consolidated::add,
+        primary::measure,
+        consolidated::measure);
+  }
+
+  @Test
+  public void maxRandom() {
+    Id id = Id.create("test");
+    Id measurementId = id.withTag("atlas.dstype", "gauge").withTag(Statistic.max);
+    ManualClock clock = new ManualClock();
+
+    Gauge primary = registry(clock, PRIMARY_STEP).maxGauge(id);
+    Gauge consolidated = registry(clock, CONSOLIDATED_STEP).maxGauge(id);
+
+    Consolidator consolidator = new Consolidator.Max(CONSOLIDATED_STEP, MULTIPLE);
+
+    consolidateRandomData(
+        id,
+        measurementId,
+        clock,
+        consolidator,
+        primary::set,
+        consolidated::set,
+        primary::measure,
+        consolidated::measure);
+  }
+
+  @Test
+  public void lastRandom() {
+    Id id = Id.create("test");
+    Id measurementId = id.withTag("atlas.dstype", "gauge").withTag(Statistic.gauge);
+    ManualClock clock = new ManualClock();
+
+    Gauge primary = registry(clock, PRIMARY_STEP).gauge(id);
+    Gauge consolidated = registry(clock, CONSOLIDATED_STEP).gauge(id);
+
+    Consolidator consolidator = new Consolidator.Last(CONSOLIDATED_STEP, MULTIPLE);
+
+    consolidateRandomData(
+        id,
+        measurementId,
+        clock,
+        consolidator,
+        primary::set,
+        consolidated::set,
+        primary::measure,
+        consolidated::measure);
+  }
+
+  @Test
+  public void noneRandom() {
+    Id id = Id.create("test");
+    Id measurementId = id.withTag("atlas.dstype", "rate").withTag(Statistic.count);
+    ManualClock clock = new ManualClock();
+
+    Counter primary = registry(clock, CONSOLIDATED_STEP).counter(id);
+    Counter consolidated = registry(clock, CONSOLIDATED_STEP).counter(id);
+
+    Consolidator consolidator = new Consolidator.None();
+
+    consolidateRandomData(
+        id,
+        measurementId,
+        clock,
+        consolidator,
+        primary::add,
+        consolidated::add,
+        primary::measure,
+        consolidated::measure);
+  }
+
+  @Test
+  public void createFromStatistic() {
+    EnumSet<Statistic> counters = EnumSet.of(
+        Statistic.count,
+        Statistic.totalAmount,
+        Statistic.totalTime,
+        Statistic.totalOfSquares,
+        Statistic.percentile);
+    EnumSet<Statistic> maxGauges = EnumSet.of(
+        Statistic.max,
+        Statistic.duration,
+        Statistic.activeTasks);
+    EnumSet<Statistic> gauges = EnumSet.of(Statistic.gauge);
+    for (Statistic statistic : Statistic.values()) {
+      Consolidator consolidator = Consolidator.create(statistic, CONSOLIDATED_STEP, MULTIPLE);
+      if (counters.contains(statistic)) {
+        Assertions.assertTrue(consolidator instanceof Consolidator.Avg, statistic.name());
+      } else if (maxGauges.contains(statistic)) {
+        Assertions.assertTrue(consolidator instanceof Consolidator.Max, statistic.name());
+      } else if (gauges.contains(statistic)) {
+        Assertions.assertTrue(consolidator instanceof Consolidator.Last, statistic.name());
+      } else {
+        Assertions.fail(statistic.name());
+      }
+    }
+  }
+
+  @Test
+  public void createFromIdCounter() {
+    Id id = Id.create("foo").withTag(Statistic.count);
+    Consolidator consolidator = Consolidator.create(id, CONSOLIDATED_STEP, MULTIPLE);
+    Assertions.assertTrue(consolidator instanceof Consolidator.Avg);
+  }
+
+  @Test
+  public void createFromIdGauge() {
+    Id id = Id.create("foo").withTag(Statistic.gauge);
+    Consolidator consolidator = Consolidator.create(id, CONSOLIDATED_STEP, MULTIPLE);
+    Assertions.assertTrue(consolidator instanceof Consolidator.Last);
+  }
+
+  @Test
+  public void createFromIdNoStatistic() {
+    Id id = Id.create("foo");
+    Consolidator consolidator = Consolidator.create(id, CONSOLIDATED_STEP, MULTIPLE);
+    Assertions.assertTrue(consolidator instanceof Consolidator.Last);
+  }
+
+  @Test
+  public void createFromIdMultipleOne() {
+    Id id = Id.create("foo");
+    Consolidator consolidator = Consolidator.create(id, CONSOLIDATED_STEP, 1);
+    Assertions.assertTrue(consolidator instanceof Consolidator.None);
+  }
+}

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/EvaluatorTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/EvaluatorTest.java
@@ -16,6 +16,7 @@
 package com.netflix.spectator.atlas.impl;
 
 import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.ManualClock;
 import com.netflix.spectator.api.Measurement;
 import com.netflix.spectator.api.Registry;
@@ -25,10 +26,10 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 
 public class EvaluatorTest {
@@ -36,14 +37,14 @@ public class EvaluatorTest {
   private final ManualClock clock = new ManualClock();
   private final Registry registry = new DefaultRegistry(clock);
 
-  private List<TagsValuePair> data(String name, double... vs) {
+  private List<Measurement> data(String name, double... vs) {
     List<Measurement> ms = new ArrayList<>();
     for (int i = 0; i < vs.length; ++i) {
       String pos = String.format("%03d", i);
       String value = String.format("%f", vs[i]);
       ms.add(new Measurement(registry.createId(name, "i", pos, "v", value), 0L, vs[i]));
     }
-    return ms.stream().map(this::newTagsValuePair).collect(Collectors.toList());
+    return ms;
   }
 
   private TagsValuePair newTagsValuePair(Measurement m) {
@@ -55,10 +56,41 @@ public class EvaluatorTest {
     return new TagsValuePair(tags, m.value());
   }
 
+  private Map<String, String> toMap(Id id) {
+    Map<String, String> tags = new HashMap<>();
+    for (Tag t : id.tags()) {
+      tags.put(t.key(), t.value());
+    }
+    tags.put("name", id.name());
+    return tags;
+  }
+
+  private Evaluator newEvaluator(String... commonTags) {
+    return new Evaluator(tags(commonTags), this::toMap, 5000);
+  }
+
+  private Map<String, String> tags(String... ts) {
+    Map<String, String> map = new HashMap<>();
+    for (int i = 0; i < ts.length; i += 2) {
+      map.put(ts[i], ts[i + 1]);
+    }
+    return map;
+  }
+
+  private Subscription newSubscription(String name, String expr) {
+    return new Subscription().withId(name).withExpression(expr).withFrequency(5000);
+  }
+
+  private EvalPayload sort(EvalPayload p) {
+    List<EvalPayload.Metric> ms = p.getMetrics();
+    ms.sort(Comparator.comparing(EvalPayload.Metric::getId));
+    return new EvalPayload(p.getTimestamp(), p.getMetrics());
+  }
+
   @Test
   public void noSubsForGroup() {
-    Evaluator evaluator = new Evaluator();
-    EvalPayload payload = evaluator.eval("test", 0L, Collections.emptyList());
+    Evaluator evaluator = newEvaluator();
+    EvalPayload payload = evaluator.eval(0L);
     EvalPayload expected = new EvalPayload(0L, Collections.emptyList());
     Assertions.assertEquals(expected, payload);
   }
@@ -66,31 +98,18 @@ public class EvaluatorTest {
   @Test
   public void sumAndMaxForGroup() {
     List<Subscription> subs = new ArrayList<>();
-    subs.add(new Subscription().withId("sum").withExpression(":true,:sum"));
-    subs.add(new Subscription().withId("max").withExpression(":true,:max"));
+    subs.add(newSubscription("sum", ":true,:sum"));
+    subs.add(newSubscription("max", ":true,:max"));
 
-    Evaluator evaluator = new Evaluator().addGroupSubscriptions("local", subs);
-    EvalPayload payload = evaluator.eval("local", 0L, data("foo", 1.0, 2.0, 3.0));
+    Evaluator evaluator = newEvaluator();
+    evaluator.sync(subs);
+    EvalPayload payload = evaluator.eval(0L, data("foo", 1.0, 2.0, 3.0));
 
     List<EvalPayload.Metric> metrics = new ArrayList<>();
-    metrics.add(new EvalPayload.Metric("sum", Collections.emptyMap(), 6.0));
     metrics.add(new EvalPayload.Metric("max", Collections.emptyMap(), 3.0));
+    metrics.add(new EvalPayload.Metric("sum", Collections.emptyMap(), 6.0));
     EvalPayload expected = new EvalPayload(0L, metrics);
-    Assertions.assertEquals(expected, payload);
-  }
-
-  @Test
-  public void removeSub() {
-    List<Subscription> subs = new ArrayList<>();
-    subs.add(new Subscription().withId("sum").withExpression(":true,:sum"));
-    subs.add(new Subscription().withId("max").withExpression(":true,:max"));
-    Evaluator evaluator = new Evaluator().addGroupSubscriptions("local", subs);
-
-    evaluator.removeGroupSubscriptions("local");
-    EvalPayload payload = evaluator.eval("test", 0L, Collections.emptyList());
-
-    EvalPayload expected = new EvalPayload(0L, Collections.emptyList());
-    Assertions.assertEquals(expected, payload);
+    Assertions.assertEquals(expected, sort(payload));
   }
 
   @Test
@@ -98,9 +117,10 @@ public class EvaluatorTest {
 
     // Eval with sum
     List<Subscription> sumSub = new ArrayList<>();
-    sumSub.add(new Subscription().withId("sum").withExpression(":true,:sum"));
-    Evaluator evaluator = new Evaluator().addGroupSubscriptions("local", sumSub);
-    EvalPayload payload = evaluator.eval("local", 0L, data("foo", 1.0, 2.0, 3.0));
+    sumSub.add(newSubscription("sum", ":true,:sum"));
+    Evaluator evaluator = newEvaluator();
+    evaluator.sync(sumSub);
+    EvalPayload payload = evaluator.eval(0L, data("foo", 1.0, 2.0, 3.0));
     List<EvalPayload.Metric> metrics = new ArrayList<>();
     metrics.add(new EvalPayload.Metric("sum", Collections.emptyMap(), 6.0));
     EvalPayload expected = new EvalPayload(0L, metrics);
@@ -108,12 +128,55 @@ public class EvaluatorTest {
 
     // Update to use max instead
     List<Subscription> maxSub = new ArrayList<>();
-    maxSub.add(new Subscription().withId("sum").withExpression(":true,:max"));
-    evaluator.addGroupSubscriptions("local", maxSub);
-    payload = evaluator.eval("local", 0L, data("foo", 1.0, 2.0, 3.0));
+    maxSub.add(newSubscription("sum", ":true,:max"));
+    evaluator.sync(maxSub);
+    payload = evaluator.eval(0L, data("foo", 1.0, 2.0, 3.0));
     metrics = new ArrayList<>();
     metrics.add(new EvalPayload.Metric("sum", Collections.emptyMap(), 3.0));
     expected = new EvalPayload(0L, metrics);
+    Assertions.assertEquals(expected, payload);
+  }
+
+  @Test
+  public void commonTagsMatch() {
+    List<Subscription> subs = new ArrayList<>();
+    subs.add(newSubscription("sum", "app,www,:eq,name,foo,:eq,:and,:sum"));
+
+    Evaluator evaluator = newEvaluator("app", "www");
+    evaluator.sync(subs);
+    EvalPayload payload = evaluator.eval(0L, data("foo", 1.0, 2.0, 3.0));
+
+    List<EvalPayload.Metric> metrics = new ArrayList<>();
+    metrics.add(new EvalPayload.Metric("sum", tags("app", "www", "name", "foo"), 6.0));
+    EvalPayload expected = new EvalPayload(0L, metrics);
+    Assertions.assertEquals(expected, payload);
+  }
+
+  @Test
+  public void commonTagsNoMatch() {
+    List<Subscription> subs = new ArrayList<>();
+    subs.add(newSubscription("sum", "app,abc,:eq,name,foo,:eq,:and,:sum"));
+
+    Evaluator evaluator = newEvaluator("app", "www");
+    evaluator.sync(subs);
+    EvalPayload payload = evaluator.eval(0L, data("foo", 1.0, 2.0, 3.0));
+
+    EvalPayload expected = new EvalPayload(0L, Collections.emptyList());
+    Assertions.assertEquals(expected, payload);
+  }
+
+  @Test
+  public void commonTagsGroupBy() {
+    List<Subscription> subs = new ArrayList<>();
+    subs.add(newSubscription("sum", "name,foo,:eq,:sum,(,app,),:by"));
+
+    Evaluator evaluator = newEvaluator("app", "www");
+    evaluator.sync(subs);
+    EvalPayload payload = evaluator.eval(0L, data("foo", 1.0, 2.0, 3.0));
+
+    List<EvalPayload.Metric> metrics = new ArrayList<>();
+    metrics.add(new EvalPayload.Metric("sum", tags("app", "www", "name", "foo"), 6.0));
+    EvalPayload expected = new EvalPayload(0L, metrics);
     Assertions.assertEquals(expected, payload);
   }
 }


### PR DESCRIPTION
Updates the LWC integration to support subscribing to
expressions with various step sizes. The meters will
collect data with a base step size. LWC subscriptions
can use any even multiple of that. The data to publish
to Atlas storage will be generated by consolidating the
measurements collected with the base LWC step. The step
size used for publishing must be greater than or equal
and an even multiple of the base LWC step.