### PR TITLE
fix NPE for log4j appender with null filename

### DIFF
--- a/spectator-ext-log4j2/src/main/java/com/netflix/spectator/log4j/SpectatorAppender.java
+++ b/spectator-ext-log4j2/src/main/java/com/netflix/spectator/log4j/SpectatorAppender.java
@@ -137,7 +137,7 @@ public final class SpectatorAppender extends AbstractAppender {
       final String file = (event.getSource() == null) ? "unknown" : event.getSource().getFileName();
       Id stackTraceId = numStackTraces[level.ordinal()]
           .withTag("exception", event.getThrown().getClass().getSimpleName())
-          .withTag("file", file);
+          .withTag("file", file == null ? "unknown" : file);
       registry.counter(stackTraceId).increment();
     }
   }

--- a/spectator-ext-log4j2/src/test/java/com/netflix/spectator/log4j/SpectatorAppenderTest.java
+++ b/spectator-ext-log4j2/src/test/java/com/netflix/spectator/log4j/SpectatorAppenderTest.java
@@ -111,4 +111,28 @@ public class SpectatorAppenderTest {
     Assertions.assertEquals(0, c.count());
   }
 
+  @Test
+  public void nullFilename() {
+    Counter c = registry.counter("log4j.numStackTraces",
+        "appender", "foo",
+        "loglevel", "2_ERROR",
+        "exception", "RuntimeException",
+        "file", "unknown");
+    Assertions.assertEquals(0, c.count());
+
+    String cname = SpectatorAppender.class.getName();
+    Throwable t = new RuntimeException("test");
+    t.fillInStackTrace();
+    StackTraceElement source = new StackTraceElement(cname, "foo", null, 0);
+    LogEvent event = new Log4jLogEvent.Builder()
+        .setLoggerName(cname)
+        .setLoggerFqcn(cname)
+        .setLevel(Level.ERROR)
+        .setThrown(t)
+        .setSource(source)
+        .setTimeMillis(0L)
+        .build();
+    appender.append(event);
+    Assertions.assertEquals(1, c.count());
+  }
 }


### PR DESCRIPTION
There are some use-cases with dynamically generated
classes where the source is set, but the filename is
still null. Before this would result in an NPE due to
the precondition on the tag value.