### PR TITLE
reduce allocations for AtlasRegistry.pollMeters

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ subprojects {
     profilers = ['stack', 'gc']
     includeTests = false
     duplicateClassesStrategy = 'warn'
-    include = ['.*Ids.*']
+    include = ['.*PollMetersBench.*']
   }
 
   checkstyle {

--- a/spectator-reg-atlas/src/jmh/java/com/netflix/spectator/atlas/PollMetersBench.java
+++ b/spectator-reg-atlas/src/jmh/java/com/netflix/spectator/atlas/PollMetersBench.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2014-2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.ManualClock;
+import com.netflix.spectator.api.histogram.PercentileTimer;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Thread)
+public class PollMetersBench {
+
+  private ManualClock clock;
+  private AtlasRegistry registry;
+
+  @Setup
+  public void setup() {
+    clock = new ManualClock();
+    registry = new AtlasRegistry(clock, System::getProperty);
+    Random r = new Random(42);
+    for (int i = 0; i < 100_000; ++i) {
+      switch (r.nextInt(8)) {
+        case 0:
+          registry.timer(randomId(r)).record(42, TimeUnit.MILLISECONDS);
+          break;
+        case 1:
+          registry.distributionSummary(randomId(r)).record(42);
+          break;
+        case 2:
+          registry.gauge(randomId(r)).set(42.0);
+          break;
+        case 3:
+          registry.maxGauge(randomId(r)).set(42.0);
+          break;
+        case 4:
+          PercentileTimer.builder(registry)
+              .withId(randomId(r))
+              .build()
+              .record(r.nextInt(60_000), TimeUnit.MILLISECONDS);
+          break;
+        default:
+          registry.counter(randomId(r)).increment();
+          break;
+      }
+    }
+  }
+
+  private Id randomId(Random r) {
+    Id tmp = Id.create(randomString(r, 2 + r.nextInt(120)));
+    int n = r.nextInt(20);
+    for (int i = 0; i < n; ++i) {
+      String k = randomString(r, 2 + r.nextInt(60));
+      String v = randomString(r, 2 + r.nextInt(120));
+      tmp = tmp.withTag(k, v);
+    }
+    return tmp;
+  }
+
+  private String randomString(Random r, int len) {
+    StringBuilder builder = new StringBuilder(len);
+    for (int i = 0; i < len; ++i) {
+      builder.append(randomChar(r));
+    }
+    return builder.toString();
+  }
+
+  private char randomChar(Random r) {
+    final int range = '~' - '!';
+    return (char) ('!' + r.nextInt(range));
+  }
+
+  @Benchmark
+  public void pollMeters(Blackhole bh) {
+    long t = clock.wallTime() + 1;
+    clock.setWallTime(t);
+    registry.pollMeters(t);
+    bh.consume(registry.getBatches(t));
+  }
+}

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasCounter.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasCounter.java
@@ -18,11 +18,8 @@ package com.netflix.spectator.atlas;
 import com.netflix.spectator.api.Clock;
 import com.netflix.spectator.api.Counter;
 import com.netflix.spectator.api.Id;
-import com.netflix.spectator.api.Measurement;
 import com.netflix.spectator.api.Statistic;
 import com.netflix.spectator.impl.StepDouble;
-
-import java.util.List;
 
 /**
  * Counter that reports a rate per second to Atlas. Note that {@link #count()} will
@@ -43,9 +40,9 @@ class AtlasCounter extends AtlasMeter implements Counter {
     this.stat = id.withTag(Statistic.count).withTags(id.tags()).withTag(DsType.rate);
   }
 
-  @Override void measure(List<Measurement> ms) {
+  @Override void measure(MeasurementConsumer consumer) {
     final double rate = value.pollAsRate();
-    ms.add(new Measurement(stat, value.timestamp(), rate));
+    consumer.accept(stat, value.timestamp(), rate);
   }
 
   @Override public void add(double amount) {

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasGauge.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasGauge.java
@@ -18,11 +18,8 @@ package com.netflix.spectator.atlas;
 import com.netflix.spectator.api.Clock;
 import com.netflix.spectator.api.Gauge;
 import com.netflix.spectator.api.Id;
-import com.netflix.spectator.api.Measurement;
 import com.netflix.spectator.api.Statistic;
 import com.netflix.spectator.impl.AtomicDouble;
-
-import java.util.List;
 
 /**
  * Meter that reports a single value to Atlas.
@@ -41,10 +38,10 @@ class AtlasGauge extends AtlasMeter implements Gauge {
     this.stat = id.withTag(Statistic.gauge).withTags(id.tags()).withTag(DsType.gauge);
   }
 
-  @Override void measure(List<Measurement> ms) {
+  @Override void measure(MeasurementConsumer consumer) {
     final double v = value();
     if (Double.isFinite(v)) {
-      ms.add(new Measurement(stat, clock.wallTime(), v));
+      consumer.accept(stat, clock.wallTime(), v);
     }
   }
 

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasMaxGauge.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasMaxGauge.java
@@ -18,11 +18,8 @@ package com.netflix.spectator.atlas;
 import com.netflix.spectator.api.Clock;
 import com.netflix.spectator.api.Gauge;
 import com.netflix.spectator.api.Id;
-import com.netflix.spectator.api.Measurement;
 import com.netflix.spectator.api.Statistic;
 import com.netflix.spectator.impl.StepDouble;
-
-import java.util.List;
 
 /**
  * Gauge that reports the maximum value submitted during an interval to Atlas. Main use-case
@@ -43,12 +40,12 @@ class AtlasMaxGauge extends AtlasMeter implements Gauge {
     this.stat = id.withTag(Statistic.max).withTags(id.tags()).withTag(DsType.gauge);
   }
 
-  @Override void measure(List<Measurement> ms) {
+  @Override void measure(MeasurementConsumer consumer) {
     // poll needs to be called before accessing the timestamp to ensure
     // the counters have been rotated if there was no activity in the
     // current interval.
     double v = value.poll();
-    ms.add(new Measurement(stat, value.timestamp(), v));
+    consumer.accept(stat, value.timestamp(), v);
   }
 
   @Override public void set(double v) {

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasMeter.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasMeter.java
@@ -64,9 +64,9 @@ abstract class AtlasMeter implements Meter {
 
   @Override public Iterable<Measurement> measure() {
     List<Measurement> ms = new ArrayList<>();
-    measure(ms);
+    measure((id, timestamp, value) -> ms.add(new Measurement(id, timestamp, value)));
     return ms;
   }
 
-  abstract void measure(List<Measurement> ms);
+  abstract void measure(MeasurementConsumer consumer);
 }

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/MeasurementConsumer.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/MeasurementConsumer.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2014-2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import com.netflix.spectator.api.Id;
+
+@FunctionalInterface
+interface MeasurementConsumer {
+
+  void accept(Id id, long timestamp, double value);
+}


### PR DESCRIPTION
Refactors the code to avoid creating temporary Measurement
lambda instances.

**Throughput**

| Benchmark            |        Before |         After | % Delta |
|----------------------|---------------|---------------|---------|
| pollMeters           |          11.2 |          14.5 |    30.0 |

**Allocations**

| Benchmark            |        Before |         After | % Delta |
|----------------------|---------------|---------------|---------|
| pollMeters           |   9,077,604.8 |     933,845.9 |   -89.7 |