### PR TITLE
Add rate metrics for survivor pool growth

### DIFF
--- a/spectator-ext-gc/src/main/java/com/netflix/spectator/gc/HelperFunctions.java
+++ b/spectator-ext-gc/src/main/java/com/netflix/spectator/gc/HelperFunctions.java
@@ -74,6 +74,10 @@ final class HelperFunctions {
         || "ZHeap".equals(name);
   }
 
+  static boolean isSurvivorPool(String name) {
+    return name.endsWith("Survivor Space");
+  }
+
   /** Compute the total usage across all pools. */
   static long getTotalUsage(Map<String, MemoryUsage> usages) {
     long sum = 0L;
@@ -101,4 +105,5 @@ final class HelperFunctions {
     long totalAfter = getTotalUsage(info.getMemoryUsageAfterGc());
     return totalAfter - totalBefore;
   }
+
 }


### PR DESCRIPTION
I was troubleshooting an GC pause outlier issue caused by survivor space growth and the associated copying, while overall allocation/tenuring rates remained stable. Issue was obvious from GC logs, but it occured to me this was a gap in our existing pool rates.