### PR TITLE
fix promotion and live data size for new GCs

### DIFF
--- a/spectator-ext-gc/src/main/java/com/netflix/spectator/gc/GcLogger.java
+++ b/spectator-ext-gc/src/main/java/com/netflix/spectator/gc/GcLogger.java
@@ -161,6 +161,7 @@ public final class GcLogger {
     return logs;
   }
 
+  @SuppressWarnings("PMD.AvoidDeeplyNestedIfStmts")
   private void updateMetrics(String name, GcInfo info) {
     final Map<String, MemoryUsage> before = info.getMemoryUsageBeforeGc();
     final Map<String, MemoryUsage> after = info.getMemoryUsageAfterGc();

--- a/spectator-ext-gc/src/main/java/com/netflix/spectator/gc/HelperFunctions.java
+++ b/spectator-ext-gc/src/main/java/com/netflix/spectator/gc/HelperFunctions.java
@@ -61,8 +61,8 @@ final class HelperFunctions {
   static boolean isOldGenPool(String name) {
     return name.endsWith("Old Gen")
         || name.endsWith("Tenured Gen")
-        || name.equals("Shenandoah")
-        || name.equals("ZHeap");
+        || "Shenandoah".equals(name)
+        || "ZHeap".equals(name);
   }
 
   /** Returns true if memory pool name matches an young generation pool. */

--- a/spectator-ext-gc/src/main/java/com/netflix/spectator/gc/HelperFunctions.java
+++ b/spectator-ext-gc/src/main/java/com/netflix/spectator/gc/HelperFunctions.java
@@ -52,9 +52,17 @@ final class HelperFunctions {
     return (t == null) ? GcType.UNKNOWN : t;
   }
 
+  /** Return true if it is an old GC type. */
+  static boolean isOldGcType(String name) {
+    return getGcType(name) == GcType.OLD;
+  }
+
   /** Returns true if memory pool name matches an old generation pool. */
   static boolean isOldGenPool(String name) {
-    return name.endsWith("Old Gen") || name.endsWith("Tenured Gen");
+    return name.endsWith("Old Gen")
+        || name.endsWith("Tenured Gen")
+        || name.equals("Shenandoah")
+        || name.equals("ZHeap");
   }
 
   /** Returns true if memory pool name matches an young generation pool. */

--- a/spectator-ext-gc/src/main/java/com/netflix/spectator/gc/HelperFunctions.java
+++ b/spectator-ext-gc/src/main/java/com/netflix/spectator/gc/HelperFunctions.java
@@ -67,7 +67,9 @@ final class HelperFunctions {
 
   /** Returns true if memory pool name matches an young generation pool. */
   static boolean isYoungGenPool(String name) {
-    return name.endsWith("Eden Space");
+    return name.endsWith("Eden Space")
+        || "Shenandoah".equals(name)
+        || "ZHeap".equals(name);
   }
 
   /** Compute the total usage across all pools. */


### PR DESCRIPTION
ZGC and Shenandoah are not generational. They do not have
the normal allocation behavior seen with other GCs that
allow us to measure the allocation rate by comparing the
young gen pool size with a previous event. These new GCs
will only increment the promotion rate since there is
one memory pool.

Live data size also checks for entries with all zeroes
that sometimes get reported causing bogus values to show
up for the user.