### PR TITLE
deprecate IpcTagKey entries that are not in spec

### DIFF
--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcLogEntry.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcLogEntry.java
@@ -641,15 +641,11 @@ public final class IpcLogEntry {
       putTag(tags, getAttemptFinal());
 
       // Optional for client
-      putTag(tags, IpcTagKey.serverRegion.key(), serverRegion);
-      putTag(tags, IpcTagKey.serverZone.key(), serverZone);
       putTag(tags, IpcTagKey.serverApp.key(), serverApp);
       putTag(tags, IpcTagKey.serverCluster.key(), serverCluster);
       putTag(tags, IpcTagKey.serverAsg.key(), serverAsg);
     } else {
       // Optional for server
-      putTag(tags, IpcTagKey.clientRegion.key(), clientRegion);
-      putTag(tags, IpcTagKey.clientZone.key(), clientZone);
       putTag(tags, IpcTagKey.clientApp.key(), clientApp);
       putTag(tags, IpcTagKey.clientCluster.key(), clientCluster);
       putTag(tags, IpcTagKey.clientAsg.key(), clientAsg);

--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcTagKey.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcTagKey.java
@@ -105,12 +105,20 @@ public enum IpcTagKey {
 
   /**
    * Region where the client is located.
+   *
+   * @deprecated Not included in the spec. Common IPC tags should bias towards consistency
+   * across integrations and only use tags that are part of the spec.
    */
+  @Deprecated
   clientRegion("ipc.client.region"),
 
   /**
    * Availability zone where the client is located.
+   *
+   * @deprecated Not included in the spec. Common IPC tags should bias towards consistency
+   * across integrations and only use tags that are part of the spec.
    */
+  @Deprecated
   clientZone("ipc.client.zone"),
 
   /**
@@ -130,12 +138,20 @@ public enum IpcTagKey {
 
   /**
    * Region where the server is located.
+   *
+   * @deprecated Not included in the spec. Common IPC tags should bias towards consistency
+   * across integrations and only use tags that are part of the spec.
    */
+  @Deprecated
   serverRegion("ipc.server.region"),
 
   /**
    * Availability zone where the server is located.
+   *
+   * @deprecated Not included in the spec. Common IPC tags should bias towards consistency
+   * across integrations and only use tags that are part of the spec.
    */
+  @Deprecated
   serverZone("ipc.server.zone"),
 
   /**
@@ -156,12 +172,20 @@ public enum IpcTagKey {
   /**
    * Instance id for the server. <b>Do not use this unless you know it will not
    * cause a metrics explosion. If there is any doubt, then do not enable it.</b>
+   *
+   * @deprecated Not included in the spec. Common IPC tags should bias towards consistency
+   * across integrations and only use tags that are part of the spec.
    */
+  @Deprecated
   serverNode("ipc.server.node"),
 
   /**
    * The port number connected to on the server.
+   *
+   * @deprecated Not included in the spec. Common IPC tags should bias towards consistency
+   * across integrations and only use tags that are part of the spec.
    */
+  @Deprecated
   serverPort("ipc.server.port"),
 
   /**


### PR DESCRIPTION
Consistency should be a high priority for the common IPC
metrics and we should discourage additions that are not
part of the [spec]. As a first step, the existing entries
for the IpcTagKey enum that are not in the spec have been
deprecated.

[spec]: https://netflix.github.io/spectator/en/latest/ext/ipc/