### PR TITLE
Support java library plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,8 +24,7 @@ allprojects {
 }
 
 subprojects {
-  apply plugin: 'nebula.compile-api'
-  apply plugin: 'java'
+  apply plugin: 'java-library'
   apply plugin: 'build-dashboard'
   apply plugin: 'com.github.spotbugs'
   apply plugin: 'checkstyle'

--- a/build.gradle
+++ b/build.gradle
@@ -73,9 +73,9 @@ subprojects {
   }
 
   dependencies {
-    compile "org.slf4j:slf4j-api"
-    testCompile 'org.junit.jupiter:junit-jupiter-engine'
-    testCompile 'nl.jqno.equalsverifier:equalsverifier'
+    implementation "org.slf4j:slf4j-api"
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine'
+    testImplementation 'nl.jqno.equalsverifier:equalsverifier'
     jmh "org.slf4j:slf4j-simple"
     jmh "org.openjdk.jmh:jmh-core:1.22"
     jmh "org.openjdk.jmh:jmh-generator-annprocess:1.22"

--- a/spectator-agent/build.gradle
+++ b/spectator-agent/build.gradle
@@ -3,13 +3,13 @@ plugins {
 }
 
 dependencies {
-  compile project(':spectator-api')
-  compile project(':spectator-ext-gc')
-  compile project(':spectator-ext-jvm')
-  compile project(':spectator-reg-atlas')
-  compile 'com.typesafe:config'
-  compile 'org.slf4j:slf4j-simple'
-  testCompile 'com.fasterxml.jackson.core:jackson-databind'
+  api project(':spectator-api')
+  api project(':spectator-ext-gc')
+  api project(':spectator-ext-jvm')
+  api project(':spectator-reg-atlas')
+  implementation 'com.typesafe:config'
+  implementation 'org.slf4j:slf4j-simple'
+  testImplementation 'com.fasterxml.jackson.core:jackson-databind'
 }
 
 jar {

--- a/spectator-api/build.gradle
+++ b/spectator-api/build.gradle
@@ -1,6 +1,6 @@
 
 dependencies {
-  testCompile files("$projectDir/src/test/lib/compatibility-0.68.0.jar")
+  testImplementation files("$projectDir/src/test/lib/compatibility-0.68.0.jar")
   jmh "com.google.re2j:re2j:1.2"
   jmh "com.github.ben-manes.caffeine:caffeine:2.7.0"
 }

--- a/spectator-ext-aws/build.gradle
+++ b/spectator-ext-aws/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
-  compileApi project(":spectator-api")
-  compileApi "com.amazonaws:aws-java-sdk-core"
+  api project(":spectator-api")
+  api "com.amazonaws:aws-java-sdk-core"
   testCompile "com.amazonaws:aws-java-sdk-cloudwatch"
 }
 

--- a/spectator-ext-aws/build.gradle
+++ b/spectator-ext-aws/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
   api project(":spectator-api")
   api "com.amazonaws:aws-java-sdk-core"
-  testCompile "com.amazonaws:aws-java-sdk-cloudwatch"
+  testImplementation "com.amazonaws:aws-java-sdk-cloudwatch"
 }
 
 jar {

--- a/spectator-ext-aws2/build.gradle
+++ b/spectator-ext-aws2/build.gradle
@@ -2,8 +2,8 @@ dependencies {
   api project(":spectator-api")
   api "software.amazon.awssdk:sdk-core"
 
-  compile project(":spectator-ext-ipc")
-  compile "software.amazon.awssdk:aws-core"
+  api project(":spectator-ext-ipc")
+  implementation "software.amazon.awssdk:aws-core"
 }
 
 jar {

--- a/spectator-ext-aws2/build.gradle
+++ b/spectator-ext-aws2/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
-  compileApi project(":spectator-api")
-  compileApi "software.amazon.awssdk:sdk-core"
+  api project(":spectator-api")
+  api "software.amazon.awssdk:sdk-core"
 
   compile project(":spectator-ext-ipc")
   compile "software.amazon.awssdk:aws-core"

--- a/spectator-ext-gc/build.gradle
+++ b/spectator-ext-gc/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-  compileApi project(':spectator-api')
+  api project(':spectator-api')
 }
 
 jar {

--- a/spectator-ext-ipc/build.gradle
+++ b/spectator-ext-ipc/build.gradle
@@ -1,9 +1,9 @@
 dependencies {
   api project(':spectator-api')
   jmh 'com.netflix.frigga:frigga:0.18.0'
-  testCompile 'com.fasterxml.jackson.core:jackson-core'
-  testCompile 'com.fasterxml.jackson.core:jackson-databind'
-  testCompile 'com.netflix.frigga:frigga:0.18.0'
+  testImplementation 'com.fasterxml.jackson.core:jackson-core'
+  testImplementation 'com.fasterxml.jackson.core:jackson-databind'
+  testImplementation 'com.netflix.frigga:frigga:0.18.0'
 }
 
 jar {

--- a/spectator-ext-ipc/build.gradle
+++ b/spectator-ext-ipc/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-  compileApi project(':spectator-api')
+  api project(':spectator-api')
   jmh 'com.netflix.frigga:frigga:0.18.0'
   testCompile 'com.fasterxml.jackson.core:jackson-core'
   testCompile 'com.fasterxml.jackson.core:jackson-databind'

--- a/spectator-ext-ipcservlet/build.gradle
+++ b/spectator-ext-ipcservlet/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
-  compileApi project(':spectator-api')
-  compileApi project(':spectator-ext-ipc')
+  api project(':spectator-api')
+  api project(':spectator-ext-ipc')
   compile 'javax.inject:javax.inject:1'
   compileOnly 'javax.servlet:javax.servlet-api:4.0.1'
   testCompile 'org.eclipse.jetty:jetty-servlet:9.4.11.v20180605'

--- a/spectator-ext-ipcservlet/build.gradle
+++ b/spectator-ext-ipcservlet/build.gradle
@@ -1,11 +1,11 @@
 dependencies {
   api project(':spectator-api')
   api project(':spectator-ext-ipc')
-  compile 'javax.inject:javax.inject:1'
+  implementation 'javax.inject:javax.inject:1'
   compileOnly 'javax.servlet:javax.servlet-api:4.0.1'
-  testCompile 'org.eclipse.jetty:jetty-servlet:9.4.11.v20180605'
-  testCompile 'org.eclipse.jetty:jetty-webapp:9.4.11.v20180605'
-  testCompile 'com.google.inject.extensions:guice-servlet:4.1.0'
+  testImplementation 'org.eclipse.jetty:jetty-servlet:9.4.11.v20180605'
+  testImplementation 'org.eclipse.jetty:jetty-webapp:9.4.11.v20180605'
+  testImplementation 'com.google.inject.extensions:guice-servlet:4.1.0'
 }
 
 jar {

--- a/spectator-ext-jvm/build.gradle
+++ b/spectator-ext-jvm/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
   api project(':spectator-api')
-  compile 'com.typesafe:config'
+  implementation 'com.typesafe:config'
 }
 
 jar {

--- a/spectator-ext-jvm/build.gradle
+++ b/spectator-ext-jvm/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-  compileApi project(':spectator-api')
+  api project(':spectator-api')
   compile 'com.typesafe:config'
 }
 

--- a/spectator-ext-log4j1/build.gradle
+++ b/spectator-ext-log4j1/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
-  compileApi project(':spectator-api')
-  compileApi "log4j:log4j:1.2.17"
+  api project(':spectator-api')
+  api "log4j:log4j:1.2.17"
 }
 
 jar {

--- a/spectator-ext-log4j2/build.gradle
+++ b/spectator-ext-log4j2/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
-  compileApi project(':spectator-api')
-  compileApi "org.apache.logging.log4j:log4j-api"
-  compileApi "org.apache.logging.log4j:log4j-core"
+  api project(':spectator-api')
+  api "org.apache.logging.log4j:log4j-api"
+  api "org.apache.logging.log4j:log4j-core"
 }
 
 jar {

--- a/spectator-ext-placeholders/build.gradle
+++ b/spectator-ext-placeholders/build.gradle
@@ -3,8 +3,8 @@ dependencies {
 
   // The MdcTagFactoryTest requires a logging implementation that supports the MDC
   // functionality, which the slf4j-nop (default) and slf4j-simple implementations do not.
-  testCompile "org.slf4j:slf4j-log4j12"
-  testCompile "log4j:log4j"
+  testImplementation "org.slf4j:slf4j-log4j12"
+  testImplementation "log4j:log4j"
 }
 
 jar {

--- a/spectator-ext-placeholders/build.gradle
+++ b/spectator-ext-placeholders/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-  compileApi project(':spectator-api')
+  api project(':spectator-api')
 
   // The MdcTagFactoryTest requires a logging implementation that supports the MDC
   // functionality, which the slf4j-nop (default) and slf4j-simple implementations do not.

--- a/spectator-ext-sandbox/build.gradle
+++ b/spectator-ext-sandbox/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-  compileApi project(':spectator-api')
+  api project(':spectator-api')
 }
 
 jar {

--- a/spectator-ext-spark/build.gradle
+++ b/spectator-ext-spark/build.gradle
@@ -3,13 +3,13 @@ plugins {
 }
 
 dependencies {
-  compile project(':spectator-api')
-  compile project(':spectator-ext-gc')
-  compile project(':spectator-ext-jvm')
-  compile "com.eclipsesource.minimal-json:minimal-json"
-  compile "com.typesafe:config"
-  compile 'io.dropwizard.metrics:metrics-core:3.1.2'
-  compile 'org.apache.spark:spark-core_2.10:1.6.1'
+  api project(':spectator-api')
+  api project(':spectator-ext-gc')
+  api project(':spectator-ext-jvm')
+  implementation "com.eclipsesource.minimal-json:minimal-json"
+  implementation "com.typesafe:config"
+  implementation 'io.dropwizard.metrics:metrics-core:3.1.2'
+  implementation 'org.apache.spark:spark-core_2.10:1.6.1'
 }
 
 jar {

--- a/spectator-nflx-plugin/build.gradle
+++ b/spectator-nflx-plugin/build.gradle
@@ -1,14 +1,14 @@
 dependencies {
-  compile project(':spectator-api')
-  compile project(':spectator-ext-gc')
-  compile project(':spectator-ext-jvm')
-  compile project(':spectator-reg-atlas')
-  compile 'javax.inject:javax.inject'
-  compile "com.google.inject:guice"
-  compile "com.google.inject.extensions:guice-multibindings"
-  compile "com.netflix.archaius:archaius2-core"
-  compile "com.netflix.servo:servo-core"
-  testCompile "com.netflix.governator:governator"
+  api project(':spectator-api')
+  api project(':spectator-ext-gc')
+  api project(':spectator-ext-jvm')
+  api project(':spectator-reg-atlas')
+  implementation 'javax.inject:javax.inject'
+  implementation "com.google.inject:guice"
+  implementation "com.google.inject.extensions:guice-multibindings"
+  implementation "com.netflix.archaius:archaius2-core"
+  implementation "com.netflix.servo:servo-core"
+  testImplementation "com.netflix.governator:governator"
 }
 
 jar {

--- a/spectator-nflx/build.gradle
+++ b/spectator-nflx/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-  compile project(':spectator-nflx-plugin')
+  api project(':spectator-nflx-plugin')
 }
 
 jar {

--- a/spectator-perf/build.gradle
+++ b/spectator-perf/build.gradle
@@ -1,8 +1,8 @@
 dependencies {
-  compile project(':spectator-api')
-  compile project(':spectator-reg-atlas')
-  compile project(':spectator-reg-servo')
-  compile 'org.openjdk.jol:jol-core:0.8'
+  api project(':spectator-api')
+  api project(':spectator-reg-atlas')
+  api project(':spectator-reg-servo')
+  implementation 'org.openjdk.jol:jol-core:0.8'
 }
 
 jar {

--- a/spectator-reg-atlas/build.gradle
+++ b/spectator-reg-atlas/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 dependencies {
-  compileApi project(':spectator-api')
+  api project(':spectator-api')
   compile project(':spectator-ext-ipc')
   compile 'com.fasterxml.jackson.core:jackson-core'
   compile 'com.fasterxml.jackson.core:jackson-databind'

--- a/spectator-reg-atlas/build.gradle
+++ b/spectator-reg-atlas/build.gradle
@@ -6,11 +6,11 @@ plugins {
 
 dependencies {
   api project(':spectator-api')
-  compile project(':spectator-ext-ipc')
-  compile 'com.fasterxml.jackson.core:jackson-core'
-  compile 'com.fasterxml.jackson.core:jackson-databind'
-  compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-smile'
-  compile 'javax.inject:javax.inject'
+  api project(':spectator-ext-ipc')
+  implementation 'com.fasterxml.jackson.core:jackson-core'
+  implementation 'com.fasterxml.jackson.core:jackson-databind'
+  implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-smile'
+  implementation 'javax.inject:javax.inject'
   jmh project(':spectator-api')
 }
 
@@ -32,7 +32,7 @@ static boolean shouldBeShaded(String name) {
 
 shadowJar {
   classifier = null
-  configurations = [project.configurations.runtime]
+  configurations = [project.configurations.runtimeClasspath]
   dependencies {
     exclude(dependency {
       !shouldBeShaded(it.moduleName)

--- a/spectator-reg-metrics3/build.gradle
+++ b/spectator-reg-metrics3/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
-  compileApi project(':spectator-api')
-  compileApi 'io.dropwizard.metrics:metrics-core:3.1.2'
+  api project(':spectator-api')
+  api 'io.dropwizard.metrics:metrics-core:3.1.2'
   jmh project(':spectator-api')
 }
 

--- a/spectator-reg-micrometer/build.gradle
+++ b/spectator-reg-micrometer/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-  compileApi project(':spectator-api')
+  api project(':spectator-api')
   compile 'io.micrometer:micrometer-core'
 }
 

--- a/spectator-reg-micrometer/build.gradle
+++ b/spectator-reg-micrometer/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
   api project(':spectator-api')
-  compile 'io.micrometer:micrometer-core'
+  implementation 'io.micrometer:micrometer-core'
 }
 
 jar {

--- a/spectator-reg-servo/build.gradle
+++ b/spectator-reg-servo/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
-  compileApi project(':spectator-api')
+  api project(':spectator-api')
   compile 'com.google.guava:guava'
-  compileApi 'com.netflix.servo:servo-core'
+  api 'com.netflix.servo:servo-core'
   jmh project(':spectator-api')
 }
 

--- a/spectator-reg-servo/build.gradle
+++ b/spectator-reg-servo/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
   api project(':spectator-api')
-  compile 'com.google.guava:guava'
+  implementation 'com.google.guava:guava'
   api 'com.netflix.servo:servo-core'
   jmh project(':spectator-api')
 }

--- a/spectator-reg-stateless/build.gradle
+++ b/spectator-reg-stateless/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
   api project(':spectator-api')
-  compile project(':spectator-ext-ipc')
-  compile 'com.fasterxml.jackson.core:jackson-core'
+  api project(':spectator-ext-ipc')
+  implementation 'com.fasterxml.jackson.core:jackson-core'
 }
 
 jar {

--- a/spectator-reg-stateless/build.gradle
+++ b/spectator-reg-stateless/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-  compileApi project(':spectator-api')
+  api project(':spectator-api')
   compile project(':spectator-ext-ipc')
   compile 'com.fasterxml.jackson.core:jackson-core'
 }

--- a/spectator-web-spring/build.gradle
+++ b/spectator-web-spring/build.gradle
@@ -15,11 +15,11 @@
  */
 
 dependencies {
-  compile project(':spectator-api')
-  compile 'org.springframework.boot:spring-boot-autoconfigure:1.2.8.RELEASE'
-  compile 'org.springframework:spring-beans:4.1.9.RELEASE'
-  compile 'org.springframework:spring-web:4.1.9.RELEASE'
-  compile 'com.fasterxml.jackson.core:jackson-databind'
+  api project(':spectator-api')
+  implementation 'org.springframework.boot:spring-boot-autoconfigure:1.2.8.RELEASE'
+  implementation 'org.springframework:spring-beans:4.1.9.RELEASE'
+  implementation 'org.springframework:spring-web:4.1.9.RELEASE'
+  api 'com.fasterxml.jackson.core:jackson-databind'
 }
 
 jar {


### PR DESCRIPTION
We are doing some work to remove compileApi configuration from nebula (https://github.com/nebula-plugins/nebula-publishing-plugin/pull/159)

`nebula.compile-api `plugin was created for:

* adds a compileApi configuration which will put dependencies in the compile scope of maven poms
* This configuration should only be used for dependencies that are actually present in the api and needed to compile.

This is now accomplished via java-library plugin (https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_separation)
