### PR TITLE
add helper to get SQL LIKE pattern

### DIFF
--- a/spectator-api/build.gradle
+++ b/spectator-api/build.gradle
@@ -1,6 +1,7 @@
 
 dependencies {
   testImplementation files("$projectDir/src/test/lib/compatibility-0.68.0.jar")
+  testImplementation "org.hsqldb:hsqldb:2.5.1"
   jmh "com.google.re2j:re2j:1.4"
   jmh "com.github.ben-manes.caffeine:caffeine:2.8.5"
 }

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/PatternMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/PatternMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -96,6 +96,15 @@ public interface PatternMatcher {
    */
   default PatternMatcher ignoreCase() {
     return this;
+  }
+
+  /**
+   * Returns a pattern that can be used with a SQL LIKE clause or null if this expression
+   * cannot be expressed as a SQL pattern. Can be used to more optimally map the pattern
+   * to a SQL data store.
+   */
+  default String toSqlPattern() {
+    return null;
   }
 
   /**

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/Matcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/Matcher.java
@@ -53,6 +53,11 @@ interface Matcher extends PatternMatcher {
     return new IgnoreCaseMatcher(m);
   }
 
+  @Override
+  default String toSqlPattern() {
+    return PatternUtils.toSqlPattern(this);
+  }
+
   /** Cast the matcher to type {@code T}. */
   @SuppressWarnings("unchecked")
   default <T> T as() {

--- a/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/SqlPatternMatcherTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/SqlPatternMatcherTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2014-2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.impl.matcher;
+
+import com.netflix.spectator.impl.PatternMatcher;
+import org.junit.jupiter.api.Assertions;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+public class SqlPatternMatcherTest extends AbstractPatternMatcherTest {
+
+  @Override
+  protected void testRE(String regex, String value) {
+    PatternMatcher matcher = PatternMatcher.compile(regex);
+    String sqlPattern = PatternMatcher.compile(regex).toSqlPattern();
+    if (sqlPattern != null) {
+      String desc = "[" + matcher + "] => [" + sqlPattern + "]";
+      if (matcher.matches(value)) {
+        Assertions.assertTrue(sqlMatches(sqlPattern, value), desc + " should match " + value);
+      } else {
+        Assertions.assertFalse(sqlMatches(sqlPattern, value), desc + " shouldn't match " + value);
+      }
+    }
+  }
+
+  private boolean sqlMatches(String pattern, String value) {
+    try {
+      Class.forName("org.hsqldb.jdbcDriver");
+      try (Connection con = DriverManager.getConnection("jdbc:hsqldb:mem:test")) {
+        try (Statement stmt = con.createStatement()) {
+          String v = enquoteLiteral(value);
+          String p = enquoteLiteral(pattern);
+          stmt.executeUpdate("drop table if exists test");
+          stmt.executeUpdate("create table test(v clob)");
+          stmt.executeUpdate("insert into test (v) values (" + v + ")");
+          String query = "select * from test where v like " + p + " escape '\\'";
+          try (ResultSet rs = stmt.executeQuery(query)) {
+            return rs.next();
+          }
+        }
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  // Corresponding method on the Statement interface wasn't added until JDK9 so we cannot
+  // use it.
+  private String enquoteLiteral(String str) {
+    return "'" + str.replace("'", "''") + "'";
+  }
+}

--- a/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/ToSqlPatternTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/ToSqlPatternTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2014-2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.impl.matcher;
+
+import com.netflix.spectator.impl.PatternMatcher;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ToSqlPatternTest {
+
+  @Test
+  public void any() {
+    String sql = PatternMatcher.compile(".*").toSqlPattern();
+    Assertions.assertEquals("%", sql);
+  }
+
+  @Test
+  public void single() {
+    String sql = PatternMatcher.compile("^.$").toSqlPattern();
+    Assertions.assertEquals("_", sql);
+  }
+
+  @Test
+  public void exactSeq() {
+    String sql = PatternMatcher.compile("^abc$").toSqlPattern();
+    Assertions.assertEquals("abc", sql);
+  }
+
+  @Test
+  public void indexOf() {
+    String sql = PatternMatcher.compile(".*foo.*").toSqlPattern();
+    Assertions.assertEquals("%foo%", sql);
+  }
+
+  @Test
+  public void indexOfImplicit() {
+    String sql = PatternMatcher.compile("foo").toSqlPattern();
+    Assertions.assertEquals("%foo%", sql);
+  }
+
+  @Test
+  public void startsWith() {
+    String sql = PatternMatcher.compile("^foo.*").toSqlPattern();
+    Assertions.assertEquals("foo%", sql);
+  }
+
+  @Test
+  public void endsWith() {
+    String sql = PatternMatcher.compile(".*foo$").toSqlPattern();
+    Assertions.assertEquals("%foo", sql);
+  }
+
+  @Test
+  public void combination() {
+    String sql = PatternMatcher.compile(".*foo.*bar.baz.*").toSqlPattern();
+    Assertions.assertEquals("%foo%bar_baz%", sql);
+  }
+
+  @Test
+  public void escaping() {
+    String sql = PatternMatcher.compile(".*foo_bar%baz.*").toSqlPattern();
+    Assertions.assertEquals("%foo\\_bar\\%baz%", sql);
+  }
+
+  @Test
+  public void tooComplex() {
+    String sql = PatternMatcher.compile(".*foo_(bar|baz).*").toSqlPattern();
+    Assertions.assertNull(sql);
+  }
+}


### PR DESCRIPTION
Adds a helper on the pattern matcher to get an equivalent
SQL LIKE pattern if possible. Can be used to more optimally
map a regex into a SQL where clause.