### PR TITLE
switch from log4j1 to reload4j

### DIFF
--- a/spectator-ext-log4j1/build.gradle
+++ b/spectator-ext-log4j1/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
   api project(':spectator-api')
-  api "log4j:log4j:1.2.17"
+  api "ch.qos.reload4j:reload4j:1.2.18.3"
 }
 
 jar {


### PR DESCRIPTION
For more details see https://reload4j.qos.ch/. Builds using
nebula resolution rules will replace log4j with reload4j if
both are present ([5c087f]).

[5c087f]: https://github.com/nebula-plugins/gradle-resolution-rules/commit/5c087f742a9f0efe84855118e266c69a5fd4a58b