### PR TITLE
reduce overhead of cache compaction

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,7 @@ subprojects {
     profilers = ['stack', 'gc']
     includeTests = false
     duplicateClassesStrategy = DuplicatesStrategy.WARN
-    includes = ['.*PathSanitizerBench.*']
+    includes = ['.*Caching.*']
   }
 
   checkstyle {


### PR DESCRIPTION
Switch to reusable priority queue rather than a on demand
set and separate sorting operation. This helps to reduce
allocations and improve throughput for the compaction.