### PR TITLE
ipc: use sanitized path as default endpoint

### DIFF
--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcLogEntry.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcLogEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Tag;
 import com.netflix.spectator.api.histogram.PercentileTimer;
+import com.netflix.spectator.ipc.http.PathSanitizer;
 import org.slf4j.Marker;
 import org.slf4j.event.Level;
 
@@ -636,7 +637,9 @@ public final class IpcLogEntry {
   }
 
   private String getEndpoint() {
-    return (endpoint == null) ? "unknown" : endpoint;
+    return (endpoint == null)
+        ? (path == null) ? "unknown" : PathSanitizer.sanitize(path)
+        : endpoint;
   }
 
   private boolean isClient() {
@@ -832,7 +835,7 @@ public final class IpcLogEntry {
         .addField("protocol", protocol)
         .addField("uri", uri)
         .addField("path", path)
-        .addField("endpoint", endpoint)
+        .addField("endpoint", getEndpoint())
         .addField("vip", vip)
         .addField("clientRegion", clientRegion)
         .addField("clientZone", clientZone)

--- a/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/IpcLogEntryTest.java
+++ b/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/IpcLogEntryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -213,6 +213,16 @@ public class IpcLogEntryTest {
         .convert(this::toMap)
         .get("endpoint");
     Assertions.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void endpointViaUri() {
+    String path = "/api/v1/1234567890";
+    String actual = (String) entry
+        .withUri(URI.create(path))
+        .convert(this::toMap)
+        .get("endpoint");
+    Assertions.assertEquals("_api_v1_-", actual);
   }
 
   @Test

--- a/spectator-ext-ipcservlet/src/test/java/com/netflix/spectator/ipcservlet/IpcServletFilterTest.java
+++ b/spectator-ext-ipcservlet/src/test/java/com/netflix/spectator/ipcservlet/IpcServletFilterTest.java
@@ -117,7 +117,7 @@ public class IpcServletFilterTest {
     checkClientErrorReason(registry, null);
     checkServerErrorReason(registry, "RuntimeException");
     checkMethod(registry, "GET");
-    checkClientEndpoint(registry, "unknown");
+    checkClientEndpoint(registry, "_throw_-");
     checkServerEndpoint(registry, "/throw");
     IpcMetric.validate(registry, true);
   }


### PR DESCRIPTION
Update log entry helper to use the sanitized path for the
endpoint if not explicitly set.