### PR TITLE
Faster approach to set the default statistic tag

### DIFF
--- a/spectator-api/src/jmh/java/com/netflix/spectator/perf/DefaultStat.java
+++ b/spectator-api/src/jmh/java/com/netflix/spectator/perf/DefaultStat.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014-2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.spectator.perf;
 
 import com.netflix.spectator.api.DefaultRegistry;
@@ -12,7 +27,6 @@ import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.infra.Blackhole;
 
 /**
- *
  * Benchmark different approaches to override the statistic tag if present.
  *
  * <pre>

--- a/spectator-api/src/jmh/java/com/netflix/spectator/perf/DefaultStat.java
+++ b/spectator-api/src/jmh/java/com/netflix/spectator/perf/DefaultStat.java
@@ -1,0 +1,66 @@
+package com.netflix.spectator.perf;
+
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Statistic;
+import com.netflix.spectator.api.Tag;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ *
+ * Benchmark different approaches to override the statistic tag if present.
+ *
+ * <pre>
+ * Benchmark                      Mode  Cnt        Score        Error  Units
+ * DefaultStat.withIdWithTags    thrpt    9  2693269.613 ± 189599.585  ops/s
+ * DefaultStat.withNameWithTags  thrpt    9  3485856.299 ± 116456.216  ops/s
+ * </pre>
+ */
+@State(Scope.Thread)
+public class DefaultStat {
+  private final Registry registry = new DefaultRegistry();
+
+  private final Id baseId = registry.createId("http.req.complete")
+      .withTag("nf.app", "test_app")
+      .withTag("nf.cluster", "test_app-main")
+      .withTag("nf.asg", "test_app-main-v042")
+      .withTag("nf.stack", "main")
+      .withTag("nf.ami", "ami-0987654321")
+      .withTag("nf.region", "us-east-1")
+      .withTag("nf.zone", "us-east-1e")
+      .withTag("nf.node", "i-1234567890");
+
+  @Threads(1)
+  @Benchmark
+  public void withIdWithTags(Blackhole bh) {
+    bh.consume(baseId.withTag(Statistic.count).withTags(baseId.tags()).withTag(DsType.rate));
+  }
+
+  @Threads(1)
+  @Benchmark
+  public void withNameWithTags(Blackhole bh) {
+    bh.consume(
+        registry.createId(
+            baseId.name()).withTag(Statistic.count).withTags(baseId.tags()).withTag(DsType.rate));
+  }
+
+  static enum DsType implements Tag {
+    gauge,
+    rate;
+
+    @Override
+    public String key() {
+      return "atlas.dstype";
+    }
+
+    @Override
+    public String value() {
+      return name();
+    }
+  }
+}

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasCounter.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasCounter.java
@@ -18,6 +18,7 @@ package com.netflix.spectator.atlas;
 import com.netflix.spectator.api.Clock;
 import com.netflix.spectator.api.Counter;
 import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Statistic;
 import com.netflix.spectator.impl.StepDouble;
 
