### PR TITLE
add registry that reports to SpectatorD

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -19,6 +19,7 @@ include 'spectator-api',
         'spectator-reg-metrics5',
         'spectator-reg-micrometer',
         'spectator-reg-servo',
+        'spectator-reg-sidecar',
         'spectator-reg-stateless',
         'spectator-web-spring'
 

--- a/spectator-api/src/main/java/com/netflix/spectator/api/TagList.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/TagList.java
@@ -18,6 +18,7 @@ package com.netflix.spectator.api;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.function.BiConsumer;
 import java.util.function.BiPredicate;
@@ -28,6 +29,11 @@ import java.util.function.Predicate;
  * if the underlying implementation does not store them as Tag objects.
  */
 public interface TagList extends Iterable<Tag>, Comparable<TagList> {
+
+  /** Create a new tag list from a map. */
+  static TagList create(Map<String, String> tags) {
+    return ArrayTagSet.create(tags);
+  }
 
   /** Return the key at the specified index. */
   String getKey(int i);

--- a/spectator-reg-sidecar/README.md
+++ b/spectator-reg-sidecar/README.md
@@ -1,0 +1,11 @@
+## Description
+
+Registry implementation for reporting data to [SpectatorD] sidecar.
+
+[SpectatorD]: https://github.com/Netflix-Skunkworks/spectatord/blob/main/README.md
+
+## Gradle
+
+```
+compile "com.netflix.spectator:spectator-reg-sidecar:${version}"
+```

--- a/spectator-reg-sidecar/build.gradle
+++ b/spectator-reg-sidecar/build.gradle
@@ -1,0 +1,11 @@
+dependencies {
+  api project(':spectator-api')
+}
+
+jar {
+  manifest {
+    attributes(
+      "Automatic-Module-Name": "com.netflix.spectator.sidecar"
+    )
+  }
+}

--- a/spectator-reg-sidecar/src/main/java/com/netflix/spectator/sidecar/CommonTags.java
+++ b/spectator-reg-sidecar/src/main/java/com/netflix/spectator/sidecar/CommonTags.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2014-2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.sidecar;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Helper for accessing common tags that are specific to a process and thus cannot be
+ * managed by a shared spectatord instance.
+ */
+final class CommonTags {
+
+  private CommonTags() {
+  }
+
+  /**
+   * Extract common infrastructure tags from the Netflix environment variables.
+   *
+   * @param getenv
+   *     Function used to retrieve the value of an environment variable.
+   * @return
+   *     Common tags based on the environment.
+   */
+  static Map<String, String> commonTags(Function<String, String> getenv) {
+    Map<String, String> tags = new HashMap<>();
+    putIfNotEmptyOrNull(getenv, tags, "nf.container", "TITUS_CONTAINER_NAME");
+    putIfNotEmptyOrNull(getenv, tags, "nf.process", "NETFLIX_PROCESS_NAME");
+    return tags;
+  }
+
+  private static void putIfNotEmptyOrNull(
+      Function<String, String> getenv, Map<String, String> tags, String key, String... envVars) {
+    for (String envVar : envVars) {
+      String value = getenv.apply(envVar);
+      if (value != null) {
+        value = value.trim();
+        if (!value.isEmpty()) {
+          tags.put(key, value.trim());
+          break;
+        }
+      }
+    }
+  }
+}

--- a/spectator-reg-sidecar/src/main/java/com/netflix/spectator/sidecar/NoopWriter.java
+++ b/spectator-reg-sidecar/src/main/java/com/netflix/spectator/sidecar/NoopWriter.java
@@ -22,7 +22,7 @@ final class NoopWriter extends SidecarWriter {
 
   /** Create a new instance. */
   NoopWriter() {
-    super();
+    super("none");
   }
 
   @Override void writeImpl(String line) throws IOException {

--- a/spectator-reg-sidecar/src/main/java/com/netflix/spectator/sidecar/NoopWriter.java
+++ b/spectator-reg-sidecar/src/main/java/com/netflix/spectator/sidecar/NoopWriter.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2014-2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.sidecar;
+
+import java.io.IOException;
+
+/** Writer that does nothing. Used to disable output. */
+final class NoopWriter extends SidecarWriter {
+
+  /** Create a new instance. */
+  NoopWriter() {
+    super();
+  }
+
+  @Override void writeImpl(String line) throws IOException {
+  }
+
+  @Override public void close() throws IOException {
+  }
+}

--- a/spectator-reg-sidecar/src/main/java/com/netflix/spectator/sidecar/PrintStreamWriter.java
+++ b/spectator-reg-sidecar/src/main/java/com/netflix/spectator/sidecar/PrintStreamWriter.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2014-2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.sidecar;
+
+import java.io.IOException;
+import java.io.PrintStream;
+
+/** Writer that outputs data to a PrintStream instance. */
+final class PrintStreamWriter extends SidecarWriter {
+
+  private final PrintStream stream;
+
+  /** Create a new instance. */
+  PrintStreamWriter(PrintStream stream) {
+    super();
+    this.stream = stream;
+  }
+
+  @Override public void writeImpl(String line) throws IOException {
+    stream.println(line);
+  }
+
+  @Override public void close() throws IOException {
+    stream.close();
+  }
+}

--- a/spectator-reg-sidecar/src/main/java/com/netflix/spectator/sidecar/PrintStreamWriter.java
+++ b/spectator-reg-sidecar/src/main/java/com/netflix/spectator/sidecar/PrintStreamWriter.java
@@ -24,8 +24,8 @@ final class PrintStreamWriter extends SidecarWriter {
   private final PrintStream stream;
 
   /** Create a new instance. */
-  PrintStreamWriter(PrintStream stream) {
-    super();
+  PrintStreamWriter(String location, PrintStream stream) {
+    super(location);
     this.stream = stream;
   }
 

--- a/spectator-reg-sidecar/src/main/java/com/netflix/spectator/sidecar/SidecarConfig.java
+++ b/spectator-reg-sidecar/src/main/java/com/netflix/spectator/sidecar/SidecarConfig.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014-2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.sidecar;
+
+import com.netflix.spectator.api.RegistryConfig;
+
+import java.util.Map;
+
+/**
+ * Configuration for sidecar registry.
+ */
+public interface SidecarConfig extends RegistryConfig {
+
+  /**
+   * Returns the location for where to emit the data. The default is
+   * {@code udp://127.0.0.1:1234}. Supported values include:
+   *
+   * <ul>
+   *   <li><code>none</code>: to disable output.</li>
+   *   <li><code>stdout</code>: write to standard out for the process.</li>
+   *   <li><code>stderr</code>: write to standard error for the process.</li>
+   *   <li><code>file://$path_to_file</code>: write to a file.</li>
+   *   <li><code>udp://$host:$port</code>: write to a UDP socket.</li>
+   * </ul>
+   */
+  default String outputLocation() {
+    String v = get("sidecar.output-location");
+    return (v == null) ? "udp://127.0.0.1:1234" : v;
+  }
+
+  /**
+   * Returns the common tags to apply to all metrics.
+   */
+  default Map<String, String> commonTags() {
+    return CommonTags.commonTags(System::getenv);
+  }
+}

--- a/spectator-reg-sidecar/src/main/java/com/netflix/spectator/sidecar/SidecarCounter.java
+++ b/spectator-reg-sidecar/src/main/java/com/netflix/spectator/sidecar/SidecarCounter.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2014-2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.sidecar;
+
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.Id;
+
+/**
+ * Counter that writes updates in format compatible with SpectatorD.
+ */
+class SidecarCounter extends SidecarMeter implements Counter {
+
+  private final SidecarWriter writer;
+
+  /** Create a new instance. */
+  SidecarCounter(Id id, SidecarWriter writer) {
+    super(id, 'c');
+    this.writer = writer;
+  }
+
+  @Override public void increment() {
+    writer.write(idString, 1L);
+  }
+
+  @Override public void increment(long delta) {
+    if (delta > 0L) {
+      writer.write(idString, delta);
+    }
+  }
+
+  @Override public void add(double amount) {
+    if (amount > 0.0) {
+      writer.write(idString, amount);
+    }
+  }
+
+  @Override public double actualCount() {
+    return Double.NaN;
+  }
+}

--- a/spectator-reg-sidecar/src/main/java/com/netflix/spectator/sidecar/SidecarDistributionSummary.java
+++ b/spectator-reg-sidecar/src/main/java/com/netflix/spectator/sidecar/SidecarDistributionSummary.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2014-2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.sidecar;
+
+import com.netflix.spectator.api.DistributionSummary;
+import com.netflix.spectator.api.Id;
+
+/**
+ * Distribution summary that writes updates in format compatible with SpectatorD.
+ */
+class SidecarDistributionSummary extends SidecarMeter implements DistributionSummary {
+
+  private final SidecarWriter writer;
+
+  /** Create a new instance. */
+  SidecarDistributionSummary(Id id, SidecarWriter writer) {
+    super(id, 'd');
+    this.writer = writer;
+  }
+
+  @Override public void record(long amount) {
+    if (amount >= 0) {
+      writer.write(idString, amount);
+    }
+  }
+
+  @Override public long count() {
+    return 0L;
+  }
+
+  @Override public long totalAmount() {
+    return 0L;
+  }
+}

--- a/spectator-reg-sidecar/src/main/java/com/netflix/spectator/sidecar/SidecarGauge.java
+++ b/spectator-reg-sidecar/src/main/java/com/netflix/spectator/sidecar/SidecarGauge.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2014-2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.sidecar;
+
+import com.netflix.spectator.api.Gauge;
+import com.netflix.spectator.api.Id;
+
+/**
+ * Gauge that writes updates in format compatible with SpectatorD.
+ */
+class SidecarGauge extends SidecarMeter implements Gauge {
+
+  private final SidecarWriter writer;
+
+  /** Create a new instance. */
+  SidecarGauge(Id id, SidecarWriter writer) {
+    super(id, 'g');
+    this.writer = writer;
+  }
+
+  @Override public void set(double v) {
+    writer.write(idString, v);
+  }
+
+  @Override public double value() {
+    return Double.NaN;
+  }
+}

--- a/spectator-reg-sidecar/src/main/java/com/netflix/spectator/sidecar/SidecarMaxGauge.java
+++ b/spectator-reg-sidecar/src/main/java/com/netflix/spectator/sidecar/SidecarMaxGauge.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2014-2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.sidecar;
+
+import com.netflix.spectator.api.Gauge;
+import com.netflix.spectator.api.Id;
+
+/**
+ * Max gauge that writes updates in format compatible with SpectatorD.
+ */
+class SidecarMaxGauge extends SidecarMeter implements Gauge {
+
+  private final SidecarWriter writer;
+
+  /** Create a new instance. */
+  SidecarMaxGauge(Id id, SidecarWriter writer) {
+    super(id, 'm');
+    this.writer = writer;
+  }
+
+  @Override public void set(double v) {
+    writer.write(idString, v);
+  }
+
+  @Override public double value() {
+    return Double.NaN;
+  }
+}

--- a/spectator-reg-sidecar/src/main/java/com/netflix/spectator/sidecar/SidecarMeter.java
+++ b/spectator-reg-sidecar/src/main/java/com/netflix/spectator/sidecar/SidecarMeter.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2014-2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.sidecar;
+
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.Meter;
+import com.netflix.spectator.impl.AsciiSet;
+
+import java.util.Collections;
+
+/** Base class for core meter types used by {@link SidecarRegistry}. */
+abstract class SidecarMeter implements Meter {
+
+  private static final AsciiSet ALLOWED_CHARS = AsciiSet.fromPattern("-._A-Za-z0-9~^");
+
+  /** Base identifier for all measurements supplied by this meter. */
+  protected final Id id;
+
+  /** Prefix string for line to output to SpectatorD. */
+  protected final String idString;
+
+  /** Create a new instance. */
+  SidecarMeter(Id id, char type) {
+    this.id = id;
+    this.idString = createIdString(id, type);
+  }
+
+  private String replaceInvalidChars(String s) {
+    return ALLOWED_CHARS.replaceNonMembers(s, '_');
+  }
+
+  private String createIdString(Id id, char type) {
+    StringBuilder builder = new StringBuilder();
+    builder.append(type).append(':').append(replaceInvalidChars(id.name()));
+    int n = id.size();
+    for (int i = 1; i < n; ++i) {
+      String k = replaceInvalidChars(id.getKey(i));
+      String v = replaceInvalidChars(id.getValue(i));
+      builder.append(',').append(k).append('=').append(v);
+    }
+    return builder.append(':').toString();
+  }
+
+  @Override public Id id() {
+    return id;
+  }
+
+  @Override public boolean hasExpired() {
+    return false;
+  }
+
+  @Override public Iterable<Measurement> measure() {
+    return Collections.emptyList();
+  }
+}

--- a/spectator-reg-sidecar/src/main/java/com/netflix/spectator/sidecar/SidecarRegistry.java
+++ b/spectator-reg-sidecar/src/main/java/com/netflix/spectator/sidecar/SidecarRegistry.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2014-2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.sidecar;
+
+import com.netflix.spectator.api.Clock;
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.DistributionSummary;
+import com.netflix.spectator.api.Gauge;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Meter;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Tag;
+import com.netflix.spectator.api.TagList;
+import com.netflix.spectator.api.Timer;
+import com.netflix.spectator.api.patterns.PolledMeter;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Registry for reporting data to <a href="https://github.com/Netflix-Skunkworks/spectatord">
+ * SpectatorD</a>.
+ */
+public final class SidecarRegistry implements Registry, Closeable {
+
+  private final Clock clock;
+  private final TagList commonTags;
+  private final SidecarWriter writer;
+
+  private final ConcurrentHashMap<Id, Object> state;
+
+  /** Create a new instance. */
+  public SidecarRegistry(Clock clock, SidecarConfig config) {
+    this(clock, config, SidecarWriter.create(config.outputLocation()));
+  }
+
+  /** Create a new instance. */
+  SidecarRegistry(Clock clock, SidecarConfig config, SidecarWriter writer) {
+    this.clock = clock;
+    this.commonTags = TagList.create(config.commonTags());
+    this.writer = writer;
+    this.state = new ConcurrentHashMap<>();
+  }
+
+  /**
+   * Stop the scheduler reporting data.
+   */
+  @Override public void close() throws IOException {
+    writer.close();
+    state.clear();
+  }
+
+  @Override
+  public Clock clock() {
+    return clock;
+  }
+
+  @Override
+  public Id createId(String name) {
+    return Id.create(name);
+  }
+
+  @Override
+  public Id createId(String name, Iterable<Tag> tags) {
+    return Id.create(name).withTags(tags);
+  }
+
+  @Deprecated
+  @Override
+  public void register(Meter meter) {
+    PolledMeter.monitorMeter(this, meter);
+  }
+
+  @Override
+  public ConcurrentMap<Id, Object> state() {
+    return state;
+  }
+
+  private Id mergeCommonTags(Id id) {
+    return commonTags.size() == 0 ? id : id.withTags(commonTags);
+  }
+
+  @Override
+  public Counter counter(Id id) {
+    return new SidecarCounter(mergeCommonTags(id), writer);
+  }
+
+  @Override
+  public DistributionSummary distributionSummary(Id id) {
+    return new SidecarDistributionSummary(mergeCommonTags(id), writer);
+  }
+
+  @Override
+  public Timer timer(Id id) {
+    return new SidecarTimer(mergeCommonTags(id), clock, writer);
+  }
+
+  @Override
+  public Gauge gauge(Id id) {
+    return new SidecarGauge(mergeCommonTags(id), writer);
+  }
+
+  @Override
+  public Gauge maxGauge(Id id) {
+    return new SidecarMaxGauge(mergeCommonTags(id), writer);
+  }
+
+  @Override
+  public Meter get(Id id) {
+    return null;
+  }
+
+  @Override
+  public Iterator<Meter> iterator() {
+    return Collections.emptyIterator();
+  }
+}

--- a/spectator-reg-sidecar/src/main/java/com/netflix/spectator/sidecar/SidecarTimer.java
+++ b/spectator-reg-sidecar/src/main/java/com/netflix/spectator/sidecar/SidecarTimer.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2014-2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.sidecar;
+
+import com.netflix.spectator.api.Clock;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Timer;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Timer that writes updates in format compatible with SpectatorD.
+ */
+class SidecarTimer extends SidecarMeter implements Timer {
+
+  private final Clock clock;
+  private final SidecarWriter writer;
+
+  /** Create a new instance. */
+  SidecarTimer(Id id, Clock clock, SidecarWriter writer) {
+    super(id, 't');
+    this.clock = clock;
+    this.writer = writer;
+  }
+
+  @Override public void record(long amount, TimeUnit unit) {
+    final double seconds = unit.toNanos(amount) / 1e9;
+    if (seconds >= 0.0) {
+      writer.write(idString, seconds);
+    }
+  }
+
+  @Override public <T> T record(Callable<T> f) throws Exception {
+    final long start = clock.monotonicTime();
+    try {
+      return f.call();
+    } finally {
+      record(clock.monotonicTime() - start, TimeUnit.NANOSECONDS);
+    }
+  }
+
+  @Override public void record(Runnable f) {
+    final long start = clock.monotonicTime();
+    try {
+      f.run();
+    } finally {
+      record(clock.monotonicTime() - start, TimeUnit.NANOSECONDS);
+    }
+  }
+
+  @Override public long count() {
+    return 0L;
+  }
+
+  @Override public long totalTime() {
+    return 0L;
+  }
+}

--- a/spectator-reg-sidecar/src/main/java/com/netflix/spectator/sidecar/SidecarWriter.java
+++ b/spectator-reg-sidecar/src/main/java/com/netflix/spectator/sidecar/SidecarWriter.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2014-2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.sidecar;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.io.UncheckedIOException;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+/** Base type for writer that accepts SpectatorD line protocol. */
+abstract class SidecarWriter implements Closeable {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SidecarWriter.class);
+
+  /**
+   * Create a new writer based on a location string.
+   */
+  static SidecarWriter create(String location) {
+    try {
+      if ("none".equals(location)) {
+        return new NoopWriter();
+      } else if ("stderr".equals(location)) {
+        return new PrintStreamWriter(System.err);
+      } else if ("stdout".equals(location)) {
+        return new PrintStreamWriter(System.out);
+      } else if (location.startsWith("file://")) {
+        OutputStream out = Files.newOutputStream(Paths.get(URI.create(location)));
+        return new PrintStreamWriter(new PrintStream(out, false, "UTF-8"));
+      } else if (location.startsWith("udp://")) {
+        URI uri = URI.create(location);
+        String host = uri.getHost();
+        int port = uri.getPort();
+        SocketAddress address = new InetSocketAddress(host, port);
+        return new UdpWriter(address);
+      } else {
+        throw new IllegalArgumentException("unsupported location: " + location);
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  abstract void writeImpl(String line) throws IOException;
+
+  void write(String line) {
+    try {
+      LOGGER.trace("writing: {}", line);
+      writeImpl(line);
+    } catch (IOException e) {
+      LOGGER.warn("write failed: {}", line, e);
+    }
+  }
+
+  void write(String prefix, long value) {
+    write(prefix + value);
+  }
+
+  void write(String prefix, double value) {
+    write(prefix + value);
+  }
+}

--- a/spectator-reg-sidecar/src/main/java/com/netflix/spectator/sidecar/UdpWriter.java
+++ b/spectator-reg-sidecar/src/main/java/com/netflix/spectator/sidecar/UdpWriter.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2014-2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.sidecar;
+
+import java.io.IOException;
+import java.net.SocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.DatagramChannel;
+import java.nio.charset.StandardCharsets;
+
+/** Writer that outputs data to UDP socket. */
+final class UdpWriter extends SidecarWriter {
+
+  private final DatagramChannel channel;
+
+  /** Create a new instance. */
+  UdpWriter(SocketAddress address) throws IOException {
+    super();
+    this.channel = DatagramChannel.open();
+    this.channel.connect(address);
+  }
+
+  @Override public void writeImpl(String line) throws IOException {
+    ByteBuffer buffer = ByteBuffer.wrap(line.getBytes(StandardCharsets.UTF_8));
+    channel.write(buffer);
+  }
+
+  @Override public void close() throws IOException {
+    channel.close();
+  }
+}

--- a/spectator-reg-sidecar/src/main/java/com/netflix/spectator/sidecar/UdpWriter.java
+++ b/spectator-reg-sidecar/src/main/java/com/netflix/spectator/sidecar/UdpWriter.java
@@ -27,8 +27,8 @@ final class UdpWriter extends SidecarWriter {
   private final DatagramChannel channel;
 
   /** Create a new instance. */
-  UdpWriter(SocketAddress address) throws IOException {
-    super();
+  UdpWriter(String location, SocketAddress address) throws IOException {
+    super(location);
     this.channel = DatagramChannel.open();
     this.channel.connect(address);
   }

--- a/spectator-reg-sidecar/src/main/resources/META-INF/services/com.netflix.spectator.api.Registry
+++ b/spectator-reg-sidecar/src/main/resources/META-INF/services/com.netflix.spectator.api.Registry
@@ -1,0 +1,1 @@
+com.netflix.spectator.sidecar.SidecarRegistry

--- a/spectator-reg-sidecar/src/test/java/com/netflix/spectator/sidecar/MemoryWriter.java
+++ b/spectator-reg-sidecar/src/test/java/com/netflix/spectator/sidecar/MemoryWriter.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2014-2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.sidecar;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+class MemoryWriter extends SidecarWriter {
+
+  private final List<String> messages;
+
+  MemoryWriter() {
+    messages = new ArrayList<>();
+  }
+
+  List<String> messages() {
+    return messages;
+  }
+
+  @Override
+  void writeImpl(String line) throws IOException {
+    messages.add(line);
+  }
+
+  @Override
+  public void close() throws IOException {
+    messages.clear();
+  }
+}

--- a/spectator-reg-sidecar/src/test/java/com/netflix/spectator/sidecar/MemoryWriter.java
+++ b/spectator-reg-sidecar/src/test/java/com/netflix/spectator/sidecar/MemoryWriter.java
@@ -24,6 +24,7 @@ class MemoryWriter extends SidecarWriter {
   private final List<String> messages;
 
   MemoryWriter() {
+    super("memory");
     messages = new ArrayList<>();
   }
 

--- a/spectator-reg-sidecar/src/test/java/com/netflix/spectator/sidecar/PrintStreamWriterTest.java
+++ b/spectator-reg-sidecar/src/test/java/com/netflix/spectator/sidecar/PrintStreamWriterTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2014-2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.sidecar;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+public class PrintStreamWriterTest {
+
+  private SidecarWriter newWriter(Path path) throws IOException {
+    String location = "file://" + path.toString();
+    return SidecarWriter.create(location);
+  }
+
+  @Test
+  public void file() throws IOException {
+    Path tmp = Files.createTempFile("spectator", "test");
+    try (SidecarWriter w = newWriter(tmp)) {
+      w.write("foo");
+      w.write("bar");
+    }
+
+    List<String> lines = Files.readAllLines(tmp, StandardCharsets.UTF_8);
+    Assertions.assertEquals(2, lines.size());
+    Assertions.assertEquals("foo", lines.get(0));
+    Assertions.assertEquals("bar", lines.get(1));
+
+    Files.deleteIfExists(tmp);
+  }
+
+  @Test
+  public void concurrentWrites() throws Exception {
+    Path tmp = Files.createTempFile("spectator", "test");
+    try (SidecarWriter w = newWriter(tmp)) {
+      Thread[] threads = new Thread[4];
+      for (int i = 0; i < threads.length; ++i) {
+        final int n = i;
+        Runnable task = () -> {
+          int base = n * 10_000;
+          for (int j = 0; j < 10_000; ++j) {
+            w.write("" + (base + j));
+          }
+        };
+        threads[i] = new Thread(task);
+        threads[i].start();
+      }
+      for (Thread t : threads) {
+        t.join();
+      }
+    }
+
+    List<String> lines = Files.readAllLines(tmp, StandardCharsets.UTF_8);
+    int N = 40_000;
+    Assertions.assertEquals(N, lines.size());
+    Assertions.assertEquals(N * (N - 1) / 2, lines.stream().mapToInt(Integer::parseInt).sum());
+
+    Files.deleteIfExists(tmp);
+  }
+}

--- a/spectator-reg-sidecar/src/test/java/com/netflix/spectator/sidecar/SidecarConfigTest.java
+++ b/spectator-reg-sidecar/src/test/java/com/netflix/spectator/sidecar/SidecarConfigTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2014-2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.sidecar;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+
+public class SidecarConfigTest {
+
+}

--- a/spectator-reg-sidecar/src/test/java/com/netflix/spectator/sidecar/SidecarRegistryTest.java
+++ b/spectator-reg-sidecar/src/test/java/com/netflix/spectator/sidecar/SidecarRegistryTest.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2014-2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.sidecar;
+
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.DistributionSummary;
+import com.netflix.spectator.api.Gauge;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.ManualClock;
+import com.netflix.spectator.api.Timer;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+
+public class SidecarRegistryTest {
+
+  private final ManualClock clock = new ManualClock();
+  private final TestConfig config = new TestConfig();
+  private final SidecarRegistry registry = new SidecarRegistry(clock, config, config.writer());
+
+  @BeforeEach
+  public void beforeEach() throws Exception {
+    clock.setWallTime(0L);
+    clock.setMonotonicTime(0L);
+    registry.close();
+  }
+
+  private void assertSingleMessage(String expected) {
+    List<String> messages = config.writer().messages();
+    Assertions.assertEquals(1, messages.size());
+    Assertions.assertEquals(messages.get(0), expected);
+  }
+
+  private void assertNoMessage() {
+    List<String> messages = config.writer().messages();
+    Assertions.assertEquals(0, messages.size());
+  }
+
+  @Test
+  public void idJustName() {
+    registry.counter("test").increment();
+    assertSingleMessage("c:test:1");
+  }
+
+  @Test
+  public void idJustNameInvalidChars() {
+    registry.counter("test name").increment();
+    assertSingleMessage("c:test_name:1");
+  }
+
+  @Test
+  public void idWithTags() {
+    registry.counter("test", "app", "foo", "node", "i$1234").increment();
+    assertSingleMessage("c:test,app=foo,node=i_1234:1");
+  }
+
+  @Test
+  public void counter() {
+    Counter c = registry.counter("test");
+    c.increment();
+    assertSingleMessage("c:test:1");
+    Assertions.assertTrue(Double.isNaN(c.actualCount()));
+  }
+
+  @Test
+  public void counterIncrementAmount() {
+    registry.counter("test").increment(42);
+    assertSingleMessage("c:test:42");
+  }
+
+  @Test
+  public void counterIncrementNegative() {
+    registry.counter("test").increment(-42);
+    assertNoMessage();
+  }
+
+  @Test
+  public void counterIncrementZero() {
+    registry.counter("test").increment(0);
+    assertNoMessage();
+  }
+
+  @Test
+  public void counterAdd() {
+    registry.counter("test").add(42.0);
+    assertSingleMessage("c:test:42.0");
+  }
+
+  @Test
+  public void counterAddNegative() {
+    registry.counter("test").add(-42.0);
+    assertNoMessage();
+  }
+
+  @Test
+  public void counterAddZero() {
+    registry.counter("test").add(0.0);
+    assertNoMessage();
+  }
+
+  @Test
+  public void distributionSummary() {
+    DistributionSummary d = registry.distributionSummary("test");
+    d.record(42);
+    assertSingleMessage("d:test:42");
+    Assertions.assertEquals(0L, d.count());
+    Assertions.assertEquals(0L, d.totalAmount());
+  }
+
+  @Test
+  public void distributionSummaryNegative() {
+    DistributionSummary d = registry.distributionSummary("test");
+    d.record(-42);
+    assertNoMessage();
+  }
+
+  @Test
+  public void distributionSummaryZero() {
+    DistributionSummary d = registry.distributionSummary("test");
+    d.record(0);
+    assertSingleMessage("d:test:0");
+  }
+
+  @Test
+  public void gauge() {
+    Gauge g = registry.gauge("test");
+    g.set(42);
+    assertSingleMessage("g:test:42.0");
+    Assertions.assertTrue(Double.isNaN(g.value()));
+  }
+
+  @Test
+  public void maxGauge() {
+    Gauge g = registry.maxGauge("test");
+    g.set(42);
+    assertSingleMessage("m:test:42.0");
+    Assertions.assertTrue(Double.isNaN(g.value()));
+  }
+
+  @Test
+  public void timer() {
+    Timer t = registry.timer("test");
+    t.record(42, TimeUnit.MILLISECONDS);
+    assertSingleMessage("t:test:0.042");
+    Assertions.assertEquals(0L, t.count());
+    Assertions.assertEquals(0L, t.totalTime());
+  }
+
+  @Test
+  public void timerNegative() {
+    Timer t = registry.timer("test");
+    t.record(-42, TimeUnit.MILLISECONDS);
+    assertNoMessage();
+  }
+
+  @Test
+  public void timerZero() {
+    Timer t = registry.timer("test");
+    t.record(0, TimeUnit.MILLISECONDS);
+    assertSingleMessage("t:test:0.0");
+  }
+
+  @Test
+  public void timerRecordCallable() throws Exception {
+    Timer t = registry.timer("test");
+    long v = t.record(() -> {
+      clock.setMonotonicTime(100_000_000);
+      return registry.clock().monotonicTime();
+    });
+    Assertions.assertEquals(100_000_000L, v);
+    assertSingleMessage("t:test:0.1");
+  }
+
+  @Test
+  public void timerRecordRunnable() {
+    Timer t = registry.timer("test");
+    t.record(() -> {
+      clock.setMonotonicTime(100_000_000);
+    });
+    assertSingleMessage("t:test:0.1");
+  }
+
+  @Test
+  public void get() {
+    registry.counter("test").increment();
+    Assertions.assertNull(registry.get(Id.create("test")));
+  }
+
+  @Test
+  public void iterator() {
+    registry.counter("test").increment();
+    Assertions.assertFalse(registry.iterator().hasNext());
+  }
+
+  private static class TestConfig implements SidecarConfig {
+
+    private final MemoryWriter writer = new MemoryWriter();
+
+    @Override public String get(String k) {
+      return null;
+    }
+
+    @Override public String outputLocation() {
+      return "none";
+    }
+
+    MemoryWriter writer() {
+      return writer;
+    }
+  }
+}

--- a/spectator-reg-sidecar/src/test/java/com/netflix/spectator/sidecar/UdpServer.java
+++ b/spectator-reg-sidecar/src/test/java/com/netflix/spectator/sidecar/UdpServer.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014-2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.sidecar;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.DatagramChannel;
+import java.nio.charset.StandardCharsets;
+
+class UdpServer implements Closeable {
+
+  private final DatagramChannel channel;
+
+  UdpServer() throws IOException {
+    channel = DatagramChannel.open();
+    channel.bind(new InetSocketAddress("localhost", 0));
+  }
+
+  String address() throws IOException {
+    InetSocketAddress addr = (InetSocketAddress) channel.getLocalAddress();
+    return "udp://" + addr.getHostName() + ":" + addr.getPort();
+  }
+
+  String read() throws IOException {
+    ByteBuffer buffer = ByteBuffer.allocate(1024);
+    channel.receive(buffer);
+    int length = buffer.position();
+    return new String(buffer.array(), 0, length, StandardCharsets.UTF_8);
+  }
+
+  @Override public void close() throws IOException {
+    channel.close();
+  }
+}

--- a/spectator-reg-sidecar/src/test/java/com/netflix/spectator/sidecar/UdpWriterTest.java
+++ b/spectator-reg-sidecar/src/test/java/com/netflix/spectator/sidecar/UdpWriterTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2014-2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.sidecar;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class UdpWriterTest {
+
+  @Test
+  public void udp() throws IOException {
+    try (UdpServer server = new UdpServer()) {
+      try (SidecarWriter w = SidecarWriter.create(server.address())) {
+        w.write("foo");
+        Assertions.assertEquals("foo", server.read());
+        w.write("bar");
+        Assertions.assertEquals("bar", server.read());
+      }
+    }
+  }
+
+  // Disabled because it can have issues on CI
+  @Test
+  @Disabled
+  public void concurrentWrites() throws Exception {
+    List<String> lines = Collections.synchronizedList(new ArrayList<>());
+    try (UdpServer server = new UdpServer()) {
+      try (SidecarWriter w = SidecarWriter.create(server.address())) {
+        Thread reader = new Thread(() -> {
+          while (true) {
+            try {
+              String line = server.read();
+              if (!"done".equals(line)) {
+                lines.add(line);
+              } else {
+                break;
+              }
+            } catch (IOException e) {
+              throw new UncheckedIOException(e);
+            }
+          }
+        });
+        reader.start();
+
+        Thread[] threads = new Thread[4];
+        for (int i = 0; i < threads.length; ++i) {
+          final int n = i;
+          Runnable task = () -> {
+            int base = n * 10_000;
+            for (int j = 0; j < 10_000; ++j) {
+              w.write("" + (base + j));
+            }
+          };
+          threads[i] = new Thread(task);
+          threads[i].start();
+        }
+        for (Thread t : threads) {
+          t.join();
+        }
+
+        w.write("done");
+        reader.join();
+      }
+    }
+
+    int N = 40_000;
+    Assertions.assertEquals(N, lines.size());
+    Assertions.assertEquals(N * (N - 1) / 2, lines.stream().mapToInt(Integer::parseInt).sum());
+  }
+}


### PR DESCRIPTION
With this implementation Java would be consistent
with other languages based on thin clients.