### PR TITLE
improve indexing for :in clauses

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Parser.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Parser.java
@@ -124,7 +124,7 @@ public final class Parser {
         case ":in":
           tmp = (List<String>) stack.pop();
           k = (String) stack.pop();
-          stack.push(new Query.In(k, new HashSet<>(tmp)));
+          pushIn(stack, k, tmp);
           break;
         case ":lt":
           v = (String) stack.pop();
@@ -212,5 +212,12 @@ public final class Parser {
     } else {
       stack.push(q);
     }
+  }
+
+  private static void pushIn(Deque<Object> stack, String k, List<String> values) {
+    if (values.size() == 1)
+      stack.push(new Query.Equal(k, values.get(0)));
+    else
+      stack.push(new Query.In(k, new HashSet<>(values)));
   }
 }

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Query.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Query.java
@@ -587,6 +587,22 @@ public interface Query {
       return value != null && vs.contains(value);
     }
 
+    @Override public List<Query> dnfList() {
+      // For smaller sets expand to a disjunction of equal clauses. This allows them
+      // to be indexed more efficiently. The size is limited because if there are
+      // multiple large in clauses in an expression the cross produce can become really
+      // large.
+      if (vs.size() <= 5) {
+        List<Query> queries = new ArrayList<>(vs.size());
+        for (String v : vs) {
+          queries.add(new Query.Equal(k, v));
+        }
+        return queries;
+      } else {
+        return Collections.singletonList(this);
+      }
+    }
+
     @Override public String toString() {
       String values = String.join(",", vs);
       return k + ",(," + values + ",),:in";

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/QueryIndexTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/QueryIndexTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -38,8 +39,17 @@ public class QueryIndexTest {
     return registry.createId(name, tags);
   }
 
+  private List<Query> sort(List<Query> vs) {
+    vs.sort(Comparator.comparing(Object::toString));
+    return vs;
+  }
+
   private List<Query> list(Query... vs) {
-    return Arrays.asList(vs);
+    return sort(Arrays.asList(vs));
+  }
+
+  private List<Query> findMatches(QueryIndex<Query> idx, Id id) {
+    return sort(idx.findMatches(id));
   }
 
   @Test
@@ -194,16 +204,16 @@ public class QueryIndexTest {
     idx.add(IN_QUERY, IN_QUERY);
 
     Id id1 = id("a", "key", "b", "c", "12345");
-    Assertions.assertEquals(list(SIMPLE_QUERY, IN_QUERY, HASKEY_QUERY), idx.findMatches(id1));
+    Assertions.assertEquals(list(SIMPLE_QUERY, IN_QUERY, HASKEY_QUERY), findMatches(idx, id1));
 
     Assertions.assertFalse(remove(idx, Parser.parseQuery("name,a,:eq")));
-    Assertions.assertEquals(list(SIMPLE_QUERY, IN_QUERY, HASKEY_QUERY), idx.findMatches(id1));
+    Assertions.assertEquals(list(SIMPLE_QUERY, IN_QUERY, HASKEY_QUERY), findMatches(idx, id1));
 
     Assertions.assertTrue(remove(idx, IN_QUERY));
-    Assertions.assertEquals(list(SIMPLE_QUERY, HASKEY_QUERY), idx.findMatches(id1));
+    Assertions.assertEquals(list(SIMPLE_QUERY, HASKEY_QUERY), findMatches(idx, id1));
 
     Assertions.assertTrue(remove(idx, SIMPLE_QUERY));
-    Assertions.assertEquals(list(HASKEY_QUERY), idx.findMatches(id1));
+    Assertions.assertEquals(list(HASKEY_QUERY), findMatches(idx, id1));
 
     Assertions.assertTrue(remove(idx, HASKEY_QUERY));
     Assertions.assertTrue(idx.isEmpty());
@@ -391,9 +401,9 @@ public class QueryIndexTest {
         "    equal checks:\n" +
         "    - [b]\n" +
         "        matches:\n" +
+        "        - [name,a,:eq,key,(,b,c,),:in,:and]\n" +
         "        - [name,a,:eq,key,b,:eq,:and]\n" +
-        "    other checks:\n" +
-        "    - [key,(,b,c,),:in]\n" +
+        "    - [c]\n" +
         "        matches:\n" +
         "        - [name,a,:eq,key,(,b,c,),:in,:and]\n" +
         "    other keys:\n" +

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/QueryTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/QueryTest.java
@@ -22,12 +22,16 @@ import nl.jqno.equalsverifier.Warning;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
+import java.util.TreeSet;
 
 
 public class QueryTest {
@@ -88,6 +92,12 @@ public class QueryTest {
   @Test
   public void inQueryEmpty() {
     Assertions.assertThrows(IllegalArgumentException.class, () -> parse("name,(,),:in"));
+  }
+
+  @Test
+  public void inQuerySingle() {
+    Query q = Parser.parseQuery("name,(,bar,),:in");
+    Assertions.assertEquals(new Query.Equal("name", "bar"), q);
   }
 
   @Test
@@ -350,6 +360,22 @@ public class QueryTest {
   public void dnfListA() {
     Query a = new Query.Has("a");
     Assertions.assertEquals(Collections.singletonList(a), a.dnfList());
+  }
+
+  @Test
+  public void dnfListIn() {
+    List<Query> expected = new ArrayList<>();
+    Set<String> values = new TreeSet<>();
+    for (int i = 0; i < 5; ++i) {
+      values.add("" + i);
+      expected.add(new Query.Equal("k", "" + i));
+    }
+    Query q = new Query.In("k", values);
+    Assertions.assertEquals(expected, q.dnfList());
+
+    values.add("5");
+    Assertions.assertEquals(Collections.singletonList(q), q.dnfList());
+
   }
 
   @Test


### PR DESCRIPTION
Smaller in clauses will now get expanded to a disjunction
or equal clauses. This allows them to get indexed using
the faster exact match path and avoid being lumped into
the other checks. Looking at existing expressions ~95%
of in clauses are covered with the current size limit.