### PR TITLE
use sum dstype for Atlas rollups

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/DsType.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/DsType.java
@@ -27,7 +27,13 @@ enum DsType implements Tag {
   gauge,
 
   /** Rate per second that should use weighted averaging during normalization. */
-  rate;
+  rate,
+
+  /**
+   * Sum type used for inline aggregations on the backend. Sender must be careful to avoid
+   * overcounting since the backend cannot dedup.
+   */
+  sum;
 
   @Override public String key() {
     return "atlas.dstype";

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/Rollups.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/Rollups.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,9 +89,10 @@ final class Rollups {
     DoubleBinaryOperator af = MAX;
     String statistic = Utils.getTagValue(id, "statistic");
     if (statistic != null && SUM_STATS.contains(statistic)) {
-      af = SUM;
+      return new Aggregator(id.withTag(DsType.sum), m.timestamp(), SUM, m.value());
+    } else {
+      return new Aggregator(id, m.timestamp(), MAX, m.value());
     }
-    return new Aggregator(id, m.timestamp(), af, m.value());
   }
 
   private static class Aggregator {

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/Rollups.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/Rollups.java
@@ -86,7 +86,6 @@ final class Rollups {
   }
 
   private static Aggregator newAggregator(Id id, Measurement m) {
-    DoubleBinaryOperator af = MAX;
     String statistic = Utils.getTagValue(id, "statistic");
     if (statistic != null && SUM_STATS.contains(statistic)) {
       return new Aggregator(id.withTag(DsType.sum), m.timestamp(), SUM, m.value());

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/RollupsTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/RollupsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,7 +74,7 @@ public class RollupsTest {
 
     Measurement m = aggr.get(0);
     Id id = registry.createId("test")
-        .withTag("atlas.dstype", "rate")
+        .withTag("atlas.dstype", "sum")
         .withTag(Statistic.count);
     Assertions.assertEquals(id, m.id());
     Assertions.assertEquals(10.0 / 5.0, m.value(), 1e-12);
@@ -131,17 +131,17 @@ public class RollupsTest {
       Id id = registry.createId("test");
       switch (Utils.getTagValue(m.id(), "statistic")) {
         case "count":
-          id = id.withTag("atlas.dstype", "rate").withTag(Statistic.count);
+          id = id.withTag("atlas.dstype", "sum").withTag(Statistic.count);
           Assertions.assertEquals(id, m.id());
           Assertions.assertEquals(10.0 / 5.0, m.value(), 1e-12);
           break;
         case "totalTime":
-          id = id.withTag("atlas.dstype", "rate").withTag(Statistic.totalTime);
+          id = id.withTag("atlas.dstype", "sum").withTag(Statistic.totalTime);
           Assertions.assertEquals(id, m.id());
           Assertions.assertEquals(45.0 / 5.0, m.value(), 1e-12);
           break;
         case "totalOfSquares":
-          id = id.withTag("atlas.dstype", "rate").withTag(Statistic.totalOfSquares);
+          id = id.withTag("atlas.dstype", "sum").withTag(Statistic.totalOfSquares);
           Assertions.assertEquals(id, m.id());
           Assertions.assertEquals(285.0 / 5.0, m.value(), 1e-12);
           break;
@@ -171,17 +171,17 @@ public class RollupsTest {
       Id id = registry.createId("test");
       switch (Utils.getTagValue(m.id(), "statistic")) {
         case "count":
-          id = id.withTag("atlas.dstype", "rate").withTag(Statistic.count);
+          id = id.withTag("atlas.dstype", "sum").withTag(Statistic.count);
           Assertions.assertEquals(id, m.id());
           Assertions.assertEquals(10.0 / 5.0, m.value(), 1e-12);
           break;
         case "totalAmount":
-          id = id.withTag("atlas.dstype", "rate").withTag(Statistic.totalAmount);
+          id = id.withTag("atlas.dstype", "sum").withTag(Statistic.totalAmount);
           Assertions.assertEquals(id, m.id());
           Assertions.assertEquals(45.0 / 5.0, m.value(), 1e-12);
           break;
         case "totalOfSquares":
-          id = id.withTag("atlas.dstype", "rate").withTag(Statistic.totalOfSquares);
+          id = id.withTag("atlas.dstype", "sum").withTag(Statistic.totalOfSquares);
           Assertions.assertEquals(id, m.id());
           Assertions.assertEquals(285.0 / 5.0, m.value(), 1e-12);
           break;


### PR DESCRIPTION
This allows inline aggregation of dimensions like node
that can cause duplicate ids across systems.