### PR TITLE
fix(aws): change default handler context key

### DIFF
--- a/spectator-ext-aws/README.md
+++ b/spectator-ext-aws/README.md
@@ -86,10 +86,10 @@ that caused the throttling to occur.
 
 To help distinguish metrics from multiple clients, it's possible to specify a
 [HandlerContextKey](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/handlers/HandlerContextKey.html)
-for a SpectatorRequestMetricCollector (HandlerContextKey.OPERATION_NAME by
-default).  The SpectatorRequestMetricCollector looks for a value from each
-request's handler context for the given key, and, if there's a value for that
-key, adds a tag to each metric of the form
+for a SpectatorRequestMetricCollector ("ClientIdKey" by default).  The
+SpectatorRequestMetricCollector looks for a value from each request's handler
+context for the given key, and, if there's a value for that key, adds a tag to
+each metric of the form
 
 `handlerContextKey.getName()`:value
 
@@ -100,7 +100,7 @@ requests from a particular client is:
 class MyRequestHandler extends RequestHandler2 {
   @Override
   public void beforeRequest(Request<?> request) {
-    request.addHandlerContext(HandlerContextKey.OPERATION_NAME, "myValue");
+    request.addHandlerContext(SpectatorRequestMetricCollector.DEFAULT_HANDLER_CONTEXT_KEY, "myValue");
   }
 }
 `````
@@ -112,6 +112,6 @@ AmazonS3ClientBuilder builder = AmazonS3ClientBuilder.standard();
 builder.setRequestHandlers(myRequestHandler);
 `````
 
-Note that a custom handler context key (e.g. new
-HandlerContextKey<String>("myContextKey") works in addition to the predefined
-ones in HandlerContextKey.
+Note that it's possible to use a predefined handler context key
+(e.g. HandlerContextKey.OPERATION_NAME), but the aws sdk may assign a value to
+it outside what a custom request handler does.

--- a/spectator-ext-aws/src/main/java/com/netflix/spectator/aws/SpectatorRequestMetricCollector.java
+++ b/spectator-ext-aws/src/main/java/com/netflix/spectator/aws/SpectatorRequestMetricCollector.java
@@ -45,7 +45,7 @@ public class SpectatorRequestMetricCollector extends RequestMetricCollector {
    * at this key in a request, that key/value pair is an additional tag on each
    * metrics for that request.
    */
-  public static final HandlerContextKey<String> DEFAULT_HANDLER_CONTEXT_KEY = HandlerContextKey.OPERATION_NAME;
+  public static final HandlerContextKey<String> DEFAULT_HANDLER_CONTEXT_KEY = new HandlerContextKey("ClientIdKey");
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SpectatorRequestMetricCollector.class);
 
@@ -175,7 +175,7 @@ public class SpectatorRequestMetricCollector extends RequestMetricCollector {
       }
 
       // Only include gauge metrics if there is a value in the context handler
-      // key.  Without that, it's likely that guage metrics from multiple
+      // key.  Without that, it's likely that gauge metrics from multiple
       // connection pools don't make sense.  This assumes that all gauge metrics
       // are about connection pools.
       if (request.getHandlerContext(handlerContextKey) != null) {


### PR DESCRIPTION
The aws sdk places a value in HandlerContextKey.OPERATION_NAME (e.g. GetObject) at least
some of the time, so use a default that's not one of the predefined HandlerContextKey
objects to avoid that.

I noticed this with a test of spectator 1.0.5 against a localstack container.  Happy to add a test like that here is it's OK to add a test dependency on https://github.com/testcontainers/testcontainers-java.  Sorry I didn't catch this earlier.