### PR TITLE
reduce allocations for other key queries

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/QueryIndex.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/QueryIndex.java
@@ -302,14 +302,18 @@ public final class QueryIndex<T> {
           // Scan for matches with other conditions
           List<QueryIndex<T>> otherMatches = otherChecksCache.get(v);
           if (otherMatches == null) {
-            List<QueryIndex<T>> tmp = new ArrayList<>();
-            otherChecks.forEach((kq, idx) -> {
-              if (kq.matches(v)) {
-                tmp.add(idx);
-                idx.forEachMatch(tags, i + 1, consumer);
-              }
-            });
-            otherChecksCache.put(v, tmp);
+            // Avoid the list and cache allocations if there are no other checks at
+            // this level
+            if (!otherChecks.isEmpty()) {
+              List<QueryIndex<T>> tmp = new ArrayList<>();
+              otherChecks.forEach((kq, idx) -> {
+                if (kq.matches(v)) {
+                  tmp.add(idx);
+                  idx.forEachMatch(tags, i + 1, consumer);
+                }
+              });
+              otherChecksCache.put(v, tmp);
+            }
           } else {
             for (QueryIndex<T> idx : otherMatches) {
               idx.forEachMatch(tags, i + 1, consumer);


### PR DESCRIPTION
Updates the query index to avoid allocating the list and
caching an empty list for cases where there are no other
checks (key queries that are not exact equality). For most
cases it is a small overhead, but for some data sets it
can be significant.