### PR TITLE
ipc: set entity sizes for http client helper

### DIFF
--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/http/HttpRequestBuilder.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/http/HttpRequestBuilder.java
@@ -343,6 +343,7 @@ public class HttpRequestBuilder {
       entry.addRequestHeader(h.getKey(), h.getValue());
       con.setRequestProperty(h.getKey(), h.getValue());
     }
+    entry.withRequestContentLength(entity.length);
     configureHTTPS(con);
 
     try {
@@ -373,6 +374,7 @@ public class HttpRequestBuilder {
 
       try (InputStream in = (status >= 400) ? con.getErrorStream() : con.getInputStream()) {
         byte[] data = readAll(in);
+        entry.withResponseContentLength(data.length);
         return new HttpResponse(status, headers, data);
       }
     } catch (IOException e) {


### PR DESCRIPTION
Update the helper around the built in JDK client to set
the entity sizes on the ipc log entry.