### PR TITLE
make cardinality limiters serializable

### DIFF
--- a/codequality/findbugs-exclude.xml
+++ b/codequality/findbugs-exclude.xml
@@ -60,4 +60,10 @@
       <Bug pattern="SF_SWITCH_FALLTHROUGH"/>
     </And>
   </Match>
+  <Match>
+    <And>
+      <Class name="com.netflix.spectator.api.Clock"/>
+      <Bug pattern="IC_SUPERCLASS_USES_SUBCLASS_DURING_INITIALIZATION"/>
+    </And>
+  </Match>
 </FindBugsFilter>

--- a/spectator-api/src/main/java/com/netflix/spectator/api/Clock.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/Clock.java
@@ -40,13 +40,5 @@ public interface Clock {
   /**
    * Default clock implementation based on corresponding calls in {@link java.lang.System}.
    */
-  Clock SYSTEM = new Clock() {
-    @Override public long wallTime() {
-      return System.currentTimeMillis();
-    }
-
-    @Override public long monotonicTime() {
-      return System.nanoTime();
-    }
-  };
+  Clock SYSTEM = SystemClock.INSTANCE;
 }

--- a/spectator-api/src/main/java/com/netflix/spectator/api/SystemClock.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/SystemClock.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.api;
+
+/**
+ * Clock implementation that uses {@link System#currentTimeMillis()} and {@link System#nanoTime()}.
+ * Implemented as an enum to that the clock instance will be serializable if using in environments
+ * like Spark or Flink.
+ */
+enum SystemClock implements Clock {
+
+  /** Singleton instance for the system clock. */
+  INSTANCE;
+
+  @Override public long wallTime() {
+    return System.currentTimeMillis();
+  }
+
+  @Override public long monotonicTime() {
+    return System.nanoTime();
+  }
+}

--- a/spectator-api/src/main/java/com/netflix/spectator/api/patterns/CardinalityLimiters.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/patterns/CardinalityLimiters.java
@@ -18,6 +18,7 @@ package com.netflix.spectator.api.patterns;
 import com.netflix.spectator.api.Clock;
 import com.netflix.spectator.api.Utils;
 
+import java.io.Serializable;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -154,7 +155,10 @@ public final class CardinalityLimiters {
     return new RollupLimiter(n);
   }
 
-  private static class FirstLimiter implements Function<String, String> {
+  private static class FirstLimiter implements Function<String, String>, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
     private final ReentrantLock lock = new ReentrantLock();
     private final ConcurrentHashMap<String, String> values = new ConcurrentHashMap<>();
     private final AtomicInteger remaining;
@@ -200,7 +204,10 @@ public final class CardinalityLimiters {
     }
   }
 
-  private static class MostFrequentLimiter implements Function<String, String> {
+  private static class MostFrequentLimiter implements Function<String, String>, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
     // With a 10m refresh interval this is ~2h for it to return to normal if there
     // is a temporary window with lots of churn
     private static final int MAX_UPDATES = 12;
@@ -312,10 +319,11 @@ public final class CardinalityLimiters {
           .collect(Collectors.joining(","));
       return "MostFrequentLimiter(" + cutoff + "," + limiter + ",values=[" + vs + "])";
     }
-
   }
 
-  private static class RollupLimiter implements Function<String, String> {
+  private static class RollupLimiter implements Function<String, String>, Serializable {
+
+    private static final long serialVersionUID = 1L;
 
     private final int n;
     private final Set<String> values;
@@ -342,6 +350,11 @@ public final class CardinalityLimiters {
       } else {
         return s;
       }
+    }
+
+    @Override public String toString() {
+      final String state = rollup ? "true" : values.size()  + " of " + n;
+      return "RollupLimiter(" + state + ")";
     }
   }
 }


### PR DESCRIPTION
This can be useful when using in environments such as
Spark or Flink