### PR TITLE
jackson-databind 2.13.2.2

### DIFF
--- a/dependencies.properties
+++ b/dependencies.properties
@@ -2,7 +2,7 @@
 com.amazonaws:aws-java-sdk-core = 1.12.173
 com.amazonaws:aws-java-sdk-cloudwatch = 1.12.173
 com.fasterxml.jackson.core:jackson-core = 2.13.2
-com.fasterxml.jackson.core:jackson-databind = 2.13.2
+com.fasterxml.jackson.core:jackson-databind = 2.13.2.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-smile = 2.13.2
 com.google.inject.extensions:guice-servlet = 5.1.0
 com.google.inject:guice = 5.1.0


### PR DESCRIPTION
Pull in fix for [CVE-2020-36518].

[CVE-2020-36518]: https://nvd.nist.gov/vuln/detail/CVE-2020-36518