### PR TITLE
batch increment for BucketCounter

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/histogram/BucketCounter.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/histogram/BucketCounter.java
@@ -76,6 +76,18 @@ public final class BucketCounter implements DistributionSummary {
     counter(f.apply(amount)).increment();
   }
 
+  /**
+   * Update the counter associated with the amount by {@code n}.
+   *
+   * @param amount
+   *     Amount to use for determining the bucket.
+   * @param n
+   *     The delta to apply to the counter.
+   */
+  public void increment(long amount, int n) {
+    counter(f.apply(amount)).increment(n);
+  }
+
   /** Return the count for a given bucket. */
   Counter counter(String bucket) {
     return Utils.computeIfAbsent(counters, bucket, counterFactory);

--- a/spectator-api/src/test/java/com/netflix/spectator/api/histogram/BucketCounterTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/histogram/BucketCounterTest.java
@@ -49,4 +49,20 @@ public class BucketCounterTest {
     Assertions.assertEquals(3, sum(r, "test"));
   }
 
+
+  @Test
+  public void increment() {
+    Registry r = new DefaultRegistry();
+    BucketCounter c = BucketCounter.get(
+        r, r.createId("test"), BucketFunctions.latency(4, TimeUnit.SECONDS));
+
+    c.record(TimeUnit.MILLISECONDS.toNanos(3750));
+    Assertions.assertEquals(1, r.counters().count());
+    Assertions.assertEquals(1, sum(r, "test"));
+
+    c.increment(TimeUnit.MILLISECONDS.toNanos(3750), 5);
+    Assertions.assertEquals(1, r.counters().count());
+    Assertions.assertEquals(6, sum(r, "test"));
+  }
+
 }


### PR DESCRIPTION
Add `increment` method to BucketCounter to allow for
batch increments of the same amount.