### PR TITLE
fix client used for subscription manager

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
@@ -167,7 +167,7 @@ public final class AtlasRegistry extends AbstractRegistry implements AutoCloseab
 
     this.client = client != null ? client : HttpClient.create(debugRegistry);
 
-    this.subManager = new SubscriptionManager(jsonMapper, client, clock, config);
+    this.subManager = new SubscriptionManager(jsonMapper, this.client, clock, config);
     this.evaluator = new Evaluator(commonTags, this::toMap, lwcStepMillis);
 
     if (config.autoStart()) {


### PR DESCRIPTION
Fix NPE if the client passed into the constructor is not
already set.

```
java.lang.NullPointerException: Cannot invoke "com.netflix.spectator.ipc.http.HttpClient.get(java.net.URI)" because "this.client" is null
        at com.netflix.spectator.atlas.SubscriptionManager.refresh(SubscriptionManager.java:81) ~[spectator-reg-atlas-0.128.0.jar:0.128.0]
        at com.netflix.spectator.atlas.AtlasRegistry.fetchSubscriptions(AtlasRegistry.java:452) ~[spectator-reg-atlas-0.128.0.jar:0.128.0]
        at com.netflix.spectator.impl.Scheduler$DelayedTask.runAndReschedule(Scheduler.java:401) ~[spectator-api-0.128.0.jar:0.128.0]
        at com.netflix.spectator.impl.Scheduler$Worker.lambda$run$0(Scheduler.java:475) ~[spectator-api-0.128.0.jar:0.128.0]
        at com.netflix.spectator.api.SwapTimer.record(SwapTimer.java:53) ~[spectator-api-0.128.0.jar:0.128.0]
        at com.netflix.spectator.impl.Scheduler$Worker.run(Scheduler.java:475) ~[spectator-api-0.128.0.jar:0.128.0]
        at java.lang.Thread.run(Thread.java:832) [?:?]
```