### PR TITLE
ipc: add `application_error` status

### DIFF
--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcStatus.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcStatus.java
@@ -76,7 +76,13 @@ public enum IpcStatus implements Tag {
   /**
    * The request was denied access for authentication or authorization reasons.
    */
-  access_denied;
+  access_denied,
+
+  /**
+   * The request had an application level error. Application specific diagnostics would
+   * need to be used to determine the issue.
+   */
+  application_error;
 
   @Override public String key() {
     return IpcTagKey.status.key();


### PR DESCRIPTION
This is for some uses like GraphQL where the response code
at the HTTP level is typically 200 even if there are various
errors returned in the response payload.