### PR TITLE
limit gh-actions to the main repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.repository == 'Netflix/spectator' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.repository == 'Netflix/spectator' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Previously, when maintaining a fork of this repo, merging
updates from the upstream would trigger GitHub actions for
the snapshot workflow, which failed because the secrets
are missing. We do not want forks to run either the
snapshot or the release actions.