### PR TITLE
add zero or one matcher

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/Optimizer.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/Optimizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2022 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -157,6 +157,11 @@ final class Optimizer {
   static Matcher zeroOrMoreFalse(Matcher matcher) {
     if (matcher instanceof ZeroOrMoreMatcher) {
       ZeroOrMoreMatcher zm = matcher.as();
+      if (zm.repeated() instanceof FalseMatcher || zm.next() instanceof FalseMatcher) {
+        return zm.next();
+      }
+    } else if (matcher instanceof ZeroOrOneMatcher) {
+      ZeroOrOneMatcher zm = matcher.as();
       if (zm.repeated() instanceof FalseMatcher || zm.next() instanceof FalseMatcher) {
         return zm.next();
       }

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/Parser.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/Parser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2022 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -332,7 +332,7 @@ class Parser {
         }
       case "??":
       case "?+":
-        return OrMatcher.create(matcher, TrueMatcher.INSTANCE);
+        return new ZeroOrOneMatcher(matcher, term());
       case "*":
       case "*?":
         return new ZeroOrMoreMatcher(matcher, term());

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/ZeroOrOneMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/ZeroOrOneMatcher.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2014-2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.impl.matcher;
+
+import com.netflix.spectator.impl.Preconditions;
+
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * Matcher that looks for a pattern zero or one time followed by another pattern.
+ */
+final class ZeroOrOneMatcher implements GreedyMatcher, Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  private final Matcher repeated;
+  private final Matcher next;
+
+  /** Create a new instance. */
+  ZeroOrOneMatcher(Matcher repeated, Matcher next) {
+    this.repeated = Preconditions.checkNotNull(repeated, "repeated");
+    this.next = Preconditions.checkNotNull(next, "next");
+  }
+
+  /** Return the matcher for the repeated portion. */
+  Matcher repeated() {
+    return repeated;
+  }
+
+  /** Return the matcher for the portion that follows. */
+  Matcher next() {
+    return next;
+  }
+
+  @Override
+  public int matches(String str, int start, int length) {
+    final int end = start + length;
+    int pos = repeated.matches(str, start, end - start);
+    if (pos >= start) {
+      pos = next.matches(str, pos, end - pos);
+      if (pos >= start)
+        return pos;
+    }
+    return next.matches(str, start, end - start);
+  }
+
+  @Override
+  public int minLength() {
+    return next.minLength();
+  }
+
+  @Override
+  public boolean isEndAnchored() {
+    return next.isEndAnchored();
+  }
+
+  @Override
+  public boolean alwaysMatches() {
+    return repeated instanceof AnyMatcher && next instanceof TrueMatcher;
+  }
+
+  @Override
+  public Matcher mergeNext(Matcher after) {
+    if (after instanceof TrueMatcher) {
+      return this;
+    }
+    Matcher m = (next instanceof TrueMatcher) ? after : SeqMatcher.create(next, after);
+    return new ZeroOrOneMatcher(repeated, m);
+  }
+
+  @Override
+  public Matcher rewrite(Function<Matcher, Matcher> f) {
+    return f.apply(new ZeroOrOneMatcher(repeated.rewrite(f), next.rewrite(f)));
+  }
+
+  @Override
+  public Matcher rewriteEnd(Function<Matcher, Matcher> f) {
+    return f.apply(new ZeroOrOneMatcher(repeated, next.rewriteEnd(f)));
+  }
+
+  @Override
+  public String toString() {
+    return "(?:" + repeated + ")?" + (next instanceof TrueMatcher ? "" : next.toString());
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ZeroOrOneMatcher that = (ZeroOrOneMatcher) o;
+    return Objects.equals(repeated, that.repeated) && Objects.equals(next, that.next);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = 1;
+    result = 31 * result + repeated.hashCode();
+    result = 31 * result + next.hashCode();
+    return result;
+  }
+}

--- a/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/MatcherEqualsTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/MatcherEqualsTest.java
@@ -126,4 +126,12 @@ public class MatcherEqualsTest {
         .withNonnullFields("repeated", "next")
         .verify();
   }
+
+  @Test
+  public void zeroOrOne() {
+    EqualsVerifier
+        .forClass(ZeroOrOneMatcher.class)
+        .withNonnullFields("repeated", "next")
+        .verify();
+  }
 }

--- a/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/OptimizerTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/OptimizerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2022 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,6 +68,20 @@ public class OptimizerTest {
   @Test
   public void zeroOrMoreFalse_Next() {
     Matcher input = new ZeroOrMoreMatcher(AnyMatcher.INSTANCE, FalseMatcher.INSTANCE);
+    Matcher expected = FalseMatcher.INSTANCE;
+    Assertions.assertEquals(expected, Optimizer.zeroOrMoreFalse(input));
+  }
+
+  @Test
+  public void zeroOrOneFalse_Repeated() {
+    Matcher input = new ZeroOrOneMatcher(FalseMatcher.INSTANCE, AnyMatcher.INSTANCE);
+    Matcher expected = AnyMatcher.INSTANCE;
+    Assertions.assertEquals(expected, Optimizer.zeroOrMoreFalse(input));
+  }
+
+  @Test
+  public void zeroOrOneFalse_Next() {
+    Matcher input = new ZeroOrOneMatcher(AnyMatcher.INSTANCE, FalseMatcher.INSTANCE);
     Matcher expected = FalseMatcher.INSTANCE;
     Assertions.assertEquals(expected, Optimizer.zeroOrMoreFalse(input));
   }
@@ -413,8 +427,8 @@ public class OptimizerTest {
   public void optimizeOptionValue() {
     PatternMatcher actual = PatternMatcher.compile("^a?a");
     PatternMatcher expected = SeqMatcher.create(
-        new StartsWithMatcher("a"),
-        OrMatcher.create(new CharSeqMatcher("a"), TrueMatcher.INSTANCE)
+        StartMatcher.INSTANCE,
+        new ZeroOrOneMatcher(new CharSeqMatcher("a"), new CharSeqMatcher("a"))
     );
     Assertions.assertEquals(expected, actual);
   }


### PR DESCRIPTION
Before it would use an OR matcher to handle the zero or
one case. This is mostly to make it easier to experiment
with rewriting to simpler pattern formats used by some
data stores. It can be convenient to expand OR clauses,
but that can be expensive if there are many different
combinations. The zero or one, `?`, operator is commonly
used and often supported with simpler patterns so having
the explicit matcher reduces the number of combinations
from expanding OR clauses.