### PR TITLE
fix removal for exprs with regex prefix

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/QueryIndex.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/QueryIndex.java
@@ -251,18 +251,19 @@ public final class QueryIndex<T> {
               hasKeyIdx = null;
           }
         } else {
-          if (kq instanceof Query.Regex) {
-            Query.Regex re = (Query.Regex) kq;
-            otherChecksTree.remove(re.pattern().prefix(), kq);
-          } else {
-            otherChecksTree.remove(null, kq);
-          }
           QueryIndex<T> idx = otherChecks.get(kq);
           if (idx != null && idx.remove(queries, j, value)) {
             result = true;
             otherChecksCache.clear();
-            if (idx.isEmpty())
+            if (idx.isEmpty()) {
               otherChecks.remove(kq);
+              if (kq instanceof Query.Regex) {
+                Query.Regex re = (Query.Regex) kq;
+                otherChecksTree.remove(re.pattern().prefix(), kq);
+              } else {
+                otherChecksTree.remove(null, kq);
+              }
+            }
           }
 
           // Not queries should match if the key is missing from the id, so they need to

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/QueryIndexTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/QueryIndexTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Random;
@@ -385,6 +386,26 @@ public class QueryIndexTest {
     QueryIndex<Query> idx = QueryIndex.<Query>newInstance(registry).add(q, q);
     Assertions.assertTrue(remove(idx, q));
     Assertions.assertTrue(idx.isEmpty());
+  }
+
+  @Test
+  public void removalPrefixRegexSubtree() {
+    Query q1 = Parser.parseQuery("name,test,:eq,a,foo,:re,:and,b,bar,:eq,:and");
+    Query q2 = Parser.parseQuery("name,test,:eq,a,foo,:re,:and");
+    QueryIndex<Query> idx = QueryIndex.<Query>newInstance(registry)
+        .add(q1, q1)
+        .add(q2, q2);
+
+    Id id = id("test", "a", "foo", "b", "bar");
+
+    Set<Query> expected = new HashSet<>();
+    expected.add(q1);
+    expected.add(q2);
+    Assertions.assertEquals(expected, new HashSet<>(idx.findMatches(id)));
+
+    idx.remove(q1, q1);
+    expected.remove(q1);
+    Assertions.assertEquals(expected, new HashSet<>(idx.findMatches(id)));
   }
 
   @Test


### PR DESCRIPTION
Before it would always remove from the prefix tree even
if there were other similar expressions with the same
prefix. After that those other expressions would never
match because the sub-index would no longer be in the
tree. Now it will only remove from the prefix tree if
the sub-index is empty.