### PR TITLE
improve exception message for null tag value

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/BasicTag.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/BasicTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,11 @@ public final class BasicTag implements Tag {
    */
   public BasicTag(String key, String value) {
     this.key = Preconditions.checkNotNull(key, "key");
-    this.value = Preconditions.checkNotNull(value, "value");
+    this.value = value;
+    if (value == null) {
+      String msg = String.format("parameter 'value' cannot be null (key=%s)", key);
+      throw new NullPointerException(msg);
+    }
     this.hc = 31 * key.hashCode() + value.hashCode();
   }
 

--- a/spectator-api/src/test/java/com/netflix/spectator/api/BasicTagTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/BasicTagTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for the BasicTag class.
- * 
- * Created on 10/1/15.
  */
 public class BasicTagTest {
 
@@ -78,6 +76,8 @@ public class BasicTagTest {
 
   @Test
   public void testNullValue() {
-    Assertions.assertThrows(NullPointerException.class, () -> new BasicTag("k", null));
+    NullPointerException e = Assertions.assertThrows(
+        NullPointerException.class, () -> new BasicTag("k", null));
+    Assertions.assertEquals("parameter 'value' cannot be null (key=k)", e.getMessage());
   }
 }


### PR DESCRIPTION
Include the key name as part of the message. When used
as part of a tag list this helps narrow down the which
entry was causing problems.