### PR TITLE
Fix calculation of array size in ArrayTagSet::addAll

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/ArrayTagSet.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/ArrayTagSet.java
@@ -203,7 +203,7 @@ final class ArrayTagSet implements TagList {
       int len = dedup(ts, 0, ts, 0, tsLength);
       return new ArrayTagSet(ts, len);
     } else {
-      String[] newTags = new String[(length + tsLength) * 2];
+      String[] newTags = new String[length + tsLength];
       insertionSort(ts, tsLength);
       int newLength = merge(newTags, tags, length, ts, tsLength);
       return new ArrayTagSet(newTags, newLength);


### PR DESCRIPTION
The backing array was being allocated with double the required size when merging tags in ArrayTagSet::addAll.