### PR TITLE
ipc: add inbound/outbound size metrics

### DIFF
--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcMetric.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcMetric.java
@@ -89,6 +89,110 @@ public enum IpcMetric {
   ),
 
   /**
+   * Distribution summary recording the size of the entity for client responses.
+   */
+  clientCallSizeInbound(
+      "ipc.client.call.size.inbound",
+      EnumSet.of(
+          IpcTagKey.attempt,
+          IpcTagKey.attemptFinal,
+          IpcTagKey.owner,
+          IpcTagKey.result,
+          IpcTagKey.status
+      ),
+      EnumSet.of(
+          IpcTagKey.endpoint,
+          IpcTagKey.failureInjected,
+          IpcTagKey.httpMethod,
+          IpcTagKey.httpStatus,
+          IpcTagKey.id,
+          IpcTagKey.protocol,
+          IpcTagKey.serverApp,
+          IpcTagKey.serverCluster,
+          IpcTagKey.serverAsg,
+          IpcTagKey.statusDetail,
+          IpcTagKey.vip
+      )
+  ),
+
+  /**
+   * Distribution summary recording the size of the entity for client requests.
+   */
+  clientCallSizeOutbound(
+      "ipc.client.call.size.outbound",
+      EnumSet.of(
+          IpcTagKey.attempt,
+          IpcTagKey.attemptFinal,
+          IpcTagKey.owner,
+          IpcTagKey.result,
+          IpcTagKey.status
+      ),
+      EnumSet.of(
+          IpcTagKey.endpoint,
+          IpcTagKey.failureInjected,
+          IpcTagKey.httpMethod,
+          IpcTagKey.httpStatus,
+          IpcTagKey.id,
+          IpcTagKey.protocol,
+          IpcTagKey.serverApp,
+          IpcTagKey.serverCluster,
+          IpcTagKey.serverAsg,
+          IpcTagKey.statusDetail,
+          IpcTagKey.vip
+      )
+  ),
+
+  /**
+   * Distribution summary recording the size of the entity for server requests.
+   */
+  serverCallSizeInbound(
+      "ipc.server.call.size.inbound",
+      EnumSet.of(
+          IpcTagKey.owner,
+          IpcTagKey.result,
+          IpcTagKey.status
+      ),
+      EnumSet.of(
+          IpcTagKey.endpoint,
+          IpcTagKey.clientApp,
+          IpcTagKey.clientCluster,
+          IpcTagKey.clientAsg,
+          IpcTagKey.failureInjected,
+          IpcTagKey.httpMethod,
+          IpcTagKey.httpStatus,
+          IpcTagKey.id,
+          IpcTagKey.protocol,
+          IpcTagKey.statusDetail,
+          IpcTagKey.vip
+      )
+  ),
+
+  /**
+   * Distribution summary recording the size of the entity for server responses.
+   */
+  serverCallSizeOutbound(
+      "ipc.server.call.size.outbound",
+      EnumSet.of(
+          IpcTagKey.owner,
+          IpcTagKey.result,
+          IpcTagKey.status
+      ),
+      EnumSet.of(
+          IpcTagKey.endpoint,
+          IpcTagKey.clientApp,
+          IpcTagKey.clientCluster,
+          IpcTagKey.clientAsg,
+          IpcTagKey.failureInjected,
+          IpcTagKey.httpMethod,
+          IpcTagKey.httpStatus,
+          IpcTagKey.id,
+          IpcTagKey.protocol,
+          IpcTagKey.statusDetail,
+          IpcTagKey.vip
+      )
+  ),
+
+  /**
    * Number of outbound requests that are currently in flight.
    */
   clientInflight(
@@ -220,6 +324,10 @@ public enum IpcMetric {
   public static void validate(Registry registry, boolean strict) {
     validateIpcMeter(registry, IpcMetric.clientCall, Timer.class, strict);
     validateIpcMeter(registry, IpcMetric.serverCall, Timer.class, strict);
+    validateIpcMeter(registry, IpcMetric.clientCallSizeInbound, DistributionSummary.class, strict);
+    validateIpcMeter(registry, IpcMetric.clientCallSizeOutbound, DistributionSummary.class, strict);
+    validateIpcMeter(registry, IpcMetric.serverCallSizeInbound, DistributionSummary.class, strict);
+    validateIpcMeter(registry, IpcMetric.serverCallSizeOutbound, DistributionSummary.class, strict);
     validateIpcMeter(registry, IpcMetric.clientInflight, DistributionSummary.class, strict);
     validateIpcMeter(registry, IpcMetric.serverInflight, DistributionSummary.class, strict);
   }

--- a/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/IpcLogEntryTest.java
+++ b/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/IpcLogEntryTest.java
@@ -620,6 +620,26 @@ public class IpcLogEntryTest {
   }
 
   @Test
+  public void requestContentLength() {
+    long expected = 42L;
+    Number actual = (Number) entry
+        .withRequestContentLength(expected)
+        .convert(this::toMap)
+        .get("requestContentLength");
+    Assertions.assertEquals(expected, actual.longValue());
+  }
+
+  @Test
+  public void responseContentLength() {
+    long expected = 42L;
+    Number actual = (Number) entry
+        .withResponseContentLength(expected)
+        .convert(this::toMap)
+        .get("responseContentLength");
+    Assertions.assertEquals(expected, actual.longValue());
+  }
+
+  @Test
   public void inflightRequests() {
     Registry registry = new DefaultRegistry();
     DistributionSummary summary = registry.distributionSummary("ipc.client.inflight");
@@ -670,6 +690,8 @@ public class IpcLogEntryTest {
         .markStart()
         .markEnd()
         .withHttpStatus(200)
+        .withRequestContentLength(123)
+        .withResponseContentLength(456)
         .log();
 
     IpcMetric.validate(registry, true);


### PR DESCRIPTION
Updates the metric enum and logging helper to include
the inbound/outbound size metrics from the spec.