### PR TITLE
immediately stop polling in PolledMeter.remove

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/patterns/GaugePoller.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/patterns/GaugePoller.java
@@ -48,13 +48,13 @@ final class GaugePoller {
       Executors.newSingleThreadScheduledExecutor(FACTORY);
 
   /** Schedule collection of gauges for a registry. */
-  static <T> void schedule(WeakReference<T> ref, long delay, Consumer<T> poll) {
-    schedule(DEFAULT_EXECUTOR, ref, delay, poll);
+  static <T> Future<?> schedule(WeakReference<T> ref, long delay, Consumer<T> poll) {
+    return schedule(DEFAULT_EXECUTOR, ref, delay, poll);
   }
 
   /** Schedule collection of gauges for a registry. */
   @SuppressWarnings("PMD")
-  static <T> void schedule(
+  static <T> Future<?> schedule(
       ScheduledExecutorService executor, WeakReference<T> ref, long delay, Consumer<T> poll) {
     final AtomicReference<Future<?>> futureRef = new AtomicReference<>();
     final Runnable cancel = () -> {
@@ -76,6 +76,7 @@ final class GaugePoller {
       }
     };
     futureRef.set(executor.scheduleWithFixedDelay(task, delay, delay, TimeUnit.MILLISECONDS));
+    return futureRef.get();
   }
 
   private GaugePoller() {

--- a/spectator-api/src/test/java/com/netflix/spectator/api/patterns/PolledMeterTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/patterns/PolledMeterTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.api.patterns;
+
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Registry;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+public class PolledMeterTest {
+
+  @Test
+  public void removeAndAddRepeatedlyCounter() {
+    Registry r = new DefaultRegistry();
+    Id id = r.createId("test");
+
+    AtomicLong value = new AtomicLong();
+    for (int i = 0; i < 10; ++i) {
+      PolledMeter.using(r).withId(id).monitorMonotonicCounter(value);
+      PolledMeter.update(r);
+      value.incrementAndGet();
+      PolledMeter.update(r);
+      PolledMeter.remove(r, id);
+    }
+
+    Assertions.assertEquals(10, r.counter("test").count());
+  }
+
+  @Test
+  public void removeAndAddRepeatedlyGauge() {
+    Registry r = new DefaultRegistry();
+    Id id = r.createId("test");
+
+    AtomicLong value = new AtomicLong();
+    for (int i = 0; i < 10; ++i) {
+      PolledMeter.using(r).withId(id).monitorValue(value);
+      value.set(i);
+      PolledMeter.update(r);
+      PolledMeter.remove(r, id);
+    }
+
+    Assertions.assertEquals(9.0, r.gauge("test").value(), 1e-12);
+  }
+}


### PR DESCRIPTION
Before it would remove the meter from the state map and
then wait for the object to get garbage collected. In
some cases this could take a while and if a new meter
was registered with the same id, then the value could
get overwritten. Now the polling will get stopped as
part of the remove.