### PR TITLE
nebula oss plugin 8.6.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
   dependencies {
     classpath 'com.github.ben-manes:gradle-versions-plugin:0.27.0'
     classpath 'com.netflix.nebula:nebula-dependency-recommender:9.0.1'
-    classpath 'com.netflix.nebula:gradle-netflixoss-project-plugin:8.5.1'
+    classpath 'com.netflix.nebula:gradle-netflixoss-project-plugin:8.6.0'
   }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Pull in fix to disable publishing the gradle module file
when using the shadow plugin. This incorrectly includes the
shaded dependencies which can cause issues for consumers.