### PR TITLE
fix endless loop in matcher

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/ZeroOrMoreMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/ZeroOrMoreMatcher.java
@@ -54,7 +54,7 @@ final class ZeroOrMoreMatcher implements GreedyMatcher, Serializable {
       final int stop = end - next.minLength();
       for (int pos = start; pos >= 0 && pos <= stop; ++pos) {
         int p = next.matches(str, pos, end - pos);
-        if (p >= 0) {
+        if (p >= start) {
           return p;
         }
       }
@@ -62,15 +62,18 @@ final class ZeroOrMoreMatcher implements GreedyMatcher, Serializable {
     } else if (next != TrueMatcher.INSTANCE) {
       final int stop = end - next.minLength();
       int pos = start;
-      while (pos >= 0 && pos <= stop) {
+      while (pos >= start && pos <= stop) {
         int p = next.matches(str, pos, end - pos);
-        if (p >= 0) {
+        if (p >= start) {
           return p;
         }
-        pos = repeated.matches(str, pos, end - pos);
-        if (pos == start) {
+        // The repeated portion could potentially be an empty string matcher, to avoid an
+        // endless loop we need to ensure that the position has moved forward
+        int tmp = repeated.matches(str, pos, end - pos);
+        if (tmp == pos) {
           return Constants.NO_MATCH;
         }
+        pos = tmp;
       }
       return Constants.NO_MATCH;
     } else {

--- a/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/AbstractPatternMatcherTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/AbstractPatternMatcherTest.java
@@ -367,4 +367,16 @@ public abstract class AbstractPatternMatcherTest {
     // https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html
     loadTestFile("jdk.dat").forEach(pair -> testRE(pair[0], pair[1]));
   }
+
+  @Test
+  public void zeroOrMoreEmptyOrClause() throws Exception {
+    testRE("foo-h2(prod|)*-bar-*", "foo-h2prod-abc-v123");
+    testRE("foo-h2(prod|)*-bar-*", "foo-h2prod-bar-v123");
+  }
+
+  @Test
+  public void repeatedEmptyOrClause() throws Exception {
+    testRE("foo-h2(prod|)+-bar-*", "foo-h2prod-abc-v123");
+    testRE("foo-h2(prod|)+-bar-*", "foo-h2prod-bar-v123");
+  }
 }


### PR DESCRIPTION
The zero or more matcher could result in an endless loop
when the repeated portion could match an empty string.