### PR TITLE
add defaults for context environment variables

### DIFF
--- a/spectator-nflx-plugin/src/main/java/com/netflix/spectator/nflx/NetflixConfig.java
+++ b/spectator-nflx-plugin/src/main/java/com/netflix/spectator/nflx/NetflixConfig.java
@@ -76,8 +76,9 @@ public final class NetflixConfig {
     }
   }
 
-  private static Config loadPropFiles() {
+  static Config loadPropFiles() {
     final Properties props = new Properties();
+    Env.addDefaults(props);
     final String env = Env.environment();
     final String acctId = Env.accountId();
     tryLoadingConfig(props, "atlas_plugin");
@@ -151,11 +152,11 @@ public final class NetflixConfig {
     }
 
     private static String environment() {
-      return getenv(ENVIRONMENT, "dev");
+      return getenv(ENVIRONMENT, "test");
     }
 
     private static String accountId() {
-      return getenv(OWNER, "dc");
+      return getenv(OWNER, "unknown");
     }
 
     private static String region() {
@@ -205,6 +206,17 @@ public final class NetflixConfig {
       } catch (UnknownHostException e) {
         throw new RuntimeException(e);
       }
+    }
+
+    /**
+     * Set default values for environment variables that are used for the basic context
+     * of where an app is running. Helps avoid startup issues when running locally and
+     * these are not set.
+     */
+    private static void addDefaults(Properties props) {
+      props.put(ENVIRONMENT, "test");
+      props.put(OWNER, "unknown");
+      props.put(REGION, "us-east-1");
     }
   }
 }

--- a/spectator-nflx-plugin/src/test/java/com/netflix/spectator/nflx/NetflixConfigTest.java
+++ b/spectator-nflx-plugin/src/test/java/com/netflix/spectator/nflx/NetflixConfigTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.nflx;
+
+import com.netflix.archaius.api.Config;
+import com.netflix.archaius.config.MapConfig;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class NetflixConfigTest {
+
+  @Test
+  public void defaultEnvVarsAreSet() {
+    Config config = NetflixConfig.loadPropFiles();
+    Assertions.assertEquals("test", config.getString("NETFLIX_ENVIRONMENT"));
+    Assertions.assertEquals("unknown", config.getString("EC2_OWNER_ID"));
+    Assertions.assertEquals("us-east-1", config.getString("EC2_REGION"));
+  }
+
+  @Test
+  public void defaultOverrides() {
+    Config overrides = MapConfig.builder()
+        .put("NETFLIX_ENVIRONMENT", "prod")
+        .put("substitutions", "${NETFLIX_ENVIRONMENT}-${EC2_OWNER_ID}")
+        .build();
+    Config config = NetflixConfig.createConfig(overrides);
+    Assertions.assertEquals("prod", config.getString("NETFLIX_ENVIRONMENT"));
+    Assertions.assertEquals("unknown", config.getString("EC2_OWNER_ID"));
+    Assertions.assertEquals("us-east-1", config.getString("EC2_REGION"));
+    Assertions.assertEquals("prod-unknown", config.getString("substitutions"));
+  }
+}


### PR DESCRIPTION
These will be set when running in environments that are
supported. However, when running locally they may not be
set which can lead to some errors when used as substitutions
for other settings.