### PR TITLE
reuse current time when updating last mod

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasCounter.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasCounter.java
@@ -51,8 +51,9 @@ class AtlasCounter extends AtlasMeter implements Counter {
 
   @Override public void add(double amount) {
     if (Double.isFinite(amount) && amount > 0.0) {
-      value.getCurrent().addAndGet(amount);
-      updateLastModTime();
+      long now = clock.wallTime();
+      value.getCurrent(now).addAndGet(amount);
+      updateLastModTime(now);
     }
   }
 

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasDistributionSummary.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasDistributionSummary.java
@@ -100,7 +100,7 @@ class AtlasDistributionSummary extends AtlasMeter implements DistributionSummary
       totalOfSquares.getCurrent(now).addAndGet((double) amount * amount);
       updateMax(max.getCurrent(now), amount);
     }
-    updateLastModTime();
+    updateLastModTime(now);
   }
 
   private void updateMax(AtomicLong maxValue, long v) {

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasGauge.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasGauge.java
@@ -51,7 +51,7 @@ class AtlasGauge extends AtlasMeter implements Gauge {
 
   @Override public void set(double v) {
     value.set(v);
-    updateLastModTime();
+    updateLastModTime(clock.wallTime());
   }
 
   @Override public double value() {

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasMaxGauge.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasMaxGauge.java
@@ -56,8 +56,9 @@ class AtlasMaxGauge extends AtlasMeter implements Gauge {
   }
 
   @Override public void set(double v) {
-    value.getCurrent().max(v);
-    updateLastModTime();
+    long now = clock.wallTime();
+    value.getCurrent(now).max(v);
+    updateLastModTime(now);
   }
 
   @Override public double value() {

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasMeter.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasMeter.java
@@ -50,8 +50,8 @@ abstract class AtlasMeter implements Meter {
    * Updates the last updated timestamp for the meter to indicate it is active and should
    * not be considered expired.
    */
-  void updateLastModTime() {
-    lastUpdated = clock.wallTime();
+  void updateLastModTime(long now) {
+    lastUpdated = now;
   }
 
   @Override public Id id() {

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasTimer.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasTimer.java
@@ -103,7 +103,7 @@ class AtlasTimer extends AtlasMeter implements Timer {
       totalOfSquares.getCurrent(now).addAndGet((double) nanos * nanos);
       updateMax(max.getCurrent(now), nanos);
     }
-    updateLastModTime();
+    updateLastModTime(now);
   }
 
   private void updateMax(AtomicLong maxValue, long v) {


### PR DESCRIPTION
Atlas meters get the current time to ensure they are
updating the correct entry for the step value. Now that
timestamp will be reused when updating the last mod time
for the meter.