### PR TITLE
Delegate to ConcurrentHashMap values Spliterator in AbstractRegistry

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/AbstractRegistry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/AbstractRegistry.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Spliterator;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
@@ -276,6 +277,11 @@ public abstract class AbstractRegistry implements Registry {
 
   @Override public final Iterator<Meter> iterator() {
     return meters.values().iterator();
+  }
+
+  @Override
+  public final Spliterator<Meter> spliterator() {
+    return meters.values().spliterator();
   }
 
   /**

--- a/spectator-api/src/test/java/com/netflix/spectator/api/RegistryTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/RegistryTest.java
@@ -27,6 +27,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.LongSummaryStatistics;
 import java.util.Map;
+import java.util.Spliterator;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
@@ -583,6 +584,20 @@ public class RegistryTest {
     DefaultRegistry r = newRegistry(false, 10);
     r.maxGauge("test").set(-42);
     Assertions.assertEquals(-42.0, r.maxGauge("test").value(), 1e-12);
+  }
+
+  @Test
+  public void spliteratorCharacteristicsAndEstimatedSize() {
+    Registry registry = newRegistry(false, 20);
+    registry.counter("foo").increment();
+    registry.counter("bar").increment();
+    registry.counter("baz").increment();
+
+    Spliterator<Meter> spliterator = registry.spliterator();
+
+    Assertions.assertTrue(spliterator.hasCharacteristics(Spliterator.NONNULL));
+    Assertions.assertTrue(spliterator.hasCharacteristics(Spliterator.CONCURRENT));
+    Assertions.assertEquals(3, spliterator.estimateSize());
   }
 
   @Test


### PR DESCRIPTION
Override AbstractRegistry::spliterator to return the ConcurrentHashMap's values Spliterator, which has estimated size and other characteristics set.