### PR TITLE
fix concurrent phase check for Shenandoah

### DIFF
--- a/spectator-ext-gc/src/main/java/com/netflix/spectator/gc/GcLogger.java
+++ b/spectator-ext-gc/src/main/java/com/netflix/spectator/gc/GcLogger.java
@@ -198,7 +198,6 @@ public final class GcLogger {
     if (LOGGER.isDebugEnabled()) {
       LOGGER.debug(event.toString());
     }
-    System.out.println(isConcurrentPhase(info) + "==> " + event.toString());
 
     // Update pause timer for the action and cause...
     Id eventId = (isConcurrentPhase(info) ? CONCURRENT_PHASE_TIME : PAUSE_TIME)

--- a/spectator-ext-gc/src/main/java/com/netflix/spectator/gc/GcLogger.java
+++ b/spectator-ext-gc/src/main/java/com/netflix/spectator/gc/GcLogger.java
@@ -198,6 +198,7 @@ public final class GcLogger {
     if (LOGGER.isDebugEnabled()) {
       LOGGER.debug(event.toString());
     }
+    System.out.println(isConcurrentPhase(info) + "==> " + event.toString());
 
     // Update pause timer for the action and cause...
     Id eventId = (isConcurrentPhase(info) ? CONCURRENT_PHASE_TIME : PAUSE_TIME)
@@ -222,8 +223,8 @@ public final class GcLogger {
   private boolean isConcurrentPhase(GarbageCollectionNotificationInfo info) {
     // So far the only indicator known is that the cause will be reported as "No GC"
     // when using CMS.
-    return "No GC".equals(info.getGcCause())         // CMS
-        || "Concurrent GC".equals(info.getGcCause()) // Shenandoah
+    return "No GC".equals(info.getGcCause())            // CMS
+        || "Shenandoah Cycles".equals(info.getGcName()) // Shenandoah
         || "ZGC".equals(info.getGcName());
   }
 


### PR DESCRIPTION
The `Concurrent GC` cause is used for both STW and
concurrent work. The name will be `Shenandoah Pauses`
for STW pauses and `Shenandoah Cycles` for concurrent.