### PR TITLE
Check if meter is instance of supported type prior to returning new meter type

### DIFF
--- a/spectator-reg-micrometer/src/main/java/com/netflix/spectator/micrometer/MicrometerRegistry.java
+++ b/spectator-reg-micrometer/src/main/java/com/netflix/spectator/micrometer/MicrometerRegistry.java
@@ -74,12 +74,16 @@ public final class MicrometerRegistry implements Registry {
 
   private Meter convert(io.micrometer.core.instrument.Meter meter) {
     Id id = convert(meter.getId());
-    switch (meter.getId().getType()) {
-      case COUNTER:              return counter(id);
-      case TIMER:                return timer(id);
-      case DISTRIBUTION_SUMMARY: return distributionSummary(id);
-      case GAUGE:                return gauge(id);
-      default:                   return null;
+    if (meter instanceof io.micrometer.core.instrument.Counter) {
+      return counter(id);
+    } else if (meter instanceof io.micrometer.core.instrument.Timer) {
+      return timer(id);
+    } else if (meter instanceof io.micrometer.core.instrument.DistributionSummary) {
+      return distributionSummary(id);
+    } else if (meter instanceof io.micrometer.core.instrument.Gauge) {
+      return gauge(id);
+    } else {
+      return null;
     }
   }
 


### PR DESCRIPTION
I'm in the process of rolling out `spectator-reg-micrometer` as a bridge to Micrometer.  There are some Micrometer core types that do not jive with the Micrometer `Type` enum - for example `FunctionalTimer` is a distinct core meter type, even though the Type enum that it receives is that of `TIMER`. 

This resolves that issue and allows us to move forward in a backwards compatible (+/-) way.

@brharrington 