### PR TITLE
update travis build to include jdk13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
     env: GRADLE_PUBLISH=true
   - jdk: openjdk11
     env: GRADLE_PUBLISH=false
-  - jdk: openjdk12
+  - jdk: openjdk13
     env: GRADLE_PUBLISH=false
 dist: xenial
 install: ./installViaTravis.sh

--- a/build.gradle
+++ b/build.gradle
@@ -106,7 +106,7 @@ subprojects {
   }
   
   spotbugs {
-    toolVersion = '3.1.12'
+    toolVersion = '4.0.0-beta4'
     excludeFilter = rootProject.file('codequality/findbugs-exclude.xml')
     ignoreFailures = false
     sourceSets = [sourceSets.main]


### PR DESCRIPTION
It was pending update to gradle 6, see #761. Support
for jdk12 has been dropped consistent with policy of
supporting 2 LTS plus latest.