### PR TITLE
avoid NPE if registry is shutdown without starting

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
@@ -300,7 +300,7 @@ public final class AtlasRegistry extends AbstractRegistry implements AutoCloseab
 
   void sendToAtlas() {
     publishTaskTimer("sendToAtlas").record(() -> {
-      if (config.enabled()) {
+      if (config.enabled() && senderPool != null) {
         long t = lastCompletedTimestamp(stepMillis);
         pollMeters(t);
         logger.debug("sending to Atlas for time: {}", t);

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasRegistryTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasRegistryTest.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.spectator.atlas;
 
+import com.netflix.spectator.api.Clock;
 import com.netflix.spectator.api.ManualClock;
 import com.netflix.spectator.api.Measurement;
 import com.netflix.spectator.api.NoopRegistry;
@@ -193,5 +194,13 @@ public class AtlasRegistryTest {
     clock.setWallTime(Duration.ofMinutes(15).toMillis() + 1);
     registry.sendToAtlas();
     Assertions.assertEquals(0, getBatches().size());
+  }
+
+  @Test
+  public void shutdownWithoutStarting() {
+    AtlasRegistry r = new AtlasRegistry(
+        Clock.SYSTEM,
+        k -> k.equals("atlas.enabled") ? "true" : null);
+    r.close();
   }
 }


### PR DESCRIPTION
If the application has a bug in its initialization, then
we sometimes see the stop method get called without the
registry having been started. This would result in an NPE
getting logged because the sender pool was not setup. With
this change the send will get ignored if the pool is not
setup. Should avoid support requests from users asking
about the exception.