### PR TITLE
reduce calls to access time on record

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/impl/StepDouble.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/StepDouble.java
@@ -63,19 +63,34 @@ public class StepDouble implements StepValue {
 
   /** Get the AtomicDouble for the current bucket. */
   public AtomicDouble getCurrent() {
-    rollCount(clock.wallTime());
+    return getCurrent(clock.wallTime());
+  }
+
+  /** Get the AtomicDouble for the current bucket. */
+  public AtomicDouble getCurrent(long now) {
+    rollCount(now);
     return current;
   }
 
   /** Get the value for the last completed interval. */
   public double poll() {
-    rollCount(clock.wallTime());
+    return poll(clock.wallTime());
+  }
+
+  /** Get the value for the last completed interval. */
+  public double poll(long now) {
+    rollCount(now);
     return previous;
   }
 
   /** Get the value for the last completed interval as a rate per second. */
   @Override public double pollAsRate() {
-    final double amount = poll();
+    return pollAsRate(clock.wallTime());
+  }
+
+  /** Get the value for the last completed interval as a rate per second. */
+  @Override public double pollAsRate(long now) {
+    final double amount = poll(now);
     final double period = step / 1000.0;
     return amount / period;
   }

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/StepLong.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/StepLong.java
@@ -63,19 +63,34 @@ public class StepLong implements StepValue {
 
   /** Get the AtomicLong for the current bucket. */
   public AtomicLong getCurrent() {
-    rollCount(clock.wallTime());
+    return getCurrent(clock.wallTime());
+  }
+
+  /** Get the AtomicLong for the current bucket. */
+  public AtomicLong getCurrent(long now) {
+    rollCount(now);
     return current;
   }
 
   /** Get the value for the last completed interval. */
   public long poll() {
-    rollCount(clock.wallTime());
+    return poll(clock.wallTime());
+  }
+
+  /** Get the value for the last completed interval. */
+  public long poll(long now) {
+    rollCount(now);
     return previous;
   }
 
   /** Get the value for the last completed interval as a rate per second. */
   @Override public double pollAsRate() {
-    final long amount = poll();
+    return pollAsRate(clock.wallTime());
+  }
+
+  /** Get the value for the last completed interval as a rate per second. */
+  @Override public double pollAsRate(long now) {
+    final long amount = poll(now);
     final double period = step / 1000.0;
     return amount / period;
   }

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/StepValue.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/StepValue.java
@@ -23,6 +23,9 @@ public interface StepValue {
   /** Get the value for the last completed interval as a rate per second. */
   double pollAsRate();
 
+  /** Get the value for the last completed interval as a rate per second. */
+  double pollAsRate(long now);
+
   /** Get the timestamp for the end of the last completed interval. */
   long timestamp();
 }

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasDistributionSummary.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasDistributionSummary.java
@@ -93,11 +93,12 @@ class AtlasDistributionSummary extends AtlasMeter implements DistributionSummary
   }
 
   @Override public void record(long amount) {
-    count.getCurrent().incrementAndGet();
+    long now = clock.wallTime();
+    count.getCurrent(now).incrementAndGet();
     if (amount > 0) {
-      total.getCurrent().addAndGet(amount);
-      totalOfSquares.getCurrent().addAndGet((double) amount * amount);
-      updateMax(max.getCurrent(), amount);
+      total.getCurrent(now).addAndGet(amount);
+      totalOfSquares.getCurrent(now).addAndGet((double) amount * amount);
+      updateMax(max.getCurrent(now), amount);
     }
     updateLastModTime();
   }

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasTimer.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasTimer.java
@@ -95,12 +95,13 @@ class AtlasTimer extends AtlasMeter implements Timer {
   }
 
   @Override public void record(long amount, TimeUnit unit) {
-    count.getCurrent().incrementAndGet();
+    long now = clock.wallTime();
+    count.getCurrent(now).incrementAndGet();
     if (amount > 0) {
       final long nanos = unit.toNanos(amount);
-      total.getCurrent().addAndGet(nanos);
-      totalOfSquares.getCurrent().addAndGet((double) nanos * nanos);
-      updateMax(max.getCurrent(), nanos);
+      total.getCurrent(now).addAndGet(nanos);
+      totalOfSquares.getCurrent(now).addAndGet((double) nanos * nanos);
+      updateMax(max.getCurrent(now), nanos);
     }
     updateLastModTime();
   }


### PR DESCRIPTION
Update the Atlas distribution summary and timer so that
the record calls will only access the time value once for
a record call. Before it would happen internally to the
step value for each summary statistic. This can add up if
the meter is updated from a tight loop.