### PR TITLE
improve indexing for :has and :re

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Evaluator.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Evaluator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2022 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -98,7 +98,8 @@ public class Evaluator {
 
     for (Subscription sub : removed) {
       SubscriptionEntry entry = subscriptions.remove(sub);
-      index.remove(entry);
+      Query q = sub.dataExpr().query().simplify(commonTags);
+      index.remove(q, entry);
       LOGGER.debug("subscription removed: {}", sub);
     }
   }

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/PrefixTree.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/PrefixTree.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2014-2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+import java.util.function.Consumer;
+
+/**
+ * Simple tree for finding all values associated with a prefix that matches the search
+ * key. The prefix is a simple ascii string. If unsupported characters are used in the
+ * prefix or search key, then the prefix match will only check up to the unsupported
+ * character and the caller will need to perform further checks on the returned value.
+ */
+final class PrefixTree<T> {
+
+  private static final int FIRST_CHAR = ' ';
+  private static final int LAST_CHAR = '~';
+  private static final int TABLE_SIZE = LAST_CHAR - FIRST_CHAR + 1;
+
+  private static int indexOf(char c) {
+    int i = c - FIRST_CHAR;
+    return (i >= TABLE_SIZE) ? -1 : i;
+  }
+
+  private final AtomicReferenceArray<PrefixTree<T>> children;
+  private final Set<T> values;
+
+  /** Create a new instance. */
+  PrefixTree() {
+    children = new AtomicReferenceArray<>(TABLE_SIZE);
+    values = ConcurrentHashMap.newKeySet();
+  }
+
+  private PrefixTree<T> computeIfAbsent(int i) {
+    PrefixTree<T> child = children.get(i);
+    if (child == null) {
+      synchronized (this) {
+        child = children.get(i);
+        if (child == null) {
+          child = new PrefixTree<>();
+          children.set(i, child);
+        }
+      }
+    }
+    return child;
+  }
+
+  /**
+   * Put a value into the tree.
+   *
+   * @param prefix
+   *     ASCII string that represents a prefix for the search key.
+   * @param value
+   *     Value to associate with the prefix.
+   */
+  void put(String prefix, T value) {
+    if (prefix == null)
+      values.add(value);
+    else
+      put(prefix, 0, value);
+  }
+
+  private void put(String prefix, int pos, T value) {
+    if (pos == prefix.length()) {
+      values.add(value);
+    } else {
+      int i = indexOf(prefix.charAt(pos));
+      if (i < 0) {
+        values.add(value);
+      } else {
+        PrefixTree<T> child = computeIfAbsent(i);
+        child.put(prefix, pos + 1, value);
+      }
+    }
+  }
+
+  /**
+   * Remove a value from the tree with the associated prefix.
+   *
+   * @param prefix
+   *     ASCII string that represents a prefix for the search key.
+   * @param value
+   *     Value to associate with the prefix.
+   * @return
+   *     Returns true if a value was removed from the tree.
+   */
+  boolean remove(String prefix, T value) {
+    if (prefix == null)
+      return values.remove(value);
+    else
+      return remove(prefix, 0, value);
+  }
+
+  private boolean remove(String prefix, int pos, T value) {
+    if (pos == prefix.length()) {
+      return values.remove(value);
+    } else {
+      int i = indexOf(prefix.charAt(pos));
+      if (i < 0) {
+        return values.remove(value);
+      } else {
+        PrefixTree<T> child = children.get(i);
+        if (child == null) {
+          return false;
+        } else {
+          boolean result = child.remove(prefix, pos + 1, value);
+          if (result && child.isEmpty()) {
+            synchronized (this) {
+              if (child.isEmpty()) {
+                children.set(i, null);
+              }
+            }
+          }
+          return result;
+        }
+      }
+    }
+  }
+
+  /**
+   * Get a list of values associated with a prefix of the search key.
+   *
+   * @param key
+   *     Key to compare against the prefixes.
+   * @return
+   *     Values associated with a matching prefix.
+   */
+  List<T> get(String key) {
+    List<T> results = new ArrayList<>();
+    forEach(key, results::add);
+    return results;
+  }
+
+  /**
+   * Invokes the consumer function for each value associated with a prefix of the search key.
+   *
+   * @param key
+   *     Key to compare against the prefixes.
+   * @param consumer
+   *     Function to call for matching values.
+   */
+  void forEach(String key, Consumer<T> consumer) {
+    forEach(key, 0, consumer);
+  }
+
+  private void forEach(String key, int pos, Consumer<T> consumer) {
+    values.forEach(consumer);
+    if (pos < key.length()) {
+      int i = indexOf(key.charAt(pos));
+      if (i >= 0) {
+        PrefixTree<T> child = children.get(i);
+        if (child != null) {
+          child.forEach(key, pos + 1, consumer);
+        }
+      }
+    }
+  }
+
+  /**
+   * Returns true if the tree is empty.
+   */
+  boolean isEmpty() {
+    if (values.isEmpty()) {
+      for (int i = 0; i < TABLE_SIZE; ++i) {
+        if (children.get(i) != null) {
+          return false;
+        }
+      }
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  /**
+   * Returns the overall number of values in the tree. The size is computed on demand
+   * by traversing the tree, so this call may be expensive.
+   */
+  int size() {
+    int sz = values.size();
+    for (int i = 0; i < TABLE_SIZE; ++i) {
+      PrefixTree<T> child = children.get(i);
+      if (child != null) {
+        sz += child.size();
+      }
+    }
+    return sz;
+  }
+}

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/PrefixTree.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/PrefixTree.java
@@ -123,7 +123,10 @@ final class PrefixTree<T> {
           boolean result = child.remove(prefix, pos + 1, value);
           if (result && child.isEmpty()) {
             synchronized (this) {
-              if (child.isEmpty()) {
+              // Check that the children array still has the reference to the
+              // same child object. The entry may have been replaced by another
+              // thread.
+              if (child == children.get(i) && child.isEmpty()) {
                 children.set(i, null);
               }
             }

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Query.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Query.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2022 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -815,6 +815,11 @@ public interface Query {
 
     @Override public String key() {
       return k;
+    }
+
+    /** Returns the pattern matcher for checking the values. */
+    public PatternMatcher pattern() {
+      return pattern;
     }
 
     @Override public boolean matches(String value) {

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/PrefixTreeTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/PrefixTreeTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2014-2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas.impl;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class PrefixTreeTest {
+
+  private List<String> list(String... values) {
+    return Arrays.asList(values);
+  }
+
+  private List<String> sort(List<String> values) {
+    values.sort(String::compareTo);
+    return values;
+  }
+
+  private void assertSize(PrefixTree<?> tree, int expected) {
+    Assertions.assertEquals(expected, tree.size());
+    Assertions.assertEquals(expected == 0, tree.isEmpty());
+  }
+
+  @Test
+  public void nullPrefix() {
+    PrefixTree<String> tree = new PrefixTree<>();
+    tree.put(null, "1");
+    assertSize(tree, 1);
+
+    Assertions.assertEquals(list("1"), tree.get("foo"));
+    Assertions.assertEquals(list("1"), tree.get("bar"));
+    Assertions.assertEquals(list("1"), tree.get(""));
+
+    Assertions.assertFalse(tree.remove(null, "2"));
+    Assertions.assertTrue(tree.remove(null, "1"));
+    assertSize(tree, 0);
+    Assertions.assertEquals(Collections.emptyList(), tree.get("foo"));
+  }
+
+  @Test
+  public void emptyPrefix() {
+    PrefixTree<String> tree = new PrefixTree<>();
+    tree.put("", "1");
+    Assertions.assertEquals(list("1"), tree.get("foo"));
+    Assertions.assertEquals(list("1"), tree.get("bar"));
+    Assertions.assertEquals(list("1"), tree.get(""));
+
+    Assertions.assertFalse(tree.remove("", "2"));
+    Assertions.assertTrue(tree.remove("", "1"));
+    Assertions.assertEquals(Collections.emptyList(), tree.get("foo"));
+  }
+
+  @Test
+  public void simplePrefix() {
+    PrefixTree<String> tree = new PrefixTree<>();
+    tree.put("abc", "1");
+    assertSize(tree, 1);
+
+    Assertions.assertEquals(list("1"), tree.get("abcdef"));
+    Assertions.assertEquals(list("1"), tree.get("abcghi"));
+    Assertions.assertEquals(list("1"), tree.get("abc"));
+    Assertions.assertEquals(Collections.emptyList(), tree.get("abd"));
+    Assertions.assertEquals(Collections.emptyList(), tree.get("ab"));
+
+    Assertions.assertTrue(tree.remove("abc", "1"));
+    Assertions.assertFalse(tree.remove("abc", "1"));
+    assertSize(tree, 0);
+    Assertions.assertEquals(Collections.emptyList(), tree.get("abcdef"));
+  }
+
+  @Test
+  public void multipleMatches() {
+    PrefixTree<String> tree = new PrefixTree<>();
+    tree.put("abc", "1");
+    tree.put("ab", "2");
+    tree.put("a", "3");
+    tree.put("abc", "4");
+    assertSize(tree, 4);
+
+    Assertions.assertEquals(list("1", "2", "3", "4"), sort(tree.get("abcdef")));
+    Assertions.assertEquals(list("2", "3"), sort(tree.get("abdef")));
+    Assertions.assertEquals(list("3"), tree.get("adef"));
+    Assertions.assertEquals(Collections.emptyList(), tree.get("bcdef"));
+
+    Assertions.assertFalse(tree.remove("ab", "1"));
+    Assertions.assertTrue(tree.remove("abc", "1"));
+    assertSize(tree, 3);
+    Assertions.assertEquals(list("2", "3", "4"), sort(tree.get("abcdef")));
+  }
+
+  @Test
+  public void unsupportedCharInPrefix() {
+    PrefixTree<String> tree = new PrefixTree<>();
+    tree.put("aβc", "1");
+    assertSize(tree, 1);
+
+    Assertions.assertEquals(list("1"), tree.get("abcdef"));
+    Assertions.assertEquals(list("1"), tree.get("abcghi"));
+    Assertions.assertEquals(list("1"), tree.get("abc"));
+    Assertions.assertEquals(list("1"), tree.get("abd"));
+    Assertions.assertEquals(list("1"), tree.get("ab"));
+    Assertions.assertEquals(Collections.emptyList(), tree.get("b"));
+
+    Assertions.assertTrue(tree.remove("aβc", "1"));
+    assertSize(tree, 0);
+    Assertions.assertEquals(Collections.emptyList(), tree.get("abcdef"));
+  }
+}

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/QueryIndexTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/QueryIndexTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2021 Netflix, Inc.
+ * Copyright 2014-2022 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Random;
@@ -87,7 +86,7 @@ public class QueryIndexTest {
   @Test
   public void simpleRemoveValue() {
     QueryIndex<Query> idx = simpleIdx();
-    Assertions.assertTrue(idx.remove(SIMPLE_QUERY));
+    Assertions.assertTrue(idx.remove(SIMPLE_QUERY, SIMPLE_QUERY));
     Assertions.assertTrue(idx.isEmpty());
 
     Id id = id("a", "key", "b");
@@ -175,16 +174,17 @@ public class QueryIndexTest {
     Id id1 = id("a", "key", "b", "c", "12345");
     Assertions.assertEquals(list(SIMPLE_QUERY, IN_QUERY, HASKEY_QUERY), idx.findMatches(id1));
 
-    Assertions.assertFalse(idx.remove(Parser.parseQuery("name,a,:eq")));
+    Query q = Parser.parseQuery("name,a,:eq");
+    Assertions.assertFalse(idx.remove(q, q));
     Assertions.assertEquals(list(SIMPLE_QUERY, IN_QUERY, HASKEY_QUERY), idx.findMatches(id1));
 
-    Assertions.assertTrue(idx.remove(IN_QUERY));
+    Assertions.assertTrue(idx.remove(IN_QUERY, IN_QUERY));
     Assertions.assertEquals(list(SIMPLE_QUERY, HASKEY_QUERY), idx.findMatches(id1));
 
-    Assertions.assertTrue(idx.remove(SIMPLE_QUERY));
+    Assertions.assertTrue(idx.remove(SIMPLE_QUERY, SIMPLE_QUERY));
     Assertions.assertEquals(list(HASKEY_QUERY), idx.findMatches(id1));
 
-    Assertions.assertTrue(idx.remove(HASKEY_QUERY));
+    Assertions.assertTrue(idx.remove(HASKEY_QUERY, HASKEY_QUERY));
     Assertions.assertTrue(idx.isEmpty());
     Assertions.assertTrue(idx.findMatches(id1).isEmpty());
 
@@ -375,7 +375,7 @@ public class QueryIndexTest {
   public void removalOfNotQuery() {
     Query q = Parser.parseQuery("name,cpu,:eq,id,user,:eq,:not,:and");
     QueryIndex<Query> idx = QueryIndex.<Query>newInstance(registry).add(q, q);
-    Assertions.assertTrue(idx.remove(q));
+    Assertions.assertTrue(idx.remove(q, q));
     Assertions.assertTrue(idx.isEmpty());
   }
 
@@ -408,8 +408,7 @@ public class QueryIndexTest {
         "        - [name,a,:eq,key,(,b,c,),:in,:and]\n" +
         "    other keys:\n" +
         "        key: [c]\n" +
-        "        other checks:\n" +
-        "        - [c,:has]\n" +
+        "        has key:\n" +
         "            key: [key]\n" +
         "            equal checks:\n" +
         "            - [b]\n" +


### PR DESCRIPTION
Two improvements to make it more efficient to check
incoming ids:

1. The :has queries are no longer lumped into the other
   checks as all that needs to be verified is that the
   key is present.
2. Uses a prefix tree for the other checks. The pattern
   matcher for :re queries can be used to extract an
   exact match prefix if possible for a regex. This makes
   it much faster to perform the matching if there are a
   lot of prefix regex queries. Looking at the current
   set of expressions internally, this is quite common.

Running a test with an index of ~341k actual expressions
and a real set of ids for incoming datapoints, the indexing
improvements significantly increase the throughput in terms
of datapoints per second checked via the index.

| Test                         | Throughput |
|------------------------------|------------|
| Baseline                     |     71,719 |
| After `:in` expansion (#960) |     97,209 |
| After this change            |    184,856 |

This change also drops an inefficient remove method from the
index to simplify ongoing maintenance.