### PR TITLE
support expanding OR clauses in regex

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/impl/PatternMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/PatternMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2020 Netflix, Inc.
+ * Copyright 2014-2022 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,9 @@
 package com.netflix.spectator.impl;
 
 import com.netflix.spectator.impl.matcher.PatternUtils;
+
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Efficient alternative to using {@link java.util.regex.Pattern} for use cases that just
@@ -96,6 +99,21 @@ public interface PatternMatcher {
    */
   default PatternMatcher ignoreCase() {
     return this;
+  }
+
+  /**
+   * Split OR clauses in the pattern to separate matchers. Logically the original pattern
+   * will match if at least one of the patterns in the expanded list matches.
+   *
+   * @param max
+   *     Maximum size of the expanded list. This can be used to stop early for some expressions
+   *     that may expand to a really large set.
+   * @return
+   *     List of expanded patterns or null if this pattern cannot be expanded due to exceeding
+   *     the maximum limit.
+   */
+  default List<PatternMatcher> expandOrClauses(int max) {
+    return Collections.singletonList(this);
   }
 
   /**

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/IndexOfMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/IndexOfMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2022 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/Matcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/Matcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2022 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ interface Matcher extends PatternMatcher {
     List<Matcher> ms = PatternUtils.expandOrClauses(this, max);
     if (ms == null)
       return null;
-    List<PatternMatcher> results = new ArrayList<>();
+    List<PatternMatcher> results = new ArrayList<>(ms.size());
     for (Matcher m : ms) {
       results.add(Optimizer.optimize(m));
     }

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/Matcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/Matcher.java
@@ -17,6 +17,8 @@ package com.netflix.spectator.impl.matcher;
 
 import com.netflix.spectator.impl.PatternMatcher;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Function;
 
 /**
@@ -51,6 +53,18 @@ interface Matcher extends PatternMatcher {
   default PatternMatcher ignoreCase() {
     Matcher m = rewrite(PatternUtils::ignoreCase);
     return new IgnoreCaseMatcher(m);
+  }
+
+  @Override
+  default List<PatternMatcher> expandOrClauses(int max) {
+    List<Matcher> ms = PatternUtils.expandOrClauses(this, max);
+    if (ms == null)
+      return null;
+    List<PatternMatcher> results = new ArrayList<>();
+    for (Matcher m : ms) {
+      results.add(Optimizer.optimize(m));
+    }
+    return results;
   }
 
   @Override

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/NegativeLookaheadMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/NegativeLookaheadMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2022 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,10 @@ final class NegativeLookaheadMatcher implements Matcher, Serializable {
   /** Create a new instance. */
   NegativeLookaheadMatcher(Matcher matcher) {
     this.matcher = matcher;
+  }
+
+  Matcher matcher() {
+    return matcher;
   }
 
   @Override

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/Optimizer.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/Optimizer.java
@@ -86,7 +86,16 @@ final class Optimizer {
       List<Matcher> ms = new ArrayList<>();
       for (int i = 0; i < matchers.size(); ++i) {
         Matcher m = matchers.get(i);
-        if (m instanceof GreedyMatcher) {
+        if (m instanceof OrMatcher) {
+          // Don't merge sequential OR clauses
+          if (i + 1 < matchers.size() && matchers.get(i + 1) instanceof OrMatcher) {
+            ms.add(m);
+          } else {
+            List<Matcher> after = matchers.subList(i + 1, matchers.size());
+            ms.add(m.<GreedyMatcher>as().mergeNext(SeqMatcher.create(after)));
+            break;
+          }
+        } else if (m instanceof GreedyMatcher) {
           List<Matcher> after = matchers.subList(i + 1, matchers.size());
           ms.add(m.<GreedyMatcher>as().mergeNext(SeqMatcher.create(after)));
           break;

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/OrMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/OrMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2022 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/PatternUtils.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/PatternUtils.java
@@ -17,7 +17,10 @@ package com.netflix.spectator.impl.matcher;
 
 import com.netflix.spectator.impl.PatternMatcher;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
 
 /**
  * Helper functions for working with patterns.
@@ -205,6 +208,108 @@ public final class PatternUtils {
     } else {
       return matcher;
     }
+  }
+
+  /**
+   * Expand OR clauses in the provided matcher up to the max limit. If expanding would exceed
+   * the max, then null will be returned.
+   */
+  static List<Matcher> expandOrClauses(Matcher matcher, int max) {
+    if (matcher instanceof IndexOfMatcher) {
+      IndexOfMatcher m = matcher.as();
+      return map(expandOrClauses(m.next(), max), n -> new IndexOfMatcher(m.pattern(), n), max);
+    } else if (matcher instanceof ZeroOrMoreMatcher) {
+      ZeroOrMoreMatcher m = matcher.as();
+      return map(expandOrClauses(m.next(), max), n -> new ZeroOrMoreMatcher(m.repeated(), n), max);
+    } else if (matcher instanceof ZeroOrOneMatcher) {
+      ZeroOrOneMatcher m = matcher.as();
+      List<Matcher> rs = expandOrClauses(m.repeated(), max);
+      List<Matcher> ns = expandOrClauses(m.next(), max);
+      if (rs == null || ns == null) {
+        return null;
+      } else if (rs.size() == 1 && ns.size() == 1) {
+        return Collections.singletonList(matcher);
+      } else {
+        List<Matcher> results = new ArrayList<>(ns);
+        for (Matcher r : rs) {
+          for (Matcher n : ns) {
+            results.add(new ZeroOrOneMatcher(r, n));
+          }
+        }
+        return results;
+      }
+    } else if (matcher instanceof PositiveLookaheadMatcher) {
+      PositiveLookaheadMatcher m = matcher.as();
+      return map(expandOrClauses(m.matcher(), max), PositiveLookaheadMatcher::new, max);
+    } else if (matcher instanceof SeqMatcher) {
+      return expandSeq(matcher.as(), max);
+    } else if (matcher instanceof OrMatcher) {
+      return expandOr(matcher.as(), max);
+    } else {
+      return Collections.singletonList(matcher);
+    }
+  }
+
+  private static List<Matcher> map(List<Matcher> ms, Function<Matcher, Matcher> f, int max) {
+    if (ms == null || ms.size() > max) {
+      return null;
+    }
+    List<Matcher> results = new ArrayList<>(ms.size());
+    for (Matcher m : ms) {
+      results.add(f.apply(m));
+    }
+    return results;
+  }
+
+  private static List<Matcher> expandSeq(SeqMatcher seqMatcher, int max) {
+    List<List<Matcher>> results = new ArrayList<>();
+    for (Matcher matcher : seqMatcher.matchers()) {
+      if (results.isEmpty()) {
+        List<Matcher> rs = expandOrClauses(matcher, max);
+        if (rs == null)
+          return null;
+        for (Matcher m : rs) {
+          List<Matcher> tmp = new ArrayList<>();
+          tmp.add(m);
+          results.add(tmp);
+        }
+      } else {
+        List<Matcher> rs = expandOrClauses(matcher, max);
+        if (rs == null || results.size() * rs.size() > max)
+          return null;
+        List<List<Matcher>> tmp = new ArrayList<>(results.size() * rs.size());
+        for (List<Matcher> ms : results) {
+          for (Matcher r : rs) {
+            List<Matcher> seq = new ArrayList<>(ms);
+            seq.add(r);
+            tmp.add(seq);
+          }
+        }
+        results = tmp;
+      }
+    }
+
+    List<Matcher> tmp = new ArrayList<>(results.size());
+    for (List<Matcher> ms : results) {
+      tmp.add(SeqMatcher.create(ms));
+    }
+    return tmp;
+  }
+
+  private static List<Matcher> expandOr(OrMatcher matcher, int max) {
+    List<Matcher> ms = matcher.matchers();
+    if (ms.size() > max) {
+      return null;
+    }
+    List<Matcher> results = new ArrayList<>();
+    for (Matcher m : ms) {
+      List<Matcher> tmp = expandOrClauses(m, max);
+      if (tmp == null || results.size() + tmp.size() > max) {
+        return null;
+      }
+      results.addAll(tmp);
+    }
+    return results;
   }
 
   /** Convert a matcher to a SQL pattern or return null if not possible. */

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/PatternUtils.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/PatternUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2020 Netflix, Inc.
+ * Copyright 2014-2022 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -225,7 +225,7 @@ public final class PatternUtils {
       ZeroOrOneMatcher m = matcher.as();
       List<Matcher> rs = expandOrClauses(m.repeated(), max);
       List<Matcher> ns = expandOrClauses(m.next(), max);
-      if (rs == null || ns == null) {
+      if (rs == null || ns == null || ns.size() * (rs.size() + 1) > max) {
         return null;
       } else if (rs.size() == 1 && ns.size() == 1) {
         return Collections.singletonList(matcher);

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/PositiveLookaheadMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/PositiveLookaheadMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2022 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,10 @@ final class PositiveLookaheadMatcher implements Matcher, Serializable {
   /** Create a new instance. */
   PositiveLookaheadMatcher(Matcher matcher) {
     this.matcher = matcher;
+  }
+
+  Matcher matcher() {
+    return matcher;
   }
 
   @Override

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/RepeatMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/RepeatMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2022 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,18 @@ final class RepeatMatcher implements Matcher, Serializable {
     this.repeated = repeated;
     this.min = min;
     this.max = max;
+  }
+
+  Matcher repeated() {
+    return repeated;
+  }
+
+  int min() {
+    return min;
+  }
+
+  int max() {
+    return max;
   }
 
   @Override

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/SeqMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/SeqMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2022 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/ZeroOrMoreMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/ZeroOrMoreMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2022 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/AbstractPatternMatcherTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/AbstractPatternMatcherTest.java
@@ -389,4 +389,43 @@ public abstract class AbstractPatternMatcherTest {
     testRE("foo-h2(prod|)+-bar-*", "foo-h2prod-abc-v123");
     testRE("foo-h2(prod|)+-bar-*", "foo-h2prod-bar-v123");
   }
+
+  @Test
+  public void negativeLookaheadWithOr() {
+    testRE("foo-(?!b|c|d)", "foo-a");
+    testRE("foo-(?!b|c|d)", "foo-b");
+    testRE("foo-(?!b|c|d)", "foo-f");
+  }
+
+  @Test
+  public void positiveLookaheadWithOr() {
+    testRE("foo-(?=b|c|d)", "foo-a");
+    testRE("foo-(?=b|c|d)", "foo-b");
+    testRE("foo-(?=b|c|d)", "foo-f");
+  }
+
+  @Test
+  public void zeroOrMoreThenOr() {
+    testRE("a*(b|c|d)", "aaa");
+    testRE("a*(b|c|d)", "aab");
+    testRE("a*(b|c|d)", "ac");
+    testRE("a*(b|c|d)", "b");
+    testRE("a*(b|c|d)", "af");
+    testRE("a*(b|c|d)", "f");
+  }
+
+  @Test
+  public void zeroOrMoreWithOr() {
+    testRE("(a|b|c)*d", "aaad");
+    testRE("(a|b|c)*d", "aaa");
+    testRE("(a|b|c)*d", "ababcd");
+  }
+
+  @Test
+  public void repeatWithOr() {
+    testRE("(a|b|c){1,3}d", "aaad");
+    testRE("(a|b|c){1,3}d", "aaa");
+    testRE("(a|b|c){1,3}d", "ababcd");
+    testRE("(a|b|c){1,5}d", "ababcd");
+  }
 }

--- a/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/ExpandOrPatternMatcherTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/ExpandOrPatternMatcherTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2014-2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.impl.matcher;
+
+import com.netflix.spectator.impl.PatternMatcher;
+import org.junit.jupiter.api.Assertions;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+public class ExpandOrPatternMatcherTest extends AbstractPatternMatcherTest {
+
+  @Override
+  protected void testRE(String regex, String value) {
+    Pattern pattern = Pattern.compile("^.*(" + regex + ")", Pattern.DOTALL);
+    List<PatternMatcher> matchers = PatternMatcher.compile(regex).expandOrClauses(1000);
+    if (pattern.matcher(value).find()) {
+      Assertions.assertTrue(matches(matchers, value), regex + " should match " + value);
+    } else {
+      Assertions.assertFalse(matches(matchers, value), regex + " shouldn't match " + value);
+    }
+  }
+
+  private boolean matches(List<PatternMatcher> matchers, String value) {
+    for (PatternMatcher m : matchers) {
+      if (m.matches(value))
+        return true;
+    }
+    return false;
+  }
+}

--- a/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/ExpandOrTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/ExpandOrTest.java
@@ -88,6 +88,14 @@ public class ExpandOrTest {
   }
 
   @Test
+  public void expandZeroOrOneMatcherExceedsLimit() {
+    List<PatternMatcher> rs = PatternMatcher
+        .compile("^(ABC|abc)?(DEF|def)")
+        .expandOrClauses(5);
+    Assertions.assertNull(rs);
+  }
+
+  @Test
   public void expandZeroOrOneMatcherNoChange() {
     List<String> rs = expand("ab?c");
     List<String> expected = list(".*a(?:b)?c");

--- a/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/ExpandOrTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/ExpandOrTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2014-2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.impl.matcher;
+
+import com.netflix.spectator.impl.PatternMatcher;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ExpandOrTest {
+
+  private static List<String> expand(String pattern) {
+    return PatternMatcher.compile(pattern)
+        .expandOrClauses(50)
+        .stream()
+        .map(Object::toString)
+        .sorted()
+        .collect(Collectors.toList());
+  }
+
+  private static List<String> list(String... vs) {
+    return Arrays.asList(vs);
+  }
+
+  @Test
+  public void expandIndexOf() {
+    Assertions.assertEquals(list(".*fooABC", ".*fooabc"), expand("foo(ABC|abc)"));
+  }
+
+  @Test
+  public void expandNegativeLookaheadMatcher() {
+    // OR within negative lookahead cannot be expanded without changing the
+    // interpretation.
+    Assertions.assertEquals(list("(.)*(?!(ABC|abc))"), expand("(?!ABC|abc)"));
+  }
+
+  @Test
+  public void expandPositiveLookaheadMatcher() {
+    Assertions.assertEquals(list("(.)*(?=ABC)", "(.)*(?=abc)"), expand("(?=ABC|abc)"));
+  }
+
+  @Test
+  public void expandRepeatMatcher() {
+    // OR within repeat cannot be expanded without changing the interpretation.
+    Assertions.assertEquals(list("(.)*(?:((ABC)|(abc))){2,5}"), expand("(ABC|abc){2,5}"));
+  }
+
+  @Test
+  public void expandZeroOrMoreMatcher() {
+    // OR within repeat cannot be expanded without changing the interpretation, however, pattern
+    // following it can be expanded.
+    List<String> rs = expand("(ABC|abc)*(DEF|def)");
+    List<String> expected = list(
+        "(.)*((ABC|abc))*DEF",
+        "(.)*((ABC|abc))*def"
+    );
+    Assertions.assertEquals(expected, rs);
+  }
+
+  @Test
+  public void expandZeroOrOneMatcher() {
+    List<String> rs = expand("(ABC|abc)?(DEF|def)");
+    List<String> expected = list(
+        "(.)*(?:ABC)?DEF",
+        "(.)*(?:ABC)?def",
+        "(.)*(?:abc)?DEF",
+        "(.)*(?:abc)?def",
+        ".*DEF",
+        ".*def"
+    );
+    Assertions.assertEquals(expected, rs);
+  }
+
+  @Test
+  public void expandZeroOrOneMatcherNoChange() {
+    List<String> rs = expand("ab?c");
+    List<String> expected = list(".*a(?:b)?c");
+    Assertions.assertEquals(expected, rs);
+  }
+
+  @Test
+  public void expandSeqMatcher() {
+    List<String> rs = expand("(ABC|abc).(DEF|def)");
+    List<String> expected = list(
+       ".*ABC(.DEF)",
+        ".*ABC(.def)",
+        ".*abc(.DEF)",
+        ".*abc(.def)"
+    );
+    Assertions.assertEquals(expected, rs);
+  }
+
+  @Test
+  public void expandOrClauses() {
+    List<String> rs = expand("abc(d|e(f|g|h)ijk|lm)nop(qrs|tuv)wxyz");
+    List<String> expected = list(
+        ".*abcdnopqrswxyz",
+        ".*abcdnoptuvwxyz",
+        ".*abcefijknopqrswxyz",
+        ".*abcefijknoptuvwxyz",
+        ".*abcegijknopqrswxyz",
+        ".*abcegijknoptuvwxyz",
+        ".*abcehijknopqrswxyz",
+        ".*abcehijknoptuvwxyz",
+        ".*abclmnopqrswxyz",
+        ".*abclmnoptuvwxyz"
+    );
+    Assertions.assertEquals(expected, rs);
+  }
+
+  @Test
+  public void crossProduct() {
+    // Pattern with 26^10 expanded patterns, ~141 trillion
+    String alpha = "(a|b|c|d|e|f|g|h|i|j|k|l|m|n|o|p|q|r|s|t|u|v|w|x|y|z)";
+    String pattern = "";
+    for (int i = 0; i < 10; ++i) {
+      pattern += alpha;
+    }
+    Assertions.assertNull(PatternMatcher.compile(pattern).expandOrClauses(5));
+  }
+}


### PR DESCRIPTION
Add helper to PatternMatcher for expanding OR clauses
to a set where the original pattern should match if
at least one of the expanded patterns match. This can
be a useful first step for other processing such as
indexing the query or rewriting for data stores that
support a more limited pattern matching.