### PR TITLE
add timers for publish tasks

### DIFF
--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/RollupsTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/RollupsTest.java
@@ -18,6 +18,8 @@ package com.netflix.spectator.atlas;
 import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.ManualClock;
 import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.NoopRegistry;
+import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Statistic;
 import com.netflix.spectator.api.Tag;
 import com.netflix.spectator.api.Utils;
@@ -38,7 +40,16 @@ public class RollupsTest {
   @BeforeEach
   public void before() {
     clock = new ManualClock();
-    registry = new AtlasRegistry(clock, k -> "atlas.step".equals(k) ? "PT5S" : null);
+    AtlasConfig config = new AtlasConfig() {
+      @Override public String get(String k) {
+        return "atlas.step".equals(k) ? "PT5S" : null;
+      }
+
+      @Override public Registry debugRegistry() {
+        return new NoopRegistry();
+      }
+    };
+    registry = new AtlasRegistry(clock, config);
   }
 
   private Id removeIdxTag(Id id) {


### PR DESCRIPTION
Add timers for some of the main methods used when sending
to Atlas or to LWC. Will be used for tracking if we are
unable to collect all of the data on time.