### PR TITLE
support negative values for max gauge

### DIFF
--- a/spectator-api/src/test/java/com/netflix/spectator/api/RegistryTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/RegistryTest.java
@@ -579,6 +579,13 @@ public class RegistryTest {
   }
 
   @Test
+  public void maxGaugeCanBeNegative() {
+    DefaultRegistry r = newRegistry(false, 10);
+    r.maxGauge("test").set(-42);
+    Assertions.assertEquals(-42.0, r.maxGauge("test").value(), 1e-12);
+  }
+
+  @Test
   public void customIdTags() {
     DefaultRegistry r = newRegistry(false, 10000);
     Id id = new CustomId("test").withTags("b", "2", "a", "1");

--- a/spectator-api/src/test/java/com/netflix/spectator/impl/AtomicDoubleTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/AtomicDoubleTest.java
@@ -110,6 +110,13 @@ public class AtomicDoubleTest {
   }
 
   @Test
+  public void maxNegativeNaN() {
+    AtomicDouble v = new AtomicDouble(Double.NaN);
+    v.max(-42.0);
+    Assertions.assertEquals(-42.0, v.get(), 1e-12);
+  }
+
+  @Test
   public void maxValueInfinity() {
     AtomicDouble v = new AtomicDouble(0.0);
     v.max(Double.POSITIVE_INFINITY);

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasMaxGauge.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasMaxGauge.java
@@ -35,7 +35,8 @@ class AtlasMaxGauge extends AtlasMeter implements Gauge {
   /** Create a new instance. */
   AtlasMaxGauge(Registry registry, Id id, Clock clock, long ttl, long step) {
     super(id, clock, ttl);
-    this.value = new StepDouble(0.0, clock, step);
+    // Initialize to NaN so that it can be used with negative values
+    this.value = new StepDouble(Double.NaN, clock, step);
     // Add the statistic for typing. Re-adding the tags from the id is to retain
     // the statistic from the id if it was already set
     this.stat = registry.createId(id.name())
@@ -49,7 +50,9 @@ class AtlasMaxGauge extends AtlasMeter implements Gauge {
     // the counters have been rotated if there was no activity in the
     // current interval.
     double v = value.poll();
-    consumer.accept(stat, value.timestamp(), v);
+    if (Double.isFinite(v)) {
+      consumer.accept(stat, value.timestamp(), v);
+    }
   }
 
   @Override public void set(double v) {

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasRegistryTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasRegistryTest.java
@@ -16,6 +16,7 @@
 package com.netflix.spectator.atlas;
 
 import com.netflix.spectator.api.Clock;
+import com.netflix.spectator.api.Gauge;
 import com.netflix.spectator.api.ManualClock;
 import com.netflix.spectator.api.Measurement;
 import com.netflix.spectator.api.NoopRegistry;
@@ -41,6 +42,7 @@ public class AtlasRegistryTest {
     Map<String, String> props = new LinkedHashMap<>();
     props.put("atlas.enabled", "false");
     props.put("atlas.step", "PT10S");
+    props.put("atlas.lwc.step", "PT10S");
     props.put("atlas.batchSize", "3");
 
     return new AtlasConfig() {
@@ -55,6 +57,7 @@ public class AtlasRegistryTest {
   }
 
   private List<Measurement> getMeasurements() {
+    clock.setWallTime(clock.wallTime() + 10000);
     return registry.measurements().collect(Collectors.toList());
   }
 
@@ -116,6 +119,7 @@ public class AtlasRegistryTest {
   @Test
   public void measurementsWithMaxGauge() {
     registry.maxGauge(registry.createId("test")).set(4.0);
+    Gauge g = registry.maxGauge("test");
     Assertions.assertEquals(1, getMeasurements().size());
   }
 

--- a/spectator-reg-stateless/src/main/java/com/netflix/spectator/stateless/StatelessMaxGauge.java
+++ b/spectator-reg-stateless/src/main/java/com/netflix/spectator/stateless/StatelessMaxGauge.java
@@ -35,15 +35,13 @@ class StatelessMaxGauge extends StatelessMeter implements Gauge {
   /** Create a new instance. */
   StatelessMaxGauge(Id id, Clock clock, long ttl) {
     super(id, clock, ttl);
-    value = new AtomicDouble(0.0);
+    value = new AtomicDouble(Double.NaN);
     stat = id.withTag(Statistic.max).withTags(id.tags());
   }
 
   @Override public void set(double v) {
-    if (v > 0.0) {
-      value.max(v);
-      updateLastModTime();
-    }
+    value.max(v);
+    updateLastModTime();
   }
 
   @Override public double value() {
@@ -51,8 +49,8 @@ class StatelessMaxGauge extends StatelessMeter implements Gauge {
   }
 
   @Override public Iterable<Measurement> measure() {
-    final double delta = value.getAndSet(0.0);
-    if (delta > 0.0) {
+    final double delta = value.getAndSet(Double.NaN);
+    if (Double.isFinite(delta)) {
       final Measurement m = new Measurement(stat, clock.wallTime(), delta);
       return Collections.singletonList(m);
     } else {

--- a/spectator-reg-stateless/src/test/java/com/netflix/spectator/stateless/StatelessRegistryTest.java
+++ b/spectator-reg-stateless/src/test/java/com/netflix/spectator/stateless/StatelessRegistryTest.java
@@ -74,6 +74,12 @@ public class StatelessRegistryTest {
   }
 
   @Test
+  public void maxGaugeSetNegative() {
+    registry.maxGauge("test").set(-4.0);
+    Assertions.assertEquals(-4.0, registry.maxGauge("test").value(), 1e-12);
+  }
+
+  @Test
   public void batchesEmpty() {
     Assertions.assertEquals(0, registry.getBatches().size());
   }


### PR DESCRIPTION
This change makes the initial value for a max gauge `NaN`
rather than `0`. As a result negative values will be
treated as being larger and can be used with the max gauge
types.

The benefit is that when using an aggregator normal gauges
flow into a max guage on the remote service. So with this
change those gauges should behave more consistently with
expectations.

Note, this does mean that if someone was using a max gauge
directly via this library, it will now init to `NaN` on
each step interval rather than `0.0`. That is not a common
use-case so it is not a big concern. The local behavior
for the max on timers and distribution summaries has not
changed which is the common use-case.