### PR TITLE
fix NPE for removing not queries

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/QueryIndex.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/QueryIndex.java
@@ -217,7 +217,7 @@ public final class QueryIndex<T> {
   }
 
   private boolean removeFromMissingKeysIdx(T value) {
-    if (missingKeysIdx != null && otherKeysIdx.remove(value)) {
+    if (missingKeysIdx != null && missingKeysIdx.remove(value)) {
       if (missingKeysIdx.isEmpty()) {
         missingKeysIdx = null;
       }
@@ -232,11 +232,13 @@ public final class QueryIndex<T> {
    * removed.
    */
   public boolean remove(T value) {
+    // Note, we use | instead of || because a value could get added on multiple paths
+    // and so the short circuiting behavior is not desirable here.
     return matches.remove(value)
-        || remove(equalChecks, value)
-        || removeFromOtherChecks(value)
-        || removeFromOtherKeysIdx(value)
-        || removeFromMissingKeysIdx(value);
+        | remove(equalChecks, value)
+        | removeFromOtherChecks(value)
+        | removeFromOtherKeysIdx(value)
+        | removeFromMissingKeysIdx(value);
   }
 
   /**

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/QueryIndexTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/QueryIndexTest.java
@@ -330,6 +330,14 @@ public class QueryIndexTest {
   }
 
   @Test
+  public void removalOfNotQuery() {
+    Query q = Parser.parseQuery("name,cpu,:eq,id,user,:eq,:not,:and");
+    QueryIndex<Query> idx = QueryIndex.<Query>newInstance(registry).add(q, q);
+    Assertions.assertTrue(idx.remove(q));
+    Assertions.assertTrue(idx.isEmpty());
+  }
+
+  @Test
   public void toStringMethod() {
     QueryIndex<Query> idx = QueryIndex.newInstance(registry);
     idx.add(SIMPLE_QUERY, SIMPLE_QUERY);


### PR DESCRIPTION
The wrong variable was used for the removal portion
of the condition leading to:

```
java.lang.NullPointerException: null
    at com.netflix.spectator.atlas.impl.QueryIndex.removeFromMissingKeysIdx(QueryIndex.java:220)
    at com.netflix.spectator.atlas.impl.QueryIndex.remove(QueryIndex.java:239)
    at com.netflix.spectator.atlas.impl.QueryIndex.remove(QueryIndex.java:189)
    at com.netflix.spectator.atlas.impl.QueryIndex.remove(QueryIndex.java:236)
    at com.netflix.spectator.atlas.impl.Evaluator.sync(Evaluator.java:91)
    at com.netflix.spectator.atlas.AtlasRegistry.fetchSubscriptions(AtlasRegistry.java:402)
```