### PR TITLE
avoid storing ids for CompositeRegistry

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/AbstractRegistry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/AbstractRegistry.java
@@ -27,12 +27,17 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
+import java.util.function.LongSupplier;
 
 /**
  * Base class to make it easier to implement a simple registry that only needs to customise the
  * types returned for Counter, DistributionSummary, and Timer calls.
  */
 public abstract class AbstractRegistry implements Registry {
+
+  /** Not used for this registry, always return 0. */
+  private static final LongSupplier VERSION = () -> 0L;
+
   /** Logger instance for the class. */
   protected final Logger logger;
 
@@ -173,7 +178,7 @@ public abstract class AbstractRegistry implements Registry {
   @Override public final Counter counter(Id id) {
     Id normId = normalizeId(id);
     Counter c = getOrCreate(normId, Counter.class, NoopCounter.INSTANCE, this::newCounter);
-    return new SwapCounter(this, normId, c);
+    return new SwapCounter(this, VERSION, normId, c);
   }
 
   @Override public final DistributionSummary distributionSummary(Id id) {
@@ -183,25 +188,25 @@ public abstract class AbstractRegistry implements Registry {
         DistributionSummary.class,
         NoopDistributionSummary.INSTANCE,
         this::newDistributionSummary);
-    return new SwapDistributionSummary(this, normId, ds);
+    return new SwapDistributionSummary(this, VERSION, normId, ds);
   }
 
   @Override public final Timer timer(Id id) {
     Id normId = normalizeId(id);
     Timer t = getOrCreate(normId, Timer.class, NoopTimer.INSTANCE, this::newTimer);
-    return new SwapTimer(this, normId, t);
+    return new SwapTimer(this, VERSION, normId, t);
   }
 
   @Override public final Gauge gauge(Id id) {
     Id normId = normalizeId(id);
     Gauge g = getOrCreate(normId, Gauge.class, NoopGauge.INSTANCE, this::newGauge);
-    return new SwapGauge(this, normId, g);
+    return new SwapGauge(this, VERSION, normId, g);
   }
 
   @Override public final Gauge maxGauge(Id id) {
     Id normId = normalizeId(id);
     Gauge g = getOrCreate(normId, Gauge.class, NoopGauge.INSTANCE, this::newMaxGauge);
-    return new SwapMaxGauge(this, normId, g);
+    return new SwapMaxGauge(this, VERSION, normId, g);
   }
 
   /**

--- a/spectator-api/src/main/java/com/netflix/spectator/api/SwapCounter.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/SwapCounter.java
@@ -17,12 +17,14 @@ package com.netflix.spectator.api;
 
 import com.netflix.spectator.impl.SwapMeter;
 
+import java.util.function.LongSupplier;
+
 /** Wraps another counter allowing the underlying type to be swapped. */
 final class SwapCounter extends SwapMeter<Counter> implements Counter {
 
   /** Create a new instance. */
-  SwapCounter(Registry registry, Id id, Counter underlying) {
-    super(registry, id, underlying);
+  SwapCounter(Registry registry, LongSupplier versionSupplier, Id id, Counter underlying) {
+    super(registry, versionSupplier, id, underlying);
   }
 
   @Override public Counter lookup() {

--- a/spectator-api/src/main/java/com/netflix/spectator/api/SwapDistributionSummary.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/SwapDistributionSummary.java
@@ -17,12 +17,18 @@ package com.netflix.spectator.api;
 
 import com.netflix.spectator.impl.SwapMeter;
 
+import java.util.function.LongSupplier;
+
 /** Wraps another distribution summary allowing the underlying type to be swapped. */
 final class SwapDistributionSummary extends SwapMeter<DistributionSummary> implements DistributionSummary {
 
   /** Create a new instance. */
-  SwapDistributionSummary(Registry registry, Id id, DistributionSummary underlying) {
-    super(registry, id, underlying);
+  SwapDistributionSummary(
+      Registry registry,
+      LongSupplier versionSupplier,
+      Id id,
+      DistributionSummary underlying) {
+    super(registry, versionSupplier, id, underlying);
   }
 
   @Override public DistributionSummary lookup() {

--- a/spectator-api/src/main/java/com/netflix/spectator/api/SwapGauge.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/SwapGauge.java
@@ -17,12 +17,14 @@ package com.netflix.spectator.api;
 
 import com.netflix.spectator.impl.SwapMeter;
 
+import java.util.function.LongSupplier;
+
 /** Wraps another gauge allowing the underlying type to be swapped. */
 final class SwapGauge extends SwapMeter<Gauge> implements Gauge {
 
   /** Create a new instance. */
-  SwapGauge(Registry registry, Id id, Gauge underlying) {
-    super(registry, id, underlying);
+  SwapGauge(Registry registry, LongSupplier versionSupplier, Id id, Gauge underlying) {
+    super(registry, versionSupplier, id, underlying);
   }
 
   @Override public Gauge lookup() {

--- a/spectator-api/src/main/java/com/netflix/spectator/api/SwapMaxGauge.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/SwapMaxGauge.java
@@ -17,12 +17,14 @@ package com.netflix.spectator.api;
 
 import com.netflix.spectator.impl.SwapMeter;
 
+import java.util.function.LongSupplier;
+
 /** Wraps another gauge allowing the underlying type to be swapped. */
 final class SwapMaxGauge extends SwapMeter<Gauge> implements Gauge {
 
   /** Create a new instance. */
-  SwapMaxGauge(Registry registry, Id id, Gauge underlying) {
-    super(registry, id, underlying);
+  SwapMaxGauge(Registry registry, LongSupplier versionSupplier, Id id, Gauge underlying) {
+    super(registry, versionSupplier, id, underlying);
   }
 
   @Override public Gauge lookup() {

--- a/spectator-api/src/main/java/com/netflix/spectator/api/SwapTimer.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/SwapTimer.java
@@ -19,13 +19,14 @@ import com.netflix.spectator.impl.SwapMeter;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
+import java.util.function.LongSupplier;
 
 /** Wraps another timer allowing the underlying type to be swapped. */
 final class SwapTimer extends SwapMeter<Timer> implements Timer {
 
   /** Create a new instance. */
-  SwapTimer(Registry registry, Id id, Timer underlying) {
-    super(registry, id, underlying);
+  SwapTimer(Registry registry, LongSupplier versionSupplier, Id id, Timer underlying) {
+    super(registry, versionSupplier, id, underlying);
   }
 
   @Override public Timer lookup() {

--- a/spectator-api/src/test/java/com/netflix/spectator/api/CompositeRegistryTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/CompositeRegistryTest.java
@@ -255,8 +255,7 @@ public class CompositeRegistryTest {
 
     Registry r1 = new DefaultRegistry(clock);
     r.add(r1);
-    // depends on registry type, some will be expired until first increment
-    Assertions.assertFalse(c1.hasExpired());
+    Assertions.assertTrue(c1.hasExpired());
 
     c1.increment();
     Assertions.assertFalse(c1.hasExpired());
@@ -324,5 +323,32 @@ public class CompositeRegistryTest {
     registry.add(r);
     registry.counter("test").increment();
     Assertions.assertEquals(1, r.counter("test").count());
+  }
+
+  @Test
+  public void meterLookupAfterRegistryChange() {
+    CompositeRegistry r = new CompositeRegistry(clock);
+    Registry r1 = new DefaultRegistry(clock);
+    Registry r2 = new DefaultRegistry(clock);
+
+    Counter c = r.counter("test");
+    c.increment();
+    Assertions.assertEquals(0, r1.counter("test").count());
+    Assertions.assertEquals(0, r2.counter("test").count());
+
+    r.add(r1);
+    c.increment();
+    Assertions.assertEquals(1, r1.counter("test").count());
+    Assertions.assertEquals(0, r2.counter("test").count());
+
+    r.add(r2);
+    c.increment();
+    Assertions.assertEquals(2, r1.counter("test").count());
+    Assertions.assertEquals(1, r2.counter("test").count());
+
+    r.remove(r1);
+    c.increment();
+    Assertions.assertEquals(2, r1.counter("test").count());
+    Assertions.assertEquals(2, r2.counter("test").count());
   }
 }

--- a/spectator-api/src/test/java/com/netflix/spectator/api/SwapMeterTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/SwapMeterTest.java
@@ -19,28 +19,29 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
 
 public class SwapMeterTest {
+
+  private static final LongSupplier VERSION = () -> 0L;
+
   private final ManualClock clock = new ManualClock();
   private final Registry registry = new DefaultRegistry();
 
   private final Id counterId = registry.createId("counter");
-  private final Counter counter = registry.counter(counterId);
 
   private final Id gaugeId = registry.createId("gauge");
-  private final Gauge gauge = registry.gauge(gaugeId);
 
   private final Id timerId = registry.createId("timer");
-  private final Timer timer = registry.timer(timerId);
 
   private final Id distSummaryId = registry.createId("distSummary");
-  private final DistributionSummary distSummary = registry.distributionSummary(distSummaryId);
 
   @Test
   public void wrappedCounters() {
     Counter c = new DefaultCounter(clock, counterId);
-    SwapCounter sc1 = new SwapCounter(registry, counterId, c);
-    SwapCounter sc2 = new SwapCounter(registry, counterId, sc1);
+    SwapCounter sc1 = new SwapCounter(registry, VERSION, counterId, c);
+    SwapCounter sc2 = new SwapCounter(registry, VERSION, counterId, sc1);
     Assertions.assertFalse(sc2.hasExpired());
     sc2.increment();
     Assertions.assertEquals(1, c.count());
@@ -53,7 +54,7 @@ public class SwapMeterTest {
     ExpiringRegistry registry = new ExpiringRegistry(clock);
     Counter c = registry.counter(counterId);
     clock.setWallTime(60000 * 30);
-    SwapCounter s1 = new SwapCounter(registry, counterId, c);
+    SwapCounter s1 = new SwapCounter(registry, VERSION, counterId, c);
     s1.increment();
     Assertions.assertEquals(1, c.count());
     Assertions.assertEquals(1, s1.count());
@@ -64,7 +65,7 @@ public class SwapMeterTest {
     ExpiringRegistry registry = new ExpiringRegistry(clock);
     Timer t = registry.timer(timerId);
     clock.setWallTime(60000 * 30);
-    SwapTimer s1 = new SwapTimer(registry, timerId, t);
+    SwapTimer s1 = new SwapTimer(registry, VERSION, timerId, t);
     s1.record(42, TimeUnit.NANOSECONDS);
     Assertions.assertEquals(1, t.count());
     Assertions.assertEquals(1, s1.count());
@@ -75,7 +76,7 @@ public class SwapMeterTest {
     ExpiringRegistry registry = new ExpiringRegistry(clock);
     Gauge c = registry.gauge(gaugeId);
     clock.setWallTime(60000 * 30);
-    SwapGauge s1 = new SwapGauge(registry, gaugeId, c);
+    SwapGauge s1 = new SwapGauge(registry, VERSION, gaugeId, c);
     s1.set(1.0);
     Assertions.assertEquals(1.0, c.value(), 1e-12);
     Assertions.assertEquals(1.0, s1.value(), 1e-12);
@@ -86,9 +87,24 @@ public class SwapMeterTest {
     ExpiringRegistry registry = new ExpiringRegistry(clock);
     DistributionSummary c = registry.distributionSummary(distSummaryId);
     clock.setWallTime(60000 * 30);
-    SwapDistributionSummary s1 = new SwapDistributionSummary(registry, distSummaryId, c);
+    SwapDistributionSummary s1 = new SwapDistributionSummary(registry, VERSION, distSummaryId, c);
     s1.record(1);
     Assertions.assertEquals(1, c.count());
     Assertions.assertEquals(1, s1.count());
+  }
+
+  @Test
+  public void versionUpdateExpiration() {
+    AtomicLong version = new AtomicLong();
+    Counter c = new DefaultCounter(clock, counterId);
+    SwapCounter sc = new SwapCounter(registry, version::get, counterId, c);
+
+    sc.increment();
+    Assertions.assertFalse(sc.hasExpired());
+
+    version.incrementAndGet();
+    Assertions.assertTrue(sc.hasExpired());
+    sc.increment();
+    Assertions.assertFalse(sc.hasExpired());
   }
 }


### PR DESCRIPTION
If instrumented properly, the number of distinct ids should
not grow unbounded for the life of the process. However, if
users are not disciplined enough with their tagging, this can
occur. With the previous implementation of CompositeRegistry
it would keep track of all of the ids it saw so it could
update the mapping if the registries ever changed. This would
lead to the set of ids growing and eventually using up all
of the heap.

With this change, the composite registry no longer stores the
ids, it just returns a new copy of the SwapMeter instance. A
version is used to indicate if a change has occured that would
require it to perform a new lookup.

This will result in additional allocations if the same id is
looked up repeatedly. Before it would have just returned the
meter instance from the map.