### PR TITLE
ipc: add strict validation mode

### DIFF
--- a/docs/ext/ipc.md
+++ b/docs/ext/ipc.md
@@ -75,7 +75,6 @@ This is a [percentile timer] that is recorded for each inbound message to a serv
 * `ipc.status`
 * `ipc.status.detail`
 * `ipc.failure.injected`
-* `ipc.attempt`
 * `ipc.client.app`
 * `ipc.client.cluster`
 * `ipc.client.asg`

--- a/spectator-ext-aws2/src/test/java/com/netflix/spectator/aws2/SpectatorExecutionInterceptorTest.java
+++ b/spectator-ext-aws2/src/test/java/com/netflix/spectator/aws2/SpectatorExecutionInterceptorTest.java
@@ -64,7 +64,7 @@ public class SpectatorExecutionInterceptorTest {
 
   @AfterEach
   public void after() {
-    IpcMetric.validate(registry);
+    IpcMetric.validate(registry, true);
   }
 
   private void execute(TestContext context, ExecutionAttributes attrs, long latency) {

--- a/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/IpcLogEntryTest.java
+++ b/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/IpcLogEntryTest.java
@@ -657,7 +657,7 @@ public class IpcLogEntryTest {
         .markEnd()
         .log();
 
-    IpcMetric.validate(registry);
+    IpcMetric.validate(registry, true);
   }
 
   @Test
@@ -672,7 +672,7 @@ public class IpcLogEntryTest {
         .withHttpStatus(200)
         .log();
 
-    IpcMetric.validate(registry);
+    IpcMetric.validate(registry, true);
   }
 
   @Test

--- a/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/IpcMetricTest.java
+++ b/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/IpcMetricTest.java
@@ -42,7 +42,7 @@ public class IpcMetricTest {
         .withTag(IpcStatus.success)
         .withTag(IpcAttempt.initial)
         .withTag(IpcTagKey.attemptFinal.key(), true);
-    IpcMetric.clientCall.validate(id);
+    IpcMetric.clientCall.validate(id, true);
   }
 
   @Test
@@ -53,7 +53,7 @@ public class IpcMetricTest {
         .withTag(IpcStatus.success)
         .withTag(IpcAttempt.initial)
         .withTag(IpcAttemptFinal.is_true);
-    IpcMetric.clientCall.validate(id);
+    IpcMetric.clientCall.validate(id, true);
   }
 
   @Test
@@ -64,7 +64,7 @@ public class IpcMetricTest {
         .withTag(IpcStatus.success)
         .withTag(IpcAttempt.initial)
         .withTag(IpcAttemptFinal.is_false);
-    IpcMetric.clientCall.validate(id);
+    IpcMetric.clientCall.validate(id, true);
   }
 
   @Test
@@ -76,7 +76,7 @@ public class IpcMetricTest {
           .withTag(IpcStatus.success)
           .withTag(IpcAttempt.initial)
           .withTag(IpcTagKey.attemptFinal.key(), true);
-      IpcMetric.clientCall.validate(id);
+      IpcMetric.clientCall.validate(id, true);
     });
   }
 
@@ -88,7 +88,7 @@ public class IpcMetricTest {
           .withTag(IpcStatus.success)
           .withTag(IpcAttempt.initial)
           .withTag(IpcTagKey.attemptFinal.key(), true);
-      IpcMetric.clientCall.validate(id);
+      IpcMetric.clientCall.validate(id, true);
     });
   }
 
@@ -101,7 +101,7 @@ public class IpcMetricTest {
           .withTag(IpcStatus.bad_request)
           .withTag(IpcAttempt.initial)
           .withTag(IpcTagKey.attemptFinal.key(), true);
-      IpcMetric.clientCall.validate(id);
+      IpcMetric.clientCall.validate(id, true);
     });
   }
 
@@ -113,7 +113,7 @@ public class IpcMetricTest {
         .withTag(IpcStatus.bad_request)
         .withTag(IpcAttempt.initial)
         .withTag(IpcTagKey.attemptFinal.key(), true);
-    IpcMetric.clientCall.validate(id);
+    IpcMetric.clientCall.validate(id, true);
   }
 
   @Test
@@ -125,7 +125,7 @@ public class IpcMetricTest {
           .withTag(IpcStatus.success)
           .withTag(IpcAttempt.initial)
           .withTag(IpcTagKey.attemptFinal.key(), true);
-      IpcMetric.clientCall.validate(id);
+      IpcMetric.clientCall.validate(id, true);
     });
   }
 
@@ -137,7 +137,7 @@ public class IpcMetricTest {
         .withTag(IpcTagKey.statusDetail.tag("foo"))
         .withTag(IpcAttempt.initial)
         .withTag(IpcTagKey.attemptFinal.key(), true);
-    IpcMetric.clientCall.validate(id);
+    IpcMetric.clientCall.validate(id, true);
   }
 
   @Test
