### PR TITLE
Replace bintray with publishing directly to maven central and NetflixOSS repositories

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,19 @@ jobs:
           key: ${{ runner.os }}-gradlewrapper-${{ hashFiles('gradle/wrapper/*') }}
       - name: Build candidate
         if: contains(github.ref, '-rc.')
-        run: ./gradlew -Psonatype.username=${{ secrets.ORG_SONATYPE_USERNAME }} -Psonatype.password=${{ secrets.ORG_SONATYPE_PASSWORD }} -Pbintray.user=${{ secrets.ORG_BINTRAY_USER }} -Pbintray.apiKey=${{ secrets.ORG_BINTRAY_KEY }} -Prelease.travisci=true -Prelease.useLastTag=true candidate
+        run: ./gradlew --info --stacktrace -Prelease.useLastTag=true candidate
+        env:
+          NETFLIX_OSS_SIGNING_KEY: ${{ secrets.ORG_SIGNING_KEY }}
+          NETFLIX_OSS_SIGNING_PASSWORD: ${{ secrets.ORG_SIGNING_PASSWORD }}
+          NETFLIX_OSS_REPO_USERNAME: ${{ secrets.ORG_NETFLIXOSS_USERNAME }}
+          NETFLIX_OSS_REPO_PASSWORD: ${{ secrets.ORG_NETFLIXOSS_PASSWORD }}
       - name: Build release
         if: (!contains(github.ref, '-rc.'))
-        run: ./gradlew -Psonatype.username=${{ secrets.ORG_SONATYPE_USERNAME }} -Psonatype.password=${{ secrets.ORG_SONATYPE_PASSWORD }} -Pbintray.user=${{ secrets.ORG_BINTRAY_USER }} -Pbintray.apiKey=${{ secrets.ORG_BINTRAY_KEY }} -Prelease.travisci=true -Prelease.useLastTag=true final
+        run: ./gradlew --info -Prelease.useLastTag=true final
+        env:
+          NETFLIX_OSS_SONATYPE_USERNAME: ${{ secrets.ORG_SONATYPE_USERNAME }}
+          NETFLIX_OSS_SONATYPE_PASSWORD: ${{ secrets.ORG_SONATYPE_PASSWORD }}
+          NETFLIX_OSS_SIGNING_KEY: ${{ secrets.ORG_SIGNING_KEY }}
+          NETFLIX_OSS_SIGNING_PASSWORD: ${{ secrets.ORG_SIGNING_PASSWORD }}
+          NETFLIX_OSS_REPO_USERNAME: ${{ secrets.ORG_NETFLIXOSS_USERNAME }}
+          NETFLIX_OSS_REPO_PASSWORD: ${{ secrets.ORG_NETFLIXOSS_PASSWORD }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -29,4 +29,9 @@ jobs:
             ~/.gradle/wrapper
           key: ${{ runner.os }}-gradlewrapper-${{ hashFiles('gradle/wrapper/*') }}
       - name: Build
-        run: ./gradlew -Prelease.travisci=true -Psonatype.username=${{ secrets.ORG_SONATYPE_USERNAME }} -Psonatype.password=${{ secrets.ORG_SONATYPE_PASSWORD }} -Pbintray.user=${{ secrets.ORG_BINTRAY_USER }} -Pbintray.apiKey=${{ secrets.ORG_BINTRAY_KEY }} build snapshot
+        run: ./gradlew build snapshot
+        env:
+          NETFLIX_OSS_SIGNING_KEY: ${{ secrets.ORG_SIGNING_KEY }}
+          NETFLIX_OSS_SIGNING_PASSWORD: ${{ secrets.ORG_SIGNING_PASSWORD }}
+          NETFLIX_OSS_REPO_USERNAME: ${{ secrets.ORG_NETFLIXOSS_USERNAME }}
+          NETFLIX_OSS_REPO_PASSWORD: ${{ secrets.ORG_NETFLIXOSS_PASSWORD }}

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
   dependencies {
     classpath 'com.github.ben-manes:gradle-versions-plugin:0.36.0'
     classpath 'com.netflix.nebula:nebula-dependency-recommender:9.1.1'
-    classpath 'com.netflix.nebula:gradle-netflixoss-project-plugin:8.10.0'
+    classpath 'com.netflix.nebula:gradle-netflixoss-project-plugin:9.1.0'
   }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Hi folks,

This upgrades to Nebula NetflixOSS which will publish to Nebula's OSS repos and Maven Central.

Repositories based on status:

* https://netflixoss.jfrog.io/artifactory/maven-oss-snapshots
* https://netflixoss.jfrog.io/artifactory/maven-oss-candidates
* https://netflixoss.jfrog.io/artifactory/maven-oss-releases

