### PR TITLE
Fix issues with ArrayTagSet's hashCode

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/ArrayTagSet.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/ArrayTagSet.java
@@ -467,14 +467,15 @@ final class ArrayTagSet implements TagList {
   }
 
   @Override public int hashCode() {
-    if (cachedHashCode == 0) {
-      int result = length;
+    int hc = cachedHashCode;
+    if (hc == 0) {
+      hc = 1;
       for (int i = 0; i < length; ++i) {
-        result = 31 * result + tags[i].hashCode();
+        hc = 31 * hc + tags[i].hashCode();
       }
-      cachedHashCode = result;
+      cachedHashCode = hc;
     }
-    return cachedHashCode;
+    return hc;
   }
 
   @Override public String toString() {

--- a/spectator-api/src/test/java/com/netflix/spectator/api/ArrayTagSetTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/ArrayTagSetTest.java
@@ -49,6 +49,12 @@ public class ArrayTagSetTest {
   }
 
   @Test
+  public void testHashCode() {
+    Assertions.assertEquals(1, ArrayTagSet.EMPTY.hashCode());
+    Assertions.assertEquals(ArrayTagSet.create("k1", "v1", "k2", "v2"), ArrayTagSet.create("k2", "v2", "k1", "v1"));
+  }
+
+  @Test
   public void testToString() {
     ArrayTagSet ts1 = ArrayTagSet.create("k1", "v1");
     ArrayTagSet ts2 = ArrayTagSet.create("k2", "v2").addAll(ts1);


### PR DESCRIPTION
- Only read cached hash code field once to avoid running afoul of edge case involving re-ordering of operations permitted by the Java memory model. (see [this blog post](http://jeremymanson.blogspot.com/2008/12/benign-data-races-in-java.html) for details).
- Make computed hash code consistent with Arrays.hashCode (e.g., ArrayTagSet.EMPTY hashes to 1).