### PR TITLE
improve hash code performance for Subscription

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Subscription.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Subscription.java
@@ -94,8 +94,7 @@ public final class Subscription {
     Subscription that = (Subscription) o;
     return frequency == that.frequency
         && equalsOrNull(id, that.id)
-        && equalsOrNull(expression, that.expression)
-        && equalsOrNull(expr, that.expr);
+        && equalsOrNull(expression, that.expression);
   }
 
   private boolean equalsOrNull(Object a, Object b) {
@@ -106,7 +105,6 @@ public final class Subscription {
     int result = hashCodeOrZero(id);
     result = 31 * result + hashCodeOrZero(expression);
     result = 31 * result + (int) (frequency ^ (frequency >>> 32));
-    result = 31 * result + hashCodeOrZero(expr);
     return result;
   }
 

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/SubscriptionTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/SubscriptionTest.java
@@ -27,6 +27,7 @@ public class SubscriptionTest {
   public void equalsContract() {
     EqualsVerifier.forClass(Subscription.class)
         .suppress(Warning.NONFINAL_FIELDS)
+        .withIgnoredFields("expr")
         .verify();
   }
 


### PR DESCRIPTION
The `expr` field is computed from the string and the only
setter will update both. Using only the string for the
hash code computation is much faster in particular for
subsequent calls because string caches the hash code.