### PR TITLE
shade jackson for spectator-reg-atlas

### DIFF
--- a/spectator-reg-atlas/build.gradle
+++ b/spectator-reg-atlas/build.gradle
@@ -34,6 +34,9 @@ shadowJar {
     exclude(dependency('org.slf4j:slf4j-api'))
   }
   minimize()
+  exclude('module-info.class')
+  exclude('META-INF/maven/com.fasterxml.jackson.*/**')
+  exclude('META-INF/services/com.fasterxml.*')
   relocate('com.fasterxml.jackson', 'spectator-atlas.json')
 }
 

--- a/spectator-reg-atlas/build.gradle
+++ b/spectator-reg-atlas/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+  id 'com.github.johnrengelman.shadow' version '5.1.0'
+}
+
 dependencies {
   compileApi project(':spectator-api')
   compile project(':spectator-ext-ipc')
@@ -9,9 +13,45 @@ dependencies {
 }
 
 jar {
+  // We only want to generate the shadow jar that hides the use of
+  // Jackson to prevent issues with other uses
+  enabled = false
   manifest {
     attributes(
       "Automatic-Module-Name": "com.netflix.spectator.atlas"
     )
+  }
+}
+jar.dependsOn(shadowJar)
+
+shadowJar {
+  classifier = null
+  configurations = [project.configurations.runtime]
+  dependencies {
+    exclude(project(':spectator-api'))
+    exclude(project(':spectator-ext-ipc'))
+    exclude(dependency('javax.inject:javax.inject'))
+    exclude(dependency('org.slf4j:slf4j-api'))
+  }
+  minimize()
+  relocate('com.fasterxml.jackson', 'spectator-atlas.json')
+}
+
+// Remove the Jackson dependencies from the POM file
+afterEvaluate {
+  publishing {
+    publications {
+      withType(MavenPublication) {
+        pom.withXml {
+          asNode()
+            .dependencies
+            .dependency
+            .findAll {
+              it.artifactId.text().startsWith("jackson-")
+            }
+            .each { it.parent().remove(it) }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Internally there are some apps that cannot move beyond
guava 19. When spectator updated to jackson 2.10.0 an
alignment rule forced all jackson subprojects to that
version include jackson-datatype-guava which as of
2.10.0 now dependes on guava 20.

To try and minimize the chances we will be in the middle
of such a mess in the future, this change shades the
jackson usage. The dependency has been relocated, inlined,
and POM file has those dependencies removed.