### PR TITLE
fix NPE for IPC retry policy

### DIFF
--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/http/RetryPolicy.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/http/RetryPolicy.java
@@ -58,7 +58,9 @@ public interface RetryPolicy {
      * </pre>
      */
     private boolean isConnectTimeout(Throwable t) {
-      return t instanceof SocketTimeoutException && t.getMessage().contains("connect");
+      return t instanceof SocketTimeoutException
+          && t.getMessage() != null
+          && t.getMessage().contains("connect");
     }
 
     @Override public boolean shouldRetry(String method, HttpResponse response) {

--- a/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/http/RetryPolicyTest.java
+++ b/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/http/RetryPolicyTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2014-2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.ipc.http;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.net.SocketTimeoutException;
+
+public class RetryPolicyTest {
+
+  @Test
+  public void safeIsConnectNullMessage() {
+    RetryPolicy policy = RetryPolicy.SAFE;
+    Assertions.assertTrue(policy.shouldRetry("GET", new SocketTimeoutException(null)));
+  }
+}


### PR DESCRIPTION
If the `SocketTimeoutException` had a null message, then
it would result in an NPE.