### PR TITLE
ipc: more robust connect timeout detection

### DIFF
--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/http/RetryPolicy.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/http/RetryPolicy.java
@@ -17,6 +17,7 @@ package com.netflix.spectator.ipc.http;
 
 import java.net.ConnectException;
 import java.net.SocketTimeoutException;
+import java.util.Locale;
 
 /**
  * Policy that determines if a request can be retried based on the response.
@@ -60,7 +61,7 @@ public interface RetryPolicy {
     private boolean isConnectTimeout(Throwable t) {
       return t instanceof SocketTimeoutException
           && t.getMessage() != null
-          && t.getMessage().contains("connect");
+          && t.getMessage().toLowerCase(Locale.US).contains("connect");
     }
 
     @Override public boolean shouldRetry(String method, HttpResponse response) {

--- a/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/http/RetryPolicyTest.java
+++ b/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/http/RetryPolicyTest.java
@@ -27,4 +27,13 @@ public class RetryPolicyTest {
     RetryPolicy policy = RetryPolicy.SAFE;
     Assertions.assertTrue(policy.shouldRetry("GET", new SocketTimeoutException(null)));
   }
+
+  @Test
+  public void safeConnectMessageCapitalization() {
+    RetryPolicy policy = RetryPolicy.SAFE;
+    Assertions.assertTrue(policy.shouldRetry("GET", new SocketTimeoutException("connect")));
+    Assertions.assertTrue(policy.shouldRetry("GET", new SocketTimeoutException("Connect")));
+    Assertions.assertTrue(policy.shouldRetry("GET", new SocketTimeoutException("failed to connect")));
+    Assertions.assertTrue(policy.shouldRetry("GET", new SocketTimeoutException("Connection timed out")));
+  }
 }


### PR DESCRIPTION
In some cases the message is "Connect timed out" and didn't
match because of the casing. The message is now converted
to lowercase to make the matching more likley. It is still
pretty hacky, but not sure of a better way.