### PR TITLE
eliminate allocations for matcher hashcode

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/CharClassMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/CharClassMatcher.java
@@ -97,6 +97,9 @@ final class CharClassMatcher implements Matcher, Serializable {
 
   @Override
   public int hashCode() {
-    return Objects.hash(set, ignoreCase);
+    int result = 1;
+    result = 31 * result + set.hashCode();
+    result = 31 * result + Boolean.hashCode(ignoreCase);
+    return result;
   }
 }

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/CharSeqMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/CharSeqMatcher.java
@@ -81,6 +81,9 @@ final class CharSeqMatcher implements Matcher, Serializable {
 
   @Override
   public int hashCode() {
-    return Objects.hash(pattern, ignoreCase);
+    int result = 1;
+    result = 31 * result + pattern.hashCode();
+    result = 31 * result + Boolean.hashCode(ignoreCase);
+    return result;
   }
 }

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/IgnoreCaseMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/IgnoreCaseMatcher.java
@@ -59,6 +59,8 @@ final class IgnoreCaseMatcher implements PatternMatcher, Serializable {
 
   @Override
   public int hashCode() {
-    return Objects.hash(matcher);
+    int result = 1;
+    result = 31 * result + matcher.hashCode();
+    return result;
   }
 }

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/IndexOfMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/IndexOfMatcher.java
@@ -158,6 +158,10 @@ final class IndexOfMatcher implements GreedyMatcher, Serializable {
 
   @Override
   public int hashCode() {
-    return Objects.hash(pattern, next, ignoreCase);
+    int result = 1;
+    result = 31 * result + pattern.hashCode();
+    result = 31 * result + next.hashCode();
+    result = 31 * result + Boolean.hashCode(ignoreCase);
+    return result;
   }
 }

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/NegativeLookaheadMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/NegativeLookaheadMatcher.java
@@ -74,6 +74,8 @@ final class NegativeLookaheadMatcher implements Matcher, Serializable {
 
   @Override
   public int hashCode() {
-    return Objects.hash(matcher);
+    int result = 1;
+    result = 31 * result + matcher.hashCode();
+    return result;
   }
 }

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/OrMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/OrMatcher.java
@@ -153,7 +153,7 @@ final class OrMatcher implements GreedyMatcher, Serializable {
 
   @Override
   public int hashCode() {
-    int result = Objects.hash(minLength);
+    int result = minLength;
     result = 31 * result + Arrays.hashCode(matchers);
     return result;
   }

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/OrMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/OrMatcher.java
@@ -21,7 +21,6 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 import java.util.function.Function;
 
 /** Matcher that checks if any of the sub-matchers matchers the string. */

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/PositiveLookaheadMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/PositiveLookaheadMatcher.java
@@ -74,6 +74,8 @@ final class PositiveLookaheadMatcher implements Matcher, Serializable {
 
   @Override
   public int hashCode() {
-    return Objects.hash(matcher);
+    int result = 1;
+    result = 31 * result + matcher.hashCode();
+    return result;
   }
 }

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/RepeatMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/RepeatMatcher.java
@@ -88,6 +88,10 @@ final class RepeatMatcher implements Matcher, Serializable {
 
   @Override
   public int hashCode() {
-    return Objects.hash(repeated, min, max);
+    int result = 1;
+    result = 31 * result + repeated.hashCode();
+    result = 31 * result + min;
+    result = 31 * result + max;
+    return result;
   }
 }

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/SeqMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/SeqMatcher.java
@@ -21,7 +21,6 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 import java.util.function.Function;
 
 /**

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/SeqMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/SeqMatcher.java
@@ -137,7 +137,7 @@ final class SeqMatcher implements Matcher, Serializable {
 
   @Override
   public int hashCode() {
-    int result = Objects.hash(minLength);
+    int result = minLength;
     result = 31 * result + Arrays.hashCode(matchers);
     return result;
   }

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/StartsWithMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/StartsWithMatcher.java
@@ -86,6 +86,9 @@ final class StartsWithMatcher implements Matcher, Serializable {
 
   @Override
   public int hashCode() {
-    return Objects.hash(pattern, ignoreCase);
+    int result = 1;
+    result = 31 * result + pattern.hashCode();
+    result = 31 * result + Boolean.hashCode(ignoreCase);
+    return result;
   }
 }

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/ZeroOrMoreMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/ZeroOrMoreMatcher.java
@@ -141,6 +141,9 @@ final class ZeroOrMoreMatcher implements GreedyMatcher, Serializable {
 
   @Override
   public int hashCode() {
-    return Objects.hash(repeated, next);
+    int result = 1;
+    result = 31 * result + repeated.hashCode();
+    result = 31 * result + next.hashCode();
+    return result;
   }
 }

--- a/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/MatcherEqualsTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/MatcherEqualsTest.java
@@ -27,12 +27,18 @@ public class MatcherEqualsTest {
 
   @Test
   public void charClass() {
-    EqualsVerifier.forClass(CharClassMatcher.class).verify();
+    EqualsVerifier
+        .forClass(CharClassMatcher.class)
+        .withNonnullFields("set")
+        .verify();
   }
 
   @Test
   public void charSeq() {
-    EqualsVerifier.forClass(CharSeqMatcher.class).verify();
+    EqualsVerifier
+        .forClass(CharSeqMatcher.class)
+        .withNonnullFields("pattern")
+        .verify();
   }
 
   @Test
@@ -47,17 +53,26 @@ public class MatcherEqualsTest {
 
   @Test
   public void ignoreCase() {
-    EqualsVerifier.forClass(IgnoreCaseMatcher.class).verify();
+    EqualsVerifier
+        .forClass(IgnoreCaseMatcher.class)
+        .withNonnullFields("matcher")
+        .verify();
   }
 
   @Test
   public void indexOf() {
-    EqualsVerifier.forClass(IndexOfMatcher.class).verify();
+    EqualsVerifier
+        .forClass(IndexOfMatcher.class)
+        .withNonnullFields("pattern", "next")
+        .verify();
   }
 
   @Test
   public void negativeLookahead() {
-    EqualsVerifier.forClass(NegativeLookaheadMatcher.class).verify();
+    EqualsVerifier
+        .forClass(NegativeLookaheadMatcher.class)
+        .withNonnullFields("matcher")
+        .verify();
   }
 
   @Test
@@ -67,12 +82,18 @@ public class MatcherEqualsTest {
 
   @Test
   public void positiveLookahead() {
-    EqualsVerifier.forClass(PositiveLookaheadMatcher.class).verify();
+    EqualsVerifier
+        .forClass(PositiveLookaheadMatcher.class)
+        .withNonnullFields("matcher")
+        .verify();
   }
 
   @Test
   public void repeat() {
-    EqualsVerifier.forClass(RepeatMatcher.class).verify();
+    EqualsVerifier
+        .forClass(RepeatMatcher.class)
+        .withNonnullFields("repeated")
+        .verify();
   }
 
   @Test
@@ -87,7 +108,10 @@ public class MatcherEqualsTest {
 
   @Test
   public void startsWith() {
-    EqualsVerifier.forClass(StartsWithMatcher.class).verify();
+    EqualsVerifier
+        .forClass(StartsWithMatcher.class)
+        .withNonnullFields("pattern")
+        .verify();
   }
 
   @Test
@@ -97,6 +121,9 @@ public class MatcherEqualsTest {
 
   @Test
   public void zeroOrMore() {
-    EqualsVerifier.forClass(ZeroOrMoreMatcher.class).verify();
+    EqualsVerifier
+        .forClass(ZeroOrMoreMatcher.class)
+        .withNonnullFields("repeated", "next")
+        .verify();
   }
 }


### PR DESCRIPTION
In some cases where we hash expressions these will get
called a lot and the allocations add up to be a considerable
overhead. The `Objects.hash` uses a varargs parameter so
it allocates an object array and boxes any primitives.