### PR TITLE
dedup registries added to composite

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/CompositeRegistry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/CompositeRegistry.java
@@ -78,7 +78,9 @@ public final class CompositeRegistry implements Registry {
   public void add(Registry registry) {
     wlock.lock();
     try {
-      registries.add(registry);
+      if (!registries.contains(registry)) {
+        registries.add(registry);
+      }
       updateMeters();
     } finally {
       wlock.unlock();

--- a/spectator-api/src/test/java/com/netflix/spectator/api/CompositeRegistryTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/CompositeRegistryTest.java
@@ -315,4 +315,14 @@ public class CompositeRegistryTest {
     Assertions.assertEquals(2, r.gauges().count());
     Assertions.assertEquals(2, r.stream().filter(m -> m instanceof Gauge).count());
   }
+
+  @Test
+  public void dedupAddedRegistries() {
+    CompositeRegistry registry = new CompositeRegistry(clock);
+    Registry r = new DefaultRegistry();
+    registry.add(r);
+    registry.add(r);
+    registry.counter("test").increment();
+    Assertions.assertEquals(1, r.counter("test").count());
+  }
 }


### PR DESCRIPTION
This helps guard against double counting for the global
registry if an application has bugs in its initialization
that cause the same underlying registry to get added more
than once.