### PR TITLE
use iep-nflxenv to get common tags

### DIFF
--- a/dependencies.properties
+++ b/dependencies.properties
@@ -14,6 +14,7 @@ com.netflix.frigga:frigga = 0.24.0
 com.netflix.governator:governator = 1.17.11
 com.netflix.governator:governator-api = 1.17.11
 com.netflix.governator:governator-core = 1.17.11
+com.netflix.iep:iep-nflxenv = 2.6.7
 com.netflix.servo:servo-core = 0.13.0
 com.typesafe:config = 1.4.1
 io.micrometer:micrometer-core = 1.6.4

--- a/spectator-agent/build.gradle
+++ b/spectator-agent/build.gradle
@@ -7,6 +7,7 @@ dependencies {
   api project(':spectator-ext-gc')
   api project(':spectator-ext-jvm')
   api project(':spectator-reg-atlas')
+  implementation 'com.netflix.iep:iep-nflxenv'
   implementation 'com.typesafe:config'
   implementation 'org.slf4j:slf4j-simple'
   testImplementation 'com.fasterxml.jackson.core:jackson-databind'

--- a/spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java
+++ b/spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package com.netflix.spectator.agent;
 
+import com.netflix.iep.NetflixEnvironment;
 import com.netflix.spectator.api.Clock;
 import com.netflix.spectator.api.Spectator;
 import com.netflix.spectator.atlas.AtlasConfig;
@@ -31,7 +32,6 @@ import java.io.File;
 import java.lang.instrument.Instrumentation;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executors;
@@ -188,7 +188,7 @@ public final class Agent {
     }
 
     @Override public Map<String, String> commonTags() {
-      Map<String, String> tags = new HashMap<>();
+      Map<String, String> tags = NetflixEnvironment.commonTagsForAtlas();
       for (Config cfg : config.getConfigList("atlas.tags")) {
         // These are often populated by environment variables that can sometimes be empty
         // rather than not set when missing. Empty strings are not allowed by Atlas.

--- a/spectator-nflx-plugin/build.gradle
+++ b/spectator-nflx-plugin/build.gradle
@@ -7,6 +7,7 @@ dependencies {
   implementation "com.google.inject:guice"
   implementation "com.google.inject.extensions:guice-multibindings"
   implementation "com.netflix.archaius:archaius2-core"
+  implementation 'com.netflix.iep:iep-nflxenv'
   implementation "com.netflix.servo:servo-core"
   testImplementation "com.netflix.governator:governator"
 }

--- a/spectator-nflx-plugin/src/main/java/com/netflix/spectator/nflx/NetflixConfig.java
+++ b/spectator-nflx-plugin/src/main/java/com/netflix/spectator/nflx/NetflixConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,16 +22,14 @@ import com.netflix.archaius.config.DefaultCompositeConfig;
 import com.netflix.archaius.config.EnvironmentConfig;
 import com.netflix.archaius.config.MapConfig;
 import com.netflix.archaius.config.SystemConfig;
+import com.netflix.iep.NetflixEnvironment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.InetAddress;
 import java.net.URL;
-import java.net.UnknownHostException;
 import java.util.Enumeration;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
@@ -117,41 +115,16 @@ public final class NetflixConfig {
    * and for providing a scope for the metrics produced.
    */
   public static Map<String, String> commonTags() {
-    final Map<String, String> commonTags = new HashMap<>();
-    put(commonTags, "nf.app", Env.app());
-    put(commonTags, "nf.cluster", Env.cluster());
-    put(commonTags, "nf.asg", Env.asg());
-    put(commonTags, "nf.stack", Env.stack());
-    put(commonTags, "nf.shard1", Env.shard1());
-    put(commonTags, "nf.shard2", Env.shard2());
-    put(commonTags, "nf.zone", Env.zone());
-    put(commonTags, "nf.vmtype", Env.vmtype());
-    put(commonTags, "nf.node", Env.instanceId());
-    put(commonTags, "nf.region", Env.region());
-    put(commonTags, "nf.account", Env.accountId());
-    put(commonTags, "nf.task", Env.task());
-    put(commonTags, "nf.job", Env.job());
-    return commonTags;
+    return NetflixEnvironment.commonTagsForAtlas();
   }
 
   private static class Env {
     private static final String OWNER = "EC2_OWNER_ID";
     private static final String REGION = "EC2_REGION";
-    private static final String ZONE = "EC2_AVAILABILITY_ZONE";
-    private static final String INSTANCE_ID = "EC2_INSTANCE_ID";
-    private static final String VM_TYPE = "EC2_INSTANCE_TYPE";
 
     private static final String ENVIRONMENT = "NETFLIX_ENVIRONMENT";
     private static final String APP = "NETFLIX_APP";
     private static final String CLUSTER = "NETFLIX_CLUSTER";
-    private static final String ASG = "NETFLIX_AUTO_SCALE_GROUP";
-    private static final String STACK = "NETFLIX_STACK";
-    private static final String SHARD1 = "NETFLIX_SHARD1";
-    private static final String SHARD2 = "NETFLIX_SHARD2";
-
-    private static final String TASK = "TITUS_TASK_ID";
-    private static final String JOB = "TITUS_JOB_ID";
-    private static final String TITUS_INSTANCE_ID = "TITUS_TASK_INSTANCE_ID";
 
     private static String getenv(String k, String dflt) {
       String v = System.getenv(k);
@@ -164,63 +137,6 @@ public final class NetflixConfig {
 
     private static String accountId() {
       return getenv(OWNER, "unknown");
-    }
-
-    private static String region() {
-      return System.getenv(REGION);
-    }
-
-    private static String zone() {
-      return System.getenv(ZONE);
-    }
-
-    private static String app() {
-      return System.getenv(APP);
-    }
-
-    private static String cluster() {
-      return System.getenv(CLUSTER);
-    }
-
-    private static String asg() {
-      return System.getenv(ASG);
-    }
-
-    private static String task() {
-      return System.getenv(TASK);
-    }
-
-    private static String job() {
-      return System.getenv(JOB);
-    }
-
-    private static String stack() {
-      return System.getenv(STACK);
-    }
-
-    private static String shard1() {
-      return System.getenv(SHARD1);
-    }
-
-    private static String shard2() {
-      return System.getenv(SHARD2);
-    }
-
-    private static String vmtype() {
-      return System.getenv(VM_TYPE);
-    }
-
-    private static String instanceId() {
-      String id = getenv(TITUS_INSTANCE_ID, System.getenv(INSTANCE_ID));
-      if (id != null) {
-        return id;
-      }
-
-      try {
-        return InetAddress.getLocalHost().getHostName();
-      } catch (UnknownHostException e) {
-        throw new RuntimeException(e);
-      }
     }
 
     /**


### PR DESCRIPTION
Updates the agent and nflx-plugin to use the common library
for creating the set of common tags to use. Helps keep
everything in sync as changes are made.