@@ -149,7 +149,7 @@ public class IpcMetricTest {
           .withTag(IpcStatus.success)
           .withTag(IpcAttempt.initial)
           .withTag(IpcTagKey.attemptFinal.key(), true);
-      IpcMetric.clientCall.validate(id);
+      IpcMetric.clientCall.validate(id, true);
     });
   }
 
@@ -162,7 +162,7 @@ public class IpcMetricTest {
           .withTag(IpcTagKey.status.tag("foo"))
           .withTag(IpcAttempt.initial)
           .withTag(IpcTagKey.attemptFinal.key(), true);
-      IpcMetric.clientCall.validate(id);
+      IpcMetric.clientCall.validate(id, true);
     });
   }
 
@@ -174,7 +174,20 @@ public class IpcMetricTest {
           .withTag(IpcResult.success)
           .withTag(IpcAttempt.initial)
           .withTag(IpcTagKey.attemptFinal.key(), "foo");
-      IpcMetric.clientCall.validate(id);
+      IpcMetric.clientCall.validate(id, true);
+    });
+  }
+
+  @Test
+  public void validateIdUnspecifiedDimension() {
+    Assertions.assertThrows(IllegalArgumentException.class, () -> {
+      Id id = registry.createId(IpcMetric.clientCall.metricName())
+          .withTag(IpcTagKey.owner.tag("test"))
+          .withTag(IpcResult.success)
+          .withTag(IpcAttempt.initial)
+          .withTag(IpcTagKey.attemptFinal.key(), "foo")
+          .withTag(IpcTagKey.clientApp.key(), "app");
+      IpcMetric.clientCall.validate(id, true);
     });
   }
 
@@ -187,7 +200,7 @@ public class IpcMetricTest {
         .withTag(IpcAttempt.initial)
         .withTag(IpcTagKey.attemptFinal.key(), true);
     registry.timer(id).record(Duration.ofSeconds(42));
-    IpcMetric.validate(registry);
+    IpcMetric.validate(registry, true);
   }
 
   @Test
@@ -223,7 +236,7 @@ public class IpcMetricTest {
             .withTag(IpcAttempt.initial)
             .withTag(IpcFailureInjection.none)
             .withTag(IpcTagKey.attemptFinal.key(), true);
-    IpcMetric.clientCall.validate(id);
+    IpcMetric.clientCall.validate(id, true);
   }
 
   @Test

--- a/spectator-ext-ipcservlet/src/test/java/com/netflix/spectator/ipcservlet/IpcServletFilterTest.java
+++ b/spectator-ext-ipcservlet/src/test/java/com/netflix/spectator/ipcservlet/IpcServletFilterTest.java
@@ -82,21 +82,21 @@ public class IpcServletFilterTest {
     checkStatus(registry, "200");
     checkMethod(registry, "GET");
     checkEndpoint(registry, "/test/foo");
-    IpcMetric.validate(registry);
+    IpcMetric.validate(registry, true);
   }
 
   @Test
   public void validateIdApi() throws Exception {
     client.get(baseUri.resolve("/api/v1/asg/12345")).send();
     checkEndpoint(registry, "/api");
-    IpcMetric.validate(registry);
+    IpcMetric.validate(registry, true);
   }
 
   @Test
   public void validateIdRoot() throws Exception {
     client.get(baseUri.resolve("/12345")).send();
     checkEndpoint(registry, "/");
-    IpcMetric.validate(registry);
+    IpcMetric.validate(registry, true);
   }
 
   @Test
@@ -107,7 +107,7 @@ public class IpcServletFilterTest {
     checkStatus(registry, "400");
     checkMethod(registry, "POST");
     checkEndpoint(registry, "/bad");
-    IpcMetric.validate(registry);
+    IpcMetric.validate(registry, true);
   }
 
   @Test
@@ -119,7 +119,7 @@ public class IpcServletFilterTest {
     checkMethod(registry, "GET");
     checkClientEndpoint(registry, "unknown");
     checkServerEndpoint(registry, "/throw");
-    IpcMetric.validate(registry);
+    IpcMetric.validate(registry, true);
   }
 
   @Test
@@ -129,7 +129,7 @@ public class IpcServletFilterTest {
     checkStatus(registry, "200");
     checkMethod(registry, "DELETE");
     checkEndpoint(registry, "/servlet"); // header set in the servlet
-    IpcMetric.validate(registry);
+    IpcMetric.validate(registry, true);
   }
 
   public static class OkServlet extends HttpServlet {


### PR DESCRIPTION
Adds a flag that can be used to enable strict validation
for IPC metrics. The goal is that this can be used in unit
tests for integrations to promote consistency.

For now the strict validation just ensures that the only
dimensions on an id are those that are allowed by the spec.
Additional checks can get added overtime which may break
tests for some integrations, but that should help catch
issues and drive compliance going forward.