### PR TITLE
support batch record() of metrics in Timer and DistributionSummary

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/DistributionSummary.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/DistributionSummary.java
@@ -36,6 +36,27 @@ public interface DistributionSummary extends Meter {
   void record(long amount);
 
   /**
+   * Updates the statistics kept by the summary with the specified amounts as a batch. Behaves
+   * as if `record()` was called in a loop, but may be faster in some cases.
+   *
+   * @param amounts
+   *     Amounts for an event being measured. For example, if the size in bytes of responses
+   *     from a server. If the amount is less than 0 the value will be dropped.
+   * @param n
+   *     The number of elements to write from the amounts array (starting from 0). If n is
+   *     <= 0 no entries will be recorded. If n is greater than amounts.length, all amounts
+   *     will be recorded.
+   *
+   * @see #record(long)
+   */
+  default void record(long[] amounts, int n) {
+    final int limit = Math.min(amounts.length, n);
+    for (int i = 0; i < limit; i++) {
+      record(amounts[i]);
+    }
+  }
+
+  /**
    * The number of times that record has been called since this timer was last reset.
    * How often a timer is reset depends on the underlying registry implementation.
    */

--- a/spectator-api/src/main/java/com/netflix/spectator/api/ManualClock.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/ManualClock.java
@@ -25,6 +25,7 @@ public class ManualClock implements Clock {
 
   private final AtomicLong wall;
   private final AtomicLong monotonic;
+  private final AtomicLong countPolled;
 
   /** Create a new instance. */
   public ManualClock() {
@@ -42,14 +43,21 @@ public class ManualClock implements Clock {
   public ManualClock(long wallInit, long monotonicInit) {
     wall = new AtomicLong(wallInit);
     monotonic = new AtomicLong(monotonicInit);
+    countPolled = new AtomicLong(0);
   }
 
   @Override public long wallTime() {
+    countPolled.incrementAndGet();
     return wall.get();
   }
 
   @Override public long monotonicTime() {
+    countPolled.incrementAndGet();
     return monotonic.get();
+  }
+
+  public long countPolled() {
+    return countPolled.get();
   }
 
   /** Set the wall time to the value {@code t}. */

--- a/spectator-api/src/main/java/com/netflix/spectator/api/SwapDistributionSummary.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/SwapDistributionSummary.java
@@ -39,6 +39,10 @@ final class SwapDistributionSummary extends SwapMeter<DistributionSummary> imple
     get().record(amount);
   }
 
+  @Override public void record(long[] amounts, int n) {
+    get().record(amounts, n);
+  }
+
   @Override
   public long count() {
     return get().count();

--- a/spectator-api/src/main/java/com/netflix/spectator/api/Timer.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/Timer.java
@@ -52,6 +52,50 @@ public interface Timer extends Meter {
   }
 
   /**
+   * Updates the statistics kept by the counter with the specified amount. Behaves as if
+   * `record()` was called in a loop, but may be faster in some cases.
+   *
+   * @param amounts
+   *     Duration of events being measured by this timer. If the amount is less than 0
+   *     for a value, the value will be dropped.
+   * @param n
+   *     The number of elements to write from the amounts array (starting from 0). If n is
+   *     <= 0 no entries will be recorded. If n is greater than amounts.length, all amounts
+   *     will be recorded.
+   * @param unit
+   *     Time unit for the amounts being recorded.
+   *
+   * @see #record(long, TimeUnit)
+   */
+  default void record(long[] amounts, int n, TimeUnit unit) {
+    final int limit = Math.min(amounts.length, n);
+    for (int i = 0; i < limit; i++) {
+      record(amounts[i], unit);
+    }
+  }
+
+  /**
+   * Updates the statistics kept by the counter with the specified amount. Behaves as if
+   * `record()` was called in a loop, but may be faster in some cases.
+   *
+   * @param amounts
+   *     Duration of events being measured by this timer. If the amount is less than 0
+   *     for a value, the value will be dropped.
+   * @param n
+   *     The number of elements to write from the amounts array (starting from 0). If n is
+   *     <= 0 no entries will be recorded. If n is greater than amounts.length, all amounts
+   *     will be recorded.
+   *
+   * @see #record(Duration)
+   */
+  default void record(Duration[] amounts, int n) {
+    final int limit = Math.min(amounts.length, n);
+    for (int i = 0; i < limit; i++) {
+      record(amounts[i]);
+    }
+  }
+
+  /**
    * Executes the callable `f` and records the time taken.
    *
    * @param f

--- a/spectator-api/src/main/java/com/netflix/spectator/api/Timer.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/Timer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2022 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ public interface Timer extends Meter {
   }
 
   /**
-   * Updates the statistics kept by the counter with the specified amount. Behaves as if
+   * Updates the statistics kept by the timer with the specified amounts. Behaves as if
    * `record()` was called in a loop, but may be faster in some cases.
    *
    * @param amounts
@@ -75,7 +75,7 @@ public interface Timer extends Meter {
   }
 
   /**
-   * Updates the statistics kept by the counter with the specified amount. Behaves as if
+   * Updates the statistics kept by the timer with the specified amounts. Behaves as if
    * `record()` was called in a loop, but may be faster in some cases.
    *
    * @param amounts

--- a/spectator-api/src/main/java/com/netflix/spectator/api/histogram/PercentileDistributionSummary.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/histogram/PercentileDistributionSummary.java
@@ -230,6 +230,25 @@ public final class PercentileDistributionSummary implements DistributionSummary 
     }
   }
 
+  @Override public void record(long[] amounts, int n) {
+    // update core summary
+    summary.record(amounts, n);
+
+    // If 'n' is really large, it might pay to allocate and accumulate
+    // an array of counts, and then issue the increment() calls once per
+    // bucket. However, it also requires generating an array of ints of
+    // PercentileBuckets.length() (275 entries), ~1KB, so for the moment
+    // we defer this optimisation until someone can do the homework
+    // on where the right memory / CPU crossover is.
+
+    final int limit = Math.min(n, amounts.length);
+    for (int i = 0; i < limit; i++) {
+      if (amounts[i] > 0) {
+        counterFor(PercentileBuckets.indexOf(restrict(amounts[i]))).increment();
+      }
+    }
+  }
+
   /**
    * Computes the specified percentile for this distribution summary.
    *

--- a/spectator-reg-atlas/src/jmh/java/com/netflix/spectator/atlas/BatchRecordBench.java
+++ b/spectator-reg-atlas/src/jmh/java/com/netflix/spectator/atlas/BatchRecordBench.java
@@ -54,12 +54,32 @@ public class BatchRecordBench {
    * BatchRecordBench.distributionOneAtATime  thrpt   25  43.896 ± 0.789  ops/s
    *
    * As of this commit:
-   * Benchmark                                  (clock)   Mode  Cnt     Score   Error  Units
-   * BatchRecordBench.distributionBatch       fastclock  thrpt   25  3849.495 ± 2.079  ops/s
-   * BatchRecordBench.distributionBatch          system  thrpt   25  3847.196 ± 3.770  ops/s
-   * BatchRecordBench.distributionOneAtATime  fastclock  thrpt   25   105.432 ± 0.187  ops/s
-   * BatchRecordBench.distributionOneAtATime     system  thrpt   25   105.436 ± 0.111  ops/s
-   *
+   * Benchmark                                (batchSize)    (clock)   Mode  Cnt         Score       Error  Units
+   * BatchRecordBench.distributionBatch                 1  fastclock  thrpt   25  10653757.154 ± 28278.785  ops/s
+   * BatchRecordBench.distributionBatch                 1     system  thrpt   25  10698329.757 ± 32951.571  ops/s
+   * BatchRecordBench.distributionBatch                10  fastclock  thrpt   25   9522092.321 ± 28014.036  ops/s
+   * BatchRecordBench.distributionBatch                10     system  thrpt   25   9559843.855 ±  6779.719  ops/s
+   * BatchRecordBench.distributionBatch               100  fastclock  thrpt   25   2897853.712 ±  8733.913  ops/s
+   * BatchRecordBench.distributionBatch               100     system  thrpt   25   2893252.879 ±  7187.279  ops/s
+   * BatchRecordBench.distributionBatch              1000  fastclock  thrpt   25    366835.739 ±   208.298  ops/s
+   * BatchRecordBench.distributionBatch              1000     system  thrpt   25    367808.344 ±   781.413  ops/s
+   * BatchRecordBench.distributionBatch             10000  fastclock  thrpt   25     38245.067 ±    33.743  ops/s
+   * BatchRecordBench.distributionBatch             10000     system  thrpt   25     38303.265 ±    33.823  ops/s
+   * BatchRecordBench.distributionBatch            100000  fastclock  thrpt   25      3846.227 ±     3.359  ops/s
+   * BatchRecordBench.distributionBatch            100000     system  thrpt   25      3847.573 ±     2.944  ops/s
+   * BatchRecordBench.distributionOneAtATime            1  fastclock  thrpt   25  11087902.444 ± 18214.743  ops/s
+   * BatchRecordBench.distributionOneAtATime            1     system  thrpt   25  11132286.157 ± 33009.169  ops/s
+   * BatchRecordBench.distributionOneAtATime           10  fastclock  thrpt   25   1089841.847 ±  1166.172  ops/s
+   * BatchRecordBench.distributionOneAtATime           10     system  thrpt   25   1090766.388 ±  1124.590  ops/s
+   * BatchRecordBench.distributionOneAtATime          100  fastclock  thrpt   25    109084.262 ±   498.868  ops/s
+   * BatchRecordBench.distributionOneAtATime          100     system  thrpt   25    108806.769 ±   109.836  ops/s
+   * BatchRecordBench.distributionOneAtATime         1000  fastclock  thrpt   25     11547.783 ±    28.136  ops/s
+   * BatchRecordBench.distributionOneAtATime         1000     system  thrpt   25     11548.784 ±    37.187  ops/s
+   * BatchRecordBench.distributionOneAtATime        10000  fastclock  thrpt   25      1051.379 ±     1.347  ops/s
+   * BatchRecordBench.distributionOneAtATime        10000     system  thrpt   25      1054.978 ±     2.069  ops/s
+   * BatchRecordBench.distributionOneAtATime       100000  fastclock  thrpt   25       105.588 ±     0.366  ops/s
+   * BatchRecordBench.distributionOneAtATime       100000     system  thrpt   25       105.453 ±     0.186  ops/s
+   * 
    * =======
    * For an r5.xlarge
    * Base AMI: bionic-classicbase-x86_64-202201262157-ebs
@@ -68,11 +88,31 @@ public class BatchRecordBench {
    * BatchRecordBench.distributionOneAtATime  thrpt   25  40.099 ± 0.539  ops/s
    *
    * As of this commit:
-   * Benchmark                                  (clock)   Mode  Cnt     Score    Error  Units
-   * BatchRecordBench.distributionBatch       fastclock  thrpt   25  3484.762 ± 23.742  ops/s
-   * BatchRecordBench.distributionBatch          system  thrpt   25  3531.986 ± 20.345  ops/s
-   * BatchRecordBench.distributionOneAtATime  fastclock  thrpt   25    91.483 ±  0.985  ops/s
-   * BatchRecordBench.distributionOneAtATime     system  thrpt   25    92.787 ±  1.798  ops/s
+   * Benchmark                                (batchSize)    (clock)   Mode  Cnt        Score        Error  Units
+   * BatchRecordBench.distributionBatch                 1  fastclock  thrpt   25  9385655.567 ± 340778.340  ops/s
+   * BatchRecordBench.distributionBatch                 1     system  thrpt   25  9668568.661 ± 289469.212  ops/s
+   * BatchRecordBench.distributionBatch                10  fastclock  thrpt   25  8364336.008 ± 379818.726  ops/s
+   * BatchRecordBench.distributionBatch                10     system  thrpt   25  8291598.971 ± 335957.214  ops/s
+   * BatchRecordBench.distributionBatch               100  fastclock  thrpt   25  2690204.344 ±  71589.264  ops/s
+   * BatchRecordBench.distributionBatch               100     system  thrpt   25  2655837.607 ±  84584.223  ops/s
+   * BatchRecordBench.distributionBatch              1000  fastclock  thrpt   25   337184.218 ±  10589.541  ops/s
+   * BatchRecordBench.distributionBatch              1000     system  thrpt   25   338195.706 ±   8983.223  ops/s
+   * BatchRecordBench.distributionBatch             10000  fastclock  thrpt   25    35384.994 ±    940.235  ops/s
+   * BatchRecordBench.distributionBatch             10000     system  thrpt   25    35098.662 ±    898.807  ops/s
+   * BatchRecordBench.distributionBatch            100000  fastclock  thrpt   25     3544.591 ±    106.967  ops/s
+   * BatchRecordBench.distributionBatch            100000     system  thrpt   25     3481.677 ±     92.268  ops/s
+   * BatchRecordBench.distributionOneAtATime            1  fastclock  thrpt   25  9101177.222 ± 327727.423  ops/s
+   * BatchRecordBench.distributionOneAtATime            1     system  thrpt   25  9215129.213 ± 450134.957  ops/s
+   * BatchRecordBench.distributionOneAtATime           10  fastclock  thrpt   25   898688.979 ±  47922.252  ops/s
+   * BatchRecordBench.distributionOneAtATime           10     system  thrpt   25   928435.778 ±  29301.506  ops/s
+   * BatchRecordBench.distributionOneAtATime          100  fastclock  thrpt   25    96247.965 ±   3416.122  ops/s
+   * BatchRecordBench.distributionOneAtATime          100     system  thrpt   25    95073.152 ±   3232.757  ops/s
+   * BatchRecordBench.distributionOneAtATime         1000  fastclock  thrpt   25     9977.180 ±    263.313  ops/s
+   * BatchRecordBench.distributionOneAtATime         1000     system  thrpt   25    10139.411 ±    351.895  ops/s
+   * BatchRecordBench.distributionOneAtATime        10000  fastclock  thrpt   25      921.888 ±     28.627  ops/s
+   * BatchRecordBench.distributionOneAtATime        10000     system  thrpt   25      893.432 ±     27.858  ops/s
+   * BatchRecordBench.distributionOneAtATime       100000  fastclock  thrpt   25       91.880 ±      3.205  ops/s
+   * BatchRecordBench.distributionOneAtATime       100000     system  thrpt   25       92.206 ±      3.617  ops/s
    * =======
    */
 
@@ -83,6 +123,9 @@ public class BatchRecordBench {
 
   @Param({ "fastclock", "system" })
   public String clock;
+
+  @Param({ "1", "10", "100", "1000", "10000", "100000" })
+  public String batchSize;
 
   private Clock clockInstance;
 
@@ -100,7 +143,7 @@ public class BatchRecordBench {
     registry = new AtlasRegistry(clockInstance, System::getProperty);
     dist = new AtlasDistributionSummary(registry.createId("test"), Clock.SYSTEM, 10_000, 10_000);
 
-    amounts = new long[100_000];
+    amounts = new long[Integer.parseInt(batchSize)];
     Random r = new Random(42);
     for (int i = 0; i < amounts.length; i++) {
       amounts[i] = r.nextInt(2000);

--- a/spectator-reg-atlas/src/jmh/java/com/netflix/spectator/atlas/BatchRecordBench.java
+++ b/spectator-reg-atlas/src/jmh/java/com/netflix/spectator/atlas/BatchRecordBench.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2014-2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import com.netflix.spectator.api.Clock;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.Random;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+@State(Scope.Thread)
+public class BatchRecordBench {
+
+  /**
+   * This benchmark captures the relative difference between the batch and the iterative
+   * record() loop when using something like the DistributionSummary.
+   *
+   * This also contains a prototype FastClock to compare this against the system
+   * clocksource for timing performance. Results below.
+   *
+   * For both of these tests, the TSC clocksource is used, verified with:
+   * (nfsuper) ~ $ cat /sys/devices/system/clocksource/clocksource0/current_clocksource
+   * tsc
+   *
+   * Sample results as follows:
+   * =======
+   * For an m5.xlarge
+   * Base AMI: bionic-classicbase-x86_64-202112020555-ebs
+   *
+   * The baseline result as of commit 0d09722b8adc5403f767e0d1bbd827c76c2794e0 on m5.xlarge:
+   * BatchRecordBench.distributionOneAtATime  thrpt   25  43.896 ± 0.789  ops/s
+   *
+   * As of this commit:
+   * Benchmark                                  (clock)   Mode  Cnt     Score   Error  Units
+   * BatchRecordBench.distributionBatch       fastclock  thrpt   25  3849.495 ± 2.079  ops/s
+   * BatchRecordBench.distributionBatch          system  thrpt   25  3847.196 ± 3.770  ops/s
+   * BatchRecordBench.distributionOneAtATime  fastclock  thrpt   25   105.432 ± 0.187  ops/s
+   * BatchRecordBench.distributionOneAtATime     system  thrpt   25   105.436 ± 0.111  ops/s
+   *
+   * =======
+   * For an r5.xlarge
+   * Base AMI: bionic-classicbase-x86_64-202201262157-ebs
+   *
+   * The baseline result as of commit 0d09722b8adc5403f767e0d1bbd827c76c2794e0:
+   * BatchRecordBench.distributionOneAtATime  thrpt   25  40.099 ± 0.539  ops/s
+   *
+   * As of this commit:
+   * Benchmark                                  (clock)   Mode  Cnt     Score    Error  Units
+   * BatchRecordBench.distributionBatch       fastclock  thrpt   25  3484.762 ± 23.742  ops/s
+   * BatchRecordBench.distributionBatch          system  thrpt   25  3531.986 ± 20.345  ops/s
+   * BatchRecordBench.distributionOneAtATime  fastclock  thrpt   25    91.483 ±  0.985  ops/s
+   * BatchRecordBench.distributionOneAtATime     system  thrpt   25    92.787 ±  1.798  ops/s
+   * =======
+   */
+
+  private AtlasRegistry registry;
+  private AtlasDistributionSummary dist;
+
+  private long[] amounts;
+
+  @Param({ "fastclock", "system" })
+  public String clock;
+
+  private Clock clockInstance;
+
+  void selectClock() {
+    switch (clock) {
+      case "fastclock": clockInstance = new FastClock(); return;
+      case "system": clockInstance = Clock.SYSTEM; return;
+      default: throw new UnsupportedOperationException("invalid clock type selected, should be 'fastclock' or 'system'");
+    }
+  }
+
+  @Setup
+  public void setup() {
+    selectClock();
+    registry = new AtlasRegistry(clockInstance, System::getProperty);
+    dist = new AtlasDistributionSummary(registry.createId("test"), Clock.SYSTEM, 10_000, 10_000);
+
+    amounts = new long[100_000];
+    Random r = new Random(42);
+    for (int i = 0; i < amounts.length; i++) {
+      amounts[i] = r.nextInt(2000);
+    }
+  }
+
+  @TearDown
+  public void tearDown() throws Exception {
+    if (clockInstance instanceof FastClock) {
+      ((AutoCloseable) clockInstance).close();
+    }
+  }
+
+  @Benchmark
+  public void distributionOneAtATime(Blackhole bh) {
+    for (long amount : amounts) {
+      dist.record(amount);
+    }
+    bh.consume(dist);
+  }
+
+  @Benchmark
+  public void distributionBatch(Blackhole bh) {
+    dist.record(amounts, amounts.length);
+    bh.consume(dist);
+  }
+
+  public final class FastClock implements Clock, AutoCloseable {
+    private final AtomicLong now;
+    private final ScheduledExecutorService exec;
+    private ScheduledFuture future;
+
+    public FastClock() {
+      now = new AtomicLong(System.currentTimeMillis());
+      exec = Executors.newSingleThreadScheduledExecutor();
+      future = exec.scheduleWithFixedDelay(this::updateWallTime, 1, 1, TimeUnit.MILLISECONDS);
+    }
+
+    private void updateWallTime() {
+      now.set(System.currentTimeMillis());
+    }
+
+    @Override
+    public long wallTime() {
+      return now.get();
+    }
+
+    @Override
+    public long monotonicTime() {
+      return System.nanoTime();
+    }
+
+    @Override
+    public void close() throws Exception {
+      future.cancel(true);
+      exec.shutdownNow();
+    }
+  }
+
+}

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasDistributionSummaryTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasDistributionSummaryTest.java
@@ -110,6 +110,61 @@ public class AtlasDistributionSummaryTest {
   }
 
   @Test
+  public void recordBatchMismatchedLengths() {
+    dist.record(new long[0], 1);
+    clock.setWallTime(1 * step + 1);
+    checkValue(0, 0, 0, 0);
+
+    dist.record(new long[1], 0);
+    clock.setWallTime(2 * step + 1);
+    checkValue(0, 0, 0, 0);
+
+    dist.record(new long[1], -1);
+    clock.setWallTime(3 * step + 1);
+    checkValue(0, 0, 0, 0);
+
+    dist.record(new long[]{ 0, 0 }, 2);
+    clock.setWallTime(4 * step + 1);
+    checkValue(2, 0, 0, 0);
+  }
+
+  @Test
+  public void recordBatchOne() {
+    dist.record(new long[]{ 1 }, 1);
+    checkValue(0, 0, 0, 0);
+
+    clock.setWallTime(step + 1);
+    checkValue(1, 1, 1, 1);
+  }
+
+  @Test
+  public void recordBatchTwo() {
+    dist.record(new long[]{ 2 }, 1);
+    checkValue(0, 0, 0, 0);
+
+    clock.setWallTime(step + 1);
+    checkValue(1, 2, 4, 2);
+  }
+
+  @Test
+  public void recordBatchSeveralValues() {
+    dist.record(new long[]{ 1, 2, 3, 1 }, 4);
+    checkValue(0, 0, 0, 0);
+
+    clock.setWallTime(step + 1);
+    checkValue(4, 1 + 2 + 3 + 1, 1 + 4 + 9 + 1, 3);
+  }
+
+  @Test
+  public void recordBatchWithIgnoredValuesMixed() {
+    dist.record(new long[]{ 1, -1, 0, 2, -1, 0, 3, 0, -1, 1 }, 10);
+    checkValue(0, 0, 0, 0);
+
+    clock.setWallTime(step + 1);
+    checkValue(10, 1 + 2 + 3 + 1, 1 + 4 + 9 + 1, 3);
+  }
+
+  @Test
   public void rollForward() {
     dist.record(42);
     clock.setWallTime(step + 1);

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasDistributionSummaryTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasDistributionSummaryTest.java
@@ -15,6 +15,8 @@
  */
 package com.netflix.spectator.atlas;
 
+import java.util.Arrays;
+
 import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.ManualClock;
@@ -162,6 +164,18 @@ public class AtlasDistributionSummaryTest {
 
     clock.setWallTime(step + 1);
     checkValue(10, 1 + 2 + 3 + 1, 1 + 4 + 9 + 1, 3);
+  }
+
+  @Test
+  public void recordBatchPollsClockOnce() {
+    long[] amounts = new long[10000];
+    Arrays.fill(amounts, 1L);
+
+    long countPollsBefore = clock.countPolled();
+    dist.record(amounts, amounts.length);
+    long actualPolls = clock.countPolled() - countPollsBefore;
+
+    Assertions.assertEquals(1, actualPolls);
   }
 
   @Test

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasDistributionSummaryTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasDistributionSummaryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2022 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ import java.util.Arrays;
 
 import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.Id;
-import com.netflix.spectator.api.ManualClock;
 import com.netflix.spectator.api.Measurement;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Utils;
@@ -29,7 +28,7 @@ import org.junit.jupiter.api.Test;
 
 public class AtlasDistributionSummaryTest {
 
-  private final ManualClock clock = new ManualClock();
+  private final CountingManualClock clock = new CountingManualClock();
   private final Registry registry = new DefaultRegistry();
   private final long step = 10000L;
   private final AtlasDistributionSummary dist = new AtlasDistributionSummary(registry.createId("test"), clock, step, step);

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasTimerTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasTimerTest.java
@@ -244,6 +244,18 @@ public class AtlasTimerTest {
   }
 
   @Test
+  public void recordBatchPollsClockOnce() {
+    long[] amounts = new long[10000];
+    Arrays.fill(amounts, 1L);
+
+    long countPollsBefore = clock.countPolled();
+    dist.record(amounts, amounts.length, TimeUnit.NANOSECONDS);
+    long actualPolls = clock.countPolled() - countPollsBefore;
+
+    Assertions.assertEquals(1, actualPolls);
+  }
+
+  @Test
   public void recordRunnable() {
     dist.record(() -> clock.setMonotonicTime(clock.monotonicTime() + 2));
     clock.setWallTime(step + 1);

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasTimerTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasTimerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2022 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package com.netflix.spectator.atlas;
 
 import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.Id;
-import com.netflix.spectator.api.ManualClock;
 import com.netflix.spectator.api.Measurement;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Utils;
@@ -30,7 +29,7 @@ import java.util.concurrent.TimeUnit;
 
 public class AtlasTimerTest {
 
-  private final ManualClock clock = new ManualClock();
+  private final CountingManualClock clock = new CountingManualClock();
   private final Registry registry = new DefaultRegistry();
   private final long step = 10000L;
   private final AtlasTimer dist = new AtlasTimer(registry.createId("test"), clock, step, step);
@@ -193,8 +192,7 @@ public class AtlasTimerTest {
 
 
   @Test
-  public void recordBatchOverflowSingle()
-  {
+  public void recordBatchOverflowSingle() {
     // Simulate case where we have old items in a queue and when processing again we record
     // the ages of many of those items in a short span
     long amount = TimeUnit.DAYS.toNanos(14);
@@ -208,8 +206,7 @@ public class AtlasTimerTest {
   }
 
   @Test
-  public void recordBatchOverflowBatch()
-  {
+  public void recordBatchOverflowBatch() {
     // Simulate case where we have old items in a queue and when processing again we record
     // the ages of many of those items in a short span
     long amount = TimeUnit.DAYS.toNanos(14);

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasTimerTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasTimerTest.java
@@ -24,6 +24,7 @@ import com.netflix.spectator.api.Utils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
 
@@ -140,6 +141,104 @@ public class AtlasTimerTest {
     dist.record(2, TimeUnit.NANOSECONDS);
     dist.record(3, TimeUnit.NANOSECONDS);
     dist.record(1, TimeUnit.NANOSECONDS);
+    clock.setWallTime(step + 1);
+    checkValue(4, 1 + 2 + 3 + 1, 1 + 4 + 9 + 1, 3);
+  }
+
+  @Test
+  public void recordBatchMismatchedLengths() {
+    dist.record(new long[0], 1, TimeUnit.NANOSECONDS);
+    clock.setWallTime(1 * step + 1);
+    checkValue(0, 0, 0, 0);
+
+    dist.record(new long[1], 0, TimeUnit.NANOSECONDS);
+    clock.setWallTime(2 * step + 1);
+    checkValue(0, 0, 0, 0);
+
+    dist.record(new long[1], -1, TimeUnit.NANOSECONDS);
+    clock.setWallTime(3 * step + 1);
+    checkValue(0, 0, 0, 0);
+
+    dist.record(new long[]{ 0, 0 }, 2, TimeUnit.NANOSECONDS);
+    clock.setWallTime(4 * step + 1);
+    checkValue(2, 0, 0, 0);
+  }
+
+  @Test
+  public void recordBatchZero() {
+    dist.record(new long[]{ 0 }, 1, TimeUnit.NANOSECONDS);
+    checkValue(0, 0, 0, 0);
+
+    clock.setWallTime(step + 1);
+    checkValue(1, 0, 0, 0);
+  }
+
+  @Test
+  public void recordBatchOne() {
+    dist.record(new long[]{ 1 }, 1, TimeUnit.NANOSECONDS);
+    checkValue(0, 0, 0, 0);
+
+    clock.setWallTime(step + 1);
+    checkValue(1, 1, 1, 1);
+  }
+
+  @Test
+  public void recordBatchTwo() {
+    dist.record(new long[]{ 2 }, 1, TimeUnit.NANOSECONDS);
+    checkValue(0, 0, 0, 0);
+
+    clock.setWallTime(step + 1);
+    checkValue(1, 2, 4, 2);
+  }
+
+
+  @Test
+  public void recordBatchOverflowSingle()
+  {
+    // Simulate case where we have old items in a queue and when processing again we record
+    // the ages of many of those items in a short span
+    long amount = TimeUnit.DAYS.toNanos(14);
+    double square = 0.0;
+    for (int i = 0; i < 10000; ++i) {
+      dist.record(new long[]{ amount }, 1, TimeUnit.NANOSECONDS);
+      square += (double) amount * amount;
+    }
+    clock.setWallTime(step + 1);
+    checkValue(10000, 10e3 * amount, square, amount);
+  }
+
+  @Test
+  public void recordBatchOverflowBatch()
+  {
+    // Simulate case where we have old items in a queue and when processing again we record
+    // the ages of many of those items in a short span
+    long amount = TimeUnit.DAYS.toNanos(14);
+    double square = 0.0;
+
+    int COUNT = 10000;
+    long[] amounts = new long[COUNT];
+    Arrays.fill(amounts, amount);
+
+    dist.record(amounts, COUNT, TimeUnit.NANOSECONDS);
+
+    for (int i = 0; i < 10000; i++) {
+      square += (double) amount * amount;
+    }
+
+    clock.setWallTime(step + 1);
+    checkValue(10000, 10e3 * amount, square, amount);
+  }
+
+  @Test
+  public void recordBatchMixedPositiveNegativeValues() {
+    dist.record(new long[]{ 1, 0, 2, -1, 3, -4, 1}, 7, TimeUnit.NANOSECONDS);
+    clock.setWallTime(step + 1);
+    checkValue(7, 1 + 2 + 3 + 1, 1 + 4 + 9 + 1, 3);
+  }
+
+  @Test
+  public void recordBatchSeveralValues() {
+    dist.record(new long[]{ 1, 2, 3, 1}, 4, TimeUnit.NANOSECONDS);
     clock.setWallTime(step + 1);
     checkValue(4, 1 + 2 + 3 + 1, 1 + 4 + 9 + 1, 3);
   }


### PR DESCRIPTION
Supports record of many Timer and DistributionSummary metrics in a single call, and provides an optimised implementation for the Atlas implementation.