### PR TITLE
fix corner cases for error propagation check

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/CompositeRegistry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/CompositeRegistry.java
@@ -116,6 +116,7 @@ public final class CompositeRegistry implements Registry {
     return new DefaultId(name, ArrayTagSet.create(tags));
   }
 
+  @Deprecated
   @Override public void register(Meter meter) {
     PolledMeter.monitorMeter(this, meter);
   }

--- a/spectator-api/src/main/java/com/netflix/spectator/api/Utils.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,6 +72,8 @@ public final class Utils {
       final String mname = obj.getClass().getName() + "." + method;
       final String msg = "invalid method [" + mname + "], skipping registration of gauge " + id;
       registry.propagate(msg, e);
+    } catch (Exception e) {
+      registry.propagate(e);
     }
     return null;
   }

--- a/spectator-api/src/main/java/com/netflix/spectator/api/patterns/IdBuilder.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/patterns/IdBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,6 +73,11 @@ public abstract class IdBuilder<T> {
    *     Builder object to allow for method chaining.
    */
   public T withId(Id id) {
-    return createTypeBuilder(id);
+    if (id == null) {
+      registry.propagate(new NullPointerException("parameter 'id' cannot be null"));
+      return createTypeBuilder(registry.createId(null));
+    } else {
+      return createTypeBuilder(id);
+    }
   }
 }

--- a/spectator-api/src/main/java/com/netflix/spectator/api/patterns/LongTaskTimer.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/patterns/LongTaskTimer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import com.netflix.spectator.api.NoopRegistry;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Statistic;
 import com.netflix.spectator.api.Utils;
+import com.netflix.spectator.impl.Preconditions;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -48,6 +49,8 @@ public final class LongTaskTimer implements com.netflix.spectator.api.LongTaskTi
    *     Timer instance.
    */
   public static LongTaskTimer get(Registry registry, Id id) {
+    Preconditions.checkNotNull(registry, "registry");
+    Preconditions.checkNotNull(id, "id");
     ConcurrentMap<Id, Object> state = registry.state();
     Object obj = Utils.computeIfAbsent(state, id, i -> {
       LongTaskTimer timer = new LongTaskTimer(registry, id);

--- a/spectator-api/src/test/java/com/netflix/spectator/api/RegistryExceptionsTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/RegistryExceptionsTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.api;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Uses reflection to call all public methods of Registry with various values including
+ * {@code null} to try and ensure that exceptions are not propagated unless that is explicitly
+ * enabled.
+ */
+public class RegistryExceptionsTest {
+
+  private static final Object[] FALLBACK = new Object[] {null};
+
+  private static final Map<Class<?>, Object[]> SAMPLE_VALUES = new HashMap<>();
+  static {
+    SAMPLE_VALUES.put(
+        String.class,
+        new Object[] {"foo", "", null}
+    );
+    SAMPLE_VALUES.put(
+        String[].class,
+        new Object[] {
+            new String[] {"a", "1", "b", "2"},
+            new String[] {"a", "1", "b"},
+            new String[] {"a", "1", "b", null},
+            new String[] {"a", "1", null, "2"},
+            null
+        }
+    );
+    SAMPLE_VALUES.put(
+        Iterable.class,
+        new Object[] {
+            Arrays.asList("a", "1", "b", "2"),
+            Arrays.asList("a", "1", "b"),
+            null
+        }
+    );
+    SAMPLE_VALUES.put(
+        Id.class,
+        new Object[] {
+            Id.create("foo"),
+            Id.create(""),
+            null
+        }
+    );
+  }
+
+  @Test
+  public void exceptionsNotPropagated() throws Exception {
+    Method[] methods = DefaultRegistry.class.getMethods();
+    for (Method method : methods) {
+      if (Registry.class.isAssignableFrom(method.getDeclaringClass())) {
+        invokeWithSampleValues(method);
+      }
+    }
+  }
+
+  private void invokeWithSampleValues(Method method) throws Exception {
+    Object[] params = new Object[method.getParameterCount()];
+    Class<?>[] ptypes = method.getParameterTypes();
+    invoke(method, params, ptypes, 0);
+  }
+
+  private void invoke(Method method, Object[] params, Class<?>[] ptypes, int i) throws Exception {
+    if (i == params.length) {
+      method.invoke(new DefaultRegistry(Clock.SYSTEM, p -> null), params);
+    } else {
+      Object[] values = SAMPLE_VALUES.getOrDefault(ptypes[i], FALLBACK);
+      for (Object value : values) {
+        params[i] = value;
+        invoke(method, params, ptypes, i + 1);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds a test case that uses reflection to call all methods
or the registry with sample values including `null`. This
revealed a number of corner cases where the exception was
getting thrown to the user rather than just getting logged.