### PR TITLE
add defaults for app and cluster

### DIFF
--- a/spectator-nflx-plugin/src/main/java/com/netflix/spectator/nflx/NetflixConfig.java
+++ b/spectator-nflx-plugin/src/main/java/com/netflix/spectator/nflx/NetflixConfig.java
@@ -217,6 +217,8 @@ public final class NetflixConfig {
       props.put(ENVIRONMENT, "test");
       props.put(OWNER, "unknown");
       props.put(REGION, "us-east-1");
+      props.put(APP, "local");
+      props.put(CLUSTER, "local-dev");
     }
   }
 }


### PR DESCRIPTION
These can sometimes be used as well for looking up context
specific to the app rather than the general environment.