### PR TITLE
remove config to publish of shadowJar

### DIFF
--- a/spectator-agent/build.gradle
+++ b/spectator-agent/build.gradle
@@ -30,11 +30,3 @@ shadowJar {
   relocate('org.slf4j',                'spectator-agent.slf4j')
 }
 
-publishing {
-  publications {
-    nebula(MavenPublication) {
-      artifact shadowJar
-    }
-  }
-}
-

--- a/spectator-ext-spark/build.gradle
+++ b/spectator-ext-spark/build.gradle
@@ -35,11 +35,3 @@ shadowJar {
   }
 }
 
-publishing {
-  publications {
-    nebula(MavenPublication) {
-      artifact shadowJar
-    }
-  }
-}
-


### PR DESCRIPTION
Newer versions of nebula plugin does this automatically. Fixes
errors on builds:

```
Execution failed for task ':spectator-agent:publishNebulaPublicationToBintrayRepository'.
> Failed to publish publication 'nebula' to repository 'Bintray'
   > Invalid publication 'nebula': multiple artifacts with the identical extension and classifier ('jar', 'shadow').
```