### PR TITLE
update deprecation messages

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/ExtendedRegistry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/ExtendedRegistry.java
@@ -25,7 +25,8 @@ import java.util.concurrent.ConcurrentMap;
  *
  * @deprecated This class was used prior to java 8 for adding extension methods to the registry
  * without breaking all classes implementing the interface. The extension methods have now been
- * moved to Registry interface as default methods.
+ * moved to Registry interface as default methods. This class is scheduled for removal in a future
+ * release.
  */
 @Deprecated
 public final class ExtendedRegistry implements Registry {

--- a/spectator-api/src/main/java/com/netflix/spectator/api/Registry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/Registry.java
@@ -74,7 +74,8 @@ public interface Registry extends Iterable<Meter> {
    * @see #collectionSize(Id, Collection)
    * @see #mapSize(Id, Map)
    *
-   * @deprecated Code outside of Spectator should not implement the Meter interface.
+   * @deprecated Code outside of Spectator should not implement the Meter interface. This
+   * method is scheduled for removal in a future release.
    */
   @Deprecated
   void register(Meter meter);
@@ -418,7 +419,7 @@ public interface Registry extends Iterable<Meter> {
    *     Timer instance with the corresponding id.
    * @deprecated
    *     Use {@link com.netflix.spectator.api.patterns.LongTaskTimer#get(Registry, Id)}
-   *     instead. Scheduled to be removed in 2.0.
+   *     instead. This method is scheduled for removal in a future release.
    */
   @Deprecated
   default LongTaskTimer longTaskTimer(Id id) {
@@ -442,7 +443,7 @@ public interface Registry extends Iterable<Meter> {
    *     Timer instance with the corresponding id.
    * @deprecated
    *     Use {@link com.netflix.spectator.api.patterns.LongTaskTimer#get(Registry, Id)}
-   *     instead. Scheduled to be removed in 2.0.
+   *     instead. This method is scheduled for removal in a future release.
    */
   @Deprecated
   default LongTaskTimer longTaskTimer(String name) {
@@ -460,7 +461,7 @@ public interface Registry extends Iterable<Meter> {
    *     Timer instance with the corresponding id.
    * @deprecated
    *     Use {@link com.netflix.spectator.api.patterns.LongTaskTimer#get(Registry, Id)}
-   *     instead. Scheduled to be removed in 2.0.
+   *     instead. This method is scheduled for removal in a future release.
    */
   @Deprecated
   default LongTaskTimer longTaskTimer(String name, Iterable<Tag> tags) {
@@ -478,7 +479,7 @@ public interface Registry extends Iterable<Meter> {
    *     Timer instance with the corresponding id.
    * @deprecated
    *     Use {@link com.netflix.spectator.api.patterns.LongTaskTimer#get(Registry, Id)}
-   *     instead. Scheduled to be removed in 2.0.
+   *     instead. This method is scheduled for removal in a future release.
    */
   @Deprecated
   default LongTaskTimer longTaskTimer(String name, String... tags) {
@@ -502,7 +503,7 @@ public interface Registry extends Iterable<Meter> {
    *     user and passive gauges that are polled in the background. Going forward
    *     the registry methods will only be used for the core types directly updated
    *     by the user. Other patterns such as {@link PolledMeter}s will be handled
-   *     separately. Scheduled to be removed in 2.0.
+   *     separately. This method is scheduled for removal in a future release.
    */
   @Deprecated
   default <T extends Number> T gauge(Id id, T number) {
@@ -526,7 +527,7 @@ public interface Registry extends Iterable<Meter> {
    *     user and passive gauges that are polled in the background. Going forward
    *     the registry methods will only be used for the core types directly updated
    *     by the user. Other patterns such as {@link PolledMeter}s will be handled
-   *     separately. Scheduled to be removed in 2.0.
+   *     separately. This method is scheduled for removal in a future release.
    */
   @Deprecated
   default <T extends Number> T gauge(String name, T number) {
@@ -552,7 +553,7 @@ public interface Registry extends Iterable<Meter> {
    *     user and passive gauges that are polled in the background. Going forward
    *     the registry methods will only be used for the core types directly updated
    *     by the user. Other patterns such as {@link PolledMeter}s will be handled
-   *     separately. Scheduled to be removed in 2.0.
+   *     separately. This method is scheduled for removal in a future release.
    */
   @Deprecated
   default <T extends Number> T gauge(String name, Iterable<Tag> tags, T number) {
@@ -577,7 +578,7 @@ public interface Registry extends Iterable<Meter> {
    *     user and passive gauges that are polled in the background. Going forward
    *     the registry methods will only be used for the core types directly updated
    *     by the user. Other patterns such as {@link PolledMeter}s will be handled
-   *     separately. Scheduled to be removed in 2.0.
+   *     separately. This method is scheduled for removal in a future release.
    */
   @Deprecated
   default <T> T gauge(Id id, T obj, ToDoubleFunction<T> f) {
@@ -602,7 +603,7 @@ public interface Registry extends Iterable<Meter> {
    *     user and passive gauges that are polled in the background. Going forward
    *     the registry methods will only be used for the core types directly updated
    *     by the user. Other patterns such as {@link PolledMeter}s will be handled
-   *     separately. Scheduled to be removed in 2.0.
+   *     separately. This method is scheduled for removal in a future release.
    */
   @Deprecated
   default <T> T gauge(String name, T obj, ToDoubleFunction<T> f) {
@@ -631,7 +632,7 @@ public interface Registry extends Iterable<Meter> {
    *     user and passive gauges that are polled in the background. Going forward
    *     the registry methods will only be used for the core types directly updated
    *     by the user. Other patterns such as {@link PolledMeter}s will be handled
-   *     separately. Scheduled to be removed in 2.0.
+   *     separately. This method is scheduled for removal in a future release.
    */
   @Deprecated
   default <T extends Collection<?>> T collectionSize(Id id, T collection) {
@@ -655,7 +656,7 @@ public interface Registry extends Iterable<Meter> {
    *     user and passive gauges that are polled in the background. Going forward
    *     the registry methods will only be used for the core types directly updated
    *     by the user. Other patterns such as {@link PolledMeter}s will be handled
-   *     separately. Scheduled to be removed in 2.0.
+   *     separately. This method is scheduled for removal in a future release.
    */
   @Deprecated
   default <T extends Collection<?>> T collectionSize(String name, T collection) {
@@ -684,7 +685,7 @@ public interface Registry extends Iterable<Meter> {
    *     user and passive gauges that are polled in the background. Going forward
    *     the registry methods will only be used for the core types directly updated
    *     by the user. Other patterns such as {@link PolledMeter}s will be handled
-   *     separately. Scheduled to be removed in 2.0.
+   *     separately. This method is scheduled for removal in a future release.
    */
   @Deprecated
   default <T extends Map<?, ?>> T mapSize(Id id, T collection) {
@@ -708,7 +709,7 @@ public interface Registry extends Iterable<Meter> {
    *     user and passive gauges that are polled in the background. Going forward
    *     the registry methods will only be used for the core types directly updated
    *     by the user. Other patterns such as {@link PolledMeter}s will be handled
-   *     separately. Scheduled to be removed in 2.0.
+   *     separately. This method is scheduled for removal in a future release.
    */
   @Deprecated
   default <T extends Map<?, ?>> T mapSize(String name, T collection) {
@@ -741,7 +742,7 @@ public interface Registry extends Iterable<Meter> {
    *     user and passive gauges that are polled in the background. Going forward
    *     the registry methods will only be used for the core types directly updated
    *     by the user. Other patterns such as {@link PolledMeter}s will be handled
-   *     separately. Scheduled to be removed in 2.0.
+   *     separately. This method is scheduled for removal in a future release.
    */
   @Deprecated
   default void methodValue(Id id, Object obj, String method) {
@@ -768,7 +769,7 @@ public interface Registry extends Iterable<Meter> {
    *     user and passive gauges that are polled in the background. Going forward
    *     the registry methods will only be used for the core types directly updated
    *     by the user. Other patterns such as {@link PolledMeter}s will be handled
-   *     separately. Scheduled to be removed in 2.0.
+   *     separately. This method is scheduled for removal in a future release.
    */
   @Deprecated
   default void methodValue(String name, Object obj, String method) {

--- a/spectator-api/src/main/java/com/netflix/spectator/api/Spectator.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/Spectator.java
@@ -26,7 +26,8 @@ public final class Spectator {
   /**
    * Returns the global registry.
    *
-   * @deprecated Use injection or {@link #globalRegistry()} instead.
+   * @deprecated Use injection or {@link #globalRegistry()} instead. This method is scheduled
+   * for removal in a future release.
    */
   @Deprecated
   public static ExtendedRegistry registry() {

--- a/spectator-api/src/main/java/com/netflix/spectator/api/patterns/PolledMeter.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/patterns/PolledMeter.java
@@ -422,7 +422,7 @@ public final class PolledMeter {
    * method. Use the builder created with {@link #using(Registry)} instead.
    *
    * @deprecated This method only exists to allow for backwards compatibility and should
-   * be considered an internal detail. Scheduled to be removed in 2.0.
+   * be considered an internal detail. This method is scheduled for removal in a future release.
    */
   @Deprecated
   public static void monitorMeter(Registry registry, Meter meter) {

--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcErrorGroup.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcErrorGroup.java
@@ -23,8 +23,8 @@ import com.netflix.spectator.api.Tag;
  * services and client implementations. An implementation specific failure can be
  * specified with {@link IpcTagKey#errorReason}.
  *
- * @deprecated Use {@link IpcStatus} instead. This value will be removed in
- * January of 2019.
+ * @deprecated Use {@link IpcStatus} instead. This class is scheduled for removal
+ * in a future release.
  */
 @Deprecated
 public enum IpcErrorGroup implements Tag {

--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcLogEntry.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcLogEntry.java
@@ -227,8 +227,8 @@ public final class IpcLogEntry {
    * Set the high level cause for a request failure. See {@link IpcErrorGroup} for more
    * information.
    *
-   * @deprecated Use {@link #withStatus(IpcStatus)} instead. This method will be removed in
-   * January of 2019.
+   * @deprecated Use {@link #withStatus(IpcStatus)} instead. This method is scheduled for
+   * removal in a future release.
    */
   @Deprecated
   public IpcLogEntry withErrorGroup(IpcErrorGroup errorGroup) {
@@ -240,8 +240,8 @@ public final class IpcLogEntry {
    * is preferable to use {@link #withException(Throwable)} or {@link #withHttpStatus(int)}
    * instead of calling this directly.
    *
-   * @deprecated Use {@link #withStatusDetail(String)} instead. This method will be removed in
-   * January of 2019.
+   * @deprecated Use {@link #withStatusDetail(String)} instead. This method is scheduled for
+   * removal in a future release.
    */
   @Deprecated
   public IpcLogEntry withErrorReason(String errorReason) {

--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcTagKey.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcTagKey.java
@@ -52,8 +52,8 @@ public enum IpcTagKey {
    * services and client implementations. See {@link IpcErrorGroup} for permitted
    * values.
    *
-   * @deprecated Use {@link #status} instead. This value will be removed in
-   * January of 2019.
+   * @deprecated Use {@link #status} instead. This value is scheduled for removal
+   * in a future release.
    */
   @Deprecated
   errorGroup("ipc.error.group"),
@@ -61,8 +61,8 @@ public enum IpcTagKey {
   /**
    * Implementation specific error code.
    *
-   * @deprecated Use {@link #statusDetail} instead. This value will be removed in
-   * January of 2019.
+   * @deprecated Use {@link #statusDetail} instead. This value is scheduled for removal
+   * in a future release.
    */
   @Deprecated
   errorReason("ipc.error.reason"),
@@ -107,7 +107,8 @@ public enum IpcTagKey {
    * Region where the client is located.
    *
    * @deprecated Not included in the spec. Common IPC tags should bias towards consistency
-   * across integrations and only use tags that are part of the spec.
+   * across integrations and only use tags that are part of the spec. This value is scheduled
+   * for removal in a future release.
    */
   @Deprecated
   clientRegion("ipc.client.region"),
@@ -116,7 +117,8 @@ public enum IpcTagKey {
    * Availability zone where the client is located.
    *
    * @deprecated Not included in the spec. Common IPC tags should bias towards consistency
-   * across integrations and only use tags that are part of the spec.
+   * across integrations and only use tags that are part of the spec. This value is scheduled
+   * for removal in a future release.
    */
   @Deprecated
   clientZone("ipc.client.zone"),
@@ -140,7 +142,8 @@ public enum IpcTagKey {
    * Region where the server is located.
    *
    * @deprecated Not included in the spec. Common IPC tags should bias towards consistency
-   * across integrations and only use tags that are part of the spec.
+   * across integrations and only use tags that are part of the spec. This value is scheduled
+   * for removal in a future release.
    */
   @Deprecated
   serverRegion("ipc.server.region"),
@@ -149,7 +152,8 @@ public enum IpcTagKey {
    * Availability zone where the server is located.
    *
    * @deprecated Not included in the spec. Common IPC tags should bias towards consistency
-   * across integrations and only use tags that are part of the spec.
+   * across integrations and only use tags that are part of the spec. This value is scheduled
+   * for removal in a future release.
    */
   @Deprecated
   serverZone("ipc.server.zone"),
@@ -174,7 +178,8 @@ public enum IpcTagKey {
    * cause a metrics explosion. If there is any doubt, then do not enable it.</b>
    *
    * @deprecated Not included in the spec. Common IPC tags should bias towards consistency
-   * across integrations and only use tags that are part of the spec.
+   * across integrations and only use tags that are part of the spec. This value is scheduled
+   * for removal in a future release.
    */
   @Deprecated
   serverNode("ipc.server.node"),
@@ -183,7 +188,8 @@ public enum IpcTagKey {
    * The port number connected to on the server.
    *
    * @deprecated Not included in the spec. Common IPC tags should bias towards consistency
-   * across integrations and only use tags that are part of the spec.
+   * across integrations and only use tags that are part of the spec. This value is scheduled
+   * for removal in a future release.
    */
   @Deprecated
   serverPort("ipc.server.port"),

--- a/spectator-ext-sandbox/src/main/java/com/netflix/spectator/sandbox/BucketCounter.java
+++ b/spectator-ext-sandbox/src/main/java/com/netflix/spectator/sandbox/BucketCounter.java
@@ -25,7 +25,7 @@ import com.netflix.spectator.api.Spectator;
  * Counters that get incremented based on the bucket for recorded values.
  *
  * @deprecated Moved to {@code com.netflix.spectator.api.histogram} package. This is now just a
- * thin wrapper to preserve compatibility. Scheduled for removal after in Q3 2016.
+ * thin wrapper to preserve compatibility. This class is scheduled for removal in a future release.
  */
 @Deprecated
 public final class BucketCounter implements DistributionSummary {

--- a/spectator-ext-sandbox/src/main/java/com/netflix/spectator/sandbox/BucketDistributionSummary.java
+++ b/spectator-ext-sandbox/src/main/java/com/netflix/spectator/sandbox/BucketDistributionSummary.java
@@ -25,7 +25,7 @@ import com.netflix.spectator.api.Spectator;
  * Distribution summaries that get updated based on the bucket for recorded values.
  *
  * @deprecated Moved to {@code com.netflix.spectator.api.histogram} package. This is now just a
- * thin wrapper to preserve compatibility. Scheduled for removal after in Q3 2016.
+ * thin wrapper to preserve compatibility. This class is scheduled for removal in a future release.
  */
 @Deprecated
 public final class BucketDistributionSummary implements DistributionSummary {

--- a/spectator-ext-sandbox/src/main/java/com/netflix/spectator/sandbox/BucketFunction.java
+++ b/spectator-ext-sandbox/src/main/java/com/netflix/spectator/sandbox/BucketFunction.java
@@ -21,7 +21,7 @@ import java.util.function.LongFunction;
  * Function to map an amount passed to a distribution summary or timer to a bucket.
  *
  * @deprecated Moved to {@code com.netflix.spectator.api.histogram} package. This is now just a
- * thin wrapper to preserve compatibility. Scheduled for removal after in Q3 2016.
+ * thin wrapper to preserve compatibility. This class is scheduled for removal in a future release.
  */
 @Deprecated
 public interface BucketFunction extends LongFunction<String> {

--- a/spectator-ext-sandbox/src/main/java/com/netflix/spectator/sandbox/BucketFunctions.java
+++ b/spectator-ext-sandbox/src/main/java/com/netflix/spectator/sandbox/BucketFunctions.java
@@ -22,7 +22,7 @@ import java.util.function.LongFunction;
  * Helpers for creating bucketing functions.
  *
  * @deprecated Moved to {@code com.netflix.spectator.api.histogram} package. This is now just a
- * thin wrapper to preserve compatibility. Scheduled for removal after in Q3 2016.
+ * thin wrapper to preserve compatibility. This class is scheduled for removal in a future release.
  */
 @Deprecated
 public final class BucketFunctions {

--- a/spectator-ext-sandbox/src/main/java/com/netflix/spectator/sandbox/BucketTimer.java
+++ b/spectator-ext-sandbox/src/main/java/com/netflix/spectator/sandbox/BucketTimer.java
@@ -28,7 +28,7 @@ import java.util.concurrent.TimeUnit;
  * Timers that get updated based on the bucket for recorded values.
  *
  * @deprecated Moved to {@code com.netflix.spectator.api.histogram} package. This is now just a
- * thin wrapper to preserve compatibility. Scheduled for removal after in Q3 2016.
+ * thin wrapper to preserve compatibility. This class is scheduled for removal in a future release.
  */
 @Deprecated
 public final class BucketTimer implements Timer {

--- a/spectator-ext-sandbox/src/main/java/com/netflix/spectator/sandbox/HttpClient.java
+++ b/spectator-ext-sandbox/src/main/java/com/netflix/spectator/sandbox/HttpClient.java
@@ -40,7 +40,7 @@ import java.net.URI;
  * </pre>
  *
  * @deprecated Moved to {@code com.netflix.spectator.ipc.http} package. This is now just a
- * thin wrapper to preserve compatibility.
+ * thin wrapper to preserve compatibility. This class is scheduled for removal in a future release.
  */
 @Deprecated
 public interface HttpClient {

--- a/spectator-ext-sandbox/src/main/java/com/netflix/spectator/sandbox/HttpLogEntry.java
+++ b/spectator-ext-sandbox/src/main/java/com/netflix/spectator/sandbox/HttpLogEntry.java
@@ -37,7 +37,7 @@ import java.util.concurrent.TimeUnit;
  * Helper for logging http request related information.
  *
  * @deprecated Moved to {@code com.netflix.spectator.ipc.http} package. This is now just a
- * thin wrapper to preserve compatibility.
+ * thin wrapper to preserve compatibility. This class is scheduled for removal in a future release.
  */
 @Deprecated
 public class HttpLogEntry {

--- a/spectator-ext-sandbox/src/main/java/com/netflix/spectator/sandbox/HttpRequestBuilder.java
+++ b/spectator-ext-sandbox/src/main/java/com/netflix/spectator/sandbox/HttpRequestBuilder.java
@@ -41,7 +41,7 @@ import java.util.zip.Deflater;
  * library.
  *
  * @deprecated Moved to {@code com.netflix.spectator.ipc.http} package. This is now just a
- * thin wrapper to preserve compatibility.
+ * thin wrapper to preserve compatibility. This class is scheduled for removal in a future release.
  */
 @Deprecated
 public class HttpRequestBuilder {

--- a/spectator-ext-sandbox/src/main/java/com/netflix/spectator/sandbox/HttpResponse.java
+++ b/spectator-ext-sandbox/src/main/java/com/netflix/spectator/sandbox/HttpResponse.java
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
  * Response for an HTTP request made via {@link HttpRequestBuilder}.
  *
  * @deprecated Moved to {@code com.netflix.spectator.ipc.http} package. This is now just a
- * thin wrapper to preserve compatibility.
+ * thin wrapper to preserve compatibility. This class is scheduled for removal in a future release.
  */
 @Deprecated
 public class HttpResponse {

--- a/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoRegistry.java
+++ b/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoRegistry.java
@@ -34,7 +34,8 @@ import java.util.concurrent.TimeUnit;
  * Registry that maps spectator types to servo.
  *
  * @deprecated Servo is deprecated and we do not encourage new use of this implementation.
- * Consider use of another implementation.
+ * Consider use of another implementation. This class is scheduled for removal in a future
+ * release.
  */
 @Deprecated
 public class ServoRegistry extends AbstractRegistry implements CompositeMonitor<Integer> {


### PR DESCRIPTION
Cleanup deprecation notices and just note that they
will be removed in a future release. The exact timing
and release is not known at this time as we would have
to gauge the internal impact.