### PR TITLE
ensure graphql is not removed by sanitizer

### DIFF
--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/http/PathSanitizer.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/http/PathSanitizer.java
@@ -79,6 +79,12 @@ public final class PathSanitizer {
   }
 
   private static boolean shouldSuppressSegment(String segment) {
+    // GraphQL is a common endpoint, but hits the consonants check to detect strings
+    // that are likely to be random. Special case it for now.
+    if ("graphql".equals(segment)) {
+      return false;
+    }
+
     final int maxSequentialConsonants = 4;
     int sequentialConsonants = 0;
 

--- a/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/http/PathSanitizerTest.java
+++ b/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/http/PathSanitizerTest.java
@@ -102,6 +102,12 @@ public class PathSanitizerTest {
   }
 
   @Test
+  public void graphql() {
+    String path = "/graphql";
+    Assertions.assertEquals("_graphql", sanitize(path));
+  }
+
+  @Test
   public void randomLookingString() {
     String path = "/random/AOTV16LMT2";
     Assertions.assertEquals("_random_-", sanitize(path));


### PR DESCRIPTION
The path sanitizer uses runs of consonants to detect
values that are likely to be random. GraphQL is a
common path that hits that check. Special case it to
avoid removing.