### PR TITLE
spring 5.3.18

### DIFF
--- a/spectator-web-spring/build.gradle
+++ b/spectator-web-spring/build.gradle
@@ -21,9 +21,9 @@ plugins {
 
 dependencies {
   api project(':spectator-api')
-  implementation 'org.springframework.boot:spring-boot-autoconfigure:2.6.4'
-  implementation 'org.springframework:spring-beans:5.3.16'
-  implementation 'org.springframework:spring-web:5.3.16'
+  implementation 'org.springframework.boot:spring-boot-autoconfigure:2.6.6'
+  implementation 'org.springframework:spring-beans:5.3.18'
+  implementation 'org.springframework:spring-web:5.3.18'
   implementation 'com.fasterxml.jackson.core:jackson-databind'
 }
 


### PR DESCRIPTION
Update spring dependencies for [security fix].

[security fix]: https://spring.io/blog/2022/03/31/spring-framework-rce-early-announcement