### PR TITLE
deprecate AtlasConfig.validTagValueCharacters

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasConfig.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasConfig.java
@@ -176,9 +176,8 @@ public interface AtlasConfig extends RegistryConfig {
   }
 
   /**
-   * Returns a pattern indicating the valid characters for a tag key or value. The character
-   * set for tag values can be overridden for a particular tag key using
-   * {@link #validTagValueCharacters()}. The default is {@code -._A-Za-z0-9~^}.
+   * Returns a pattern indicating the valid characters for a tag key or value. The default is
+   * {@code -._A-Za-z0-9~^}.
    */
   default String validTagCharacters() {
     return "-._A-Za-z0-9~^";
@@ -187,7 +186,10 @@ public interface AtlasConfig extends RegistryConfig {
   /**
    * Returns a map from tag key to a pattern indicating the valid characters for the values
    * of that key. The default is an empty map.
+   *
+   * @deprecated This method is no longer used internally.
    */
+  @Deprecated
   default Map<String, String> validTagValueCharacters() {
     return Collections.emptyMap();
   }

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/MeasurementSerializer.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/MeasurementSerializer.java
@@ -23,7 +23,6 @@ import com.netflix.spectator.api.Measurement;
 import com.netflix.spectator.impl.AsciiSet;
 
 import java.io.IOException;
-import java.util.Map;
 
 /**
  * Jackson serializer for measurements. Values will be converted to a
@@ -36,29 +35,20 @@ import java.util.Map;
 public class MeasurementSerializer extends JsonSerializer<Measurement> {
 
   private final AsciiSet set;
-  private final Map<String, AsciiSet> overrides;
 
   /**
    * Create a new instance of the serializer.
    *
    * @param set
    *     The set of characters that are allowed to be used for tag keys.
-   * @param overrides
-   *     Overrides for the set of characters allowed to be used for tag values.
    */
-  public MeasurementSerializer(AsciiSet set, Map<String, AsciiSet> overrides) {
+  public MeasurementSerializer(AsciiSet set) {
     super();
     this.set = set;
-    this.overrides = overrides;
   }
 
-  private String fixKey(String k) {
-    return set.replaceNonMembers(k, '_');
-  }
-
-  private String fixValue(String k, String v) {
-    AsciiSet s = overrides.getOrDefault(k, set);
-    return s.replaceNonMembers(v, '_');
+  private String fix(String s) {
+    return set.replaceNonMembers(s, '_');
   }
 
   @Override
@@ -69,12 +59,12 @@ public class MeasurementSerializer extends JsonSerializer<Measurement> {
     Id id = value.id();
     gen.writeStartObject();
     gen.writeObjectFieldStart("tags");
-    gen.writeStringField("name", fixValue("name", id.name()));
+    gen.writeStringField("name", fix(id.name()));
     boolean explicitDsType = false;
     int n = id.size();
     for (int i = 1; i < n; ++i) {
-      final String k = fixKey(id.getKey(i));
-      final String v = fixValue(k, id.getValue(i));
+      final String k = fix(id.getKey(i));
+      final String v = fix(id.getValue(i));
       if (!"name".equals(k)) {
         if ("atlas.dstype".equals(k)) {
           explicitDsType = true;

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/SubscriptionManagerTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/SubscriptionManagerTest.java
@@ -47,7 +47,7 @@ public class SubscriptionManagerTest {
   private final SimpleModule module = new SimpleModule()
       .addSerializer(
           Measurement.class,
-          new MeasurementSerializer(AsciiSet.fromPattern("a-z"), Collections.emptyMap()));
+          new MeasurementSerializer(AsciiSet.fromPattern("a-z")));
 
   private final ObjectMapper mapper = new ObjectMapper(new JsonFactory()).registerModule(module);
 

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/MeasurementSerializerTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/MeasurementSerializerTest.java
@@ -25,18 +25,15 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
-import java.util.Map;
 
 
 public class MeasurementSerializerTest {
 
   private final AsciiSet set = AsciiSet.fromPattern("-._A-Za-z0-9");
-  private final Map<String, AsciiSet> overrides =
-      Collections.singletonMap("cluster", AsciiSet.fromPattern("-._A-Za-z0-9^~"));
 
   private final DefaultRegistry registry = new DefaultRegistry();
   private final SimpleModule module = new SimpleModule()
-      .addSerializer(Measurement.class, new MeasurementSerializer(set, overrides));
+      .addSerializer(Measurement.class, new MeasurementSerializer(set));
   private final ObjectMapper mapper = new ObjectMapper().registerModule(module);
 
   @Test
@@ -95,16 +92,6 @@ public class MeasurementSerializerTest {
     Measurement m = new Measurement(id, 42L, 3.0);
     String json = mapper.writeValueAsString(m);
     String tags = "{\"name\":\"foo\",\"bar\":\"b__\",\"atlas.dstype\":\"gauge\"}";
-    String expected = "{\"tags\":" + tags + ",\"timestamp\":42,\"value\":3.0}";
-    Assertions.assertEquals(expected, json);
-  }
-
-  @Test
-  public void valueCharsetOverrides() throws Exception {
-    Id id = registry.createId("foo", "bar", "abc^~def", "cluster", "abc^~def");
-    Measurement m = new Measurement(id, 42L, 3.0);
-    String json = mapper.writeValueAsString(m);
-    String tags = "{\"name\":\"foo\",\"bar\":\"abc__def\",\"cluster\":\"abc^~def\",\"atlas.dstype\":\"gauge\"}";
     String expected = "{\"tags\":" + tags + ",\"timestamp\":42,\"value\":3.0}";
     Assertions.assertEquals(expected, json);
   }


### PR DESCRIPTION
It is not used anymore at Netflix and generally having
different allowed character sets just creates confusion.