### PR TITLE
update ServerGroup helper for recent frigga changes

### DIFF
--- a/dependencies.properties
+++ b/dependencies.properties
@@ -11,6 +11,7 @@ com.fasterxml.jackson.jr:jackson-jr-objects = 2.10.3
 com.google.inject.extensions:guice-multibindings = 4.1.0
 com.google.inject:guice = 4.1.0
 com.netflix.archaius:archaius2-core = 2.3.16
+com.netflix.frigga:frigga = 0.24.0
 com.netflix.governator:governator = 1.17.10
 com.netflix.governator:governator-api = 1.17.10
 com.netflix.governator:governator-core = 1.17.10

--- a/spectator-ext-ipc/build.gradle
+++ b/spectator-ext-ipc/build.gradle
@@ -1,9 +1,9 @@
 dependencies {
   api project(':spectator-api')
-  jmh 'com.netflix.frigga:frigga:0.18.0'
+  jmh 'com.netflix.frigga:frigga'
   testImplementation 'com.fasterxml.jackson.core:jackson-core'
   testImplementation 'com.fasterxml.jackson.core:jackson-databind'
-  testImplementation 'com.netflix.frigga:frigga:0.18.0'
+  testImplementation 'com.netflix.frigga:frigga'
 }
 
 jar {

--- a/spectator-ext-ipc/src/jmh/java/com/netflix/spectator/ipc/ShardParsing.java
+++ b/spectator-ext-ipc/src/jmh/java/com/netflix/spectator/ipc/ShardParsing.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.ipc;
+
+import com.netflix.frigga.Names;
+import com.netflix.frigga.conventions.sharding.Shard;
+import com.netflix.frigga.conventions.sharding.ShardingNamingConvention;
+import com.netflix.frigga.conventions.sharding.ShardingNamingResult;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.Map;
+
+
+/**
+ * <h3>Throughput</h3>
+ *
+ * <pre>
+ * Benchmark                Mode  Cnt        Score        Error   Units
+ * string                  thrpt   10  2390746.885 ± 267046.809   ops/s
+ * frigga                  thrpt   10    49131.886 ±   1776.454   ops/s
+ * </pre>
+ *
+ * <h3>Allocations</h3>
+ *
+ * <pre>
+ * Benchmark                Mode  Cnt        Score        Error   Units
+ * string     gc.alloc.rate.norm   10      512.164 ±      0.026    B/op
+ * frigga     gc.alloc.rate.norm   10    13120.752 ±      1.047    B/op
+ * </pre>
+ */
+@State(Scope.Thread)
+public class ShardParsing {
+
+  private final String[] asgs = {
+      "application_name",
+      "application_name-stack",
+      "application_name-stack-x1foo-detail",
+      "application_name-stack-x1foo-x2bar-detail_1-detail_2",
+      "application_name--x1foo-x1bar-detail",
+      "application_name-v001",
+      "application_name-stack-v001",
+      "application_name-stack-detail-v001",
+      "application_name-stack-detail_1-detail_2-v001",
+      "application_name--detail-v001"
+  };
+
+  private final ShardingNamingConvention convention = new ShardingNamingConvention();
+
+  @Benchmark
+  public void string(Blackhole bh) {
+    for (String asg : asgs) {
+      ServerGroup group = ServerGroup.parse(asg);
+      bh.consume(group.shard1());
+      bh.consume(group.shard2());
+    }
+  }
+
+  @Benchmark
+  public void frigga(Blackhole bh) {
+    for (String asg : asgs) {
+      Names group = Names.parseName(asg);
+      String detail = group.getDetail();
+      if (detail != null) {
+        ShardingNamingResult result = convention.extractNamingConvention(group.getDetail());
+        if (result.getResult().isPresent()) {
+          Map<Integer, Shard> shards = result.getResult().get();
+          Shard s1 = shards.get(1);
+          if (s1 != null) {
+            bh.consume(s1.getShardValue());
+          }
+          Shard s2 = shards.get(2);
+          if (s2 != null) {
+            bh.consume(s2.getShardValue());
+          }
+        }
+      }
+    }
+  }
+
+}

--- a/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/ServerGroupTest.java
+++ b/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/ServerGroupTest.java
@@ -16,10 +16,15 @@
 package com.netflix.spectator.ipc;
 
 import com.netflix.frigga.Names;
+import com.netflix.frigga.conventions.sharding.Shard;
+import com.netflix.frigga.conventions.sharding.ShardingNamingConvention;
+import com.netflix.frigga.conventions.sharding.ShardingNamingResult;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
 import java.util.Random;
+import java.util.function.BiFunction;
 
 public class ServerGroupTest {
 
@@ -58,6 +63,13 @@ public class ServerGroupTest {
   public void getDetailForApp() {
     String asg = "app";
     Assertions.assertNull(ServerGroup.parse(asg).detail());
+  }
+
+  @Test
+  public void getShardsForApp() {
+    String asg = "app";
+    Assertions.assertNull(ServerGroup.parse(asg).shard1());
+    Assertions.assertNull(ServerGroup.parse(asg).shard2());
   }
 
   @Test
@@ -104,6 +116,13 @@ public class ServerGroupTest {
   }
 
   @Test
+  public void getShardsForAppStack() {
+    String asg = "app-stack";
+    Assertions.assertNull(ServerGroup.parse(asg).shard1());
+    Assertions.assertNull(ServerGroup.parse(asg).shard2());
+  }
+
+  @Test
   public void getSequenceForAppStack() {
     String asg = "app-stack";
     Assertions.assertNull(ServerGroup.parse(asg).sequence());
@@ -144,6 +163,13 @@ public class ServerGroupTest {
   public void getDetailForAppStackDetail() {
     String asg = "app-stack-detail";
     Assertions.assertEquals("detail", ServerGroup.parse(asg).detail());
+  }
+
+  @Test
+  public void getShardsForAppStackDetail() {
+    String asg = "app-stack-detail";
+    Assertions.assertNull(ServerGroup.parse(asg).shard1());
+    Assertions.assertNull(ServerGroup.parse(asg).shard2());
   }
 
   @Test
@@ -190,6 +216,13 @@ public class ServerGroupTest {
   }
 
   @Test
+  public void getShardsForAppStackDetails() {
+    String asg = "app-stack-detail_1-detail_2";
+    Assertions.assertNull(ServerGroup.parse(asg).shard1());
+    Assertions.assertNull(ServerGroup.parse(asg).shard2());
+  }
+
+  @Test
   public void getSequenceForAppStackDetails() {
     String asg = "app-stack-detail_1-detail_2";
     Assertions.assertNull(ServerGroup.parse(asg).sequence());
@@ -230,6 +263,13 @@ public class ServerGroupTest {
   public void getDetailForAppDetail() {
     String asg = "app--detail";
     Assertions.assertEquals("detail", ServerGroup.parse(asg).detail());
+  }
+
+  @Test
+  public void getShardsForAppDetail() {
+    String asg = "app--detail";
+    Assertions.assertNull(ServerGroup.parse(asg).shard1());
+    Assertions.assertNull(ServerGroup.parse(asg).shard2());
   }
 
   @Test
@@ -276,6 +316,13 @@ public class ServerGroupTest {
   }
 
   @Test
+  public void getShardsForAppSeq() {
+    String asg = "app-v001";
+    Assertions.assertNull(ServerGroup.parse(asg).shard1());
+    Assertions.assertNull(ServerGroup.parse(asg).shard2());
+  }
+
+  @Test
   public void getSequenceForAppSeq() {
     String asg = "app-v001";
     Assertions.assertEquals("v001", ServerGroup.parse(asg).sequence());
@@ -316,6 +363,13 @@ public class ServerGroupTest {
   public void getDetailForAppStackSeq() {
     String asg = "app-stack-v001";
     Assertions.assertNull(ServerGroup.parse(asg).detail());
+  }
+
+  @Test
+  public void getShardsForAppStackSeq() {
+    String asg = "app-stack-v001";
+    Assertions.assertNull(ServerGroup.parse(asg).shard1());
+    Assertions.assertNull(ServerGroup.parse(asg).shard2());
   }
 
   @Test
@@ -362,6 +416,13 @@ public class ServerGroupTest {
   }
 
   @Test
+  public void getShardsForAppStackDetailSeq() {
+    String asg = "app-stack-detail-v001";
+    Assertions.assertNull(ServerGroup.parse(asg).shard1());
+    Assertions.assertNull(ServerGroup.parse(asg).shard2());
+  }
+
+  @Test
   public void getSequenceForAppStackDetailSeq() {
     String asg = "app-stack-detail-v001";
     Assertions.assertEquals("v001", ServerGroup.parse(asg).sequence());
@@ -405,6 +466,13 @@ public class ServerGroupTest {
   }
 
   @Test
+  public void getShardsForAppStackDetailsSeq() {
+    String asg = "app-stack-detail_1-detail_2-v001";
+    Assertions.assertNull(ServerGroup.parse(asg).shard1());
+    Assertions.assertNull(ServerGroup.parse(asg).shard2());
+  }
+
+  @Test
   public void getSequenceForAppStackDetailsSeq() {
     String asg = "app-stack-detail_1-detail_2-v001";
     Assertions.assertEquals("v001", ServerGroup.parse(asg).sequence());
@@ -445,6 +513,13 @@ public class ServerGroupTest {
   public void getDetailForAppDetailSeq() {
     String asg = "app--detail-v001";
     Assertions.assertEquals("detail", ServerGroup.parse(asg).detail());
+  }
+
+  @Test
+  public void getShardsForAppDetailSeq() {
+    String asg = "app--detail-v001";
+    Assertions.assertNull(ServerGroup.parse(asg).shard1());
+    Assertions.assertNull(ServerGroup.parse(asg).shard2());
   }
 
   @Test
@@ -510,18 +585,103 @@ public class ServerGroupTest {
   }
 
   @Test
+  public void getShardsForEmptyString() {
+    String asg = "";
+    Assertions.assertNull(ServerGroup.parse(asg).shard1());
+    Assertions.assertNull(ServerGroup.parse(asg).shard2());
+  }
+
+  @Test
   public void getSequenceForEmptyString() {
     String asg = "";
     Assertions.assertNull(ServerGroup.parse(asg).sequence());
   }
 
+  @Test
+  public void getShardsOnlyShard1() {
+    String asg = "app-stack-x1shard1-detail-v000";
+    Assertions.assertEquals("shard1", ServerGroup.parse(asg).shard1());
+    Assertions.assertNull(ServerGroup.parse(asg).shard2());
+  }
+
+  @Test
+  public void getShardsOnlyShard2() {
+    String asg = "app-stack-x2shard2-detail-v000";
+    Assertions.assertNull(ServerGroup.parse(asg).shard1());
+    Assertions.assertEquals("shard2", ServerGroup.parse(asg).shard2());
+  }
+
+  @Test
+  public void getShardsBoth() {
+    String asg = "app-stack-x1shard1-x2shard2-detail-v000";
+    Assertions.assertEquals("shard1", ServerGroup.parse(asg).shard1());
+    Assertions.assertEquals("shard2", ServerGroup.parse(asg).shard2());
+  }
+
+  @Test
+  public void getShardsThree() {
+    String asg = "app-stack-x1shard1-x2shard2-x3shard3-detail-v000";
+    Assertions.assertEquals("shard1", ServerGroup.parse(asg).shard1());
+    Assertions.assertEquals("shard2", ServerGroup.parse(asg).shard2());
+  }
+
+  @Test
+  public void getShardsOutOfOrder() {
+    String asg = "app-stack-x2shard2-x1shard1-detail-v000";
+    Assertions.assertEquals("shard1", ServerGroup.parse(asg).shard1());
+    Assertions.assertEquals("shard2", ServerGroup.parse(asg).shard2());
+  }
+
+  @Test
+  public void getShardsLeadingDigits() {
+    String asg = "app-stack-x10shard1-detail-v000";
+    Assertions.assertNull(ServerGroup.parse(asg).shard1());
+    Assertions.assertNull(ServerGroup.parse(asg).shard2());
+  }
+
+  @Test
+  public void getShardsGap() {
+    String asg = "app-stack-x1shard1-foo-x2shard2-detail-v000";
+    Assertions.assertEquals("shard1", ServerGroup.parse(asg).shard1());
+    Assertions.assertNull(ServerGroup.parse(asg).shard2());
+  }
+
+  @Test
+  public void getShardsEndOfDetail() {
+    String asg = "app-stack-detail-x1shard1-x2shard2-v000";
+    Assertions.assertNull(ServerGroup.parse(asg).shard1());
+    Assertions.assertNull(ServerGroup.parse(asg).shard2());
+  }
+
+  @Test
+  public void getShardsDuplicate() {
+    String asg = "app-stack-x1a1-x2a2-x1b1-x2b2-v000";
+    Assertions.assertEquals("b1", ServerGroup.parse(asg).shard1());
+    Assertions.assertEquals("b2", ServerGroup.parse(asg).shard2());
+  }
+
+  @Test
+  public void getShardsEmpty() {
+    String asg = "app-stack-x1-x2-v000";
+    Assertions.assertNull(ServerGroup.parse(asg).shard1());
+    Assertions.assertNull(ServerGroup.parse(asg).shard2());
+  }
 
   private void appendRandomString(Random r, StringBuilder builder) {
-    int length = r.nextInt(20);
+    int length = r.nextInt(20) + 1;
     for (int i = 0; i < length; ++i) {
       char c = (char) (r.nextInt(26) + 'a');
       builder.append(c);
     }
+  }
+
+  private void appendRandomPart(Random r, StringBuilder builder) {
+    // https://github.com/cfieber/frigga/blob/master/src/main/java/com/netflix/frigga/NameConstants.java#L29
+    String[] prefixes = {"x0", "x1", "x2", "x3", "c0", "d0", "h0", "p0", "r0", "u0", "w0", "z0"};
+    if (r.nextBoolean()) {
+      builder.append(prefixes[r.nextInt(prefixes.length)]);
+    }
+    appendRandomString(r, builder);
   }
 
   private String randomServerGroup(Random r) {
@@ -529,10 +689,10 @@ public class ServerGroupTest {
     int parts = r.nextInt(6) + 1;
     for (int i = 0; i < parts; ++i) {
       if (r.nextBoolean()) {
-        appendRandomString(r, builder);
+        appendRandomPart(r, builder);
       } else {
         builder.append('v');
-        builder.append(r.nextInt(10000));
+        builder.append(r.nextInt(10_000_000));
       }
       if (i != parts - 1) {
         builder.append('-');
@@ -545,8 +705,13 @@ public class ServerGroupTest {
   public void compatibleWithFrigga() {
     // Seed the RNG so that each run is deterministic. In this case we are just using it to
     // generate a bunch of patterns to try
+    ShardingNamingConvention convention = new ShardingNamingConvention();
+    BiFunction<Map<Integer, Shard>, Integer, String> getShard = (shards, i) -> {
+      Shard s = shards.get(i);
+      return s == null ? null : s.getShardValue();
+    };
     Random r = new Random(42);
-    for (int i = 0; i < 5000; ++i) {
+    for (int i = 0; i < 50_000; ++i) {
       String asg = randomServerGroup(r);
       ServerGroup sg = ServerGroup.parse(asg);
       Names frigga = Names.parseName(asg);
@@ -555,6 +720,24 @@ public class ServerGroupTest {
       Assertions.assertEquals(frigga.getGroup(), sg.asg(), "asg: " + asg);
       Assertions.assertEquals(frigga.getStack(), sg.stack(), "stack: " + asg);
       Assertions.assertEquals(frigga.getDetail(), sg.detail(), "detail: " + asg);
+
+      if (frigga.getDetail() == null) {
+        continue;
+      }
+
+      try {
+        ShardingNamingResult result = convention.extractNamingConvention(frigga.getDetail());
+        if (result.getResult().isPresent()) {
+          Map<Integer, Shard> shards = result.getResult().get();
+          Assertions.assertEquals(getShard.apply(shards, 1), sg.shard1(), "shard1: " + asg);
+          Assertions.assertEquals(getShard.apply(shards, 2), sg.shard2(), "shard2: " + asg);
+        } else {
+          Assertions.assertNull(sg.shard1(), "shard1: " + asg);
+          Assertions.assertNull(sg.shard2(), "shard2: " + asg);
+        }
+      } catch (Exception e) {
+        throw new RuntimeException("parsing shards failed: " + asg, e);
+      }
     }
   }
 }


### PR DESCRIPTION
Updates the random ASG generator in the tests to include
the naming convention patterns and fixes gaps with recent
changes to frigga. In particular:

1. Sequence logic has been updated to match the same range
   of numeric values allowed.
2. Support for parsing shards has been added for the shard1
   and shard2 that are intended to be used as tags.