### PR TITLE
Add Hotspot Safepoint metrics

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,20 +5,32 @@ on: [pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        java: [8, 11, 17]
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Gradle wrapper validation
         uses: gradle/wrapper-validation-action@v1
-      - name: Set up JDK ${{ matrix.java }}
+      - name: Set up JDK 8
         uses: actions/setup-java@v3
         with:
-          java-version: ${{ matrix.java }}
+          java-version: 8
           distribution: 'zulu'
           cache: 'gradle'
+      - run: echo "JDK8=$JAVA_HOME" >> $GITHUB_ENV
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          distribution: 'zulu'
+          cache: 'gradle'
+      - run: echo "JDK11=$JAVA_HOME" >> $GITHUB_ENV
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: 'zulu'
+          cache: 'gradle'
+      - run: echo "JDK17=$JAVA_HOME" >> $GITHUB_ENV
       - name: Build
         run: ./gradlew build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,12 +14,27 @@ jobs:
       - uses: actions/checkout@v3
       - name: Gradle wrapper validation
         uses: gradle/wrapper-validation-action@v1
-      - name: Set up JDK
+      - name: Set up JDK 8
         uses: actions/setup-java@v3
         with:
           java-version: 8
           distribution: 'zulu'
           cache: 'gradle'
+      - run: echo "JDK8=$JAVA_HOME" >> $GITHUB_ENV
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          distribution: 'zulu'
+          cache: 'gradle'
+      - run: echo "JDK11=$JAVA_HOME" >> $GITHUB_ENV
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: 'zulu'
+          cache: 'gradle'
+      - run: echo "JDK17=$JAVA_HOME" >> $GITHUB_ENV
       - name: Build candidate
         if: contains(github.ref, '-rc.')
         run: ./gradlew --info --stacktrace -Prelease.useLastTag=true candidate

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -16,12 +16,27 @@ jobs:
           fetch-depth: 0
       - name: Gradle wrapper validation
         uses: gradle/wrapper-validation-action@v1
-      - name: Set up JDK
+      - name: Set up JDK 8
         uses: actions/setup-java@v3
         with:
           java-version: 8
           distribution: 'zulu'
           cache: 'gradle'
+      - run: echo "JDK8=$JAVA_HOME" >> $GITHUB_ENV
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          distribution: 'zulu'
+          cache: 'gradle'
+      - run: echo "JDK11=$JAVA_HOME" >> $GITHUB_ENV
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: 'zulu'
+          cache: 'gradle'
+      - run: echo "JDK17=$JAVA_HOME" >> $GITHUB_ENV
       - name: Build
         run: ./gradlew build snapshot
         env:

--- a/build.gradle
+++ b/build.gradle
@@ -31,32 +31,19 @@ subprojects {
 
   group = "com.netflix.${githubProjectName}"
 
-  sourceCompatibility = 1.8
-  targetCompatibility = 1.8
+  java {
+    toolchain {
+      languageVersion = JavaLanguageVersion.of(8)
+    }
+  }
+
+  tasks.withType(JavaCompile) {
+    options.encoding = 'UTF-8'
+  }
 
   tasks {
-    compileJava {
-      options.encoding = 'UTF-8'
-      // Generate java8 bytecode and compile against the java8 class
-      // libraries.
-      if (JavaVersion.current().isJava9Compatible()) {
-        options.release = 8
-      }
-    }
-    compileTestJava {
-      options.encoding = 'UTF-8'
-      if (JavaVersion.current().isJava9Compatible()) {
-        options.release = JavaVersion.current().majorVersion.toInteger()
-      }
-    }
-
     javadoc {
-      if (JavaVersion.current().isJava8Compatible()) {
-        options.addStringOption('Xdoclint:none', '-quiet')
-      }
-      if (JavaVersion.current().isJava9Compatible()) {
-        options.addStringOption('-release', '8')
-      }
+      options.addStringOption('Xdoclint:none', '-quiet')
     }
   }
 
@@ -79,8 +66,23 @@ subprojects {
     jmh "org.openjdk.jmh:jmh-generator-annprocess:1.33"
   }
 
-  test {
+  tasks.withType(Test) {
     useJUnitPlatform()
+  }
+
+  [11, 17].each { additionalJDK ->
+    def additionalTestTask = tasks.register("testJDK$additionalJDK", Test) {
+      description = "Runs tests against JDK $additionalJDK."
+      group = 'verification'
+
+      testClassesDirs = sourceSets.test.output.classesDirs
+      classpath = sourceSets.test.runtimeClasspath
+
+      javaLauncher = javaToolchains.launcherFor {
+        languageVersion = JavaLanguageVersion.of(additionalJDK)
+      }
+    }
+    check.dependsOn additionalTestTask
   }
 
   jmh {

--- a/spectator-ext-jvm/src/main/resources/hotspot.conf
+++ b/spectator-ext-jvm/src/main/resources/hotspot.conf
@@ -1,0 +1,43 @@
+netflix.spectator.agent.jmx {
+  mappings = ${?netflix.spectator.agent.jmx.mappings} [
+    //
+    // type=HotspotRuntime
+    //
+    {
+      query = "sun.management:type=HotspotRuntime"
+      measurements = [
+        {
+          value = "{SafepointCount}"
+          counter = true
+          name = "jvm.hotspot.runtime.safepointCount"
+          tags = [
+            {
+              key = "id"
+              value = "{name}"
+            }
+          ]
+        },
+        {
+          value = "{TotalSafepointTime},1000,:div"
+          name = "jvm.hotspot.runtime.safepointTime"
+          tags = [
+            {
+              key = "id"
+              value = "{name}"
+            }
+          ]
+        },
+        {
+          value = "{SafepointSyncTime},1000,:div"
+          name = "jvm.hotspot.runtime.safepointSyncTime"
+          tags = [
+            {
+              key = "id"
+              value = "{name}"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Add hotspot safepoint metrics to help identify when safepoints and safepoint sync times are a problem. Unfortunately this relies on a propriety API, but there's no other way of getting at this at runtime on JDK 8 through latest. JFR event streams are JDK 15 and later for instance, and this is so much simpler. Some background here:

https://mail.openjdk.org/pipermail/serviceability-dev/2021-June/038222.html

This came up in the context of issue with I/O bound GC pauses on JDK 17:

https://twitter.com/DannyThomas/status/1546758318492102657

While I was at it, I went looking for any other causes of safepoint I/O latency and issues with safepoint sync times, and I can think of several places where we could be affected not only by that, but time-to-safepoint effective pauses where we're in JNI, etc:

- https://www.evanjones.ca/jvm-mmap-pause.html
- https://blanco.io/blog/jvm-safepoint-pauses/#analyzing-safepoint-pauses
