### PR TITLE
fix toString for repeated pattern

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/RepeatMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/RepeatMatcher.java
@@ -70,8 +70,8 @@ final class RepeatMatcher implements Matcher, Serializable {
   @Override
   public String toString() {
     return min == max
-        ? repeated + "{" + min + "}"
-        : repeated + "{" + min + "," + max + "}";
+        ? "(?:" + repeated + "){" + min + "}"
+        : "(?:" + repeated + "){" + min + "," + max + "}";
   }
 
   @Override

--- a/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/AbstractPatternMatcherTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/AbstractPatternMatcherTest.java
@@ -301,6 +301,16 @@ public abstract class AbstractPatternMatcherTest {
   }
 
   @Test
+  public void charSeqRepeat() {
+    testRE("(abc){2,5}", "abc");
+    testRE("(abc){2,5}", "abcabc");
+    testRE("(abc){2,5}", "abcc");
+    testRE("(abc){2}", "abc");
+    testRE("(abc){2}", "abcabc");
+    testRE("(abc){2}", "abcc");
+  }
+
+  @Test
   public void unclosedNamedCapturingGroup() {
     Assertions.assertThrows(IllegalArgumentException.class,
         () -> PatternMatcher.compile("(?<foo)"));


### PR DESCRIPTION
Before it wouldn't explicitly group causing some patterns
like simple character sequences to get changed to only
repeat the last character. Now the repeated pattern will
get emitted as part of a non-capturing group.