### PR TITLE
add support for contains, starts, and ends

### DIFF
--- a/codequality/checkstyle.xml
+++ b/codequality/checkstyle.xml
@@ -166,17 +166,8 @@
         </module>
         <module name="UpperEll"/>
 
-      <!-- Enable suppression comments -->
-      <module name="SuppressionCommentFilter">
-        <property name="offCommentFormat" value="CHECKSTYLE IGNORE\s+(\S+)"/>
-        <property name="onCommentFormat" value="CHECKSTYLE END IGNORE\s+(\S+)"/>
-        <property name="checkFormat" value="$1"/>
-      </module>
-      <module name="SuppressWithNearbyCommentFilter">
-        <!-- Syntax is "SUPPRESS CHECKSTYLE name" -->
-        <property name="commentFormat" value="SUPPRESS CHECKSTYLE (\w+)"/>
-        <property name="checkFormat" value="$1"/>
-        <property name="influenceFormat" value="1"/>
-      </module>
+        <!-- Enable suppression via annotation -->
+        <module name="SuppressWarningsHolder"/>
     </module>
+    <module name="SuppressWarningsFilter"/>
 </module>

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Parser.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Parser.java
@@ -15,6 +15,8 @@
  */
 package com.netflix.spectator.atlas.impl;
 
+import com.netflix.spectator.impl.matcher.PatternUtils;
+
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
@@ -56,7 +58,7 @@ public final class Parser {
     }
   }
 
-  @SuppressWarnings({"unchecked", "PMD"})
+  @SuppressWarnings({"unchecked", "checkstyle:MethodLength", "PMD"})
   private static Object parse(String expr) {
     DataExpr.AggregateFunction af;
     Query q, q1, q2;
@@ -155,6 +157,21 @@ public final class Parser {
           v = (String) stack.pop();
           k = (String) stack.pop();
           pushRegex(stack, new Query.Regex(k, v, true, ":reic"));
+          break;
+        case ":contains":
+          v = (String) stack.pop();
+          k = (String) stack.pop();
+          pushRegex(stack, new Query.Regex(k, ".*" + PatternUtils.escape(v)));
+          break;
+        case ":starts":
+          v = (String) stack.pop();
+          k = (String) stack.pop();
+          pushRegex(stack, new Query.Regex(k, PatternUtils.escape(v)));
+          break;
+        case ":ends":
+          v = (String) stack.pop();
+          k = (String) stack.pop();
+          pushRegex(stack, new Query.Regex(k, ".*" + PatternUtils.escape(v) + "$"));
           break;
         case ":all":
           q = (Query) stack.pop();

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/QueryTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/QueryTest.java
@@ -42,7 +42,10 @@ public class QueryTest {
     Query q1 = Parser.parseQuery(expr);
     Query q2 = Parser.parseQuery(expr);
     Assertions.assertEquals(q1, q2);
-    Assertions.assertEquals(expr, q1.toString());
+
+    Query q3 = Parser.parseQuery(q1.toString());
+    Assertions.assertEquals(q1, q3);
+    Assertions.assertEquals(q1.toString(), q3.toString());
     return q1;
   }
 
@@ -208,6 +211,63 @@ public class QueryTest {
         .forClass(Query.Regex.class)
         .suppress(Warning.NULL_FIELDS, Warning.ALL_FIELDS_SHOULD_BE_USED)
         .verify();
+  }
+
+  @Test
+  public void containsQuery() {
+    Query q = parse("name,foo,:contains");
+    Assertions.assertTrue(q.matches(registry.createId("foo")));
+    Assertions.assertTrue(q.matches(registry.createId("foo_")));
+    Assertions.assertTrue(q.matches(registry.createId("_foo_")));
+    Assertions.assertTrue(q.matches(registry.createId("_foo")));
+    Assertions.assertFalse(q.matches(registry.createId("_Foo_")));
+  }
+
+  @Test
+  public void containsQueryEscape() {
+    Query q = parse("name,^$.?*+[](){}\\#&!%,:contains");
+    Assertions.assertEquals(
+        "name,.*\\^\\$\\.\\?\\*\\+\\[\\]\\(\\)\\{\\}\\\\#&!%,:re",
+        q.toString());
+    Assertions.assertTrue(q.matches(registry.createId("^$.?*+[](){}\\#&!%")));
+  }
+
+  @Test
+  public void startsQuery() {
+    Query q = parse("name,foo,:starts");
+    Assertions.assertTrue(q.matches(registry.createId("foo")));
+    Assertions.assertTrue(q.matches(registry.createId("foo_")));
+    Assertions.assertFalse(q.matches(registry.createId("_foo_")));
+    Assertions.assertFalse(q.matches(registry.createId("_foo")));
+    Assertions.assertFalse(q.matches(registry.createId("Foo_")));
+  }
+
+  @Test
+  public void startsQueryEscape() {
+    Query q = parse("name,^$.?*+[](){}\\#&!%,:starts");
+    Assertions.assertEquals(
+        "name,\\^\\$\\.\\?\\*\\+\\[\\]\\(\\)\\{\\}\\\\#&!%,:re",
+        q.toString());
+    Assertions.assertTrue(q.matches(registry.createId("^$.?*+[](){}\\#&!%")));
+  }
+
+  @Test
+  public void endsQuery() {
+    Query q = parse("name,foo,:ends");
+    Assertions.assertTrue(q.matches(registry.createId("foo")));
+    Assertions.assertFalse(q.matches(registry.createId("foo_")));
+    Assertions.assertFalse(q.matches(registry.createId("_foo_")));
+    Assertions.assertTrue(q.matches(registry.createId("_foo")));
+    Assertions.assertFalse(q.matches(registry.createId("_Foo")));
+  }
+
+  @Test
+  public void endsQueryEscape() {
+    Query q = parse("name,^$.?*+[](){}\\#&!%,:ends");
+    Assertions.assertEquals(
+        "name,.*\\^\\$\\.\\?\\*\\+\\[\\]\\(\\)\\{\\}\\\\#&!%$,:re",
+        q.toString());
+    Assertions.assertTrue(q.matches(registry.createId("^$.?*+[](){}\\#&!%")));
   }
 
   @Test


### PR DESCRIPTION
Update to be consistent with recent changes to Atlas backend to support `:contains`, `:starts`, and `:ends` query operations. These get mapped to regex so it only impacts the query parsing.

See: Netflix/atlas#1470 and Netflix/atlas#1471.