### PR TITLE
add jdk15 to travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
     env: GRADLE_PUBLISH=true
   - jdk: openjdk11
     env: GRADLE_PUBLISH=false
-  - jdk: openjdk14
+  - jdk: openjdk15
     env: GRADLE_PUBLISH=false
 dist: xenial
 install: "./installViaTravis.sh"


### PR DESCRIPTION
Drop jdk14 and add jdk15 to keep ensure latest version is
tested.