### PR TITLE
reduce wallTime calls when sending

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasCounter.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasCounter.java
@@ -44,8 +44,8 @@ class AtlasCounter extends AtlasMeter implements Counter {
         .withTags(id.tags());
   }
 
-  @Override void measure(MeasurementConsumer consumer) {
-    final double rate = value.pollAsRate();
+  @Override void measure(long now, MeasurementConsumer consumer) {
+    final double rate = value.pollAsRate(now);
     consumer.accept(stat, value.timestamp(), rate);
   }
 

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasDistributionSummary.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasDistributionSummary.java
@@ -67,27 +67,27 @@ class AtlasDistributionSummary extends AtlasMeter implements DistributionSummary
     };
   }
 
-  @Override void measure(MeasurementConsumer consumer) {
-    reportMeasurement(consumer, stats[0], count);
-    reportMeasurement(consumer, stats[1], total);
-    reportMeasurement(consumer, stats[2], totalOfSquares);
-    reportMaxMeasurement(consumer, stats[3], max);
+  @Override void measure(long now, MeasurementConsumer consumer) {
+    reportMeasurement(now, consumer, stats[0], count);
+    reportMeasurement(now, consumer, stats[1], total);
+    reportMeasurement(now, consumer, stats[2], totalOfSquares);
+    reportMaxMeasurement(now, consumer, stats[3], max);
   }
 
-  private void reportMeasurement(MeasurementConsumer consumer, Id mid, StepValue v) {
+  private void reportMeasurement(long now, MeasurementConsumer consumer, Id mid, StepValue v) {
     // poll needs to be called before accessing the timestamp to ensure
     // the counters have been rotated if there was no activity in the
     // current interval.
-    double rate = v.pollAsRate();
+    double rate = v.pollAsRate(now);
     long timestamp = v.timestamp();
     consumer.accept(mid, timestamp, rate);
   }
 
-  private void reportMaxMeasurement(MeasurementConsumer consumer, Id mid, StepLong v) {
+  private void reportMaxMeasurement(long now, MeasurementConsumer consumer, Id mid, StepLong v) {
     // poll needs to be called before accessing the timestamp to ensure
     // the counters have been rotated if there was no activity in the
     // current interval.
-    double maxValue = v.poll();
+    double maxValue = v.poll(now);
     long timestamp = v.timestamp();
     consumer.accept(mid, timestamp, maxValue);
   }

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasGauge.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasGauge.java
@@ -42,7 +42,7 @@ class AtlasGauge extends AtlasMeter implements Gauge {
         .withTags(id.tags());
   }
 
-  @Override void measure(MeasurementConsumer consumer) {
+  @Override void measure(long now, MeasurementConsumer consumer) {
     final double v = value();
     if (Double.isFinite(v)) {
       consumer.accept(stat, clock.wallTime(), v);

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasMaxGauge.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasMaxGauge.java
@@ -45,11 +45,11 @@ class AtlasMaxGauge extends AtlasMeter implements Gauge {
         .withTags(id.tags());
   }
 
-  @Override void measure(MeasurementConsumer consumer) {
+  @Override void measure(long now, MeasurementConsumer consumer) {
     // poll needs to be called before accessing the timestamp to ensure
     // the counters have been rotated if there was no activity in the
     // current interval.
-    double v = value.poll();
+    double v = value.poll(now);
     if (Double.isFinite(v)) {
       consumer.accept(stat, value.timestamp(), v);
     }

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasMeter.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasMeter.java
@@ -63,10 +63,11 @@ abstract class AtlasMeter implements Meter {
   }
 
   @Override public Iterable<Measurement> measure() {
+    long now = clock.wallTime();
     List<Measurement> ms = new ArrayList<>();
-    measure((id, timestamp, value) -> ms.add(new Measurement(id, timestamp, value)));
+    measure(now, (id, timestamp, value) -> ms.add(new Measurement(id, timestamp, value)));
     return ms;
   }
 
-  abstract void measure(MeasurementConsumer consumer);
+  abstract void measure(long now, MeasurementConsumer consumer);
 }

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
@@ -328,7 +328,7 @@ public final class AtlasRegistry extends AbstractRegistry implements AutoCloseab
         logger.debug("collecting measurements for time: {}", t);
         publishTaskTimer("pollMeasurements").record(() -> {
           for (Meter meter : this) {
-            ((AtlasMeter) meter).measure(consumer);
+            ((AtlasMeter) meter).measure(t, consumer);
           }
         });
         lastPollTimestamp = t;

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasTimer.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasTimer.java
@@ -69,27 +69,27 @@ class AtlasTimer extends AtlasMeter implements Timer {
     };
   }
 
-  @Override void measure(MeasurementConsumer consumer) {
-    reportMeasurement(consumer, stats[0], count, 1.0);
-    reportMeasurement(consumer, stats[1], total, 1e-9);
-    reportMeasurement(consumer, stats[2], totalOfSquares, 1e-18);
-    reportMaxMeasurement(consumer, stats[3], max);
+  @Override void measure(long now, MeasurementConsumer consumer) {
+    reportMeasurement(now, consumer, stats[0], count, 1.0);
+    reportMeasurement(now, consumer, stats[1], total, 1e-9);
+    reportMeasurement(now, consumer, stats[2], totalOfSquares, 1e-18);
+    reportMaxMeasurement(now, consumer, stats[3], max);
   }
 
-  private void reportMeasurement(MeasurementConsumer consumer, Id mid, StepValue v, double f) {
+  private void reportMeasurement(long now, MeasurementConsumer consumer, Id mid, StepValue v, double f) {
     // poll needs to be called before accessing the timestamp to ensure
     // the counters have been rotated if there was no activity in the
     // current interval.
-    double rate = v.pollAsRate() * f;
+    double rate = v.pollAsRate(now) * f;
     long timestamp = v.timestamp();
     consumer.accept(mid, timestamp, rate);
   }
 
-  private void reportMaxMeasurement(MeasurementConsumer consumer, Id mid, StepLong v) {
+  private void reportMaxMeasurement(long now, MeasurementConsumer consumer, Id mid, StepLong v) {
     // poll needs to be called before accessing the timestamp to ensure
     // the counters have been rotated if there was no activity in the
     // current interval.
-    double maxValue = v.poll() / 1e9;
+    double maxValue = v.poll(now) / 1e9;
     long timestamp = v.timestamp();
     consumer.accept(mid, timestamp, maxValue);
   }


### PR DESCRIPTION
Updates the AtlasRegistry to pass in the timestamp when
polling the meters to reduce the number of times the
`clock.wallTime()` call will need to be made.