### PR TITLE
optimize case where regex always matches

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Parser.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Parser.java
@@ -149,12 +149,12 @@ public final class Parser {
         case ":re":
           v = (String) stack.pop();
           k = (String) stack.pop();
-          stack.push(new Query.Regex(k, v));
+          pushRegex(stack, new Query.Regex(k, v));
           break;
         case ":reic":
           v = (String) stack.pop();
           k = (String) stack.pop();
-          stack.push(new Query.Regex(k, v, true, ":reic"));
+          pushRegex(stack, new Query.Regex(k, v, true, ":reic"));
           break;
         case ":all":
           q = (Query) stack.pop();
@@ -204,5 +204,13 @@ public final class Parser {
       throw new IllegalArgumentException("too many items remaining on stack: " + stack);
     }
     return obj;
+  }
+
+  private static void pushRegex(Deque<Object> stack, Query.Regex q) {
+    if (q.alwaysMatches()) {
+      stack.push(new Query.Has(q.key()));
+    } else {
+      stack.push(q);
+    }
   }
 }

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Query.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Query.java
@@ -805,6 +805,11 @@ public interface Query {
       return value != null && pattern.matches(value);
     }
 
+    /** Returns true if the pattern will always match. */
+    public boolean alwaysMatches() {
+      return pattern.alwaysMatches();
+    }
+
     @Override public String toString() {
       return k + "," + v + "," + name;
     }

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/QueryTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/QueryTest.java
@@ -179,6 +179,12 @@ public class QueryTest {
   }
 
   @Test
+  public void reQueryAlwaysMatches() {
+    Query q = Parser.parseQuery("name,.*,:re");
+    Assertions.assertEquals(Parser.parseQuery("name,:has"), q);
+  }
+
+  @Test
   public void reicQuery() {
     Query q = parse("name,foO,:reic");
     Assertions.assertTrue(q.matches(registry.createId("fOo")));


### PR DESCRIPTION
If the regex pattern will match any possible value, then
rewrite to a has key query instead.