### PR TITLE
atlas: add support for rule based rollup

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/ArrayTagSet.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/ArrayTagSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
+import java.util.function.BiPredicate;
+import java.util.function.Predicate;
 
 /**
  * An immutable set of tags sorted by the tag key.
@@ -349,6 +351,25 @@ final class ArrayTagSet implements TagList {
   /** Return the current size of this tag set. */
   @Override public int size() {
     return length / 2;
+  }
+
+  @Override public ArrayTagSet filter(BiPredicate<String, String> predicate) {
+    final int n = size();
+    String[] result = new String[2 * n];
+    int pos = 0;
+    for (int i = 0; i < n; ++i) {
+      final String k = getKey(i);
+      final String v = getValue(i);
+      if (predicate.test(k, v)) {
+        result[pos++] = k;
+        result[pos++] = v;
+      }
+    }
+    return new ArrayTagSet(result, pos);
+  }
+
+  @Override public ArrayTagSet filterByKey(Predicate<String> predicate) {
+    return filter((k, v) -> predicate.test(k));
   }
 
   @Override public boolean equals(Object o) {

--- a/spectator-api/src/main/java/com/netflix/spectator/api/DefaultId.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/DefaultId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.function.BiPredicate;
 
 /** Id implementation for the default registry. */
 final class DefaultId implements Id {
@@ -81,6 +82,10 @@ final class DefaultId implements Id {
 
   @Override public int size() {
     return tags.size() + 1;
+  }
+
+  @Override public Id filter(BiPredicate<String, String> predicate) {
+    return new DefaultId(name, tags.filter(predicate));
   }
 
   /**

--- a/spectator-api/src/main/java/com/netflix/spectator/api/Id.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/Id.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,11 @@
  */
 package com.netflix.spectator.api;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.function.BiPredicate;
+import java.util.function.Predicate;
 
 /**
  * Identifier for a meter or measurement.
@@ -157,6 +161,22 @@ public interface Id extends TagList {
   /** Return the size, number of tags, for the id including the name. */
   @Override default int size() {
     return Utils.size(tags()) + 1;
+  }
+
+  /** Return a new tag list with only tags that match the predicate. */
+  @Override default Id filter(BiPredicate<String, String> predicate) {
+    List<Tag> filtered = new ArrayList<>();
+    for (Tag tag : tags()) {
+      if (predicate.test(tag.key(), tag.value())) {
+        filtered.add(tag);
+      }
+    }
+    return new DefaultId(name(), ArrayTagSet.create(filtered));
+  }
+
+  /** Return a new tag list with only tags with keys that match the predicate. */
+  @Override default Id filterByKey(Predicate<String> predicate) {
+    return filter((k, v) -> predicate.test(k));
   }
 
   /**

--- a/spectator-api/src/main/java/com/netflix/spectator/api/TagList.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/TagList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,13 @@
  */
 package com.netflix.spectator.api;
 
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.function.BiConsumer;
+import java.util.function.BiPredicate;
+import java.util.function.Predicate;
 
 /**
  * Base type for a collection of tags. Allows access to the keys and values without allocations
@@ -37,6 +41,25 @@ public interface TagList extends Iterable<Tag> {
   /** Return the tag at the specified index. */
   default Tag getTag(int i) {
     return Tag.of(getKey(i), getValue(i));
+  }
+
+  /** Return a new tag list with only tags that match the predicate. */
+  default TagList filter(BiPredicate<String, String> predicate) {
+    final int n = size();
+    List<Tag> result = new ArrayList<>(n);
+    for (int i = 0; i < n; ++i) {
+      final String k = getKey(i);
+      final String v = getValue(i);
+      if (predicate.test(k, v)) {
+        result.add(Tag.of(k, v));
+      }
+    }
+    return ArrayTagSet.create(result);
+  }
+
+  /** Return a new tag list with only tags with keys that match the predicate. */
+  default TagList filterByKey(Predicate<String> predicate) {
+    return filter((k, v) -> predicate.test(k));
   }
 
   /** Apply the consumer function for each tag in the list. */

--- a/spectator-api/src/test/java/com/netflix/spectator/api/ArrayTagSetTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/ArrayTagSetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -377,6 +377,54 @@ public class ArrayTagSetTest {
     List<Tag> tmp = new ArrayList<>();
     expected.forEach((k, v) -> tmp.add(Tag.of(k, v)));
     Assertions.assertEquals(expected, ArrayTagSet.create(tmp));
+  }
+
+  @Test
+  public void tagListFilter() {
+    ArrayTagSet filtered = ArrayTagSet
+        .create("a", "1", "b", "2", "c", "3")
+        .filter((k, v) -> !v.equals("2"));
+    Assertions.assertEquals(ArrayTagSet.create("a", "1", "c", "3"), filtered);
+  }
+
+  @Test
+  public void tagListFilterMatchAll() {
+    ArrayTagSet filtered = ArrayTagSet
+        .create("a", "1", "b", "2", "c", "3")
+        .filter((k, v) -> true);
+    Assertions.assertEquals(ArrayTagSet.create("a", "1", "b", "2", "c", "3"), filtered);
+  }
+
+  @Test
+  public void tagListFilterMatchNone() {
+    ArrayTagSet filtered = ArrayTagSet
+        .create("a", "1", "b", "2", "c", "3")
+        .filter((k, v) -> false);
+    Assertions.assertEquals(ArrayTagSet.EMPTY, filtered);
+  }
+
+  @Test
+  public void tagListFilterByKey() {
+    ArrayTagSet filtered = ArrayTagSet
+        .create("a", "1", "b", "2", "c", "3")
+        .filterByKey(k -> !k.equals("b"));
+    Assertions.assertEquals(ArrayTagSet.create("a", "1", "c", "3"), filtered);
+  }
+
+  @Test
+  public void tagListFilterByKeyMatchAll() {
+    ArrayTagSet filtered = ArrayTagSet
+        .create("a", "1", "b", "2", "c", "3")
+        .filterByKey(k -> true);
+    Assertions.assertEquals(ArrayTagSet.create("a", "1", "b", "2", "c", "3"), filtered);
+  }
+
+  @Test
+  public void tagListFilterByKeyMatchNone() {
+    ArrayTagSet filtered = ArrayTagSet
+        .create("a", "1", "b", "2", "c", "3")
+        .filterByKey(k -> false);
+    Assertions.assertEquals(ArrayTagSet.EMPTY, filtered);
   }
 
   @Test

--- a/spectator-api/src/test/java/com/netflix/spectator/api/DefaultIdTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/DefaultIdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -281,5 +281,26 @@ public class DefaultIdTest {
     id.forEach((k, v) -> actual.add(Tag.of(k, v)));
 
     Assertions.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void tagListFilter() {
+    DefaultId id = new DefaultId("foo", ArrayTagSet.create("a", "1", "b", "2"));
+    Id expected = Id.create("foo").withTag("a", "1");
+    Assertions.assertEquals(expected, id.filter((k, v) -> !k.equals("b")));
+  }
+
+  @Test
+  public void tagListFilterByKey() {
+    DefaultId id = new DefaultId("foo", ArrayTagSet.create("a", "1", "b", "2"));
+    Id expected = Id.create("foo").withTag("a", "1");
+    Assertions.assertEquals(expected, id.filterByKey(k -> !k.equals("b")));
+  }
+
+  @Test
+  public void tagListFilterByKeyName() {
+    // Name is required and is ignored for filtering
+    DefaultId id = new DefaultId("foo", ArrayTagSet.create("a", "1", "b", "2"));
+    Assertions.assertEquals(id, id.filterByKey(k -> !k.equals("name")));
   }
 }

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasConfig.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasConfig.java
@@ -211,7 +211,7 @@ public interface AtlasConfig extends RegistryConfig {
    * policy.
    */
   default RollupPolicy rollupPolicy() {
-    return RollupPolicy.noop();
+    return RollupPolicy.noop(commonTags());
   }
 
   /**

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasRegistryTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,7 +65,11 @@ public class AtlasRegistryTest {
     }
     long t = clock.wallTime() / step * step;
     registry.pollMeters(t);
-    return registry.getBatches(t);
+    return registry
+        .getBatches(t)
+        .stream()
+        .map(RollupPolicy.Result::measurements)
+        .collect(Collectors.toList());
   }
 
   @BeforeEach

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/RollupPolicyTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/RollupPolicyTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2014-2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+public class RollupPolicyTest {
+
+  @Test
+  public void ruleEqualsContract() {
+    EqualsVerifier
+        .forClass(RollupPolicy.Rule.class)
+        .withNonnullFields("query", "rollup")
+        .verify();
+  }
+
+  @Test
+  public void resultEqualsContract() {
+    EqualsVerifier
+        .forClass(RollupPolicy.Result.class)
+        .withNonnullFields("commonTags", "measurements")
+        .verify();
+  }
+}

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/RollupsTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/RollupsTest.java
@@ -28,7 +28,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -193,6 +197,77 @@ public class RollupsTest {
         default:
           Assertions.fail("unexpected id: " + m.id());
           break;
+      }
+    }
+  }
+
+  private static Map<String, String> map(String... ts) {
+    Map<String, String> m = new HashMap<>();
+    for (int i = 0; i < ts.length; i += 2) {
+      m.put(ts[i], ts[i + 1]);
+    }
+    return m;
+  }
+
+  private static List<String> list(String... vs) {
+    return Arrays.asList(vs);
+  }
+
+  @Test
+  public void fromRulesEmpty() {
+    for (int i = 0; i < 10; ++i) {
+      registry.counter("test", "i", "" + i).increment();
+    }
+    clock.setWallTime(5000);
+    List<Measurement> input = registry.measurements().collect(Collectors.toList());
+    RollupPolicy policy = Rollups.fromRules(Collections.emptyMap(), Collections.emptyList());
+    List<RollupPolicy.Result> results = policy.apply(input);
+    Assertions.assertEquals(1, results.size());
+    Assertions.assertEquals(10, results.get(0).measurements().size());
+  }
+
+  @Test
+  public void fromRulesSingle() {
+    registry.counter("ignored").increment();
+    for (int i = 0; i < 10; ++i) {
+      registry.counter("test", "i", "" + i).increment();
+    }
+    clock.setWallTime(5000);
+    List<Measurement> input = registry.measurements().collect(Collectors.toList());
+    List<RollupPolicy.Rule> rules = new ArrayList<>();
+    rules.add(new RollupPolicy.Rule("name,test,:eq", list("i")));
+    RollupPolicy policy = Rollups.fromRules(map("app", "foo", "node", "i-123"), rules);
+
+    List<RollupPolicy.Result> results = policy.apply(input);
+    Assertions.assertEquals(1, results.size());
+    Assertions.assertEquals(2, results.get(0).measurements().size());
+
+    RollupPolicy.Result result = results.get(0);
+    Assertions.assertEquals(map("app", "foo", "node", "i-123"), result.commonTags());
+  }
+
+  @Test
+  public void fromRulesMulti() {
+    registry.counter("removeNode").increment();
+    for (int i = 0; i < 10; ++i) {
+      registry.counter("test", "i", "" + i).increment();
+    }
+    clock.setWallTime(5000);
+    List<Measurement> input = registry.measurements().collect(Collectors.toList());
+    List<RollupPolicy.Rule> rules = new ArrayList<>();
+    rules.add(new RollupPolicy.Rule("i,:has", list("i")));
+    rules.add(new RollupPolicy.Rule("name,removeNode,:eq", list("node")));
+    RollupPolicy policy = Rollups.fromRules(map("app", "foo", "node", "i-123"), rules);
+
+    List<RollupPolicy.Result> results = policy.apply(input);
+    Assertions.assertEquals(2, results.size());
+    for (RollupPolicy.Result result : results) {
+      Assertions.assertEquals(1, result.measurements().size());
+      String name = result.measurements().get(0).id().name();
+      if ("removeNode".equals(name)) {
+        Assertions.assertEquals(map("app", "foo"), result.commonTags());
+      } else {
+        Assertions.assertEquals(map("app", "foo", "node", "i-123"), result.commonTags());
       }
     }
   }


### PR DESCRIPTION
This is similar to the aggregate config used on the legacy
internal client. The rollup policy has been refactored so
that it can operate on the common tags as well as user tags.

This is a breaking change if anyone was already using the
RollupPolicy interface, but couldn't find any examples and
it was considered an experiment before. Unfortunately that
was not clearly marked.