### PR TITLE
optimize the collection of measurements

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasCounter.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasCounter.java
@@ -22,7 +22,7 @@ import com.netflix.spectator.api.Measurement;
 import com.netflix.spectator.api.Statistic;
 import com.netflix.spectator.impl.StepDouble;
 
-import java.util.Collections;
+import java.util.List;
 
 /**
  * Counter that reports a rate per second to Atlas. Note that {@link #count()} will
@@ -37,16 +37,15 @@ class AtlasCounter extends AtlasMeter implements Counter {
   /** Create a new instance. */
   AtlasCounter(Id id, Clock clock, long ttl, long step) {
     super(id, clock, ttl);
-    this.value = new StepDouble(0L, clock, step);
+    this.value = new StepDouble(0.0, clock, step);
     // Add the statistic for typing. Re-adding the tags from the id is to retain
     // the statistic from the id if it was already set
     this.stat = id.withTag(Statistic.count).withTags(id.tags()).withTag(DsType.rate);
   }
 
-  @Override public Iterable<Measurement> measure() {
+  @Override void measure(List<Measurement> ms) {
     final double rate = value.pollAsRate();
-    final Measurement m = new Measurement(stat, value.timestamp(), rate);
-    return Collections.singletonList(m);
+    ms.add(new Measurement(stat, value.timestamp(), rate));
   }
 
   @Override public void add(double amount) {

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasDistributionSummary.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasDistributionSummary.java
@@ -24,7 +24,6 @@ import com.netflix.spectator.impl.StepDouble;
 import com.netflix.spectator.impl.StepLong;
 import com.netflix.spectator.impl.StepValue;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -70,13 +69,11 @@ class AtlasDistributionSummary extends AtlasMeter implements DistributionSummary
     };
   }
 
