### PR TITLE
update for newer garbage collectors

### DIFF
--- a/spectator-ext-gc/src/main/java/com/netflix/spectator/gc/GcLogger.java
+++ b/spectator-ext-gc/src/main/java/com/netflix/spectator/gc/GcLogger.java
@@ -222,7 +222,9 @@ public final class GcLogger {
   private boolean isConcurrentPhase(GarbageCollectionNotificationInfo info) {
     // So far the only indicator known is that the cause will be reported as "No GC"
     // when using CMS.
-    return "No GC".equals(info.getGcCause());
+    return "No GC".equals(info.getGcCause())         // CMS
+        || "Concurrent GC".equals(info.getGcCause()) // Shenandoah
+        || "ZGC".equals(info.getGcName());
   }
 
   private class GcNotificationListener implements NotificationListener {

--- a/spectator-ext-gc/src/main/java/com/netflix/spectator/gc/HelperFunctions.java
+++ b/spectator-ext-gc/src/main/java/com/netflix/spectator/gc/HelperFunctions.java
@@ -40,6 +40,9 @@ final class HelperFunctions {
     m.put("PS MarkSweep",         GcType.OLD);
     m.put("PS Scavenge",          GcType.YOUNG);
     m.put("ParNew",               GcType.YOUNG);
+    m.put("ZGC",                  GcType.OLD);
+    m.put("Shenandoah Cycles",    GcType.OLD);
+    m.put("Shenandoah Pauses",    GcType.OLD);
     return Collections.unmodifiableMap(m);
   }
 


### PR DESCRIPTION
Update GC logger to better handle ZGC and Shenandoah
that will no longer be experimental in JDK15.