### PR TITLE
fix inf loop in AtomicDouble.max

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/impl/AtomicDouble.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/AtomicDouble.java
@@ -104,7 +104,7 @@ public class AtomicDouble extends Number {
     if (Double.isFinite(v)) {
       double max = get();
       while (isGreaterThan(v, max) && !compareAndSet(max, v)) {
-        max = value.get();
+        max = get();
       }
     }
   }


### PR DESCRIPTION
Before, if there was contention and the body of the loop
was accessed, then it could result in an infinite loop
because it accessed the raw value from the AtomicLong
rather than convert the bits to a double. If the long
bits for `v` treated as a long that is coerced to a double
is smaller than `v`, then the loop condition will never
be satisfied and it loops forever.

Not sure of a good test case to hit this, but the loop
behavior can be reproduced by initializing the max to
the raw long bits and running the `maxNegative` test.