### PR TITLE
update GC logger for ZGC changes in jdk17

### DIFF
--- a/spectator-ext-gc/src/main/java/com/netflix/spectator/gc/GcLogger.java
+++ b/spectator-ext-gc/src/main/java/com/netflix/spectator/gc/GcLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -233,11 +233,16 @@ public final class GcLogger {
     // So far the only indicator known is that the cause will be reported as "No GC"
     // when using CMS.
     //
-    // For ZGC, the allocation stall seems to indicate that some thread or threads are
-    // blocked trying to allocate. Even though it is not a true STW pause, counting it
-    // as such seems to be less confusing.
+    // For ZGC, behavior was changed in JDK17:
+    // https://bugs.openjdk.java.net/browse/JDK-8265136
+    //
+    // For ZGC in older versions, there is no way to accurately get the amount of time
+    // in STW pauses. The allocation stall seems to indicate that some thread
+    // or threads are blocked trying to allocate. Even though it is not a true STW pause,
+    // counting it as such seems to be less confusing.
     return "No GC".equals(info.getGcCause())            // CMS
         || "Shenandoah Cycles".equals(info.getGcName()) // Shenandoah
+        || "ZGC Cycles".equals(info.getGcName())        // ZGC in jdk17+
         || ("ZGC".equals(info.getGcName()) && !"Allocation Stall".equals(info.getGcCause()));
   }
 

--- a/spectator-ext-gc/src/main/java/com/netflix/spectator/gc/HelperFunctions.java
+++ b/spectator-ext-gc/src/main/java/com/netflix/spectator/gc/HelperFunctions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,8 @@ final class HelperFunctions {
     m.put("PS Scavenge",          GcType.YOUNG);
     m.put("ParNew",               GcType.YOUNG);
     m.put("ZGC",                  GcType.OLD);
+    m.put("ZGC Cycles",           GcType.OLD);
+    m.put("ZGC Pauses",           GcType.OLD);
     m.put("Shenandoah Cycles",    GcType.OLD);
     m.put("Shenandoah Pauses",    GcType.OLD);
     return Collections.unmodifiableMap(m);


### PR DESCRIPTION
JDK17 has an update to the notification events for ZGC
to make it possible to accurately detect STW pauses
([JDK-8265136]).

[JDK-8265136]: https://bugs.openjdk.java.net/browse/JDK-8265136