### PR TITLE
avoid id alloction for bucket type updates

### DIFF
--- a/spectator-api/src/jmh/java/com/netflix/spectator/perf/BucketMeters.java
+++ b/spectator-api/src/jmh/java/com/netflix/spectator/perf/BucketMeters.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2014-2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.perf;
+
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.histogram.BucketCounter;
+import com.netflix.spectator.api.histogram.BucketDistributionSummary;
+import com.netflix.spectator.api.histogram.BucketFunctions;
+import com.netflix.spectator.api.histogram.BucketTimer;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Thread)
+public class BucketMeters {
+
+  private final Registry registry = new DefaultRegistry();
+
+  private final BucketCounter counter = BucketCounter.get(
+      registry,
+      registry.createId("test.counter"),
+      BucketFunctions.ageBiasOld(60, TimeUnit.MILLISECONDS)
+  );
+
+  private final BucketTimer timer = BucketTimer.get(
+      registry,
+      registry.createId("test.timer"),
+      BucketFunctions.ageBiasOld(60, TimeUnit.MILLISECONDS)
+  );
+
+  private final BucketDistributionSummary dist= BucketDistributionSummary.get(
+      registry,
+      registry.createId("test.dist"),
+      BucketFunctions.bytes(60)
+  );
+
+  @Threads(1)
+  @Benchmark
+  public void counterRecord() {
+    counter.record(47000L);
+  }
+
+  @Threads(1)
+  @Benchmark
+  public void timerRecord() {
+    timer.record(47000L, TimeUnit.MILLISECONDS);
+  }
+
+  @Threads(1)
+  @Benchmark
+  public void distRecord() {
+    dist.record(47L);
+  }
+}

--- a/spectator-api/src/main/java/com/netflix/spectator/api/histogram/BucketCounter.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/histogram/BucketCounter.java
@@ -20,8 +20,10 @@ import com.netflix.spectator.api.DistributionSummary;
 import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Measurement;
 import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Utils;
 
 import java.util.Collections;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.LongFunction;
 
 /** Counters that get incremented based on the bucket for recorded values. */
@@ -47,12 +49,14 @@ public final class BucketCounter implements DistributionSummary {
   private final Registry registry;
   private final Id id;
   private final LongFunction<String> f;
+  private final ConcurrentHashMap<String, Counter> counters;
 
   /** Create a new instance. */
   BucketCounter(Registry registry, Id id, LongFunction<String> f) {
     this.registry = registry;
     this.id = id;
     this.f = f;
+    this.counters = new ConcurrentHashMap<>();
   }
 
   @Override public Id id() {
@@ -73,7 +77,11 @@ public final class BucketCounter implements DistributionSummary {
 
   /** Return the count for a given bucket. */
   Counter counter(String bucket) {
-    return registry.counter(id.withTag("bucket", bucket));
+    return Utils.computeIfAbsent(
+        counters,
+        bucket,
+        k -> registry.counter(id.withTag("bucket", k))
+    );
   }
 
   /** Not supported, will always return 0. */


### PR DESCRIPTION
The meter for a bucket will get stored so it can get quickly
looked up for subsequent updates.

**Throughput**

| Benchmark            |        Before |         After | % Delta |
|----------------------|---------------|---------------|---------|
| counterRecord        |  30,046,637.8 |  77,787,334.6 |   158.9 |
| distRecord           |  26,777,122.7 |  63,082,754.3 |   135.6 |
| timerRecord          |  25,752,977.2 |  56,120,916.6 |   117.9 |

**Allocations**

| Benchmark            |        Before |         After | % Delta |
|----------------------|---------------|---------------|---------|
| counterRecord        |          88.0 |           0.0 |  -100.0 |
| distRecord           |          88.0 |           0.0 |  -100.0 |
| timerRecord          |          88.0 |           0.0 |  -100.0 |