### PR TITLE
adjust initial polling delay

### DIFF
--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasRegistryTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasRegistryTest.java
@@ -152,14 +152,14 @@ public class AtlasRegistryTest {
   public void initialDelayTooCloseToEnd() {
     clock.setWallTime(19123);
     long d = registry.getInitialDelay(10000);
-    Assertions.assertEquals(9000, d);
+    Assertions.assertEquals(1877, d);
   }
 
   @Test
   public void initialDelayOk() {
     clock.setWallTime(12123);
     long d = registry.getInitialDelay(10000);
-    Assertions.assertEquals(2123, d);
+    Assertions.assertEquals(8877, d);
   }
 
   @Test


### PR DESCRIPTION
Change it to be close to the start of the interval. With
smaller step sizes this gives more time to publish data
when there are a lot of metrics on an instance. It also
helps get the data to the server more quickly after an
it is complete.

The main down side we'll need to watch out for is that now
the metrics collection and publishing will be more aligned
across all instances of a cluster. From initial testing it
is not expected to cause problems.