### PR TITLE
add helper to more efficiently create an Id

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ subprojects {
     profilers = ['stack', 'gc']
     includeTests = false
     duplicateClassesStrategy = 'warn'
-    include = ['.*PollMetersBench.*']
+    include = ['.*Ids.*']
   }
 
   checkstyle {

--- a/spectator-api/src/jmh/java/com/netflix/spectator/perf/Ids.java
+++ b/spectator-api/src/jmh/java/com/netflix/spectator/perf/Ids.java
@@ -53,6 +53,21 @@ public class Ids {
 
   private final Map<String, String> tags = getTags();
 
+  private final String[] tagsArray = new String[] {
+          "nf.app", "test_app",
+      "nf.cluster", "test_app-main",
+          "nf.asg", "test_app-main-v042",
+        "nf.stack", "main",
+          "nf.ami", "ami-0987654321",
+       "nf.region", "us-east-1",
+         "nf.zone", "us-east-1e",
+         "nf.node", "i-1234567890",
+         "country", "US",
+          "device", "xbox",
+          "status", "200",
+          "client", "ab"
+  };
+
   private Map<String, String> getTags() {
     Map<String, String> m = new HashMap<>();
     m.put(    "nf.app", "test_app");
@@ -86,6 +101,12 @@ public class Ids {
   @Benchmark
   public void justName(Blackhole bh) {
     bh.consume(registry.createId("http.req.complete"));
+  }
+
+  @Threads(1)
+  @Benchmark
+  public void unsafeCreate(Blackhole bh) {
+    bh.consume(Id.unsafeCreate("http.req.complete", tagsArray, tagsArray.length));
   }
 
   @Threads(1)

--- a/spectator-api/src/main/java/com/netflix/spectator/api/ArrayTagSet.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/ArrayTagSet.java
@@ -54,6 +54,24 @@ final class ArrayTagSet implements TagList {
     return EMPTY.addAll(tags);
   }
 
+  /**
+   * This method can be used to get better performance for some critical use-cases, but also
+   * has increased risk. If there is any doubt, then use {@link #create(Tag...)} instead.
+   *
+   * <p>Create a new tag set based on the provided array. The provided array will be used
+   * so it should not be modified after. Caller must ensure that:</p>
+   *
+   * <ul>
+   *   <li>Length of tags array is even.</li>
+   *   <li>There are no null values for the first length entries in the array.</li>
+   *   <li>There are no duplicate tag keys.</li>
+   * </ul>
+   */
+  static ArrayTagSet unsafeCreate(String[] tags, int length) {
+    insertionSort(tags, length);
+    return new ArrayTagSet(tags, length);
+  }
+
   private final String[] tags;
   private final int length;
 
@@ -230,7 +248,7 @@ final class ArrayTagSet implements TagList {
    * sorted in-place. Tag lists are supposed to be fairly small, typically less than 20
    * tags. With the small size a simple insertion sort works well.
    */
-  private void insertionSort(String[] ts, int length) {
+  private static void insertionSort(String[] ts, int length) {
     if (length == 4) {
       // Two key/value pairs, swap if needed
       if (ts[0].compareTo(ts[2]) > 0) {

--- a/spectator-api/src/main/java/com/netflix/spectator/api/Id.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/Id.java
@@ -188,4 +188,22 @@ public interface Id extends TagList {
   static Id create(String name) {
     return new DefaultId(name);
   }
+
+  /**
+   * <b>Warning:</b> This method can be used to get better performance for some critical
+   * use-cases, but also has increased risk. If there is any doubt, then use
+   * {@link #create(String)} instead.
+   *
+   * <p>Create a new id using the name tag set. The provided array will be used directly so
+   * it should not be modified after. Caller must ensure that:</p>
+   *
+   * <ul>
+   *   <li>Length of tags array is even.</li>
+   *   <li>There are no null values for the first length entries in the array.</li>
+   *   <li>There are no duplicate tag keys.</li>
+   * </ul>
+   */
+  static Id unsafeCreate(String name, String[] tags, int length) {
+    return new DefaultId(name, ArrayTagSet.unsafeCreate(tags, length));
+  }
 }

--- a/spectator-api/src/test/java/com/netflix/spectator/api/DefaultIdTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/DefaultIdTest.java
@@ -303,4 +303,11 @@ public class DefaultIdTest {
     DefaultId id = new DefaultId("foo", ArrayTagSet.create("a", "1", "b", "2"));
     Assertions.assertEquals(id, id.filterByKey(k -> !k.equals("name")));
   }
+
+  @Test
+  public void unsafeCreate() {
+    Id id = Id.unsafeCreate("foo", new String[] {"k2", "v2", "k1", "v1", null, null}, 4);
+    Id expected = Id.create("foo").withTags("k2", "v2", "k1", "v1");
+    Assertions.assertEquals(expected, id);
+  }
 }


### PR DESCRIPTION
For some use-cases where we already have the array this
method allows it to be reused. This method is named to
indicate it is unsafe since it depends on the caller
to have done all of the necessary sanity checks and
not modify the array after.