### PR TITLE
Upgrade netflixoss plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
   dependencies {
     classpath 'com.github.ben-manes:gradle-versions-plugin:0.27.0'
     classpath 'com.netflix.nebula:nebula-dependency-recommender:9.0.1'
-    classpath 'com.netflix.nebula:gradle-netflixoss-project-plugin:8.5.1'
+    classpath 'com.netflix.nebula:gradle-netflixoss-project-plugin:8.6.0'
   }
 }
 


### PR DESCRIPTION
In order to avoid publishing the gradle module files which incorrectly
include the shaded dependencies