### PR TITLE
add test case for replacing null char

### DIFF
--- a/spectator-api/src/test/java/com/netflix/spectator/impl/AsciiSetTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/AsciiSetTest.java
@@ -129,6 +129,12 @@ public class AsciiSetTest {
   }
 
   @Test
+  public void replaceNullChar() {
+    AsciiSet s = AsciiSet.fromPattern("*A-Z");
+    Assertions.assertEquals("ABC*DEF", s.replaceNonMembers("ABC\u0000DEF", '*'));
+  }
+
+  @Test
   public void replaceMultiCharUnicode() {
     // http://www.fileformat.info/info/unicode/char/1f701/index.htm
     AsciiSet s = AsciiSet.fromPattern("_");


### PR DESCRIPTION
Double check that null char would be replaced properly. We
saw some corrupt values come in and trying to isolate why
they were not rejected or replaced.