### PR TITLE
add setting to ignore the publish step

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasConfig.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasConfig.java
@@ -103,11 +103,11 @@ public interface AtlasConfig extends RegistryConfig {
   /**
    * Returns true if expressions with the same step size as Atlas publishing should be
    * ignored for streaming. This is used for cases where data being published to Atlas
-   * is also sent into streaming from the backend. Default is false.
+   * is also sent into streaming from the backend. Default is true.
    */
   default boolean lwcIgnorePublishStep() {
     String v = get("atlas.lwc.ignore-publish-step");
-    return v != null && Boolean.valueOf(v);
+    return v == null || Boolean.valueOf(v);
   }
 
   /** Returns the frequency for refreshing config settings from the LWC service. */

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasConfig.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasConfig.java
@@ -100,6 +100,16 @@ public interface AtlasConfig extends RegistryConfig {
     return v != null && Boolean.valueOf(v);
   }
 
+  /**
+   * Returns true if expressions with the same step size as Atlas publishing should be
+   * ignored for streaming. This is used for cases where data being published to Atlas
+   * is also sent into streaming from the backend. Default is false.
+   */
+  default boolean lwcIgnorePublishStep() {
+    String v = get("atlas.lwc.ignore-publish-step");
+    return v != null && Boolean.valueOf(v);
+  }
+
   /** Returns the frequency for refreshing config settings from the LWC service. */
   default Duration configRefreshFrequency() {
     String v = get("atlas.configRefreshFrequency");

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/SubscriptionManager.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/SubscriptionManager.java
@@ -44,6 +44,8 @@ class SubscriptionManager {
   private final int connectTimeout;
   private final int readTimeout;
   private final long stepMillis;
+  private final long lwcStepMillis;
+  private final boolean ignorePublishStep;
 
   private final long configTTL;
 
@@ -60,7 +62,9 @@ class SubscriptionManager {
     this.uri = URI.create(config.configUri());
     this.connectTimeout = (int) config.connectTimeout().toMillis();
     this.readTimeout = (int) config.readTimeout().toMillis();
-    this.stepMillis = config.lwcStep().toMillis();
+    this.stepMillis = config.step().toMillis();
+    this.lwcStepMillis = config.lwcStep().toMillis();
+    this.ignorePublishStep = config.lwcIgnorePublishStep();
     this.configTTL = config.configTTL().toMillis();
   }
 
@@ -112,6 +116,6 @@ class SubscriptionManager {
   }
 
   private boolean isSupportedFrequency(long s) {
-    return s >= stepMillis && s % stepMillis == 0;
+    return s >= lwcStepMillis && s % lwcStepMillis == 0 && (s != stepMillis || ignorePublishStep);
   }
 }

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/SubscriptionManagerTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/SubscriptionManagerTest.java
@@ -58,9 +58,7 @@ public class SubscriptionManagerTest {
         return responses[pos.getAndIncrement()];
       }
     };
-    Map<String, String> config = new HashMap<>();
-    config.put("atlas.lwc.ignore-publish-step", "true");
-    return new SubscriptionManager(mapper, client, clock, config::get);
+    return new SubscriptionManager(mapper, client, clock, v -> null);
   }
 
   private Set<Subscription> set(Subscription... subs) {
@@ -110,7 +108,9 @@ public class SubscriptionManagerTest {
         return ok(data);
       }
     };
-    SubscriptionManager mgr = new SubscriptionManager(mapper, client, clock, v -> null);
+    Map<String, String> config = new HashMap<>();
+    config.put("atlas.lwc.ignore-publish-step", "false");
+    SubscriptionManager mgr = new SubscriptionManager(mapper, client, clock, config::get);
     mgr.refresh();
     Assertions.assertTrue(mgr.subscriptions().isEmpty());
   }


### PR DESCRIPTION
For cases where data going through the normal publish path
is already forwared to LWC on the backend, the client should
not send directly for those step sizes.