### PR TITLE
simplify repeat matcher toString

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/RepeatMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/RepeatMatcher.java
@@ -69,7 +69,9 @@ final class RepeatMatcher implements Matcher, Serializable {
 
   @Override
   public String toString() {
-    return repeated + "{" + min + "," + max + "}";
+    return min == max
+        ? repeated + "{" + min + "}"
+        : repeated + "{" + min + "," + max + "}";
   }
 
   @Override


### PR DESCRIPTION
When the min and max repeat values are the same, use
the simpler form in the toString output for the matcher.
This tends to match actual usage of user written patterns
more closely.