### PR TITLE
Treat unknown or missing statistic as gauges

### DIFF
--- a/spectator-reg-stateless/src/main/java/com/netflix/spectator/stateless/JsonUtils.java
+++ b/spectator-reg-stateless/src/main/java/com/netflix/spectator/stateless/JsonUtils.java
@@ -21,8 +21,6 @@ import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Measurement;
 import com.netflix.spectator.api.Tag;
 import com.netflix.spectator.api.Utils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -38,8 +36,6 @@ import java.util.Map;
  * https://github.com/Netflix-Skunkworks/iep-apps/tree/master/atlas-aggregator
  */
 final class JsonUtils {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(JsonUtils.class);
 
   private static final JsonFactory FACTORY = new JsonFactory();
 

--- a/spectator-reg-stateless/src/main/java/com/netflix/spectator/stateless/JsonUtils.java
+++ b/spectator-reg-stateless/src/main/java/com/netflix/spectator/stateless/JsonUtils.java
@@ -43,7 +43,6 @@ final class JsonUtils {
 
   private static final JsonFactory FACTORY = new JsonFactory();
 
-  private static final int UNKNOWN = -1;
   private static final int ADD = 0;
   private static final int MAX = 10;
 
@@ -137,28 +136,25 @@ final class JsonUtils {
         return operation(t.value());
       }
     }
-    LOGGER.warn("invalid statistic for {}, value will be dropped", id);
-    return UNKNOWN;
+    return MAX;
   }
 
   private static int operation(String stat) {
     int op;
     switch (stat) {
-      case "count":          op = ADD; break;
-      case "totalAmount":    op = ADD; break;
-      case "totalTime":      op = ADD; break;
-      case "totalOfSquares": op = ADD; break;
-      case "percentile":     op = ADD; break;
-      case "max":            op = MAX; break;
-      case "gauge":          op = MAX; break;
-      case "activeTasks":    op = MAX; break;
-      case "duration":       op = MAX; break;
-      default:               op = UNKNOWN; break;
+      case "count":
+      case "totalAmount":
+      case "totalTime":
+      case "totalOfSquares":
+      case "percentile":
+        op = ADD; break;
+      default:
+        op = MAX; break;
     }
     return op;
   }
 
   private static boolean shouldSend(int op, double value) {
-    return op != UNKNOWN && !Double.isNaN(value) && (value > 0.0 || op == MAX);
+    return !Double.isNaN(value) && (value > 0.0 || op == MAX);
   }
 }

--- a/spectator-reg-stateless/src/test/java/com/netflix/spectator/stateless/JsonUtilsTest.java
+++ b/spectator-reg-stateless/src/test/java/com/netflix/spectator/stateless/JsonUtilsTest.java
@@ -108,19 +108,27 @@ public class JsonUtilsTest {
   }
 
   @Test
-  public void encodeIgnoresInvalidStatistic() throws Exception {
+  public void encodeInvalidStatisticAsGauge() throws Exception {
     List<Measurement> ms = new ArrayList<>();
     ms.add(count(42, "test", "statistic", "foo"));
     Map<Id, Delta> values = decode(JsonUtils.encode(Collections.emptyMap(), ms));
-    Assertions.assertEquals(0, values.size());
+    Assertions.assertEquals(1, values.size());
+    ms.forEach(m -> {
+      Id id = m.id();
+      Assertions.assertEquals(values.get(id).op, 10);
+    });
   }
 
   @Test
-  public void encodeIgnoresNoStatistic() throws Exception {
+  public void encodeAssumesNoStatisticIsGauge() throws Exception {
     List<Measurement> ms = new ArrayList<>();
     ms.add(unknown(42, "test"));
     Map<Id, Delta> values = decode(JsonUtils.encode(Collections.emptyMap(), ms));
-    Assertions.assertEquals(0, values.size());
+    Assertions.assertEquals(1, values.size());
+    ms.forEach(m -> {
+      Id id = m.id();
+      Assertions.assertEquals(values.get(id).op, 10);
+    });
   }
 
   @Test


### PR DESCRIPTION
Update the behavior of the `StatelessRegistry` to match the other thin
clients that assume a missing `statistic` tag, or an unknown value for
that tag encodes a gauge measurement.