### PR TITLE
avoid allocating tag objects for ids

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ subprojects {
     profilers = ['stack', 'gc']
     includeTests = false
     duplicateClassesStrategy = 'warn'
-    include = ['.*IdTraversal.*']
+    include = ['.*Ids.*']
   }
 
   checkstyle {

--- a/spectator-api/src/main/java/com/netflix/spectator/api/ArrayTagSet.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/ArrayTagSet.java
@@ -17,7 +17,11 @@ package com.netflix.spectator.api;
 
 import com.netflix.spectator.impl.Preconditions;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 
 /**

--- a/spectator-api/src/main/java/com/netflix/spectator/api/Id.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/Id.java
@@ -74,6 +74,9 @@ public interface Id extends TagList {
    */
   @SuppressWarnings("PMD.UseObjectForClearerAPI")
   default Id withTags(String k1, String v1, String k2, String v2) {
+    // The original reason for this method was to avoid allocating a string array before
+    // creating a Tag array. The internals have changed so it can work on the string array
+    // directly. The overload is kept for backwards compatiblity.
     final String[] ts = {
         k1, v1,
         k2, v2
@@ -87,6 +90,9 @@ public interface Id extends TagList {
    */
   @SuppressWarnings("PMD.UseObjectForClearerAPI")
   default Id withTags(String k1, String v1, String k2, String v2, String k3, String v3) {
+    // The original reason for this method was to avoid allocating a string array before
+    // creating a Tag array. The internals have changed so it can work on the string array
+    // directly. The overload is kept for backwards compatiblity.
     final String[] ts = {
         k1, v1,
         k2, v2,

--- a/spectator-api/src/main/java/com/netflix/spectator/api/Id.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/Id.java
@@ -74,9 +74,9 @@ public interface Id extends TagList {
    */
   @SuppressWarnings("PMD.UseObjectForClearerAPI")
   default Id withTags(String k1, String v1, String k2, String v2) {
-    final Tag[] ts = {
-        new BasicTag(k1, v1),
-        new BasicTag(k2, v2)
+    final String[] ts = {
+        k1, v1,
+        k2, v2
     };
     return withTags(ts);
   }
@@ -87,10 +87,10 @@ public interface Id extends TagList {
    */
   @SuppressWarnings("PMD.UseObjectForClearerAPI")
   default Id withTags(String k1, String v1, String k2, String v2, String k3, String v3) {
-    final Tag[] ts = {
-        new BasicTag(k1, v1),
-        new BasicTag(k2, v2),
-        new BasicTag(k3, v3)
+    final String[] ts = {
+        k1, v1,
+        k2, v2,
+        k3, v3
     };
     return withTags(ts);
   }

--- a/spectator-api/src/test/java/com/netflix/spectator/api/ArrayTagSetTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/ArrayTagSetTest.java
@@ -78,6 +78,18 @@ public class ArrayTagSetTest {
   }
 
   @Test
+  public void testAddNullKey() {
+    ArrayTagSet ts = ArrayTagSet.EMPTY;
+    Assertions.assertThrows(NullPointerException.class, () -> ts.add(null, "v"));
+  }
+
+  @Test
+  public void testAddNullValue() {
+    ArrayTagSet ts = ArrayTagSet.EMPTY;
+    Assertions.assertThrows(NullPointerException.class, () -> ts.add("k", null));
+  }
+
+  @Test
   public void testIteratorRemoveUnsupported() {
     Assertions.assertThrows(UnsupportedOperationException.class,
         () -> ArrayTagSet.create("k", "v").iterator().remove());
@@ -314,6 +326,14 @@ public class ArrayTagSetTest {
   public void addAllStringArrayEmpty() {
     ArrayTagSet ts = ArrayTagSet.EMPTY.addAll(new String[0]);
     Assertions.assertSame(ArrayTagSet.EMPTY, ts);
+  }
+
+  @Test
+  public void addAllStringArrayMutate() {
+    String[] vs = {"a", "b"};
+    ArrayTagSet ts = ArrayTagSet.EMPTY.addAll(vs);
+    vs[0] = "c";
+    Assertions.assertEquals(ArrayTagSet.create("a", "b"), ts);
   }
 
   @Test


### PR DESCRIPTION
The main use-case was to sort the list. This change
switches to a simple insertion sort that can work on
the paired string array in-place. Since the set of
tags is small, internally limited to less than 20,
this works well for current use-cases.

JMH benchmark shows throughput increased and
allocations per operation were reduced.

**Throughput**

| Benchmark            |        Before |         After | % Delta |
|----------------------|---------------|---------------|---------|
| append1              |  33,912,834.4 |  35,650,910.7 |     5.1 |
| append2              |  23,578,876.9 |  24,495,289.0 |     3.9 |
| append4              |   6,793,235.3 |   8,047,446.0 |    18.5 |
| append4sorted        |   7,863,378.4 |   8,574,785.4 |     9.0 |
| baseline             |  28,814,809.1 |  30,590,500.1 |     6.2 |
| emptyAppend1         |  99,650,153.8 | 114,432,239.4 |    14.8 |
| emptyAppend2         |  40,462,631.3 |  47,386,710.5 |    17.1 |
| emptyAppend4         |  10,530,858.7 |  18,481,010.9 |    75.5 |
| emptyAppend4sorted   |  12,437,264.6 |  25,866,061.3 |   108.0 |
| justName             | 274,166,764.5 | 279,269,202.2 |     1.9 |
| withTag              |   2,220,564.2 |   2,409,383.5 |     8.5 |
| withTagsMap          |   2,861,224.8 |   3,442,032.0 |    20.3 |
| withTagsVararg       |   2,827,086.7 |   4,055,189.6 |    43.4 |
| withTagsVarargSorted |   5,172,295.0 |   9,787,790.4 |    89.2 |

**Allocations**

| Benchmark            |        Before |         After | % Delta |
|----------------------|---------------|---------------|---------|
| append1              |         136.0 |         136.0 |    -0.0 |
| append2              |         280.0 |         288.0 |     2.9 |
| append4              |         400.1 |         352.1 |   -12.0 |
| append4sorted        |         400.1 |         352.0 |   -12.0 |
| baseline             |         312.0 |         312.0 |    -0.0 |
| emptyAppend1         |          72.0 |          72.0 |    -0.0 |
| emptyAppend2         |         152.0 |         112.0 |   -26.3 |
| emptyAppend4         |         272.0 |         144.0 |   -47.1 |
| emptyAppend4sorted   |         272.0 |         144.0 |   -47.1 |
| justName             |          24.0 |          24.0 |     0.0 |
| withTag              |       1,416.2 |       1,416.1 |    -0.0 |
| withTagsMap          |         536.1 |         184.1 |   -65.7 |
| withTagsVararg       |         648.1 |         296.1 |   -54.3 |
| withTagsVarargSorted |         648.1 |         296.0 |   -54.3 |