### PR TITLE
gradle 6.4.1 and shadow 5.2.0

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/spectator-agent/build.gradle
+++ b/spectator-agent/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'com.github.johnrengelman.shadow' version '6.0.0'
+  id 'com.github.johnrengelman.shadow' version '5.2.0'
 }
 
 dependencies {

--- a/spectator-ext-spark/build.gradle
+++ b/spectator-ext-spark/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'com.github.johnrengelman.shadow' version '6.0.0'
+  id 'com.github.johnrengelman.shadow' version '5.2.0'
 }
 
 dependencies {

--- a/spectator-reg-atlas/build.gradle
+++ b/spectator-reg-atlas/build.gradle
@@ -1,7 +1,7 @@
 import java.util.zip.ZipFile
 
 plugins {
-  id 'com.github.johnrengelman.shadow' version '6.0.0'
+  id 'com.github.johnrengelman.shadow' version '5.2.0'
 }
 
 dependencies {


### PR DESCRIPTION
Move back to older versions. Something with the combination
of gradle 6.5 and shadow 6.0.0 breaks the publishing due
to duplicate artifacts. Same error message as in #807.