### PR TITLE
aws-sdk-java-v2 2.10.56

### DIFF
--- a/dependencies.properties
+++ b/dependencies.properties
@@ -29,5 +29,5 @@ org.slf4j:slf4j-api = 1.7.30
 org.slf4j:slf4j-log4j12 = 1.7.30
 org.slf4j:slf4j-nop = 1.7.30
 org.slf4j:slf4j-simple = 1.7.30
-software.amazon.awssdk:aws-core = 2.10.47
-software.amazon.awssdk:sdk-core = 2.10.47
+software.amazon.awssdk:aws-core = 2.10.56
+software.amazon.awssdk:sdk-core = 2.10.56


### PR DESCRIPTION
Pick up fix for DNS resolution with netty client. The
usage in Spectator is just for instrumentation so this
is mostly in case someone gets it transitively.

https://github.com/aws/aws-sdk-java-v2/blob/master/CHANGELOG.md#21056-2020-01-24