### PR TITLE
Add ZGC generational memory managers

### DIFF
--- a/spectator-ext-gc/src/main/java/com/netflix/spectator/gc/HelperFunctions.java
+++ b/spectator-ext-gc/src/main/java/com/netflix/spectator/gc/HelperFunctions.java
@@ -65,7 +65,7 @@ final class HelperFunctions {
 
   /** Returns true if memory pool name matches an old generation pool. */
   static boolean isOldGenPool(String name) {
-    return name.endsWith("Old Gen")
+    return name.contains("Old Gen")
         || name.endsWith("Tenured Gen")
         || "Shenandoah".equals(name)
         || "ZHeap".equals(name);
@@ -73,7 +73,8 @@ final class HelperFunctions {
 
   /** Returns true if memory pool name matches an young generation pool. */
   static boolean isYoungGenPool(String name) {
-    return name.endsWith("Eden Space")
+    return name.contains("Young Gen")
+        || name.endsWith("Eden Space")
         || "Shenandoah".equals(name)
         || "ZHeap".equals(name);
   }

--- a/spectator-ext-gc/src/main/java/com/netflix/spectator/gc/HelperFunctions.java
+++ b/spectator-ext-gc/src/main/java/com/netflix/spectator/gc/HelperFunctions.java
@@ -43,6 +43,10 @@ final class HelperFunctions {
     m.put("ZGC",                  GcType.OLD);
     m.put("ZGC Cycles",           GcType.OLD);
     m.put("ZGC Pauses",           GcType.OLD);
+    m.put("ZGC Minor Cycles",     GcType.YOUNG);
+    m.put("ZGC Minor Pauses",     GcType.YOUNG);
+    m.put("ZGC Major Cycles",     GcType.OLD);
+    m.put("ZGC Major Pauses",     GcType.OLD);
     m.put("Shenandoah Cycles",    GcType.OLD);
     m.put("Shenandoah Pauses",    GcType.OLD);
     return Collections.unmodifiableMap(m);


### PR DESCRIPTION
Add ZGC generational memory manager labels.

genshen uses the same memory managers, but different pools and will go into a hybrid collection when necessary, so other than checking pool size changes, I'm not sure we can do anything there:

https://github.com/openjdk/shenandoah/blob/998f68b26b8d2a5178a30a6c5b596194961e3821/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp#L2928-L2935