### PR TITLE
fix validation metrics for default publisher

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasConfig.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasConfig.java
@@ -18,7 +18,6 @@ package com.netflix.spectator.atlas;
 import com.netflix.spectator.api.Clock;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.RegistryConfig;
-import com.netflix.spectator.atlas.impl.DefaultPublisher;
 
 import java.time.Duration;
 import java.util.Collections;
@@ -258,6 +257,6 @@ public interface AtlasConfig extends RegistryConfig {
    * path.
    */
   default Publisher publisher() {
-    return new DefaultPublisher(this);
+    return null;
   }
 }

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/DefaultPublisher.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/DefaultPublisher.java
@@ -72,12 +72,18 @@ public final class DefaultPublisher implements Publisher {
   }
 
   public DefaultPublisher(final AtlasConfig config, final HttpClient client) {
+    this(config, client, config.debugRegistry());
+  }
+
+  public DefaultPublisher(
+      final AtlasConfig config, final HttpClient client, final Registry registry) {
+
     this.uri = URI.create(config.uri());
     this.evalUri = URI.create(config.evalUri());
     this.connectTimeout = (int) config.connectTimeout().toMillis();
     this.readTimeout = (int) config.readTimeout().toMillis();
     this.numThreads = config.numThreads();
-    this.debugRegistry = Optional.ofNullable(config.debugRegistry()).orElse(new NoopRegistry());
+    this.debugRegistry = Optional.ofNullable(registry).orElse(new NoopRegistry());
 
     this.client = client != null ? client : HttpClient.create(debugRegistry);
 


### PR DESCRIPTION
When using the default publisher, the debug registry was
always null rather than falling back to using the registry
it is publishing for. This means that some of the validation
metrics would be missing.