### PR TITLE
helper to run task using PolledMeter pool

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/patterns/GaugePoller.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/patterns/GaugePoller.java
@@ -19,6 +19,7 @@ import java.lang.ref.WeakReference;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -46,6 +47,10 @@ final class GaugePoller {
 
   private static final ScheduledExecutorService DEFAULT_EXECUTOR =
       Executors.newSingleThreadScheduledExecutor(FACTORY);
+
+  static ScheduledFuture<?> schedule(long delay, Runnable task) {
+    return DEFAULT_EXECUTOR.scheduleWithFixedDelay(task, delay, delay, TimeUnit.MILLISECONDS);
+  }
 
   /** Schedule collection of gauges for a registry. */
   static <T> Future<?> schedule(WeakReference<T> ref, long delay, Consumer<T> poll) {


### PR DESCRIPTION
Adds a `PolledMeter.poll` method that can be used to run
an arbitrary `Runnable` task using the default thread pool
for polled meters. The main use-case is for being able to
update multiple meters each time the task is run. In this
case, the user would just use the registry to make any
updates directly.

The advantage of this method over just having the user
scheduling it themselves is it avoids having additional
polling threads running for simple use-cases. It is not
connected to the lifetime of an object, so the caller must
keep track of and use the returned future to cancel if
the polling should be stopped.