### PR TITLE
Compatibility with generational ZGC

### DIFF
--- a/spectator-ext-gc/src/main/java/com/netflix/spectator/gc/GcLogger.java
+++ b/spectator-ext-gc/src/main/java/com/netflix/spectator/gc/GcLogger.java
@@ -258,13 +258,9 @@ public final class GcLogger {
     // https://bugs.openjdk.java.net/browse/JDK-8265136
     //
     // For ZGC in older versions, there is no way to accurately get the amount of time
-    // in STW pauses. The allocation stall seems to indicate that some thread
-    // or threads are blocked trying to allocate. Even though it is not a true STW pause,
-    // counting it as such seems to be less confusing.
-    return "No GC".equals(info.getGcCause())            // CMS
-        || "Shenandoah Cycles".equals(info.getGcName()) // Shenandoah
-        || "ZGC Cycles".equals(info.getGcName())        // ZGC in jdk17+
-        || ("ZGC".equals(info.getGcName()) && !"Allocation Stall".equals(info.getGcCause()));
+    // in STW pauses.
+    return "No GC".equals(info.getGcCause())     // CMS
+        || info.getGcName().endsWith(" Cycles"); // Shenandoah, ZGC
   }
 
   private class GcNotificationListener implements NotificationListener {


### PR DESCRIPTION
Non-generational Shenandoah and ZGC have two memory managers, one concurrent, one stop-the-world, named `<gc> Cycles` and `<gc> Pauses`:

- https://github.com/openjdk/jdk/blob/master/src/hotspot/share/gc/z/zServiceability.cpp#L123-L124
- https://github.com/openjdk/jdk/blob/739769c8fc4b496f08a92225a12d07414537b6c0/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp#L477-L478

However generational ZGC splits these into major/minor cycles/pauses:

- https://github.com/openjdk/zgc/blob/zgc_generational/src/hotspot/share/gc/z/zServiceability.cpp#L174-L187

Looks like there's no change required for genshen so far, they're using the same memory managers:

- https://github.com/corretto/corretto-17/blob/generational-shenandoah/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp#L2895-L2909

`Allocation Stall` is also not a special case, and just another concurrent cycle trigger. It does indicate a allocation stall occurred, but it's not a pause and doesn't tell you how long threads were paused for:

- https://github.com/openjdk/jdk/blob/cd6b54ec40f1d60fbdb6c8aee1e6ba662daca58c/src/hotspot/share/gc/z/zDirector.cpp#L55-L65
- https://github.com/openjdk/jdk/blob/1750a6e2c06960b734f646018fc99b336bd966a5/src/hotspot/share/gc/z/zPageAllocator.cpp#L458-L459
- https://github.com/openjdk/jdk/blob/054c23f484522881a0879176383d970a8de41201/src/hotspot/share/gc/shared/gcCause.cpp#L129-L130

Found while testing genzgc early access builds:

<img width="1885" alt="Screenshot 2022-11-18 at 1 12 14 pm" src="https://user-images.githubusercontent.com/1479220/202606464-bf7b7e39-c6e7-48a4-af33-fe66162f2f6d.png">
