### PR TITLE
add Registry method to get stream of measurements

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/Registry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/Registry.java
@@ -755,6 +755,18 @@ public interface Registry extends Iterable<Meter> {
     methodValue(createId(name), obj, method);
   }
 
+  /**
+   * Returns a stream with the current flattened set of measurements across all meters.
+   * This should typically be preferred over {@link #stream()} to get the data as it will
+   * automatically handle expired meters, NaN values, etc.
+   */
+  default Stream<Measurement> measurements() {
+    return stream()
+        .filter(m -> !m.hasExpired())
+        .flatMap(m -> StreamSupport.stream(m.measure().spliterator(), false))
+        .filter(m -> !Double.isNaN(m.value()));
+  }
+
   /** Returns a stream of all registered meters. */
   default Stream<Meter> stream() {
     return StreamSupport.stream(spliterator(), false);

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
@@ -53,8 +53,6 @@ import java.util.Optional;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 import java.util.zip.Deflater;
 
 /**
@@ -304,7 +302,7 @@ public final class AtlasRegistry extends AbstractRegistry implements AutoCloseab
   synchronized void pollMeters(long t) {
     if (t > lastPollTimestamp) {
       logger.debug("collecting data for time: {}", t);
-      getMeasurements().forEach(m -> {
+      measurements().forEach(m -> {
         if ("jvm.gc.pause".equals(m.id().name())) {
           logger.trace("received measurement for time: {}: {}", t, m);
         }
@@ -385,14 +383,6 @@ public final class AtlasRegistry extends AbstractRegistry implements AutoCloseab
     tags.put("name", name);
 
     return tags;
-  }
-
-  /** Get a list of all measurements from the registry. */
-  Stream<Measurement> getMeasurements() {
-    return stream()
-        .filter(m -> !m.hasExpired())
-        .flatMap(m -> StreamSupport.stream(m.measure().spliterator(), false))
-        .filter(m -> !Double.isNaN(m.value()));
   }
 
   /**

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasRegistryTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasRegistryTest.java
@@ -54,7 +54,7 @@ public class AtlasRegistryTest {
   }
 
   private List<Measurement> getMeasurements() {
-    return registry.getMeasurements().collect(Collectors.toList());
+    return registry.measurements().collect(Collectors.toList());
   }
 
   private List<List<Measurement>> getBatches() {

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/RollupsTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/RollupsTest.java
@@ -57,7 +57,7 @@ public class RollupsTest {
       registry.counter("test", "i", "" + i).increment();
     }
     clock.setWallTime(5000);
-    List<Measurement> input = registry.getMeasurements().collect(Collectors.toList());
+    List<Measurement> input = registry.measurements().collect(Collectors.toList());
     List<Measurement> aggr = Rollups.aggregate(this::removeIdxTag, input);
     Assertions.assertEquals(1, aggr.size());
 
@@ -75,7 +75,7 @@ public class RollupsTest {
       registry.gauge("test", "i", "" + i).set(2.0);
     }
     clock.setWallTime(5000);
-    List<Measurement> input = registry.getMeasurements().collect(Collectors.toList());
+    List<Measurement> input = registry.measurements().collect(Collectors.toList());
     List<Measurement> aggr = Rollups.aggregate(this::removeIdxTag, input);
     Assertions.assertEquals(1, aggr.size());
 
@@ -94,7 +94,7 @@ public class RollupsTest {
       registry.gauge("test", "i", "" + i).set(v);
     }
     clock.setWallTime(5000);
-    List<Measurement> input = registry.getMeasurements().collect(Collectors.toList());
+    List<Measurement> input = registry.measurements().collect(Collectors.toList());
     List<Measurement> aggr = Rollups.aggregate(this::removeIdxTag, input);
     Assertions.assertEquals(1, aggr.size());
 
@@ -112,7 +112,7 @@ public class RollupsTest {
       registry.timer("test", "i", "" + i).record(i, TimeUnit.SECONDS);
     }
     clock.setWallTime(5000);
-    List<Measurement> input = registry.getMeasurements().collect(Collectors.toList());
+    List<Measurement> input = registry.measurements().collect(Collectors.toList());
     List<Measurement> aggr = Rollups.aggregate(this::removeIdxTag, input);
     Assertions.assertEquals(4, aggr.size());
 
@@ -152,7 +152,7 @@ public class RollupsTest {
       registry.distributionSummary("test", "i", "" + i).record(i);
     }
     clock.setWallTime(5000);
-    List<Measurement> input = registry.getMeasurements().collect(Collectors.toList());
+    List<Measurement> input = registry.measurements().collect(Collectors.toList());
     List<Measurement> aggr = Rollups.aggregate(this::removeIdxTag, input);
     Assertions.assertEquals(4, aggr.size());
 


### PR DESCRIPTION
Adds a Registry method to get a flattened stream of
measurements rather than having to compute that from the
set of meters. This is the most common data access pattern
and the details of this get a bit more complex with the
support for variable frequencies in AtlasRegistry for LWC.

For now it uses a simple implementation, an override will
be added to AtlasRegistry in a later PR.