### PR TITLE
empty common tag values should get ignored

### DIFF
--- a/spectator-nflx-plugin/src/main/java/com/netflix/spectator/nflx/NetflixConfig.java
+++ b/spectator-nflx-plugin/src/main/java/com/netflix/spectator/nflx/NetflixConfig.java
@@ -105,7 +105,10 @@ public final class NetflixConfig {
 
   private static void put(Map<String, String> map, String key, String maybeNullValue) {
     if (maybeNullValue != null) {
-      map.put(key, maybeNullValue);
+      String value = maybeNullValue.trim();
+      if (!value.isEmpty()) {
+        map.put(key, maybeNullValue);
+      }
     }
   }
 

--- a/spectator-nflx-plugin/src/test/java/com/netflix/spectator/nflx/NetflixConfigTest.java
+++ b/spectator-nflx-plugin/src/test/java/com/netflix/spectator/nflx/NetflixConfigTest.java
@@ -20,6 +20,8 @@ import com.netflix.archaius.config.MapConfig;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
+
 public class NetflixConfigTest {
 
   @Test
@@ -41,5 +43,11 @@ public class NetflixConfigTest {
     Assertions.assertEquals("unknown", config.getString("EC2_OWNER_ID"));
     Assertions.assertEquals("us-east-1", config.getString("EC2_REGION"));
     Assertions.assertEquals("prod-unknown", config.getString("substitutions"));
+  }
+
+  @Test
+  public void commonTagsCannotBeEmpty() {
+    Map<String, String> commonTags = NetflixConfig.commonTags();
+    commonTags.forEach((k, v) -> Assertions.assertFalse(v.isEmpty()));
   }
 }


### PR DESCRIPTION
Update the common tags for the NetflixConfig to ignore values
that are present, but empty.