### PR TITLE
always use max consolidation for gauges

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Consolidator.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Consolidator.java
@@ -117,13 +117,8 @@ public interface Consolidator {
       case "percentile":
         consolidator = new Avg(step, multiple);
         break;
-      case "max":
-      case "duration":
-      case "activeTasks":
-        consolidator = new Max(step, multiple);
-        break;
       default:
-        consolidator = new Last(step, multiple);
+        consolidator = new Max(step, multiple);
         break;
     }
     return consolidator;
@@ -260,25 +255,6 @@ public interface Consolidator {
 
     @Override protected double aggregate(double v1, double v2) {
       return Double.isNaN(v1) ? v2 : Double.isNaN(v2) ? v1 : Math.max(v1, v2);
-    }
-
-    @Override protected double complete(double v) {
-      return v;
-    }
-  }
-
-  /**
-   * Selects the last value that is reported. This is used for normal gauges to preserve the
-   * local behavior of a normal gauge collected with the consolidated step.
-   */
-  final class Last extends AbstractConsolidator {
-
-    Last(long step, int multiple) {
-      super(step, multiple);
-    }
-
-    @Override protected double aggregate(double v1, double v2) {
-      return Double.isNaN(v2) ? v1 : v2;
     }
 
     @Override protected double complete(double v) {

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/ConsolidatorTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/ConsolidatorTest.java
@@ -197,27 +197,6 @@ public class ConsolidatorTest {
   }
 
   @Test
-  public void lastRandom() {
-    Id id = Id.create("test");
-    Id measurementId = id.withTag("atlas.dstype", "gauge").withTag(Statistic.gauge);
-    ManualClock clock = new ManualClock();
-
-    Gauge primary = registry(clock, PRIMARY_STEP).gauge(id);
-    Gauge consolidated = registry(clock, CONSOLIDATED_STEP).gauge(id);
-
-    Consolidator consolidator = new Consolidator.Last(CONSOLIDATED_STEP, MULTIPLE);
-
-    consolidateRandomData(
-        measurementId,
-        clock,
-        consolidator,
-        primary::set,
-        consolidated::set,
-        primary::measure,
-        consolidated::measure);
-  }
-
-  @Test
   public void noneRandom() {
     Id id = Id.create("test");
     Id measurementId = id.withTag("atlas.dstype", "rate").withTag(Statistic.count);
@@ -246,21 +225,12 @@ public class ConsolidatorTest {
         Statistic.totalTime,
         Statistic.totalOfSquares,
         Statistic.percentile);
-    EnumSet<Statistic> maxGauges = EnumSet.of(
-        Statistic.max,
-        Statistic.duration,
-        Statistic.activeTasks);
-    EnumSet<Statistic> gauges = EnumSet.of(Statistic.gauge);
     for (Statistic statistic : Statistic.values()) {
       Consolidator consolidator = Consolidator.create(statistic, CONSOLIDATED_STEP, MULTIPLE);
       if (counters.contains(statistic)) {
         Assertions.assertTrue(consolidator instanceof Consolidator.Avg, statistic.name());
-      } else if (maxGauges.contains(statistic)) {
-        Assertions.assertTrue(consolidator instanceof Consolidator.Max, statistic.name());
-      } else if (gauges.contains(statistic)) {
-        Assertions.assertTrue(consolidator instanceof Consolidator.Last, statistic.name());
       } else {
-        Assertions.fail(statistic.name());
+        Assertions.assertTrue(consolidator instanceof Consolidator.Max, statistic.name());
       }
     }
   }
@@ -276,14 +246,14 @@ public class ConsolidatorTest {
   public void createFromIdGauge() {
     Id id = Id.create("foo").withTag(Statistic.gauge);
     Consolidator consolidator = Consolidator.create(id, CONSOLIDATED_STEP, MULTIPLE);
-    Assertions.assertTrue(consolidator instanceof Consolidator.Last);
+    Assertions.assertTrue(consolidator instanceof Consolidator.Max);
   }
 
   @Test
   public void createFromIdNoStatistic() {
     Id id = Id.create("foo");
     Consolidator consolidator = Consolidator.create(id, CONSOLIDATED_STEP, MULTIPLE);
-    Assertions.assertTrue(consolidator instanceof Consolidator.Last);
+    Assertions.assertTrue(consolidator instanceof Consolidator.Max);
   }
 
   @Test


### PR DESCRIPTION
This makes the local behavior consistent with how
aggregation works if an automatic rollup is applied
to the data.