### PR TITLE
customizable retry policy for http client

### DIFF
--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/http/RetryPolicy.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/http/RetryPolicy.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2014-2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.ipc.http;
+
+import java.net.ConnectException;
+import java.net.SocketTimeoutException;
+
+/**
+ * Policy that determines if a request can be retried based on the response.
+ */
+public interface RetryPolicy {
+
+  /** Retry all requests. */
+  RetryPolicy ALL = new RetryPolicy() {
+    @Override public boolean shouldRetry(String method, Throwable t) {
+      return true;
+    }
+
+    @Override public boolean shouldRetry(String method, HttpResponse response) {
+      return true;
+    }
+  };
+
+  /**
+   * Retry operations that are known to be safe without impacting the results and the operation
+   * will potentially have a different response.
+   */
+  RetryPolicy SAFE = new RetryPolicy() {
+    /**
+     * For modifications, only retries on connection exceptions. Others such as a read timeout
+     * may have already started doing some work. Reads can be retried on all exceptions.
+     */
+    @Override public boolean shouldRetry(String method, Throwable t) {
+      return isConnectException(t) || allowedMethod(method);
+    }
+
+    private boolean isConnectException(Throwable t) {
+      return t instanceof ConnectException || isConnectTimeout(t);
+    }
+
+    /**
+     * This is fragile and based on the message, but not sure of a better way. Expecting:
+     * <pre>
+     * java.net.SocketTimeoutException: connect timed out
+     * </pre>
+     */
+    private boolean isConnectTimeout(Throwable t) {
+      return t instanceof SocketTimeoutException && t.getMessage().contains("connect");
+    }
+
+    @Override public boolean shouldRetry(String method, HttpResponse response) {
+      return allowedMethod(method) && allowedStatus(response.status());
+    }
+
+    private boolean allowedMethod(String method) {
+      return "GET".equals(method) || "HEAD".equals(method);
+    }
+
+    private boolean allowedStatus(int status) {
+      return status == 429 || status >= 500;
+    }
+  };
+
+  /**
+   * Returns true if the request should be retried when it fails with an exception.
+   */
+  boolean shouldRetry(String method, Throwable t);
+
+  /**
+   * Returns true if the request should be retried when it fails with an HTTP error code.
+   */
+  boolean shouldRetry(String method, HttpResponse response);
+}

--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/http/RetryPolicy.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/http/RetryPolicy.java
@@ -62,6 +62,14 @@ public interface RetryPolicy {
     }
 
     @Override public boolean shouldRetry(String method, HttpResponse response) {
+      return isThrottled(response.status()) || isAllowed(method, response);
+    }
+
+    private boolean isThrottled(int status) {
+      return status == 429 || status == 503;
+    }
+
+    private boolean isAllowed(String method, HttpResponse response) {
       return allowedMethod(method) && allowedStatus(response.status());
     }
 
@@ -70,7 +78,7 @@ public interface RetryPolicy {
     }
 
     private boolean allowedStatus(int status) {
-      return status == 429 || status >= 500;
+      return status >= 500;
     }
   };
 


### PR DESCRIPTION
Updates the sample HTTP client that wraps HttpURLConnection
to support a RetryPolicy. By default it uses a safe policy
that will retry read requests for all exceptions, throttling,
and 5xx errors. Write requests will only get retried for
connect exceptions and throttling. Other failures could have
a partial write and are considered unsafe to retry.