### PR TITLE
add metrics to track measurements sent and dropped

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/ValidationHelper.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/ValidationHelper.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2014-2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.ipc.http.HttpResponse;
+import org.slf4j.Logger;
+
+final class ValidationHelper {
+
+  private final Logger logger;
+  private final ObjectMapper jsonMapper;
+
+  private final Counter measurementsSent;
+  private final Counter measurementsDroppedInvalid;
+  private final Counter measurementsDroppedHttp;
+  private final Counter measurementsDroppedOther;
+
+  ValidationHelper(Logger logger, ObjectMapper jsonMapper, Registry registry) {
+    this.logger = logger;
+    this.jsonMapper = jsonMapper;
+
+    Id baseId = registry.createId("spectator.measurements");
+    Id droppedId = baseId.withTag("id", "dropped");
+    this.measurementsSent = registry.counter(baseId.withTag("id", "sent"));
+    this.measurementsDroppedHttp = registry.counter(droppedId.withTag("error", "http-error"));
+    this.measurementsDroppedInvalid = registry.counter(droppedId.withTag("error", "validation"));
+    this.measurementsDroppedOther = registry.counter(droppedId.withTag("error", "other"));
+  }
+
+  void incrementDroppedHttp(int amount) {
+    measurementsDroppedHttp.increment(amount);
+  }
+
+  /**
+   * Report metrics and do basic logging of validation results to help the user with
+   * debugging.
+   */
+  void recordResults(int numMeasurements, HttpResponse res) {
+    if (res.status() == 200) {
+      measurementsSent.increment(numMeasurements);
+    } else if (res.status() < 500) {
+      // For validation:
+      // 202 - partial failure
+      // 400 - all failed, could also be some other sort of failure
+      try {
+        ValidationResponse vres = jsonMapper.readValue(res.entity(), ValidationResponse.class);
+        measurementsDroppedInvalid.increment(vres.getErrorCount());
+        measurementsSent.increment(numMeasurements - vres.getErrorCount());
+        logger.warn("{} measurement(s) dropped due to validation errors: {}",
+            vres.getErrorCount(), vres.errorSummary());
+      } catch (Exception e) {
+        // Likely some other 400 error. Log at trace level in case the cause is really needed.
+        logger.trace("failed to parse response", e);
+        logger.warn("{} measurement(s) dropped. Http status: {}", numMeasurements, res.status());
+        measurementsDroppedOther.increment(numMeasurements);
+      }
+    } else {
+      // Some sort of server side failure
+      measurementsDroppedHttp.increment(numMeasurements);
+    }
+  }
+}

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/ValidationResponse.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/ValidationResponse.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2014-2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import java.util.List;
+
+/**
+ * Validation failure response from Atlas publish endpoint.
+ */
+@SuppressWarnings("PMD.DataClass")
+final class ValidationResponse {
+
+  private String type;
+  private int errorCount;
+  private List<String> message; // singular to match server response
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(String type) {
+    this.type = type;
+  }
+
+  public int getErrorCount() {
+    return errorCount;
+  }
+
+  public void setErrorCount(int errorCount) {
+    this.errorCount = errorCount;
+  }
+
+  public List<String> getMessage() {
+    return message;
+  }
+
+  public void setMessage(List<String> message) {
+    this.message = message;
+  }
+
+  String errorSummary() {
+    return (message == null || message.isEmpty())
+        ? "unknown cause"
+        : String.join("; ", message);
+  }
+}

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/ValidationHelperTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/ValidationHelperTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2014-2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.ipc.http.HttpResponse;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+
+public class ValidationHelperTest {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ValidationHelperTest.class);
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private void check(Registry r, long sent, long http, long invalid, long other) {
+    Id baseId = r.createId("spectator.measurements");
+    Id droppedId = baseId.withTag("id", "dropped");
+
+    Assertions.assertEquals(sent, r.counter(baseId.withTag("id", "sent")).count());
+    Assertions.assertEquals(http, r.counter(droppedId.withTag("error", "http-error")).count());
+    Assertions.assertEquals(invalid, r.counter(droppedId.withTag("error", "validation")).count());
+    Assertions.assertEquals(other, r.counter(droppedId.withTag("error", "other")).count());
+  }
+
+  private HttpResponse httpResponse(int status, ValidationResponse vres) throws IOException {
+    String json = MAPPER.writeValueAsString(vres);
+    return new HttpResponse(status, Collections.emptyMap(), json.getBytes(StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void incrementDroppedHttp() {
+    Registry registry = new DefaultRegistry();
+    ValidationHelper helper = new ValidationHelper(LOGGER, MAPPER, registry);
+    helper.incrementDroppedHttp(42);
+    check(registry, 0, 42, 0, 0);
+  }
+
+  @Test
+  public void ok() {
+    Registry registry = new DefaultRegistry();
+    ValidationHelper helper = new ValidationHelper(LOGGER, MAPPER, registry);
+    helper.recordResults(42, new HttpResponse(200, Collections.emptyMap()));
+    check(registry, 42, 0, 0, 0);
+  }
+
+  @Test
+  public void validationErrorPartial() throws IOException {
+    Registry registry = new DefaultRegistry();
+    ValidationHelper helper = new ValidationHelper(LOGGER, MAPPER, registry);
+    ValidationResponse vres = new ValidationResponse();
+    vres.setType("error");
+    vres.setErrorCount(3);
+    vres.setMessage(Collections.singletonList("foo"));
+    helper.recordResults(42, httpResponse(202, vres));
+    check(registry, 39, 0, 3, 0);
+  }
+
+  @Test
+  public void validationErrorAll() throws IOException {
+    Registry registry = new DefaultRegistry();
+    ValidationHelper helper = new ValidationHelper(LOGGER, MAPPER, registry);
+    ValidationResponse vres = new ValidationResponse();
+    vres.setType("error");
+    vres.setErrorCount(42);
+    vres.setMessage(Collections.singletonList("foo"));
+    helper.recordResults(42, httpResponse(400, vres));
+    check(registry, 0, 0, 42, 0);
+  }
+
+  @Test
+  public void validationErrorNullMessages() throws IOException {
+    Registry registry = new DefaultRegistry();
+    ValidationHelper helper = new ValidationHelper(LOGGER, MAPPER, registry);
+    ValidationResponse vres = new ValidationResponse();
+    vres.setType("error");
+    vres.setErrorCount(42);
+    helper.recordResults(42, httpResponse(400, vres));
+    check(registry, 0, 0, 42, 0);
+  }
+
+  @Test
+  public void validationErrorEmptyMessages() throws IOException {
+    Registry registry = new DefaultRegistry();
+    ValidationHelper helper = new ValidationHelper(LOGGER, MAPPER, registry);
+    ValidationResponse vres = new ValidationResponse();
+    vres.setType("error");
+    vres.setErrorCount(42);
+    vres.setMessage(Collections.emptyList());
+    helper.recordResults(42, httpResponse(400, vres));
+    check(registry, 0, 0, 42, 0);
+  }
+
+  @Test
+  public void validationErrorBadJson() throws IOException {
+    Registry registry = new DefaultRegistry();
+    ValidationHelper helper = new ValidationHelper(LOGGER, MAPPER, registry);
+    HttpResponse res = new HttpResponse(400, Collections.emptyMap());
+    helper.recordResults(42, res);
+    check(registry, 0, 0, 0, 42);
+  }
+
+  @Test
+  public void serverError() {
+    Registry registry = new DefaultRegistry();
+    ValidationHelper helper = new ValidationHelper(LOGGER, MAPPER, registry);
+    helper.recordResults(42, new HttpResponse(500, Collections.emptyMap()));
+    check(registry, 0, 42, 0, 0);
+  }
+}


### PR DESCRIPTION
Meant to be consistent with the same metrics that are already
provided by spectator-js (Netflix/spectator-js#39).