### PR TITLE
enable case-insensitive pattern tests in jdk15

### DIFF
--- a/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/CaseInsensitivePatternMatcherTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/CaseInsensitivePatternMatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,12 +22,20 @@ import java.util.regex.Pattern;
 
 public class CaseInsensitivePatternMatcherTest extends AbstractPatternMatcherTest {
 
-  @Override
-  protected void testRE(String regex, String value) {
+  private boolean shouldCheckRegex(String regex) {
     // Java regex has inconsistent behavior for POSIX character classes and the literal version
     // of the same character class. For now we skip regex that use POSIX classes.
     // https://bugs.openjdk.java.net/browse/JDK-8214245
-    if (!regex.contains("\\p{") && !regex.contains("\\P{") && !regex.contains("[^")) {
+    // Bug was fixed in jdk15.
+    return JavaVersion.major() < 15
+        && !regex.contains("\\p{")
+        && !regex.contains("\\P{")
+        && !regex.contains("[^");
+  }
+
+  @Override
+  protected void testRE(String regex, String value) {
+    if (shouldCheckRegex(regex)) {
       int flags = Pattern.DOTALL | Pattern.CASE_INSENSITIVE;
       Pattern pattern = Pattern.compile("^.*(" + regex + ")", flags);
       PatternMatcher matcher = PatternMatcher.compile(regex).ignoreCase();

--- a/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/JavaVersion.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/JavaVersion.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2014-2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.impl.matcher;
+
+import java.lang.reflect.Method;
+
+/** Helper for accessing the major Java version. */
+class JavaVersion {
+
+  private JavaVersion() {
+  }
+
+  /**
+   * Return the major java version.
+   */
+  static int major() {
+    try {
+      Method versionMethod = Runtime.class.getMethod("version");
+      Object version = versionMethod.invoke(null);
+      Method majorMethod = version.getClass().getMethod("major");
+      return (Integer) majorMethod.invoke(version);
+    } catch (Exception e) {
+      // The Runtime.version() method was added in jdk9 and spectator has a minimum
+      // version of 8.
+      return 8;
+    }
+  }
+}


### PR DESCRIPTION
There was a bug in earlier Java versions. With jdk15 the
bug has been fixed and we can test with the full set of
expressions.