### PR TITLE
allow disabling replacement during serialization

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
@@ -59,6 +59,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import java.util.stream.Stream;
 import java.util.zip.Deflater;
 
@@ -91,7 +92,7 @@ public final class AtlasRegistry extends AbstractRegistry implements AutoCloseab
   private final int numThreads;
   private final Map<String, String> commonTags;
 
-  private final AsciiSet charset;
+  private final Function<String, String> fixTagString;
 
   private final ObjectMapper jsonMapper;
   private final ObjectMapper smileMapper;
@@ -143,9 +144,9 @@ public final class AtlasRegistry extends AbstractRegistry implements AutoCloseab
     this.numThreads = config.numThreads();
     this.commonTags = new TreeMap<>(config.commonTags());
 
-    this.charset = AsciiSet.fromPattern(config.validTagCharacters());
+    this.fixTagString = createReplacementFunction(config.validTagCharacters());
     SimpleModule module = new SimpleModule()
-        .addSerializer(Measurement.class, new MeasurementSerializer(charset));
+        .addSerializer(Measurement.class, new MeasurementSerializer(fixTagString));
     this.jsonMapper = new ObjectMapper(new JsonFactory()).registerModule(module);
     this.smileMapper = new ObjectMapper(new SmileFactory()).registerModule(module);
 
@@ -160,6 +161,15 @@ public final class AtlasRegistry extends AbstractRegistry implements AutoCloseab
 
     if (config.autoStart()) {
       start();
+    }
+  }
+
+  private Function<String, String> createReplacementFunction(String pattern) {
+    if (pattern == null) {
+      return Function.identity();
+    } else {
+      AsciiSet set = AsciiSet.fromPattern(pattern);
+      return s -> set.replaceNonMembers(s, '_');
     }
   }
 
@@ -436,12 +446,12 @@ public final class AtlasRegistry extends AbstractRegistry implements AutoCloseab
     Map<String, String> tags = new HashMap<>();
 
     for (Tag t : id.tags()) {
-      String k = charset.replaceNonMembers(t.key(), '_');
-      String v = charset.replaceNonMembers(t.value(), '_');
+      String k = fixTagString.apply(t.key());
+      String v = fixTagString.apply(t.value());
       tags.put(k, v);
     }
 
-    String name = charset.replaceNonMembers(id.name(), '_');
+    String name = fixTagString.apply(id.name());
     tags.put("name", name);
 
     return tags;

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/SubscriptionManagerTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/SubscriptionManagerTest.java
@@ -47,7 +47,7 @@ public class SubscriptionManagerTest {
   private final SimpleModule module = new SimpleModule()
       .addSerializer(
           Measurement.class,
-          new MeasurementSerializer(AsciiSet.fromPattern("a-z")));
+          new MeasurementSerializer(s -> AsciiSet.fromPattern("a-z").replaceNonMembers(s, '_')));
 
   private final ObjectMapper mapper = new ObjectMapper(new JsonFactory()).registerModule(module);
 

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/MeasurementSerializerTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/MeasurementSerializerTest.java
@@ -33,7 +33,7 @@ public class MeasurementSerializerTest {
 
   private final DefaultRegistry registry = new DefaultRegistry();
   private final SimpleModule module = new SimpleModule()
-      .addSerializer(Measurement.class, new MeasurementSerializer(set));
+      .addSerializer(Measurement.class, new MeasurementSerializer(s -> set.replaceNonMembers(s, '_')));
   private final ObjectMapper mapper = new ObjectMapper().registerModule(module);
 
   @Test


### PR DESCRIPTION
Allows the set of valid tag characters to be set to null
in order to disable the conversion during serialization.
This helps improve performance for cases where the values
have already been validated and there is nothing to fix.