### PR TITLE
fix property name for frequency setting

### DIFF
--- a/spectator-reg-stateless/src/main/java/com/netflix/spectator/stateless/StatelessConfig.java
+++ b/spectator-reg-stateless/src/main/java/com/netflix/spectator/stateless/StatelessConfig.java
@@ -39,7 +39,7 @@ public interface StatelessConfig extends RegistryConfig {
    * default is 5 seconds.
    */
   default Duration frequency() {
-    String v = get("stateless.enabled");
+    String v = get("stateless.frequency");
     return v == null ? Duration.ofSeconds(5) : Duration.parse(v);
   }
 

--- a/spectator-reg-stateless/src/test/java/com/netflix/spectator/stateless/StatelessConfigTest.java
+++ b/spectator-reg-stateless/src/test/java/com/netflix/spectator/stateless/StatelessConfigTest.java
@@ -18,6 +18,7 @@ package com.netflix.spectator.stateless;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -54,5 +55,13 @@ public class StatelessConfigTest {
     props.put("stateless.enabled", "abc");
     StatelessConfig config = props::get;
     Assertions.assertFalse(config.enabled());
+  }
+
+  @Test
+  public void frequency() {
+    Map<String, String> props = new HashMap<>();
+    props.put("stateless.frequency", "PT5S");
+    StatelessConfig config = props::get;
+    Assertions.assertEquals(Duration.ofSeconds(5), config.frequency());
   }
 }


### PR DESCRIPTION
There was a copy/paste issue and it was looking at the
enabled setting before.