### PR TITLE
batch payloads to LWC API service

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/EvalPayload.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/EvalPayload.java
@@ -74,7 +74,7 @@ public final class EvalPayload {
     if (size <= batchSize) {
       return Collections.singletonList(this);
     } else {
-      List<EvalPayload> payloads = new ArrayList<>(size / batchSize + 2);
+      List<EvalPayload> payloads = new ArrayList<>(size / batchSize + 1);
       for (int i = 0; i < size; i += batchSize) {
         List<Metric> batch = metrics.subList(i, Math.min(size, i + batchSize));
         // There shouldn't be many messages, stick in the first batch


### PR DESCRIPTION
Batch the data going to LWC API. This change reuses the
batch size parameter for payloads going to the publish
endpoint. Ensures that the max request size is bounded.