### PR TITLE
add test for preserving custom statistic

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasCounter.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasCounter.java
@@ -18,7 +18,6 @@ package com.netflix.spectator.atlas;
 import com.netflix.spectator.api.Clock;
 import com.netflix.spectator.api.Counter;
 import com.netflix.spectator.api.Id;
-import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Statistic;
 import com.netflix.spectator.impl.StepDouble;
 
@@ -33,12 +32,12 @@ class AtlasCounter extends AtlasMeter implements Counter {
   private final Id stat;
 
   /** Create a new instance. */
-  AtlasCounter(Registry registry, Id id, Clock clock, long ttl, long step) {
+  AtlasCounter(Id id, Clock clock, long ttl, long step) {
     super(id, clock, ttl);
     this.value = new StepDouble(0.0, clock, step);
     // Add the statistic for typing. Re-adding the tags from the id is to retain
     // the statistic from the id if it was already set
-    this.stat = registry.createId(id.name())
+    this.stat = Id.create(id.name())
         .withTag(Statistic.count)
         .withTag(DsType.rate)
         .withTags(id.tags());

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
@@ -458,7 +458,7 @@ public final class AtlasRegistry extends AbstractRegistry implements AutoCloseab
   }
 
   @Override protected Counter newCounter(Id id) {
-    return new AtlasCounter(this, id, clock(), meterTTL, lwcStepMillis);
+    return new AtlasCounter(id, clock(), meterTTL, lwcStepMillis);
   }
 
   @Override protected DistributionSummary newDistributionSummary(Id id) {

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasCounterTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasCounterTest.java
@@ -15,10 +15,9 @@
  */
 package com.netflix.spectator.atlas;
 
-import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.ManualClock;
 import com.netflix.spectator.api.Measurement;
-import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Statistic;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -27,10 +26,8 @@ import org.junit.jupiter.api.Test;
 public class AtlasCounterTest {
 
   private final ManualClock clock = new ManualClock();
-  private final Registry registry = new DefaultRegistry();
   private final long step = 10000L;
-  private final AtlasCounter counter = new AtlasCounter(registry,
-      registry.createId("test"), clock, step, step);
+  private final AtlasCounter counter = new AtlasCounter(Id.create("test"), clock, step, step);
 
   private void checkValue(double expected) {
     int count = 0;
@@ -118,5 +115,13 @@ public class AtlasCounterTest {
 
     counter.increment(42L);
     Assertions.assertFalse(counter.hasExpired());
+  }
+
+  @Test
+  public void preferStatisticFromTags() {
+    Id id = Id.create("test").withTag(Statistic.percentile);
+    AtlasCounter c = new AtlasCounter(id, clock, step, step);
+    Id actual = c.measure().iterator().next().id();
+    Assertions.assertEquals(id.withTag(DsType.rate), actual);
   }
 }

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasDistributionSummaryTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasDistributionSummaryTest.java
@@ -17,11 +17,9 @@ package com.netflix.spectator.atlas;
 
 import java.util.Arrays;
 
-import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.DistributionSummary;
 import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Measurement;
-import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Utils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
Adds a test case for AtlasCounter to ensure that it will preserve the custom statistic if one is used.