### PR TITLE
add jdk19 to CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,13 +11,13 @@ jobs:
           fetch-depth: 0
       - name: Gradle wrapper validation
         uses: gradle/wrapper-validation-action@v1
-      - name: Set up JDK 8
+      - name: Set up JDK 19
         uses: actions/setup-java@v3
         with:
-          java-version: 8
+          java-version: 19
           distribution: 'zulu'
           cache: 'gradle'
-      - run: echo "JDK8=$JAVA_HOME" >> $GITHUB_ENV
+      - run: echo "JDK19=$JAVA_HOME" >> $GITHUB_ENV
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
@@ -25,12 +25,12 @@ jobs:
           distribution: 'zulu'
           cache: 'gradle'
       - run: echo "JDK17=$JAVA_HOME" >> $GITHUB_ENV
-      - name: Set up JDK 18
+      - name: Set up JDK 8
         uses: actions/setup-java@v3
         with:
-          java-version: 18
+          java-version: 8
           distribution: 'zulu'
           cache: 'gradle'
-      - run: echo "JDK18=$JAVA_HOME" >> $GITHUB_ENV
+      - run: echo "JDK8=$JAVA_HOME" >> $GITHUB_ENV
       - name: Build
         run: ./gradlew build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,13 +14,13 @@ jobs:
       - uses: actions/checkout@v3
       - name: Gradle wrapper validation
         uses: gradle/wrapper-validation-action@v1
-      - name: Set up JDK 8
+      - name: Set up JDK 19
         uses: actions/setup-java@v3
         with:
-          java-version: 8
+          java-version: 19
           distribution: 'zulu'
           cache: 'gradle'
-      - run: echo "JDK8=$JAVA_HOME" >> $GITHUB_ENV
+      - run: echo "JDK19=$JAVA_HOME" >> $GITHUB_ENV
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
@@ -28,13 +28,13 @@ jobs:
           distribution: 'zulu'
           cache: 'gradle'
       - run: echo "JDK17=$JAVA_HOME" >> $GITHUB_ENV
-      - name: Set up JDK 18
+      - name: Set up JDK 8
         uses: actions/setup-java@v3
         with:
-          java-version: 18
+          java-version: 8
           distribution: 'zulu'
           cache: 'gradle'
-      - run: echo "JDK18=$JAVA_HOME" >> $GITHUB_ENV
+      - run: echo "JDK8=$JAVA_HOME" >> $GITHUB_ENV
       - name: Build candidate
         if: contains(github.ref, '-rc.')
         run: ./gradlew --info --stacktrace -Prelease.useLastTag=true candidate

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -16,13 +16,13 @@ jobs:
           fetch-depth: 0
       - name: Gradle wrapper validation
         uses: gradle/wrapper-validation-action@v1
-      - name: Set up JDK 8
+      - name: Set up JDK 19
         uses: actions/setup-java@v3
         with:
-          java-version: 8
+          java-version: 19
           distribution: 'zulu'
           cache: 'gradle'
-      - run: echo "JDK8=$JAVA_HOME" >> $GITHUB_ENV
+      - run: echo "JDK19=$JAVA_HOME" >> $GITHUB_ENV
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
@@ -30,13 +30,13 @@ jobs:
           distribution: 'zulu'
           cache: 'gradle'
       - run: echo "JDK17=$JAVA_HOME" >> $GITHUB_ENV
-      - name: Set up JDK 18
+      - name: Set up JDK 8
         uses: actions/setup-java@v3
         with:
-          java-version: 18
+          java-version: 8
           distribution: 'zulu'
           cache: 'gradle'
-      - run: echo "JDK18=$JAVA_HOME" >> $GITHUB_ENV
+      - run: echo "JDK8=$JAVA_HOME" >> $GITHUB_ENV
       - name: Build
         run: ./gradlew build snapshot
         env:


### PR DESCRIPTION
Updates the actions to add JDKs from newest to oldest so that JAVA_HOME at the end will be the older version. That version should be used by gradle.