### PR TITLE
clarify expectations for common tags

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasConfig.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasConfig.java
@@ -169,8 +169,9 @@ public interface AtlasConfig extends RegistryConfig {
   }
 
   /**
-   * Returns the common tags to apply to all metrics reported to Atlas.
-   * The default is an empty map.
+   * Returns the common tags to apply to all metrics reported to Atlas. The returned tags
+   * must only use valid characters as defined by {@link #validTagCharacters()}. The default
+   * is an empty map.
    */
   default Map<String, String> commonTags() {
     return Collections.emptyMap();


### PR DESCRIPTION
Update the comment for the commonTags with AtlasRegistry
to indicate that the user is responsible for ensuring that
they conform to the valid tag character restrictions.