### PR TITLE
batch updater for counter, timer, and dist summary

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/Counter.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/Counter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2022 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,4 +50,49 @@ public interface Counter extends Meter {
    * often a counter is reset depends on the underlying registry implementation.
    */
   double actualCount();
+
+  /**
+   * Returns a helper that can be used to more efficiently update the counter within a
+   * single thread. For example, if you need to update a meter within a loop where the
+   * rest of the loop body is fairly cheap, the instrumentation code may add considerable
+   * overhead if done in the loop body. A batched updater can offset a fair amount of that
+   * cost, but the updates may be delayed a bit in reaching the meter. The updates will only
+   * be seen after the updater is explicitly flushed.
+   *
+   * The caller should ensure that the updater is closed after using to guarantee any resources
+   * associated with it are cleaned up. In some cases failure to close the updater could result
+   * in a memory leak.
+   *
+   * @param batchSize
+   *     Number of updates to batch before forcing a flush to the meter.
+   * @return
+   *     Batch updater implementation for this meter.
+   */
+  default BatchUpdater batchUpdater(int batchSize) {
+    return new CounterBatchUpdater(this, batchSize);
+  }
+
+  /** See {@link #batchUpdater(int)}. */
+  interface BatchUpdater extends AutoCloseable {
+    /** Update the counter by one. */
+    default void increment() {
+      add(1.0);
+    }
+
+    /**
+     * Update the counter by {@code amount}.
+     *
+     * @param amount
+     *     Amount to add to the counter.
+     */
+    default void increment(long amount) {
+      add(amount);
+    }
+
+    /** Update the counter by the specified amount. */
+    void add(double amount);
+
+    /** Push updates to the associated counter. */
+    void flush();
+  }
 }

--- a/spectator-api/src/main/java/com/netflix/spectator/api/CounterBatchUpdater.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/CounterBatchUpdater.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2014-2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.api;
+
+final class CounterBatchUpdater implements Counter.BatchUpdater {
+
+  private final Counter counter;
+  private final int batchSize;
+
+  private int count;
+  private double sum;
+
+  CounterBatchUpdater(Counter counter, int batchSize) {
+    this.counter = counter;
+    this.batchSize = batchSize;
+    this.count = 0;
+    this.sum = 0.0;
+  }
+
+  @Override
+  public void add(double amount) {
+    if (Double.isFinite(amount) && amount > 0.0) {
+      sum += amount;
+      ++count;
+      if (count >= batchSize) {
+        flush();
+      }
+    }
+  }
+
+  @Override
+  public void flush() {
+    counter.add(sum);
+    sum = 0.0;
+    count = 0;
+  }
+
+  @Override
+  public void close() throws Exception {
+    flush();
+  }
+}