@@ -32,12 +33,12 @@ class AtlasCounter extends AtlasMeter implements Counter {
   private final Id stat;
 
   /** Create a new instance. */
-  AtlasCounter(Id id, Clock clock, long ttl, long step) {
+  AtlasCounter(Registry registry, Id id, Clock clock, long ttl, long step) {
     super(id, clock, ttl);
     this.value = new StepDouble(0.0, clock, step);
     // Add the statistic for typing. Re-adding the tags from the id is to retain
     // the statistic from the id if it was already set
-    this.stat = id.withTag(Statistic.count).withTags(id.tags()).withTag(DsType.rate);
+    this.stat = registry.createId(id.name()).withTag(Statistic.count).withTags(id.tags()).withTag(DsType.rate);
   }
 
   @Override void measure(MeasurementConsumer consumer) {

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasGauge.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasGauge.java
@@ -18,6 +18,7 @@ package com.netflix.spectator.atlas;
 import com.netflix.spectator.api.Clock;
 import com.netflix.spectator.api.Gauge;
 import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Statistic;
 import com.netflix.spectator.impl.AtomicDouble;
 
@@ -30,12 +31,12 @@ class AtlasGauge extends AtlasMeter implements Gauge {
   private final Id stat;
 
   /** Create a new instance. */
-  AtlasGauge(Id id, Clock clock, long ttl) {
+  AtlasGauge(Registry registry, Id id, Clock clock, long ttl) {
     super(id, clock, ttl);
     this.value = new AtomicDouble(0.0);
     // Add the statistic for typing. Re-adding the tags from the id is to retain
     // the statistic from the id if it was already set
-    this.stat = id.withTag(Statistic.gauge).withTags(id.tags()).withTag(DsType.gauge);
+    this.stat = registry.createId(id.name()).withTag(Statistic.gauge).withTags(id.tags()).withTag(DsType.gauge);
   }
 
   @Override void measure(MeasurementConsumer consumer) {

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasMaxGauge.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasMaxGauge.java
@@ -18,6 +18,7 @@ package com.netflix.spectator.atlas;
 import com.netflix.spectator.api.Clock;
 import com.netflix.spectator.api.Gauge;
 import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Statistic;
 import com.netflix.spectator.impl.StepDouble;
 
@@ -32,12 +33,12 @@ class AtlasMaxGauge extends AtlasMeter implements Gauge {
   private final Id stat;
 
   /** Create a new instance. */
-  AtlasMaxGauge(Id id, Clock clock, long ttl, long step) {
+  AtlasMaxGauge(Registry registry, Id id, Clock clock, long ttl, long step) {
     super(id, clock, ttl);
     this.value = new StepDouble(0.0, clock, step);
     // Add the statistic for typing. Re-adding the tags from the id is to retain
     // the statistic from the id if it was already set
-    this.stat = id.withTag(Statistic.max).withTags(id.tags()).withTag(DsType.gauge);
+    this.stat = registry.createId(id.name()).withTag(Statistic.max).withTags(id.tags()).withTag(DsType.gauge);
   }
 
   @Override void measure(MeasurementConsumer consumer) {

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
@@ -480,7 +480,7 @@ public final class AtlasRegistry extends AbstractRegistry implements AutoCloseab
   }
 
   @Override protected Counter newCounter(Id id) {
-    return new AtlasCounter(id, clock(), meterTTL, lwcStepMillis);
+    return new AtlasCounter(this, id, clock(), meterTTL, lwcStepMillis);
   }
 
   @Override protected DistributionSummary newDistributionSummary(Id id) {
@@ -494,10 +494,10 @@ public final class AtlasRegistry extends AbstractRegistry implements AutoCloseab
   @Override protected Gauge newGauge(Id id) {
     // Be sure to get StepClock so the measurements will have step aligned
     // timestamps.
-    return new AtlasGauge(id, stepClock, meterTTL);
+    return new AtlasGauge(this, id, stepClock, meterTTL);
   }
 
   @Override protected Gauge newMaxGauge(Id id) {
-    return new AtlasMaxGauge(id, clock(), meterTTL, lwcStepMillis);
+    return new AtlasMaxGauge(this, id, clock(), meterTTL, lwcStepMillis);
   }
 }

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasCounterTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasCounterTest.java
@@ -29,7 +29,8 @@ public class AtlasCounterTest {
   private final ManualClock clock = new ManualClock();
   private final Registry registry = new DefaultRegistry();
   private final long step = 10000L;
-  private final AtlasCounter counter = new AtlasCounter(registry.createId("test"), clock, step, step);
+  private final AtlasCounter counter = new AtlasCounter(registry,
+      registry.createId("test"), clock, step, step);
 
   private void checkValue(double expected) {
     int count = 0;

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasGaugeTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasGaugeTest.java
@@ -29,7 +29,7 @@ public class AtlasGaugeTest {
   private final ManualClock clock = new ManualClock();
   private final Registry registry = new DefaultRegistry();
   private final long step = 10000L;
-  private final AtlasGauge gauge = new AtlasGauge(registry.createId("test"), clock, step);
+  private final AtlasGauge gauge = new AtlasGauge(registry, registry.createId("test"), clock, step);
 
   private void checkValue(long expected) {
     int count = 0;

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasMaxGaugeTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasMaxGaugeTest.java
@@ -29,7 +29,8 @@ public class AtlasMaxGaugeTest {
   private final ManualClock clock = new ManualClock();
   private final Registry registry = new DefaultRegistry();
   private final long step = 10000L;
-  private final AtlasMaxGauge gauge = new AtlasMaxGauge(registry.createId("test"), clock, step, step);
+  private final AtlasMaxGauge gauge = new AtlasMaxGauge(registry,
+      registry.createId("test"), clock, step, step);
 
   private void checkValue(long expected) {
     int count = 0;


### PR DESCRIPTION
The atlas counter and gauges cache the `Id` used for reporting
measurements. This change improves the performance of this operation by
creating a new `Id` from scratch instead of adding the statistic tag to
our base id, and then re-adding all the original tags. This avoid
iterating over all the tags in the original `Id` twice.

```
Benchmark                      Mode  Cnt        Score        Error  Units
DefaultStat.withIdWithTags    thrpt    9  2693269.613 ± 189599.585  ops/s
DefaultStat.withNameWithTags  thrpt    9  3485856.299 ± 116456.216  ops/s
```