### PR TITLE
use HashSet for in query

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Parser.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Parser.java
@@ -18,8 +18,8 @@ package com.netflix.spectator.atlas.impl;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
+import java.util.HashSet;
 import java.util.List;
-import java.util.TreeSet;
 
 /**
  * Parses an Atlas data or query expression.
@@ -124,7 +124,7 @@ public final class Parser {
         case ":in":
           tmp = (List<String>) stack.pop();
           k = (String) stack.pop();
-          stack.push(new Query.In(k, new TreeSet<>(tmp)));
+          stack.push(new Query.In(k, new HashSet<>(tmp)));
           break;
         case ":lt":
           v = (String) stack.pop();


### PR DESCRIPTION
Switch from TreeSet to HashSet for the in query. This
improves performance for the match check.