### PR TITLE
make size of sender pool configurable

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasConfig.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasConfig.java
@@ -65,11 +65,11 @@ public interface AtlasConfig extends RegistryConfig {
 
   /**
    * Returns the number of threads to use with the scheduler. The default is
-   * 2 threads.
+   * 4 threads.
    */
   default int numThreads() {
     String v = get("atlas.numThreads");
-    return (v == null) ? 2 : Integer.parseInt(v);
+    return (v == null) ? 4 : Integer.parseInt(v);
   }
 
   /**

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
@@ -183,7 +183,7 @@ public final class AtlasRegistry extends AbstractRegistry implements AutoCloseab
           return t;
         }
       };
-      senderPool = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors(), factory);
+      senderPool = Executors.newFixedThreadPool(numThreads, factory);
 
       // Setup main collection for publishing to Atlas
       Scheduler.Options options = new Scheduler.Options()


### PR DESCRIPTION
For now share this setting with the existing num threads
for the scheduler. In the future this may get refactored
so need to be careful how it impacts the public api.