--- a/spectator-api/src/main/java/com/netflix/spectator/api/DefaultTimer.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/DefaultTimer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2022 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ final class DefaultTimer extends AbstractTimer {
   }
 
   @Override public void record(long amount, TimeUnit unit) {
-    if (amount >= 0) {
+    if (amount >= 0L) {
       final long nanos = TimeUnit.NANOSECONDS.convert(amount, unit);
       totalTime.addAndGet(nanos);
       count.incrementAndGet();

--- a/spectator-api/src/main/java/com/netflix/spectator/api/DistSummaryBatchUpdater.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/DistSummaryBatchUpdater.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2014-2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.api;
+
+class DistSummaryBatchUpdater implements DistributionSummary.BatchUpdater {
+
+  private final DistributionSummary distSummary;
+  private final int batchSize;
+
+  private int count;
+  private final long[] amounts;
+
+  DistSummaryBatchUpdater(DistributionSummary distSummary, int batchSize) {
+    this.distSummary = distSummary;
+    this.batchSize = batchSize;
+    this.count = 0;
+    this.amounts = new long[batchSize];
+  }
+
+  @Override
+  public void record(long amount) {
+    if (amount >= 0) {
+      amounts[count++] = amount;
+      if (count >= batchSize) {
+        flush();
+      }
+    }
+  }
+
+  @Override
+  public void flush() {
+    distSummary.record(amounts, count);
+    count = 0;
+  }
+
+  @Override
+  public void close() throws Exception {
+    flush();
+  }
+}

--- a/spectator-api/src/main/java/com/netflix/spectator/api/SwapCounter.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/SwapCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2022 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,5 +37,9 @@ final class SwapCounter extends SwapMeter<Counter> implements Counter {
 
   @Override public double actualCount() {
     return get().actualCount();
+  }
+
+  @Override public BatchUpdater batchUpdater(int batchSize) {
+    return get().batchUpdater(batchSize);
   }
 }

--- a/spectator-api/src/main/java/com/netflix/spectator/api/SwapDistributionSummary.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/SwapDistributionSummary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2022 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,5 +51,9 @@ final class SwapDistributionSummary extends SwapMeter<DistributionSummary> imple
   @Override
   public long totalAmount() {
     return get().totalAmount();
+  }
+
+  @Override public BatchUpdater batchUpdater(int batchSize) {
+    return get().batchUpdater(batchSize);
   }
 }

--- a/spectator-api/src/main/java/com/netflix/spectator/api/SwapTimer.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/SwapTimer.java
@@ -19,7 +19,9 @@ import com.netflix.spectator.impl.SwapMeter;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import java.util.function.LongSupplier;
+import java.util.function.Supplier;
 
 /** Wraps another timer allowing the underlying type to be swapped. */
 final class SwapTimer extends SwapMeter<Timer> implements Timer {
@@ -65,7 +67,15 @@ final class SwapTimer extends SwapMeter<Timer> implements Timer {
     return get().totalTime();
   }
 
+  @SuppressWarnings("unchecked")
   @Override public BatchUpdater batchUpdater(int batchSize) {
-    return get().batchUpdater(batchSize);
+    BatchUpdater updater = get().batchUpdater(batchSize);
+    // Registry implementations can implement `Consumer<Supplier<Timer>>` to allow the
+    // meter to be resolved when flushed and avoid needing to hold on to a particular
+    // instance of the meter that might have expired and been removed from the registry.
+    if (updater instanceof Consumer<?>) {
+      ((Consumer<Supplier<Timer>>) updater).accept(this::get);
+    }
+    return updater;
   }
 }

--- a/spectator-api/src/main/java/com/netflix/spectator/api/SwapTimer.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/SwapTimer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2022 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,5 +63,9 @@ final class SwapTimer extends SwapMeter<Timer> implements Timer {
 
   @Override public long totalTime() {
     return get().totalTime();
+  }
+
+  @Override public BatchUpdater batchUpdater(int batchSize) {
+    return get().batchUpdater(batchSize);
   }
 }

--- a/spectator-api/src/main/java/com/netflix/spectator/api/TimerBatchUpdater.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/TimerBatchUpdater.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2014-2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.api;
+
+import java.util.concurrent.TimeUnit;
+
+final class TimerBatchUpdater implements Timer.BatchUpdater {
+
+  private final Timer timer;
+  private final int batchSize;
+
+  private int count;
+  private final long[] amounts;
+
+  TimerBatchUpdater(Timer timer, int batchSize) {
+    this.timer = timer;
+    this.batchSize = batchSize;
+    this.count = 0;
+    this.amounts = new long[batchSize];
+  }
+
+  @Override
+  public void record(long amount, TimeUnit unit) {
+    if (amount >= 0L) {
+      amounts[count++] = unit.toNanos(amount);
+      if (count >= batchSize) {
+        flush();
+      }
+    }
+  }
+
+  @Override
+  public void flush() {
+    timer.record(amounts, count, TimeUnit.NANOSECONDS);
+    count = 0;
+  }
+
+  @Override
+  public void close() throws Exception {
+    flush();
+  }
+}

--- a/spectator-api/src/test/java/com/netflix/spectator/api/DefaultCounterTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/DefaultCounterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2022 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,9 +39,32 @@ public class DefaultCounterTest {
   }
 
   @Test
+  public void testIncrementBatch() throws Exception {
+    Counter c = new DefaultCounter(clock, NoopId.INSTANCE);
+    try (Counter.BatchUpdater b = c.batchUpdater(2)) {
+      b.increment();
+      Assertions.assertEquals(c.count(), 0L);
+      b.increment();
+      Assertions.assertEquals(c.count(), 2L);
+      b.increment();
+      Assertions.assertEquals(c.count(), 2L);
+    }
+    Assertions.assertEquals(c.count(), 3L);
+  }
+
+  @Test
   public void testIncrementAmount() {
     Counter c = new DefaultCounter(clock, NoopId.INSTANCE);
     c.increment(42);
+    Assertions.assertEquals(c.count(), 42L);
+  }
+
+  @Test
+  public void testIncrementAmountBatch() throws Exception {
+    Counter c = new DefaultCounter(clock, NoopId.INSTANCE);
+    try (Counter.BatchUpdater b = c.batchUpdater(2)) {
+      b.increment(42);
+    }
     Assertions.assertEquals(c.count(), 42L);
   }
 
@@ -53,9 +76,27 @@ public class DefaultCounterTest {
   }
 
   @Test
+  public void testAddAmountBatch() throws Exception {
+    Counter c = new DefaultCounter(clock, NoopId.INSTANCE);
+    try (Counter.BatchUpdater b = c.batchUpdater(2)) {
+      b.add(42.0);
+    }
+    Assertions.assertEquals(c.actualCount(), 42.0, 1e-12);
+  }
+
+  @Test
   public void testAddNegativeAmount() {
     Counter c = new DefaultCounter(clock, NoopId.INSTANCE);
     c.add(-42.0);
+    Assertions.assertEquals(c.actualCount(), 0.0, 1e-12);
+  }
+
+  @Test
+  public void testAddNegativeAmountBatch() throws Exception {
+    Counter c = new DefaultCounter(clock, NoopId.INSTANCE);
+    try (Counter.BatchUpdater b = c.batchUpdater(2)) {
+      b.add(-42.0);
+    }
     Assertions.assertEquals(c.actualCount(), 0.0, 1e-12);
   }
 
@@ -68,9 +109,28 @@ public class DefaultCounterTest {
   }
 
   @Test
+  public void testAddNaNBatch() throws Exception {
+    Counter c = new DefaultCounter(clock, NoopId.INSTANCE);
+    try (Counter.BatchUpdater b = c.batchUpdater(2)) {
+      b.add(1.0);
+      b.add(Double.NaN);
+    }
+    Assertions.assertEquals(c.actualCount(), 1.0, 1e-12);
+  }
+
+  @Test
   public void testAddInfinity() {
     Counter c = new DefaultCounter(clock, NoopId.INSTANCE);
     c.add(Double.POSITIVE_INFINITY);
+    Assertions.assertEquals(c.actualCount(), 0.0, 1e-12);
+  }
+
+  @Test
+  public void testAddInfinityBatch() throws Exception {
+    Counter c = new DefaultCounter(clock, NoopId.INSTANCE);
+    try (Counter.BatchUpdater b = c.batchUpdater(2)) {
+      b.add(Double.POSITIVE_INFINITY);
+    }
     Assertions.assertEquals(c.actualCount(), 0.0, 1e-12);
   }
 

--- a/spectator-api/src/test/java/com/netflix/spectator/api/DefaultDistributionSummaryTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/DefaultDistributionSummaryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2022 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,20 @@ public class DefaultDistributionSummaryTest {
   }
 
   @Test
+  public void testRecordBatch() throws Exception {
+    DistributionSummary t = new DefaultDistributionSummary(clock, NoopId.INSTANCE);
+    try (DistributionSummary.BatchUpdater b = t.batchUpdater(2)) {
+      b.record(42);
+      b.record(42);
+      Assertions.assertEquals(t.count(), 2L);
+      Assertions.assertEquals(t.totalAmount(), 84L);
+      b.record(1);
+    }
+    Assertions.assertEquals(t.count(), 3L);
+    Assertions.assertEquals(t.totalAmount(), 85L);
+  }
+
+  @Test
   public void testRecordNegative() {
     DistributionSummary t = new DefaultDistributionSummary(clock, NoopId.INSTANCE);
     t.record(-42);
@@ -47,9 +61,29 @@ public class DefaultDistributionSummaryTest {
   }
 
   @Test
+  public void testRecordNegativeBatch() throws Exception {
+    DistributionSummary t = new DefaultDistributionSummary(clock, NoopId.INSTANCE);
+    try (DistributionSummary.BatchUpdater b = t.batchUpdater(2)) {
+      b.record(-42);
+    }
+    Assertions.assertEquals(t.count(), 0L);
+    Assertions.assertEquals(t.totalAmount(), 0L);
+  }
+
+  @Test
   public void testRecordZero() {
     DistributionSummary t = new DefaultDistributionSummary(clock, NoopId.INSTANCE);
     t.record(0);
+    Assertions.assertEquals(t.count(), 1L);
+    Assertions.assertEquals(t.totalAmount(), 0L);
+  }
+
+  @Test
+  public void testRecordZeroBatch() throws Exception {
+    DistributionSummary t = new DefaultDistributionSummary(clock, NoopId.INSTANCE);
+    try (DistributionSummary.BatchUpdater b = t.batchUpdater(2)) {
+      b.record(0);
+    }
     Assertions.assertEquals(t.count(), 1L);
     Assertions.assertEquals(t.totalAmount(), 0L);
   }

--- a/spectator-api/src/test/java/com/netflix/spectator/api/DefaultTimerTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/DefaultTimerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2022 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,9 +42,33 @@ public class DefaultTimerTest {
   }
 
   @Test
+  public void testRecordBatch() throws Exception {
+    Timer t = new DefaultTimer(clock, NoopId.INSTANCE);
+    try (Timer.BatchUpdater b = t.batchUpdater(2)) {
+      b.record(42, TimeUnit.MILLISECONDS);
+      b.record(42, TimeUnit.MILLISECONDS);
+      Assertions.assertEquals(t.count(), 2L);
+      Assertions.assertEquals(t.totalTime(), 84000000L);
+      b.record(1, TimeUnit.MILLISECONDS);
+    }
+    Assertions.assertEquals(t.count(), 3L);
+    Assertions.assertEquals(t.totalTime(), 85000000L);
+  }
+
+  @Test
   public void testRecordDuration() {
     Timer t = new DefaultTimer(clock, NoopId.INSTANCE);
     t.record(Duration.ofMillis(42));
+    Assertions.assertEquals(t.count(), 1L);
+    Assertions.assertEquals(t.totalTime(), 42000000L);
+  }
+
+  @Test
+  public void testRecordDurationBatch() throws Exception {
+    Timer t = new DefaultTimer(clock, NoopId.INSTANCE);
+    try (Timer.BatchUpdater b = t.batchUpdater(2)) {
+      b.record(Duration.ofMillis(42));
+    }
     Assertions.assertEquals(t.count(), 1L);
     Assertions.assertEquals(t.totalTime(), 42000000L);
   }
@@ -58,9 +82,29 @@ public class DefaultTimerTest {
   }
 
   @Test
+  public void testRecordNegativeBatch() throws Exception {
+    Timer t = new DefaultTimer(clock, NoopId.INSTANCE);
+    try (Timer.BatchUpdater b = t.batchUpdater(2)) {
+      b.record(-42, TimeUnit.MILLISECONDS);
+    }
+    Assertions.assertEquals(t.count(), 0L);
+    Assertions.assertEquals(t.totalTime(), 0L);
+  }
+
+  @Test
   public void testRecordZero() {
     Timer t = new DefaultTimer(clock, NoopId.INSTANCE);
     t.record(0, TimeUnit.MILLISECONDS);
+    Assertions.assertEquals(t.count(), 1L);
+    Assertions.assertEquals(t.totalTime(), 0L);
+  }
+
+  @Test
+  public void testRecordZeroBatch() throws Exception {
+    Timer t = new DefaultTimer(clock, NoopId.INSTANCE);
+    try (Timer.BatchUpdater b = t.batchUpdater(2)) {
+      b.record(0, TimeUnit.MILLISECONDS);
+    }
     Assertions.assertEquals(t.count(), 1L);
     Assertions.assertEquals(t.totalTime(), 0L);
   }

--- a/spectator-api/src/test/java/com/netflix/spectator/api/SwapMeterTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/SwapMeterTest.java
@@ -61,6 +61,69 @@ public class SwapMeterTest {
   }
 
   @Test
+  public void wrappedCounterBatchUpdater() throws Exception {
+    Counter c = new DefaultCounter(clock, counterId);
+    SwapCounter sc = new SwapCounter(registry, VERSION, counterId, c);
+    try (Counter.BatchUpdater b = sc.batchUpdater(2)) {
+      b.increment();
+    }
+    Assertions.assertEquals(1, c.count());
+    Assertions.assertEquals(1, sc.count());
+  }
+
+  @Test
+  public void wrappedCounterBatchUpdaterCustom() throws Exception {
+    ExpiringRegistry registry = new ExpiringRegistry(clock);
+    Counter c = registry.counter(counterId);
+    try (Counter.BatchUpdater b = c.batchUpdater(2)) {
+      b.increment();
+    }
+    Assertions.assertEquals(1, c.count());
+  }
+
+  @Test
+  public void wrappedTimerBatchUpdater() throws Exception {
+    Timer t = new DefaultTimer(clock, timerId);
+    SwapTimer st = new SwapTimer(registry, VERSION, timerId, t);
+    try (Timer.BatchUpdater b = st.batchUpdater(2)) {
+      b.record(1, TimeUnit.NANOSECONDS);
+    }
+    Assertions.assertEquals(1, t.count());
+    Assertions.assertEquals(1, st.count());
+  }
+
+  @Test
+  public void wrappedTimerBatchUpdaterCustom() throws Exception {
+    ExpiringRegistry registry = new ExpiringRegistry(clock);
+    Timer t = registry.timer(timerId);
+    try (Timer.BatchUpdater b = t.batchUpdater(2)) {
+      b.record(1, TimeUnit.NANOSECONDS);
+    }
+    Assertions.assertEquals(1, t.count());
+  }
+
+  @Test
+  public void wrappedDistributionSummaryBatchUpdater() throws Exception {
+    DistributionSummary d = new DefaultDistributionSummary(clock, distSummaryId);
+    SwapDistributionSummary sd = new SwapDistributionSummary(registry, VERSION, distSummaryId, d);
+    try (DistributionSummary.BatchUpdater b = sd.batchUpdater(2)) {
+      b.record(1);
+    }
+    Assertions.assertEquals(1, d.count());
+    Assertions.assertEquals(1, sd.count());
+  }
+
+  @Test
+  public void wrappedDistributionSummaryBatchUpdaterCustom() throws Exception {
+    ExpiringRegistry registry = new ExpiringRegistry(clock);
+    DistributionSummary d = registry.distributionSummary(distSummaryId);
+    try (DistributionSummary.BatchUpdater b = d.batchUpdater(2)) {
+      b.record(1);
+    }
+    Assertions.assertEquals(1, d.count());
+  }
+
+  @Test
   public void wrapExpiredTimer() {
     ExpiringRegistry registry = new ExpiringRegistry(clock);
     Timer t = registry.timer(timerId);

--- a/spectator-reg-atlas/src/jmh/java/com/netflix/spectator/atlas/BatchUpdates.java
+++ b/spectator-reg-atlas/src/jmh/java/com/netflix/spectator/atlas/BatchUpdates.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2014-2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import com.netflix.spectator.api.Clock;
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.DistributionSummary;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Timer;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * <pre>
+ * Benchmark                          Mode  Cnt      Score      Error   Units
+ *
+ * noInstrumentation                 thrpt    5   3978.248 ±  136.863   ops/s
+ *
+ * counter                           thrpt    5     14.138 ±    0.229   ops/s
+ * counterBatch                      thrpt    5    464.445 ±    8.175   ops/s
+ *
+ * distSummary                       thrpt    5      9.383 ±    0.732   ops/s
+ * distSummaryBatch                  thrpt    5    353.769 ±   10.698   ops/s
+ *
+ * timer                             thrpt    5     10.505 ±    0.170   ops/s
+ * timerBatch                        thrpt    5    336.505 ±    3.538   ops/s
+ * </pre>
+ */
+@State(Scope.Thread)
+public class BatchUpdates {
+
+  private Registry registry;
+
+  @Setup
+  public void setup() {
+    registry = new AtlasRegistry(Clock.SYSTEM, System::getProperty);
+  }
+
+  @TearDown
+  public void tearDown() {
+    registry = null;
+  }
+
+  @Benchmark
+  public void noInstrumentation(Blackhole bh) {
+    long sum = 0L;
+    for (int i = 0; i < 1_000_000; ++i) {
+      sum += i;
+    }
+    bh.consume(sum);
+  }
+
+  @Benchmark
+  public void counter(Blackhole bh) {
+    Counter c = registry.counter("test");
+    long sum = 0L;
+    for (int i = 0; i < 1_000_000; ++i) {
+      sum += i;
+      c.increment();
+    }
+    bh.consume(sum);
+  }
+
+  @Benchmark
+  public void counterBatch(Blackhole bh) throws Exception {
+    Counter c = registry.counter("test");
+    try (Counter.BatchUpdater b = c.batchUpdater(100_000)) {
+      long sum = 0L;
+      for (int i = 0; i < 1_000_000; ++i) {
+        sum += i;
+        b.increment();
+      }
+      bh.consume(sum);
+    }
+  }
+
+  @Benchmark
+  public void timer(Blackhole bh) {
+    Timer t = registry.timer("test");
+    long sum = 0L;
+    for (int i = 0; i < 1_000_000; ++i) {
+      sum += i;
+      t.record(i, TimeUnit.MILLISECONDS);
+    }
+    bh.consume(sum);
+  }
+
+  @Benchmark
+  public void timerBatch(Blackhole bh) throws Exception {
+    Timer t = registry.timer("test");
+    try (Timer.BatchUpdater b = t.batchUpdater(100_000)) {
+      long sum = 0L;
+      for (int i = 0; i < 1_000_000; ++i) {
+        sum += i;
+        b.record(i, TimeUnit.MILLISECONDS);
+      }
+      bh.consume(sum);
+    }
+  }
+
+  @Benchmark
+  public void distSummary(Blackhole bh) {
+    DistributionSummary d = registry.distributionSummary("test");
+    long sum = 0L;
+    for (int i = 0; i < 1_000_000; ++i) {
+      sum += i;
+      d.record(i);
+    }
+    bh.consume(sum);
+  }
+
+  @Benchmark
+  public void distSummaryBatch(Blackhole bh) throws Exception {
+    DistributionSummary d = registry.distributionSummary("test");
+    try (DistributionSummary.BatchUpdater b = d.batchUpdater(100_000)) {
+      long sum = 0L;
+      for (int i = 0; i < 1_000_000; ++i) {
+        sum += i;
+        b.record(i);
+      }
+      bh.consume(sum);
+    }
+  }
+}

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasDistSummaryBatchUpdater.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasDistSummaryBatchUpdater.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2014-2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import com.netflix.spectator.api.DistributionSummary;
+
+final class AtlasDistSummaryBatchUpdater implements DistributionSummary.BatchUpdater {
+
+  private AtlasDistributionSummary distSummary;
+  private final int batchSize;
+
+  private int count;
+  private long total;
+  private double totalOfSquares;
+  private long max;
+
+  AtlasDistSummaryBatchUpdater(AtlasDistributionSummary distSummary, int batchSize) {
+    this.distSummary = distSummary;
+    this.batchSize = batchSize;
+    distSummary.updateRefCount(1);
+  }
+
+  @Override
+  public void record(long amount) {
+    ++count;
+    if (amount > 0L) {
+      total += amount;
+      totalOfSquares += (double) amount * amount;
+      if (amount > max) {
+        max = amount;
+      }
+    }
+    if (count >= batchSize) {
+      flush();
+    }
+  }
+
+  @Override
+  public void flush() {
+    if (distSummary != null) {
+      distSummary.update(count, total, totalOfSquares, max);
+      count = 0;
+      total = 0L;
+      totalOfSquares = 0.0;
+      max = 0L;
+    }
+  }
+
+  @Override
+  public void close() throws Exception {
+    if (distSummary != null) {
+      flush();
+      distSummary.updateRefCount(-1);
+      distSummary = null;
+    }
+  }
+}

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasDistSummaryBatchUpdater.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasDistSummaryBatchUpdater.java
@@ -35,6 +35,7 @@ final class AtlasDistSummaryBatchUpdater
     this.batchSize = batchSize;
   }
 
+  @Override
   public void accept(Supplier<DistributionSummary> distSummarySupplier) {
     this.distSummarySupplier = distSummarySupplier;
   }

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasDistributionSummary.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasDistributionSummary.java
@@ -144,7 +144,9 @@ class AtlasDistributionSummary extends AtlasMeter implements DistributionSummary
   }
 
   @Override public BatchUpdater batchUpdater(int batchSize) {
-    return new AtlasDistSummaryBatchUpdater(this, batchSize);
+    AtlasDistSummaryBatchUpdater updater = new AtlasDistSummaryBatchUpdater(batchSize);
+    updater.accept(() -> this);
+    return updater;
   }
 
   /**

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasDistributionSummary.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasDistributionSummary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2022 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -141,5 +141,20 @@ class AtlasDistributionSummary extends AtlasMeter implements DistributionSummary
 
   @Override public long totalAmount() {
     return total.poll();
+  }
+
+  @Override public BatchUpdater batchUpdater(int batchSize) {
+    return new AtlasDistSummaryBatchUpdater(this, batchSize);
+  }
+
+  /**
+   * Helper to allow the batch updater to directly update the individual stats.
+   */
+  void update(long count, long total, double totalOfSquares, long max) {
+    long now = clock.wallTime();
+    this.count.getCurrent(now).addAndGet(count);
+    this.total.getCurrent(now).addAndGet(total);
+    this.totalOfSquares.getCurrent(now).addAndGet(totalOfSquares);
+    updateMax(this.max.getCurrent(now), max);
   }
 }

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasMeter.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasMeter.java
@@ -22,6 +22,7 @@ import com.netflix.spectator.api.Meter;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /** Base class for core meter types used by AtlasRegistry. */
 abstract class AtlasMeter implements Meter {
@@ -38,12 +39,19 @@ abstract class AtlasMeter implements Meter {
   /** Last time this meter was updated. */
   private volatile long lastUpdated;
 
+  /**
+   * Reference count for batch updaters. The meter cannot be expired while a batch updater
+   * instance is around.
+   */
+  private AtomicInteger batchUpdaterRefCount;
+
   /** Create a new instance. */
   AtlasMeter(Id id, Clock clock, long ttl) {
     this.id = id;
     this.clock = clock;
     this.ttl = ttl;
     lastUpdated = clock.wallTime();
+    batchUpdaterRefCount = new AtomicInteger(0);
   }
 
   /**
@@ -54,12 +62,19 @@ abstract class AtlasMeter implements Meter {
     lastUpdated = now;
   }
 
+  /**
+   * Updates the reference count for the number of batch updaters.
+   */
+  void updateRefCount(int amount) {
+    batchUpdaterRefCount.addAndGet(amount);
+  }
+
   @Override public Id id() {
     return id;
   }
 
   @Override public boolean hasExpired() {
-    return clock.wallTime() - lastUpdated > ttl;
+    return clock.wallTime() - lastUpdated > ttl && batchUpdaterRefCount.get() <= 0;
   }
 
   @Override public Iterable<Measurement> measure() {

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasTimer.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasTimer.java
@@ -194,4 +194,19 @@ class AtlasTimer extends AtlasMeter implements Timer {
     // unit tests so it is rarely a problem in practice. API can be revisited in 2.0.
     return (long) total.poll();
   }
+
+  @Override public BatchUpdater batchUpdater(int batchSize) {
+    return new AtlasTimerBatchUpdater(this, batchSize);
+  }
+
+  /**
+   * Helper to allow the batch updater to directly update the individual stats.
+   */
+  void update(long count, double total, double totalOfSquares, long max) {
+    long now = clock.wallTime();
+    this.count.getCurrent(now).addAndGet(count);
+    this.total.getCurrent(now).addAndGet(total);
+    this.totalOfSquares.getCurrent(now).addAndGet(totalOfSquares);
+    updateMax(this.max.getCurrent(now), max);
+  }
 }

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasTimer.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasTimer.java
@@ -196,7 +196,9 @@ class AtlasTimer extends AtlasMeter implements Timer {
   }
 
   @Override public BatchUpdater batchUpdater(int batchSize) {
-    return new AtlasTimerBatchUpdater(this, batchSize);
+    AtlasTimerBatchUpdater updater = new AtlasTimerBatchUpdater(batchSize);
+    updater.accept(() -> this);
+    return updater;
   }
 
   /**

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasTimerBatchUpdater.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasTimerBatchUpdater.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2014-2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import com.netflix.spectator.api.Timer;
+
+import java.util.concurrent.TimeUnit;
+
+final class AtlasTimerBatchUpdater implements Timer.BatchUpdater {
+
+  private AtlasTimer timer;
+  private final int batchSize;
+
+  private int count;
+  private double total;
+  private double totalOfSquares;
+  private long max;
+
+  AtlasTimerBatchUpdater(AtlasTimer timer, int batchSize) {
+    this.timer = timer;
+    this.batchSize = batchSize;
+    timer.updateRefCount(1);
+  }
+
+  @Override
+  public void record(long amount, TimeUnit unit) {
+    ++count;
+    if (amount > 0L) {
+      final long nanos = unit.toNanos(amount);
+      total += nanos;
+      totalOfSquares += (double) nanos * nanos;
+      if (nanos > max) {
+        max = nanos;
+      }
+    }
+    if (count >= batchSize) {
+      flush();
+    }
+  }
+
+  @Override
+  public void flush() {
+    if (timer != null) {
+      timer.update(count, total, totalOfSquares, max);
+      count = 0;
+      total = 0.0;
+      totalOfSquares = 0.0;
+      max = 0L;
+    }
+  }
+
+  @Override
+  public void close() throws Exception {
+    if (timer != null) {
+      flush();
+      timer.updateRefCount(-1);
+      timer = null;
+    }
+  }
+}

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasTimerBatchUpdater.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasTimerBatchUpdater.java
@@ -35,6 +35,7 @@ final class AtlasTimerBatchUpdater implements Timer.BatchUpdater, Consumer<Suppl
     this.batchSize = batchSize;
   }
 
+  @Override
   public void accept(Supplier<Timer> timerSupplier) {
     this.timerSupplier = timerSupplier;
   }

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasDistributionSummaryTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasDistributionSummaryTest.java
@@ -18,6 +18,7 @@ package com.netflix.spectator.atlas;
 import java.util.Arrays;
 
 import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.DistributionSummary;
 import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Measurement;
 import com.netflix.spectator.api.Registry;
@@ -108,6 +109,26 @@ public class AtlasDistributionSummaryTest {
     dist.record(1);
     clock.setWallTime(step + 1);
     checkValue(4, 1 + 2 + 3 + 1, 1 + 4 + 9 + 1, 3);
+  }
+
+  public void recordSeveralValuesBatch(int batchSize) throws Exception {
+    try (DistributionSummary.BatchUpdater b = dist.batchUpdater(batchSize)) {
+      b.record(1);
+      b.record(2);
+      b.record(3);
+      b.record(1);
+    }
+    clock.setWallTime(step + 1);
+    checkValue(4, 1 + 2 + 3 + 1, 1 + 4 + 9 + 1, 3);
+  }
+
+  @Test
+  public void recordSeveralValuesBatch() throws Exception {
+    recordSeveralValuesBatch(1);
+    recordSeveralValuesBatch(2);
+    recordSeveralValuesBatch(3);
+    recordSeveralValuesBatch(4);
+    recordSeveralValuesBatch(5);
   }
 
   @Test

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasDistributionSummaryTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasDistributionSummaryTest.java
@@ -30,9 +30,8 @@ import org.junit.jupiter.api.Test;
 public class AtlasDistributionSummaryTest {
 
   private final CountingManualClock clock = new CountingManualClock();
-  private final Registry registry = new DefaultRegistry();
   private final long step = 10000L;
-  private final AtlasDistributionSummary dist = new AtlasDistributionSummary(registry.createId("test"), clock, step, step);
+  private final AtlasDistributionSummary dist = new AtlasDistributionSummary(Id.create("test"), clock, step, step);
 
   private void checkValue(long count, long amount, long square, long max) {
     int num = 0;

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasTimerTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasTimerTest.java
@@ -19,6 +19,7 @@ import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Measurement;
 import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Timer;
 import com.netflix.spectator.api.Utils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -142,6 +143,26 @@ public class AtlasTimerTest {
     dist.record(1, TimeUnit.NANOSECONDS);
     clock.setWallTime(step + 1);
     checkValue(4, 1 + 2 + 3 + 1, 1 + 4 + 9 + 1, 3);
+  }
+
+  public void recordSeveralValuesBatch(int batchSize) throws Exception {
+    try (Timer.BatchUpdater b = dist.batchUpdater(batchSize)) {
+      b.record(1, TimeUnit.NANOSECONDS);
+      b.record(2, TimeUnit.NANOSECONDS);
+      b.record(3, TimeUnit.NANOSECONDS);
+      b.record(1, TimeUnit.NANOSECONDS);
+    }
+    clock.setWallTime(step + 1);
+    checkValue(4, 1 + 2 + 3 + 1, 1 + 4 + 9 + 1, 3);
+  }
+
+  @Test
+  public void recordSeveralValuesBatch() throws Exception {
+    recordSeveralValuesBatch(1);
+    recordSeveralValuesBatch(2);
+    recordSeveralValuesBatch(3);
+    recordSeveralValuesBatch(4);
+    recordSeveralValuesBatch(5);
   }
 
   @Test

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasTimerTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasTimerTest.java
@@ -15,10 +15,8 @@
  */
 package com.netflix.spectator.atlas;
 
-import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Measurement;
-import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Timer;
 import com.netflix.spectator.api.Utils;
 import org.junit.jupiter.api.Assertions;
@@ -31,9 +29,8 @@ import java.util.concurrent.TimeUnit;
 public class AtlasTimerTest {
 
   private final CountingManualClock clock = new CountingManualClock();
-  private final Registry registry = new DefaultRegistry();
   private final long step = 10000L;
-  private final AtlasTimer dist = new AtlasTimer(registry.createId("test"), clock, step, step);
+  private final AtlasTimer dist = new AtlasTimer(Id.create("test"), clock, step, step);
 
   private void checkValue(long count, double amount, double square, long max) {
     int num = 0;


### PR DESCRIPTION
Adds a helper that can be used to batch updates to the delegate meter. The main use-case for this is timers or distributions summaries that need to be updated from a single thread with a high throughput.

For counters, this can easily be achieved by the user with a local variable to track the count and then calling increment with the amount when complete or at the desired batch interval. However, for timers and distribution summaries that doesn't work because the implementation needs the raw samples. In #941 a method was added so the samples could be accumulated in an array and posted in a batch. This helps a bit, but it is cumbersome to use, incurs memory overhead, and the full set of samples have to be traversed and processed when recorded.

This change introduces batch updaters that can be customized for a given implementation. So for registries like Atlas where it is possible to accumulate the stats without the memory overhead, it can provide an optimized implementation to do so.