### PR TITLE
deprecate sandbox http classes

### DIFF
--- a/spectator-ext-sandbox/src/main/java/com/netflix/spectator/sandbox/BucketDistributionSummary.java
+++ b/spectator-ext-sandbox/src/main/java/com/netflix/spectator/sandbox/BucketDistributionSummary.java
@@ -27,6 +27,7 @@ import com.netflix.spectator.api.Spectator;
  * @deprecated Moved to {@code com.netflix.spectator.api.histogram} package. This is now just a
  * thin wrapper to preserve compatibility. Scheduled for removal after in Q3 2016.
  */
+@Deprecated
 public final class BucketDistributionSummary implements DistributionSummary {
 
   /**

--- a/spectator-ext-sandbox/src/main/java/com/netflix/spectator/sandbox/BucketFunction.java
+++ b/spectator-ext-sandbox/src/main/java/com/netflix/spectator/sandbox/BucketFunction.java
@@ -23,6 +23,7 @@ import java.util.function.LongFunction;
  * @deprecated Moved to {@code com.netflix.spectator.api.histogram} package. This is now just a
  * thin wrapper to preserve compatibility. Scheduled for removal after in Q3 2016.
  */
+@Deprecated
 public interface BucketFunction extends LongFunction<String> {
   /**
    * Returns a bucket for the specified amount.

--- a/spectator-ext-sandbox/src/main/java/com/netflix/spectator/sandbox/BucketFunctions.java
+++ b/spectator-ext-sandbox/src/main/java/com/netflix/spectator/sandbox/BucketFunctions.java
@@ -24,6 +24,7 @@ import java.util.function.LongFunction;
  * @deprecated Moved to {@code com.netflix.spectator.api.histogram} package. This is now just a
  * thin wrapper to preserve compatibility. Scheduled for removal after in Q3 2016.
  */
+@Deprecated
 public final class BucketFunctions {
 
   private BucketFunctions() {

--- a/spectator-ext-sandbox/src/main/java/com/netflix/spectator/sandbox/BucketTimer.java
+++ b/spectator-ext-sandbox/src/main/java/com/netflix/spectator/sandbox/BucketTimer.java
@@ -30,6 +30,7 @@ import java.util.concurrent.TimeUnit;
  * @deprecated Moved to {@code com.netflix.spectator.api.histogram} package. This is now just a
  * thin wrapper to preserve compatibility. Scheduled for removal after in Q3 2016.
  */
+@Deprecated
 public final class BucketTimer implements Timer {
 
   /**

--- a/spectator-ext-sandbox/src/main/java/com/netflix/spectator/sandbox/HttpClient.java
+++ b/spectator-ext-sandbox/src/main/java/com/netflix/spectator/sandbox/HttpClient.java
@@ -38,7 +38,11 @@ import java.net.URI;
  *   }
  * };
  * </pre>
+ *
+ * @deprecated Moved to {@code com.netflix.spectator.ipc.http} package. This is now just a
+ * thin wrapper to preserve compatibility.
  */
+@Deprecated
 public interface HttpClient {
 
   /** Client implementation based on {@link java.net.HttpURLConnection}. */

--- a/spectator-ext-sandbox/src/main/java/com/netflix/spectator/sandbox/HttpLogEntry.java
+++ b/spectator-ext-sandbox/src/main/java/com/netflix/spectator/sandbox/HttpLogEntry.java
@@ -35,7 +35,11 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * Helper for logging http request related information.
+ *
+ * @deprecated Moved to {@code com.netflix.spectator.ipc.http} package. This is now just a
+ * thin wrapper to preserve compatibility.
  */
+@Deprecated
 public class HttpLogEntry {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(HttpLogEntry.class);

--- a/spectator-ext-sandbox/src/main/java/com/netflix/spectator/sandbox/HttpRequestBuilder.java
+++ b/spectator-ext-sandbox/src/main/java/com/netflix/spectator/sandbox/HttpRequestBuilder.java
@@ -39,7 +39,11 @@ import java.util.zip.Deflater;
  * and logging via {@link HttpLogEntry}. This is mostly used for simple use-cases
  * where it is undesirable to have additional dependencies on a more robust HTTP
  * library.
+ *
+ * @deprecated Moved to {@code com.netflix.spectator.ipc.http} package. This is now just a
+ * thin wrapper to preserve compatibility.
  */
+@Deprecated
 public class HttpRequestBuilder {
   private static final Logger LOGGER = LoggerFactory.getLogger(HttpRequestBuilder.class);
 

--- a/spectator-ext-sandbox/src/main/java/com/netflix/spectator/sandbox/HttpResponse.java
+++ b/spectator-ext-sandbox/src/main/java/com/netflix/spectator/sandbox/HttpResponse.java
@@ -29,7 +29,11 @@ import java.util.stream.Collectors;
 
 /**
  * Response for an HTTP request made via {@link HttpRequestBuilder}.
+ *
+ * @deprecated Moved to {@code com.netflix.spectator.ipc.http} package. This is now just a
+ * thin wrapper to preserve compatibility.
  */
+@Deprecated
 public class HttpResponse {
 
   private final int status;


### PR DESCRIPTION
The `spectator-ext-ipc` classes should be used instead.