### PR TITLE
ipc: add helper for sanitizing paths

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,7 @@ subprojects {
     profilers = ['stack', 'gc']
     includeTests = false
     duplicateClassesStrategy = DuplicatesStrategy.WARN
-    includes = ['.*Ids.*']
+    includes = ['.*PathSanitizerBench.*']
   }
 
   checkstyle {

--- a/spectator-ext-ipc/src/jmh/java/com/netflix/spectator/ipc/http/PathSanitizerBench.java
+++ b/spectator-ext-ipc/src/jmh/java/com/netflix/spectator/ipc/http/PathSanitizerBench.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.ipc.http;
+
+import com.netflix.spectator.impl.PatternMatcher;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.Random;
+import java.util.UUID;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+/**
+ * <pre>
+ * Benchmark                     Mode  Cnt        Score        Error   Units
+ * javaRegex                    thrpt    5  1991933.684 ±  40277.438   ops/s
+ * customRegex                  thrpt    5  3647568.873 ± 130042.092   ops/s
+ * handwritten                  thrpt    5  7345612.822 ± 385125.354   ops/s
+ *
+ * Benchmark                     Mode  Cnt        Score        Error   Units
+ * javaRegex                    alloc    5      688.509 ±      0.009    B/op
+ * customRegex                  alloc    5      514.248 ±      0.008    B/op
+ * handwritten                  alloc    5      280.584 ±      0.005    B/op
+ * </pre>
+ */
+@State(Scope.Thread)
+public class PathSanitizerBench {
+
+  private final String regex = "^(v\\d+|[a-zA-Z]{1}|((?![b-df-hj-np-tv-xzB-DF-HJ-NP-TV-XZ]{4})[a-zA-Z]){3,})$";
+
+  private final Pattern javaPattern = Pattern.compile(regex);
+
+  private final PatternMatcher customPattern = PatternMatcher.compile(regex);
+
+  private final Sanitizer javaSanitizer = new Sanitizer(s -> javaPattern.matcher(s).matches());
+
+  private final Sanitizer customSanitizer = new Sanitizer(customPattern::matches);
+
+  private static class Sanitizer {
+
+    private final Predicate<String> shouldSuppressSegment;
+
+    Sanitizer(Predicate<String> shouldSuppressSegment) {
+      this.shouldSuppressSegment = shouldSuppressSegment;
+    }
+
+    private String removeMatixParameters(String path) {
+      int i = path.indexOf(';');
+      return i > 0 ? path.substring(0, i) : path;
+    }
+
+    private String sanitizeSegments(String path) {
+      StringBuilder builder = new StringBuilder();
+      int length = path.length();
+      int pos = path.charAt(0) == '/' ? 1 : 0;
+      int segmentsAdded = 0;
+
+      while (pos < length && segmentsAdded < 5) {
+        String segment = null;
+        int e = path.indexOf('/', pos);
+        if (e > 0) {
+          segment = path.substring(pos, e);
+          pos = e + 1;
+        } else {
+          segment = path.substring(pos);
+          pos = length;
+        }
+
+        if (!segment.isEmpty()) {
+          if (shouldSuppressSegment.test(segment))
+            builder.append("_-");
+          else
+            builder.append('_').append(segment);
+          ++segmentsAdded;
+        }
+      }
+
+      return builder.toString();
+    }
+
+    String sanitize(String path) {
+      return sanitizeSegments(removeMatixParameters(path));
+    }
+  }
+
+  @State(Scope.Thread)
+  public static class Paths {
+
+    private int pos;
+    private String[] paths;
+
+    public Paths() {
+      pos = 0;
+      paths = new String[10_000];
+
+      Random random = new Random();
+      for (int i = 0; i < paths.length; ++i) {
+        paths[i] = randomPath(random);
+      }
+    }
+
+    private String randomPath(Random random) {
+      StringBuilder builder = new StringBuilder();
+      builder.append('/');
+
+      int n = random.nextInt(10);
+      for (int i = 0; i < n; ++i) {
+        switch (random.nextInt(10)) {
+          case 0:
+            builder.append(random.nextLong());
+            break;
+          case 1:
+            builder.append(random.nextDouble());
+            break;
+          case 2:
+            builder.append(UUID.randomUUID());
+            break;
+          case 3:
+            builder.append("en-US");
+            break;
+          case 4:
+            builder.append(String.format("%x", random.nextLong()));
+            break;
+          default:
+            builder.append("api");
+            break;
+        }
+      }
+
+      if (random.nextBoolean()) {
+        builder.append(";q=").append(UUID.randomUUID());
+      }
+
+      return builder.toString();
+    }
+
+    public String next() {
+      int i = Integer.remainderUnsigned(pos++, paths.length);
+      return paths[i];
+    }
+  }
+
+  @Benchmark
+  public void javaRegex(Paths paths, Blackhole bh) {
+    bh.consume(javaSanitizer.sanitize(paths.next()));
+  }
+
+  @Benchmark
+  public void customRegex(Paths paths, Blackhole bh) {
+    bh.consume(customSanitizer.sanitize(paths.next()));
+  }
+
+  @Benchmark
+  public void handwritten(Paths paths, Blackhole bh) {
+    bh.consume(PathSanitizer.sanitize(paths.next()));
+  }
+}

--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/http/PathSanitizer.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/http/PathSanitizer.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.ipc.http;
+
+import com.netflix.spectator.impl.AsciiSet;
+
+/**
+ * Helper for sanitizing a URL path for including as the {@code ipc.endpoint} value. Makes
+ * a best effort to try and remove segments that tend to be variable like numbers, UUIDs,
+ * etc.
+ */
+public final class PathSanitizer {
+
+  private static final AsciiSet ALPHA_CHARS = AsciiSet.fromPattern("a-zA-Z");
+
+  private static final AsciiSet DIGITS = AsciiSet.fromPattern("0-9");
+
+  private static final AsciiSet CONSONANTS = AsciiSet.fromPattern("b-df-hj-np-tv-xzB-DF-HJ-NP-TV-XZ");
+
+  private PathSanitizer() {
+  }
+
+  /** Returns a sanitized path string for use as an endpoint tag value. */
+  public static String sanitize(String path) {
+    return sanitizeSegments(removeMatixParameters(path));
+  }
+
+  private static String removeMatixParameters(String path) {
+    int i = path.indexOf(';');
+    return i > 0 ? path.substring(0, i) : path;
+  }
+
+  private static String sanitizeSegments(String path) {
+    StringBuilder builder = new StringBuilder();
+    int length = path.length();
+    int pos = path.charAt(0) == '/' ? 1 : 0;
+    int segmentsAdded = 0;
+
+    while (pos < length && segmentsAdded < 5) {
+      String segment;
+      int e = path.indexOf('/', pos);
+      if (e > 0) {
+        segment = path.substring(pos, e);
+        pos = e + 1;
+      } else {
+        segment = path.substring(pos);
+        pos = length;
+      }
+
+      if (!segment.isEmpty()) {
+        if (shouldSuppressSegment(segment))
+          builder.append("_-");
+        else
+          builder.append('_').append(segment);
+        ++segmentsAdded;
+      }
+    }
+
+    return builder.toString();
+  }
+
+  private static boolean shouldSuppressSegment(String segment) {
+    final int maxSequentialConsonants = 4;
+    int sequentialConsonants = 0;
+
+    boolean version = false;
+    boolean allAlpha = true;
+
+    int n = segment.length();
+    for (int i = 0; i < n; ++i) {
+      char c = segment.charAt(i);
+      if (CONSONANTS.contains(c)) {
+        ++sequentialConsonants;
+        if (sequentialConsonants >= maxSequentialConsonants)
+          return true;
+      } else {
+        sequentialConsonants = 0;
+      }
+      if (i == 0 && c == 'v') {
+        version = true;
+      } else {
+        version &= DIGITS.contains(c);
+      }
+      allAlpha &= ALPHA_CHARS.contains(c);
+      if (!version && !allAlpha) {
+        return true;
+      }
+    }
+
+    return !version && n == 2;
+  }
+}

--- a/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/http/PathSanitizerTest.java
+++ b/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/http/PathSanitizerTest.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.ipc.http;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Locale;
+import java.util.Random;
+import java.util.UUID;
+
+public class PathSanitizerTest {
+
+  private final Random random = new Random(42);
+
+  private String sanitize(String path) {
+    return PathSanitizer.sanitize(path);
+  }
+
+  @Test
+  public void uuids() {
+    String path = "/api/v1/foo/" + UUID.randomUUID();
+    Assertions.assertEquals("_api_v1_foo_-", sanitize(path));
+  }
+
+  @Test
+  public void matrixParameters() {
+    String path = "/api/v1/foo;user=bob";
+    Assertions.assertEquals("_api_v1_foo", sanitize(path));
+  }
+
+  @Test
+  public void decimalNumbers() {
+    String path = "/api/v1/foo/1234567890/123";
+    Assertions.assertEquals("_api_v1_foo_-_-", sanitize(path));
+  }
+
+  @Test
+  public void floatingPointNumbers() {
+    String path = "/api/v1/foo/1234.567890/1e2";
+    Assertions.assertEquals("_api_v1_foo_-_-", sanitize(path));
+  }
+
+  @Test
+  public void hexNumbers() {
+    String path = "/api/v1/foo/a1ed5bc27";
+    Assertions.assertEquals("_api_v1_foo_-", sanitize(path));
+  }
+
+  @Test
+  public void isoDate() {
+    String path = "/api/v1/foo/2021-05-04T13:35:00.000Z";
+    Assertions.assertEquals("_api_v1_foo_-", sanitize(path));
+  }
+
+  @Test
+  public void versionNumber() {
+    String path = "/api/4.2.3";
+    Assertions.assertEquals("_api_-", sanitize(path));
+  }
+
+  @Test
+  public void unixTimestamp() {
+    String path = "/api/v1/foo/" + System.currentTimeMillis();
+    Assertions.assertEquals("_api_v1_foo_-", sanitize(path));
+  }
+
+  @Test
+  public void iso_3166_2() {
+    String path = "/country/US";
+    Assertions.assertEquals("_country_-", sanitize(path));
+  }
+
+  @Test
+  public void iso_3166_lang() {
+    String path = "/country/en-US";
+    Assertions.assertEquals("_country_-", sanitize(path));
+  }
+
+  @Test
+  public void randomLookingString() {
+    String path = "/random/AOTV16LMT2";
+    Assertions.assertEquals("_random_-", sanitize(path));
+  }
+
+  @Test
+  public void randomLookingString2() {
+    String path = "/random/f3hnq9z8t";
+    Assertions.assertEquals("_random_-", sanitize(path));
+  }
+
+  @Test
+  public void hexStringsInt() {
+    // Check that majority of hex strings are suppressed.
+    int suppressed = 0;
+    for (int i = 0; i < 1000; ++i) {
+      String path = "/hex/" + String.format("%x", random.nextInt());
+      if ("_hex_-".equals(sanitize(path))) {
+        ++suppressed;
+      }
+    }
+    Assertions.assertTrue(suppressed > 950, "suppressed " + suppressed + " of 1000");
+  }
+
+  @Test
+  public void hexStringsLong() {
+    // Check that majority of hex strings are suppressed.
+    int suppressed = 0;
+    for (int i = 0; i < 1000; ++i) {
+      String path = "/hex/" + String.format("%x", random.nextLong());
+      if ("_hex_-".equals(sanitize(path))) {
+        ++suppressed;
+      }
+    }
+    Assertions.assertTrue(suppressed > 950, "suppressed " + suppressed + " of 1000");
+  }
+
+  private String randomString(int n) {
+    int bound = '~' - '!';
+    StringBuilder builder = new StringBuilder();
+    for (int i = 0; i < n; ++i) {
+      char c = (char) ('!' + random.nextInt(bound));
+      builder.append(c == '/' || c == ';' ? 'a' : c);
+    }
+    return builder.toString();
+  }
+
+  @Test
+  public void random8() {
+    // Check that majority of random strings are suppressed.
+    int suppressed = 0;
+    for (int i = 0; i < 1000; ++i) {
+      String path = "/random/" + randomString(8);
+      if ("_random_-".equals(sanitize(path))) {
+        ++suppressed;
+      }
+    }
+    Assertions.assertTrue(suppressed > 950, "suppressed " + suppressed + " of 1000");
+  }
+
+  @Test
+  public void random16() {
+    // Check that majority of random strings are suppressed.
+    int suppressed = 0;
+    for (int i = 0; i < 1000; ++i) {
+      String path = "/random/" + randomString(16);
+      if ("_random_-".equals(sanitize(path))) {
+        ++suppressed;
+      }
+    }
+    Assertions.assertTrue(suppressed > 950, "suppressed " + suppressed + " of 1000");
+  }
+
+  private String randomAlphaString(int n) {
+    StringBuilder builder = new StringBuilder();
+    for (int i = 0; i < n; ++i) {
+      char c = (char) ('a' + random.nextInt(26));
+      builder.append(c);
+    }
+    return builder.toString();
+  }
+
+  @Test
+  public void randomAlpha8() {
+    // Check that majority of random strings with only alpha characters are suppressed. This
+    // is mostly based on runs of consonants, so shorter patterns are more likely to be missed.
+    int suppressed = 0;
+    for (int i = 0; i < 1000; ++i) {
+      String path = "/random/" + randomAlphaString(8);
+      if ("_random_-".equals(sanitize(path))) {
+        ++suppressed;
+      }
+    }
+    Assertions.assertTrue(suppressed > 500, "suppressed " + suppressed + " of 1000");
+  }
+
+  @Test
+  public void randomAlpha16() {
+    // Check that majority of random strings with only alpha characters are suppressed. This
+    // is mostly based on runs of consonants, so shorter patterns are more likely to be missed.
+    int suppressed = 0;
+    for (int i = 0; i < 1000; ++i) {
+      String path = "/random/" + randomAlphaString(16);
+      if ("_random_-".equals(sanitize(path))) {
+        ++suppressed;
+      }
+    }
+    Assertions.assertTrue(suppressed > 900, "suppressed " + suppressed + " of 1000");
+  }
+
+  @Test
+  public void randomAlphaUpper16() {
+    // Check that majority of random strings with only alpha characters are suppressed. This
+    // is mostly based on runs of consonants, so shorter patterns are more likely to be missed.
+    int suppressed = 0;
+    for (int i = 0; i < 1000; ++i) {
+      String path = "/random/" + randomAlphaString(16).toUpperCase(Locale.US);
+      if ("_random_-".equals(sanitize(path))) {
+        ++suppressed;
+      }
+    }
+    Assertions.assertTrue(suppressed > 900, "suppressed " + suppressed + " of 1000");
+  }
+
+  @Test
+  public void allowMostWords() throws Exception {
+    // Check that majority (> 95%) of actual words are allowed. Results could potentially
+    // vary if the words file is different on other machines.
+    Path file = Paths.get("/usr/share/dict/words");
+    if (Files.isRegularFile(file)) {
+      List<String> words = Files.readAllLines(file, StandardCharsets.UTF_8);
+      int suppressed = 0;
+      int total = words.size();
+      for (String word : words) {
+        String path = "/" + word;
+        if ("_-".equals(sanitize(path))) {
+          ++suppressed;
+        }
+      }
+      Assertions.assertTrue(
+          suppressed < 0.05 * total,
+          "suppressed " + suppressed + " of " + total);
+    }
+  }
+}


### PR DESCRIPTION
Adds a helper class to sanitize URL paths before using
as a tag value. This is best effort and tries to do a
reasonable job for common patterns that are seen. Users
would need to manually customize before calling if more
specific mappings are necessary.