### PR TITLE
avoid allocating Tag objects for getTagValue

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/Utils.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/Utils.java
@@ -113,9 +113,19 @@ public final class Utils {
   public static String getTagValue(Iterable<Tag> tags, String k) {
     Preconditions.checkNotNull(tags, "tags");
     Preconditions.checkNotNull(k, "key");
-    for (Tag t : tags) {
-      if (k.equals(t.key())) {
-        return t.value();
+    if (tags instanceof TagList) {
+      TagList list = (TagList) tags;
+      int n = list.size();
+      for (int i = 0; i < n; ++i) {
+        if (k.equals(list.getKey(i))) {
+          return list.getValue(i);
+        }
+      }
+    } else {
+      for (Tag t : tags) {
+        if (k.equals(t.key())) {
+          return t.value();
+        }
       }
     }
     return null;

--- a/spectator-api/src/test/java/com/netflix/spectator/api/UtilsTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/UtilsTest.java
@@ -48,6 +48,13 @@ public class UtilsTest {
   }
 
   @Test
+  public void getTagValueIterable() {
+    Registry r = new DefaultRegistry();
+    Id id = r.createId("foo", "bar", "baz", "abc", "def");
+    Assertions.assertEquals("def", Utils.getTagValue(id.tags()::iterator, "abc"));
+  }
+
+  @Test
   public void firstTag() {
     List<Measurement> ms = newList(10);
     Tag t = new BasicTag("i", "7");


### PR DESCRIPTION
Refactors Utils.getTagValue to avoid allocating the Tag
objects if the iterable is of type TagList.