-  @Override public Iterable<Measurement> measure() {
-    List<Measurement> ms = new ArrayList<>(4);
+  @Override void measure(List<Measurement> ms) {
     ms.add(newMeasurement(stats[0], count));
     ms.add(newMeasurement(stats[1], total));
     ms.add(newMeasurement(stats[2], totalOfSquares));
     ms.add(newMaxMeasurement(stats[3], max));
-    return ms;
   }
 
   private Measurement newMeasurement(Id mid, StepValue v) {

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasGauge.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasGauge.java
@@ -22,7 +22,7 @@ import com.netflix.spectator.api.Measurement;
 import com.netflix.spectator.api.Statistic;
 import com.netflix.spectator.impl.AtomicDouble;
 
-import java.util.Collections;
+import java.util.List;
 
 /**
  * Meter that reports a single value to Atlas.
@@ -41,9 +41,11 @@ class AtlasGauge extends AtlasMeter implements Gauge {
     this.stat = id.withTag(Statistic.gauge).withTags(id.tags()).withTag(DsType.gauge);
   }
 
-  @Override public Iterable<Measurement> measure() {
-    final Measurement m = new Measurement(stat, clock.wallTime(), value());
-    return Collections.singletonList(m);
+  @Override void measure(List<Measurement> ms) {
+    final double v = value();
+    if (Double.isFinite(v)) {
+      ms.add(new Measurement(stat, clock.wallTime(), v));
+    }
   }
 
   @Override public void set(double v) {

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasMaxGauge.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasMaxGauge.java
@@ -22,7 +22,7 @@ import com.netflix.spectator.api.Measurement;
 import com.netflix.spectator.api.Statistic;
 import com.netflix.spectator.impl.StepDouble;
 
-import java.util.Collections;
+import java.util.List;
 
 /**
  * Gauge that reports the maximum value submitted during an interval to Atlas. Main use-case
@@ -43,18 +43,19 @@ class AtlasMaxGauge extends AtlasMeter implements Gauge {
     this.stat = id.withTag(Statistic.max).withTags(id.tags()).withTag(DsType.gauge);
   }
 
-  @Override public Iterable<Measurement> measure() {
+  @Override void measure(List<Measurement> ms) {
     // poll needs to be called before accessing the timestamp to ensure
     // the counters have been rotated if there was no activity in the
     // current interval.
     double v = value.poll();
-    final Measurement m = new Measurement(stat, value.timestamp(), v);
-    return Collections.singletonList(m);
+    ms.add(new Measurement(stat, value.timestamp(), v));
   }
 
   @Override public void set(double v) {
-    value.getCurrent().max(v);
-    updateLastModTime();
+    if (Double.isFinite(v)) {
+      value.getCurrent().max(v);
+      updateLastModTime();
+    }
   }
 
   @Override public double value() {

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasMaxGauge.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasMaxGauge.java
@@ -52,10 +52,8 @@ class AtlasMaxGauge extends AtlasMeter implements Gauge {
   }
 
   @Override public void set(double v) {
-    if (Double.isFinite(v)) {
-      value.getCurrent().max(v);
-      updateLastModTime();
-    }
+    value.getCurrent().max(v);
+    updateLastModTime();
   }
 
   @Override public double value() {

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasMeter.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasMeter.java
@@ -17,7 +17,11 @@ package com.netflix.spectator.atlas;
 
 import com.netflix.spectator.api.Clock;
 import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Measurement;
 import com.netflix.spectator.api.Meter;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /** Base class for core meter types used by AtlasRegistry. */
 abstract class AtlasMeter implements Meter {
@@ -57,4 +61,12 @@ abstract class AtlasMeter implements Meter {
   @Override public boolean hasExpired() {
     return clock.wallTime() - lastUpdated > ttl;
   }
+
+  @Override public Iterable<Measurement> measure() {
+    List<Measurement> ms = new ArrayList<>();
+    measure(ms);
+    return ms;
+  }
+
+  abstract void measure(List<Measurement> ms);
 }

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
@@ -378,13 +378,7 @@ public final class AtlasRegistry extends AbstractRegistry implements AutoCloseab
         List<Measurement> measurements = new ArrayList<>(atlasMeasurements.size());
         publishTaskTimer("pollMeasurements").record(() -> {
           for (Meter meter : this) {
-            if (!meter.hasExpired()) {
-              for (Measurement m : meter.measure()) {
-                if (!Double.isNaN(m.value())) {
-                  measurements.add(m);
-                }
-              }
-            }
+            ((AtlasMeter) meter).measure(measurements);
           }
         });
 
@@ -514,6 +508,7 @@ public final class AtlasRegistry extends AbstractRegistry implements AutoCloseab
   @Override public Stream<Measurement> measurements() {
     long t = lastCompletedTimestamp(stepMillis);
     pollMeters(t);
+    removeExpiredMeters();
     return getBatches(t).stream().flatMap(List::stream);
   }
 

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasTimer.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasTimer.java
@@ -24,7 +24,6 @@ import com.netflix.spectator.impl.StepDouble;
 import com.netflix.spectator.impl.StepLong;
 import com.netflix.spectator.impl.StepValue;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
@@ -72,13 +71,11 @@ class AtlasTimer extends AtlasMeter implements Timer {
     };
   }
 
-  @Override public Iterable<Measurement> measure() {
-    List<Measurement> ms = new ArrayList<>(4);
+  @Override void measure(List<Measurement> ms) {
     ms.add(newMeasurement(stats[0], count, 1.0));
     ms.add(newMeasurement(stats[1], total, 1e-9));
     ms.add(newMeasurement(stats[2], totalOfSquares, 1e-18));
     ms.add(newMaxMeasurement(stats[3], max));
-    return ms;
   }
 
   private Measurement newMeasurement(Id mid, StepValue v, double f) {

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasGaugeTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasGaugeTest.java
@@ -56,6 +56,12 @@ public class AtlasGaugeTest {
   }
 
   @Test
+  public void measureNaN() {
+    gauge.set(Double.NaN);
+    Assertions.assertFalse(gauge.measure().iterator().hasNext());
+  }
+
+  @Test
   public void rollForward() {
     gauge.set(42);
     clock.setWallTime(step + 1);

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasMaxGaugeTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasMaxGaugeTest.java
@@ -56,6 +56,33 @@ public class AtlasMaxGaugeTest {
   }
 
   @Test
+  public void setNaN() {
+    gauge.set(Double.NaN);
+    checkValue(0);
+
+    clock.setWallTime(step + 1);
+    checkValue(0);
+  }
+
+  @Test
+  public void setInfinity() {
+    gauge.set(Double.POSITIVE_INFINITY);
+    checkValue(0);
+
+    clock.setWallTime(step + 1);
+    checkValue(0);
+  }
+
+  @Test
+  public void setNegative() {
+    gauge.set(-1);
+    checkValue(0);
+
+    clock.setWallTime(step + 1);
+    checkValue(0);
+  }
+
+  @Test
   public void multipleSets() {
     gauge.set(42);
     gauge.set(44);

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasRegistryTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasRegistryTest.java
@@ -174,6 +174,7 @@ public class AtlasRegistryTest {
     }
 
     clock.setWallTime(Duration.ofMinutes(15).toMillis() + 1);
+    registry.removeExpiredMeters();
     Assertions.assertEquals(0, getBatches().size());
   }
 


### PR DESCRIPTION
Removes the allocation of temporary lists from the
measure call. Also reduces some of the checks for
each meter:

- Expiration check can be avoided because the expired
  meters will get removed in the context where the
  data is collected.
- NaN checks inlined to the gauge type which is the
  only type where it would be possible to have a NaN
  value for the measurement.