### PR TITLE
add delay_and_failure failure injection type

### DIFF
--- a/docs/ext/ipc.md
+++ b/docs/ext/ipc.md
@@ -24,7 +24,7 @@ implementations.
   connection_error and detail of no_servers / connect_timeout / ssl_handshake_failure.
 * `ipc.failure.injected`: Indicates that an artificial failure was injected into the request
   processing for testing purposes. The outcome of that failure will be reflected in the other
-  error tags. Allowed Values = [`none`,`failure`,`delay`]
+  error tags. Allowed Values = [`none`,`failure`,`delay`,`delay_and_failure`]
 * `ipc.endpoint`: The name of the endpoint/function/feature the message was sent to within
   the server (eg. the URL path prefix for a java servlet, or the grpc endpoint name).
 * `ipc.attempt`: Which attempt at sending this message is this. Allowed Values =

--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcFailureInjection.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcFailureInjection.java
@@ -30,7 +30,10 @@ public enum IpcFailureInjection implements Tag {
   failure,
 
   /** Indicates there was latency into the request. */
-  delay;
+  delay,
+
+  /** Indicates there was both a latency and an fault injected into the request. */
+  delay_and_failure;
 
   @Override public String key() {
     return IpcTagKey.failureInjected.key();


### PR DESCRIPTION
This allows properly tagging IPC metrics where both a failure
and latency has been injected.