### PR TITLE
make the initial polling delay configurable

### DIFF
--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasRegistryTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasRegistryTest.java
@@ -145,22 +145,35 @@ public class AtlasRegistryTest {
 
   @Test
   public void initialDelayTooCloseToStart() {
-    long d = registry.getInitialDelay(10000);
+    long d = newConfig().initialPollingDelay(clock, 10000);
     Assertions.assertEquals(1000, d);
   }
 
   @Test
   public void initialDelayTooCloseToEnd() {
     clock.setWallTime(19123);
-    long d = registry.getInitialDelay(10000);
-    Assertions.assertEquals(1877, d);
+    long d = newConfig().initialPollingDelay(clock, 10000);
+    Assertions.assertEquals(9000, d);
   }
 
   @Test
   public void initialDelayOk() {
     clock.setWallTime(12123);
-    long d = registry.getInitialDelay(10000);
-    Assertions.assertEquals(8877, d);
+    long d = newConfig().initialPollingDelay(clock, 10000);
+    Assertions.assertEquals(2123, d);
+  }
+
+  @Test
+  public void initialDelayTooCloseToStartSmallStep() {
+    long d = newConfig().initialPollingDelay(clock, 5000);
+    Assertions.assertEquals(500, d);
+  }
+
+  @Test
+  public void initialDelayTooCloseToEndSmallStep() {
+    clock.setWallTime(19623);
+    long d = newConfig().initialPollingDelay(clock, 5000);
+    Assertions.assertEquals(877, d);
   }
 
   @Test


### PR DESCRIPTION
This gives more control over how the data coming in will
be distributed across the step interval. By default it
will try to spread it out randomly to distribute the load.

Other policies can be chosen if needed for a given setup.
See also: #756.