### PR TITLE
only parse exprs if needed

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Subscription.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Subscription.java
@@ -36,6 +36,9 @@ public final class Subscription {
 
   /** Return the data expression for this subscription. */
   public DataExpr dataExpr() {
+    if (expr == null) {
+      expr = Parser.parseDataExpr(expression);
+    }
     return expr;
   }
 
@@ -63,7 +66,7 @@ public final class Subscription {
   /** Set the expression for the subscription. */
   public void setExpression(String expression) {
     this.expression = expression;
-    this.expr = Parser.parseDataExpr(expression);
+    this.expr = null;
   }
 
   /** Set the expression for the subscription. */

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/EvaluatorTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/EvaluatorTest.java
@@ -179,4 +179,14 @@ public class EvaluatorTest {
     EvalPayload expected = new EvalPayload(0L, metrics);
     Assertions.assertEquals(expected, payload);
   }
+
+  @Test
+  public void badExpression() {
+    List<Subscription> subs = new ArrayList<>();
+    subs.add(newSubscription("sum", "invalid expression,:foo"));
+
+    Evaluator evaluator = newEvaluator("app", "www");
+    evaluator.sync(subs);
+    Assertions.assertEquals(0, evaluator.subscriptionCount());
+  }
 }

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/SubscriptionTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/SubscriptionTest.java
@@ -40,6 +40,6 @@ public class SubscriptionTest {
   @Test
   public void dataExprInvalid() {
     Assertions.assertThrows(IllegalArgumentException.class,
-        () -> new Subscription().withExpression(":true"));
+        () -> new Subscription().withExpression(":true").dataExpr());
   }
 }


### PR DESCRIPTION
Before the expression string would get parsed whenever
it was set on the Subscription object. This can be slow
in particular for exprs with complex regex where the
pattern matching optimizer will need to make many passes.

In most cases, after the first fetch the set of expressions
is fairly consistent and only a few new expressions will
need to be parsed. This change makes the parsing lazy.

The other result of this change is that a bad expression
will not be noticed until it is accessed. The evaluator
has been updated with some additional error handling and
logging.