### PR TITLE
update measurements() to use publish step

### DIFF
--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/RollupsTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/RollupsTest.java
@@ -38,7 +38,7 @@ public class RollupsTest {
   @BeforeEach
   public void before() {
     clock = new ManualClock();
-    registry = new AtlasRegistry(clock, k -> null);
+    registry = new AtlasRegistry(clock, k -> "atlas.step".equals(k) ? "PT5S" : null);
   }
 
   private Id removeIdxTag(Id id) {


### PR DESCRIPTION
The collector for the set of measurements will now get the
same step and values as publishing to Atlas storage.