### PR TITLE
add default implementations of new methods to Id

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/Id.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/Id.java
@@ -138,6 +138,21 @@ public interface Id extends TagList {
     return tmp;
   }
 
+  /** Return the key at the specified index. The name will be treated as position 0. */
+  @Override default String getKey(int i) {
+    return i == 0 ? "name" : Utils.getValue(tags(), i - 1).key();
+  }
+
+  /** Return the value at the specified index. The name will be treated as position 0. */
+  @Override default String getValue(int i) {
+    return i == 0 ? name() : Utils.getValue(tags(), i - 1).value();
+  }
+
+  /** Return the size, number of tags, for the id including the name. */
+  @Override default int size() {
+    return Utils.size(tags()) + 1;
+  }
+
   /**
    * Create an immutable Id with the provided name. In many cases it is preferable to use
    * {@link Registry#createId(String)} instead so that the overhead for instrumentation can

--- a/spectator-api/src/main/java/com/netflix/spectator/api/Utils.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/Utils.java
@@ -122,6 +122,33 @@ public final class Utils {
   }
 
   /**
+   * Return the value at a given position in the iterable.
+   *
+   * @param values
+   *     A collection of values. For deterministic behavior the iteration order of the
+   *     container type must be consistent each time.
+   * @param pos
+   *     Position of the value to extract.
+   * @return
+   *     Value at the given position.
+   */
+  public static <T> T getValue(Iterable<T> values, int pos) {
+    if (values instanceof List) {
+      List<T> vs = (List<T>) values;
+      return vs.get(pos);
+    } else {
+      int i = 0;
+      for (T v : values) {
+        if (i == pos) {
+          return v;
+        }
+        ++i;
+      }
+      throw new IndexOutOfBoundsException(pos + " >= " + i);
+    }
+  }
+
+  /**
    * Returns the first measurement with a given tag value.
    *
    * @param ms
@@ -241,8 +268,8 @@ public final class Utils {
    */
   @SuppressWarnings("PMD.UnusedLocalVariable")
   public static <T> int size(Iterable<T> iter) {
-    if (iter instanceof ArrayTagSet) {
-      return ((ArrayTagSet) iter).size();
+    if (iter instanceof TagList) {
+      return ((TagList) iter).size();
     } else if (iter instanceof Collection<?>) {
       return ((Collection<?>) iter).size();
     } else {

--- a/spectator-api/src/test/java/com/netflix/spectator/api/UtilsTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/UtilsTest.java
@@ -111,4 +111,54 @@ public class UtilsTest {
     List<Measurement> out = Utils.toList(Utils.filter(ms, v -> false));
     Assertions.assertEquals(0, out.size());
   }
+
+  @Test
+  public void sizeTagList() {
+    Id id = Id.create("test").withTags("a", "1", "b", "2");
+    Assertions.assertEquals(2, Utils.size(id.tags()));
+  }
+
+  @Test
+  public void sizeCollection() {
+    List<String> vs = new ArrayList<>();
+    vs.add("a");
+    vs.add("b");
+    vs.add("c");
+    Assertions.assertEquals(3, Utils.size(vs));
+  }
+
+  @Test
+  public void sizeIterable() {
+    List<String> vs = new ArrayList<>();
+    vs.add("a");
+    vs.add("b");
+    Assertions.assertEquals(2, Utils.size(vs::iterator));
+  }
+
+  @Test
+  public void getValueList() {
+    List<String> vs = new ArrayList<>();
+    vs.add("a");
+    vs.add("b");
+    vs.add("c");
+    Assertions.assertEquals("a", Utils.getValue(vs, 0));
+    Assertions.assertEquals("b", Utils.getValue(vs, 1));
+    Assertions.assertEquals("c", Utils.getValue(vs, 2));
+    Assertions.assertThrows(IndexOutOfBoundsException.class, () -> Utils.getValue(vs, 3));
+    Assertions.assertThrows(IndexOutOfBoundsException.class, () -> Utils.getValue(vs, -3));
+  }
+
+  @Test
+  public void getValueIterable() {
+    List<String> vs = new ArrayList<>();
+    vs.add("a");
+    vs.add("b");
+    vs.add("c");
+    Iterable<String> it = vs::iterator;
+    Assertions.assertEquals("a", Utils.getValue(it, 0));
+    Assertions.assertEquals("b", Utils.getValue(it, 1));
+    Assertions.assertEquals("c", Utils.getValue(it, 2));
+    Assertions.assertThrows(IndexOutOfBoundsException.class, () -> Utils.getValue(it, 3));
+    Assertions.assertThrows(IndexOutOfBoundsException.class, () -> Utils.getValue(it, -3));
+  }
 }


### PR DESCRIPTION
Though not recommended, in some cases users are implementing
the `Id` interface rather than using `registry.createId`. This
change adds some default implementations to avoid breaking
older code for changes introduced in #722. It also updates the
base registry implementation to normalize the ids to force them
to be a proper implementation created by the registry and avoid
confusing behavior.