### PR TITLE
avoid exceptions if map is modified concurrently

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/Id.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/Id.java
@@ -122,7 +122,14 @@ public interface Id extends TagList {
     return tmp;
   }
 
-  /** Return a new id with additional tag values. */
+  /**
+   * Return a new id with additional tag values.
+   *
+   * If using a {@link java.util.concurrent.ConcurrentMap}, note that the map <strong>should
+   * not</strong> be concurrently modified during this call. It is up to the user to ensure
+   * that it contains the correct set of tags that should be added to the id before and for the
+   * entire duration of the call until the new id is returned.
+   */
   default Id withTags(Map<String, String> tags) {
     Id tmp = this;
     for (Map.Entry<String, String> entry : tags.entrySet()) {

--- a/spectator-api/src/test/java/com/netflix/spectator/api/ArrayTagSetTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/ArrayTagSetTest.java
@@ -370,7 +370,7 @@ public class ArrayTagSetTest {
   }
 
   @Test
-  public void addAllConcurrentMapFailure() {
+  public void addAllConcurrentMapFailure() throws InterruptedException {
     // This test just checks that we do not throw if the map is being modified concurrently.
     // It seems to fail reliably when testing prior to the patch.
     // https://github.com/Netflix/spectator/issues/733
@@ -397,6 +397,8 @@ public class ArrayTagSetTest {
       }
     } finally {
       done.set(true);
+      t1.join();
+      t2.join();
     }
   }
 }


### PR DESCRIPTION
This change special cases `ConcurrentMap` to ensure that the
code will not throw if there is a concurrent modification
while it is being added to the list. A concurrent modification
should be considered a bug in the caller, but it should not
propagate and cause a bigger problem for the app. Also it
is not possible to detect all cases, only ones that fail in
a noticeable way.

The docs for `Id` have also been updated to clarify the
expectation for the user.

Fixes #733.

/cc @elandau 