### PR TITLE
reduce allocations for lambda calls

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/AbstractRegistry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/AbstractRegistry.java
@@ -49,6 +49,14 @@ public abstract class AbstractRegistry implements Registry {
 
   private final Cache<Id, Id> idNormalizationCache;
 
+  // The lambdas for creating a new meter are stored as member variables to avoid
+  // allocating a lambda that captures the "this" pointer on every invocation.
+  private final Function<Id, Counter> counterFactory = this::newCounter;
+  private final Function<Id, DistributionSummary> distSummaryFactory = this::newDistributionSummary;
+  private final Function<Id, Timer> timerFactory = this::newTimer;
+  private final Function<Id, Gauge> gaugeFactory = this::newGauge;
+  private final Function<Id, Gauge> maxGaugeFactory = this::newMaxGauge;
+
   /**
    * Create a new instance.
    *
@@ -187,7 +195,7 @@ public abstract class AbstractRegistry implements Registry {
   }
 
   @Override public final Counter counter(Id id) {
-    Counter c = getOrCreate(id, Counter.class, NoopCounter.INSTANCE, this::newCounter);
+    Counter c = getOrCreate(id, Counter.class, NoopCounter.INSTANCE, counterFactory);
     return new SwapCounter(this, VERSION, c.id(), c);
   }
 
@@ -196,22 +204,22 @@ public abstract class AbstractRegistry implements Registry {
         id,
         DistributionSummary.class,
         NoopDistributionSummary.INSTANCE,
-        this::newDistributionSummary);
+        distSummaryFactory);
     return new SwapDistributionSummary(this, VERSION, ds.id(), ds);
   }
 
   @Override public final Timer timer(Id id) {
-    Timer t = getOrCreate(id, Timer.class, NoopTimer.INSTANCE, this::newTimer);
+    Timer t = getOrCreate(id, Timer.class, NoopTimer.INSTANCE, timerFactory);
     return new SwapTimer(this, VERSION, t.id(), t);
   }
 
   @Override public final Gauge gauge(Id id) {
-    Gauge g = getOrCreate(id, Gauge.class, NoopGauge.INSTANCE, this::newGauge);
+    Gauge g = getOrCreate(id, Gauge.class, NoopGauge.INSTANCE, gaugeFactory);
     return new SwapGauge(this, VERSION, g.id(), g);
   }
 
   @Override public final Gauge maxGauge(Id id) {
-    Gauge g = getOrCreate(id, Gauge.class, NoopGauge.INSTANCE, this::newMaxGauge);
+    Gauge g = getOrCreate(id, Gauge.class, NoopGauge.INSTANCE, maxGaugeFactory);
     return new SwapMaxGauge(this, VERSION, g.id(), g);
   }
 

--- a/spectator-api/src/main/java/com/netflix/spectator/api/CompositeRegistry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/CompositeRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.LongSupplier;
 import java.util.stream.Collectors;
 
 /**
@@ -43,14 +44,17 @@ public final class CompositeRegistry implements Registry {
 
   private final List<Registry> registries;
   private final AtomicLong version;
+  private final LongSupplier versionSupplier;
 
   private final ConcurrentHashMap<Id, Object> state;
+
 
   /** Creates a new instance. */
   CompositeRegistry(Clock clock) {
     this.clock = clock;
     this.registries = new ArrayList<>();
     this.version = new AtomicLong();
+    this.versionSupplier = version::get;
     this.state = new ConcurrentHashMap<>();
   }
 
@@ -150,7 +154,7 @@ public final class CompositeRegistry implements Registry {
   }
 
   @Override public Counter counter(Id id) {
-    return new SwapCounter(this, version::get, id, newCounter(id));
+    return new SwapCounter(this, versionSupplier, id, newCounter(id));
   }
 
   private DistributionSummary newDistributionSummary(Id id) {
@@ -178,7 +182,7 @@ public final class CompositeRegistry implements Registry {
   }
 
   @Override public DistributionSummary distributionSummary(Id id) {
-    return new SwapDistributionSummary(this, version::get, id, newDistributionSummary(id));
+    return new SwapDistributionSummary(this, versionSupplier, id, newDistributionSummary(id));
   }
 
   private Timer newTimer(Id id) {
@@ -206,7 +210,7 @@ public final class CompositeRegistry implements Registry {
   }
 
   @Override public Timer timer(Id id) {
-    return new SwapTimer(this, version::get, id, newTimer(id));
+    return new SwapTimer(this, versionSupplier, id, newTimer(id));
   }
 
   private Gauge newGauge(Id id) {
@@ -234,7 +238,7 @@ public final class CompositeRegistry implements Registry {
   }
 
   @Override public Gauge gauge(Id id) {
-    return new SwapGauge(this, version::get, id, newGauge(id));
+    return new SwapGauge(this, versionSupplier, id, newGauge(id));
   }
 
   private Gauge newMaxGauge(Id id) {
@@ -262,7 +266,7 @@ public final class CompositeRegistry implements Registry {
   }
 
   @Override public Gauge maxGauge(Id id) {
-    return new SwapGauge(this, version::get, id, newMaxGauge(id));
+    return new SwapGauge(this, versionSupplier, id, newMaxGauge(id));
   }
 
   @Override public Meter get(Id id) {


### PR DESCRIPTION
Use a member variable to store capturing lambdas that
are often in a hot path in user code. This avoids the
allocation of a lambda on each call.