### PR TITLE
reduce http logging

### DIFF
--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/http/HttpRequestBuilder.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/http/HttpRequestBuilder.java
@@ -293,7 +293,7 @@ public class HttpRequestBuilder {
         if (attempt == numAttempts || !retryPolicy.shouldRetry(method, e)) {
           throw e;
         } else {
-          LOGGER.warn("attempt {} of {} failed: {} {}", attempt, numAttempts, method, uri);
+          LOGGER.info("attempt {} of {} failed: {} {}", attempt, numAttempts, method, uri);
         }
       }
     }


### PR DESCRIPTION
Only log the last failed HTTP attempt at warn level, to reduce noise in the
logging platform.