### PR TITLE
fix deprecation warning for log4j2 AbstractAppender

### DIFF
--- a/spectator-ext-log4j2/src/main/java/com/netflix/spectator/log4j/SpectatorAppender.java
+++ b/spectator-ext-log4j2/src/main/java/com/netflix/spectator/log4j/SpectatorAppender.java
@@ -28,6 +28,7 @@ import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.AbstractAppender;
 import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.config.Property;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.config.plugins.PluginAttribute;
 import org.apache.logging.log4j.core.config.plugins.PluginElement;
@@ -66,7 +67,8 @@ public final class SpectatorAppender extends AbstractAppender {
       Registry registry,
       String name,
       boolean ignoreExceptions) {
-    final Appender appender = new SpectatorAppender(registry, name, null, null, ignoreExceptions);
+    final Appender appender = new SpectatorAppender(
+        registry, name, null, null, ignoreExceptions, Property.EMPTY_ARRAY);
     appender.start();
 
     LoggerContext context = (LoggerContext) LogManager.getContext(false);
@@ -88,8 +90,9 @@ public final class SpectatorAppender extends AbstractAppender {
       String name,
       Filter filter,
       Layout<? extends Serializable> layout,
-      boolean ignoreExceptions) {
-    super(name, filter, layout, ignoreExceptions);
+      boolean ignoreExceptions,
+      Property[] properties) {
+    super(name, filter, layout, ignoreExceptions, properties);
     this.registry = registry;
   }
 
@@ -106,7 +109,10 @@ public final class SpectatorAppender extends AbstractAppender {
       return null;
     }
 
-    return new SpectatorAppender(Spectator.globalRegistry(), name, filter, layout, ignoreExceptions);
+    return new SpectatorAppender(
+        Spectator.globalRegistry(),
+        name, filter, layout, ignoreExceptions,
+        Property.EMPTY_ARRAY);
   }
 
   @Override public void start() {

--- a/spectator-ext-log4j2/src/test/java/com/netflix/spectator/log4j/SpectatorAppenderTest.java
+++ b/spectator-ext-log4j2/src/test/java/com/netflix/spectator/log4j/SpectatorAppenderTest.java
@@ -20,6 +20,7 @@ import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.Registry;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.config.Property;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -50,7 +51,8 @@ public class SpectatorAppenderTest {
   @BeforeEach
   public void before() {
     registry = new DefaultRegistry();
-    appender = new SpectatorAppender(registry, "foo", null, null, false);
+    appender = new SpectatorAppender(
+        registry, "foo", null, null, false, Property.EMPTY_ARRAY);
     appender.start();
   }
 
@@ -96,7 +98,8 @@ public class SpectatorAppenderTest {
 
   @Test
   public void ignoreExceptions() {
-    appender = new SpectatorAppender(registry, "foo", null, null, true);
+    appender = new SpectatorAppender(
+        registry, "foo", null, null, true, Property.EMPTY_ARRAY);
     appender.start();
     Counter c = registry.counter("log4j.numStackTraces",
         "appender", "foo",


### PR DESCRIPTION
Update the the new constructor for the AbstractAppender class.