### PR TITLE
add test case for AWS local zones

### DIFF
--- a/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/IpcLogEntryTest.java
+++ b/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/IpcLogEntryTest.java
@@ -580,6 +580,16 @@ public class IpcLogEntryTest {
     Assertions.assertNull(actual);
   }
 
+  @Test
+  public void regionFromZoneAwsLocalZone() {
+    String expected = "us-west-2-lax-1a";
+    String actual = (String) entry
+        .withClientZone(expected)
+        .convert(this::toMap)
+        .get("clientRegion");
+    Assertions.assertEquals("us-west-2-lax-1", actual);
+  }
+
   @SuppressWarnings("unchecked")
   @Test
   public void customHeaders() {


### PR DESCRIPTION
For now we use the same logic for extracting the region
as normal zones. This may get revisited in the future
to be the actual base AWS region.