### PR TITLE
use custom replace for substitutions

### DIFF
--- a/spectator-ext-jvm/src/jmh/java/com/netflix/spectator/jvm/MappingExprSubstitute.java
+++ b/spectator-ext-jvm/src/jmh/java/com/netflix/spectator/jvm/MappingExprSubstitute.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.jvm;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.beans.Introspector;
+import java.util.*;
+
+/**
+ * <pre>
+ * ## Java 8
+ *
+ * Benchmark                                  Mode  Cnt         Score              Error   Units
+ * customReplaceMatch                        thrpt    5  18983022.881 ±       212610.589   ops/s
+ * customReplaceNoMatch                      thrpt    5  19068305.638 ±        54315.365   ops/s
+ * stringReplaceMatch                        thrpt    5   4606323.928 ±        36878.183   ops/s
+ * stringReplaceNoMatch                      thrpt    5   4636115.030 ±        22758.712   ops/s
+ *
+ * Benchmark                                  Mode  Cnt         Score              Error   Units
+ * customReplaceMatch           gc.alloc.rate.norm    5       141.733 ±           88.578    B/op
+ * customReplaceNoMatch         gc.alloc.rate.norm    5       152.020 ±            0.002    B/op
+ * stringReplaceMatch           gc.alloc.rate.norm    5      2584.079 ±            0.006    B/op
+ * stringReplaceNoMatch         gc.alloc.rate.norm    5      2584.079 ±            0.006    B/op
+ *
+ * ## Java 17
+ *
+ * Benchmark                                  Mode  Cnt         Score        Error   Units
+ * customReplaceMatch                        thrpt    5  26738250.771 ± 203389.685   ops/s
+ * customReplaceNoMatch                      thrpt    5  27456054.651 ± 171103.076   ops/s
+ * stringReplaceMatch                        thrpt    5  18817330.662 ±  91736.795   ops/s
+ * stringReplaceNoMatch                      thrpt    5  18810950.123 ±  64060.629   ops/s
+ *
+ * Benchmark                                  Mode  Cnt         Score        Error   Units
+ * customReplaceMatch           gc.alloc.rate.norm    5       120.017 ±      0.001    B/op
+ * customReplaceNoMatch         gc.alloc.rate.norm    5       120.016 ±      0.001    B/op
+ * stringReplaceMatch           gc.alloc.rate.norm    5       120.024 ±      0.001    B/op
+ * stringReplaceNoMatch         gc.alloc.rate.norm    5       120.023 ±      0.001    B/op
+ *
+ * </pre>
+ */
+@State(Scope.Thread)
+public class MappingExprSubstitute {
+
+  private static final Map<String, String> VARS = Collections.singletonMap("{variable}", "value");
+
+  static String substituteCustom(String pattern, Map<String, String> vars) {
+    String value = pattern;
+    for (Map.Entry<String, String> entry : vars.entrySet()) {
+      String raw = entry.getValue();
+      String v = Introspector.decapitalize(raw);
+      value = MappingExpr.replace(value, "{raw:" + entry.getKey() + "}", raw);
+      value = MappingExpr.replace(value, "{" + entry.getKey() + "}", v);
+    }
+    return value;
+  }
+
+  static String substituteString(String pattern, Map<String, String> vars) {
+    String value = pattern;
+    for (Map.Entry<String, String> entry : vars.entrySet()) {
+      String raw = entry.getValue();
+      String v = Introspector.decapitalize(raw);
+      value = value.replace("{raw:" + entry.getKey() + "}", raw);
+      value = value.replace("{" + entry.getKey() + "}", v);
+    }
+    return value;
+  }
+
+  @Benchmark
+  public void customReplaceMatch(Blackhole bh) {
+    bh.consume(substituteCustom("{variable}", VARS));
+  }
+
+  @Benchmark
+  public void customReplaceNoMatch(Blackhole bh) {
+    bh.consume(substituteCustom("abcdefghi", VARS));
+  }
+
+  @Benchmark
+  public void stringReplaceMatch(Blackhole bh) {
+    bh.consume(substituteString("{variable}", VARS));
+  }
+
+  @Benchmark
+  public void stringReplaceNoMatch(Blackhole bh) {
+      bh.consume(substituteString("abcdefghi", VARS));
+  }
+}

--- a/spectator-ext-jvm/src/jmh/java/com/netflix/spectator/jvm/MappingExprSubstitute.java
+++ b/spectator-ext-jvm/src/jmh/java/com/netflix/spectator/jvm/MappingExprSubstitute.java
@@ -27,48 +27,47 @@ import java.util.*;
  * <pre>
  * ## Java 8
  *
- * Benchmark                                  Mode  Cnt         Score              Error   Units
- * customReplaceMatch                        thrpt    5  18983022.881 ±       212610.589   ops/s
- * customReplaceNoMatch                      thrpt    5  19068305.638 ±        54315.365   ops/s
- * stringReplaceMatch                        thrpt    5   4606323.928 ±        36878.183   ops/s
- * stringReplaceNoMatch                      thrpt    5   4636115.030 ±        22758.712   ops/s
+ * Benchmark                                  Mode  Cnt          Score         Error   Units
+ * customReplaceMatch                        thrpt    5   32004441.157 ± 1124280.222   ops/s
+ * customReplaceNoMatch                      thrpt    5  265951976.539 ± 3763154.472   ops/s
+ * stringReplaceMatch                        thrpt    5     793429.235 ±   11693.098   ops/s
+ * stringReplaceNoMatch                      thrpt    5     813017.866 ±   17047.396   ops/s
  *
- * Benchmark                                  Mode  Cnt         Score              Error   Units
- * customReplaceMatch           gc.alloc.rate.norm    5       141.733 ±           88.578    B/op
- * customReplaceNoMatch         gc.alloc.rate.norm    5       152.020 ±            0.002    B/op
- * stringReplaceMatch           gc.alloc.rate.norm    5      2584.079 ±            0.006    B/op
- * stringReplaceNoMatch         gc.alloc.rate.norm    5      2584.079 ±            0.006    B/op
+ *
+ * Benchmark                                  Mode  Cnt          Score         Error   Units
+ * customReplaceMatch           gc.alloc.rate.norm    5        160.012 ±       0.001    B/op
+ * customReplaceNoMatch         gc.alloc.rate.norm    5          0.001 ±       0.001    B/op
+ * stringReplaceMatch           gc.alloc.rate.norm    5      17616.448 ±       0.029    B/op
+ * stringReplaceNoMatch         gc.alloc.rate.norm    5      17616.442 ±       0.045    B/op
  *
  * ## Java 17
  *
- * Benchmark                                  Mode  Cnt         Score        Error   Units
- * customReplaceMatch                        thrpt    5  26738250.771 ± 203389.685   ops/s
- * customReplaceNoMatch                      thrpt    5  27456054.651 ± 171103.076   ops/s
- * stringReplaceMatch                        thrpt    5  18817330.662 ±  91736.795   ops/s
- * stringReplaceNoMatch                      thrpt    5  18810950.123 ±  64060.629   ops/s
+ * Benchmark                                  Mode  Cnt          Score         Error   Units
+ * customReplaceMatch                        thrpt    5   22809472.437 ± 1075058.765   ops/s
+ * customReplaceNoMatch                      thrpt    5  529952552.582 ± 7374375.509   ops/s
+ * stringReplaceMatch                        thrpt    5    2247841.555 ±   58645.893   ops/s
+ * stringReplaceNoMatch                      thrpt    5    2156524.729 ±  498269.673   ops/s
  *
- * Benchmark                                  Mode  Cnt         Score        Error   Units
- * customReplaceMatch           gc.alloc.rate.norm    5       120.017 ±      0.001    B/op
- * customReplaceNoMatch         gc.alloc.rate.norm    5       120.016 ±      0.001    B/op
- * stringReplaceMatch           gc.alloc.rate.norm    5       120.024 ±      0.001    B/op
- * stringReplaceNoMatch         gc.alloc.rate.norm    5       120.023 ±      0.001    B/op
- *
+ * Benchmark                                  Mode  Cnt          Score         Error   Units
+ * customReplaceMatch           gc.alloc.rate.norm    5        160.019 ±       0.001    B/op
+ * customReplaceNoMatch         gc.alloc.rate.norm    5          0.001 ±       0.001    B/op
+ * stringReplaceMatch           gc.alloc.rate.norm    5        888.197 ±       0.001    B/op
+ * stringReplaceNoMatch         gc.alloc.rate.norm    5        888.201 ±       0.036    B/op
  * </pre>
  */
 @State(Scope.Thread)
 public class MappingExprSubstitute {
 
-  private static final Map<String, String> VARS = Collections.singletonMap("{variable}", "value");
+  private static final Map<String, String> VARS = new HashMap<>();
 
-  static String substituteCustom(String pattern, Map<String, String> vars) {
-    String value = pattern;
-    for (Map.Entry<String, String> entry : vars.entrySet()) {
-      String raw = entry.getValue();
-      String v = Introspector.decapitalize(raw);
-      value = MappingExpr.replace(value, "{raw:" + entry.getKey() + "}", raw);
-      value = MappingExpr.replace(value, "{" + entry.getKey() + "}", v);
-    }
-    return value;
+  static {
+    VARS.put("keyspace", "test");
+    VARS.put("scope", "foo");
+    VARS.put("name", "ReadLatency");
+    VARS.put("type", "ColumnFamily");
+    VARS.put("LatencyUnit", "MICROSECONDS");
+    VARS.put("RateUnit", "SECONDS");
+    VARS.put("EventType", "calls");
   }
 
   static String substituteString(String pattern, Map<String, String> vars) {
@@ -84,12 +83,12 @@ public class MappingExprSubstitute {
 
   @Benchmark
   public void customReplaceMatch(Blackhole bh) {
-    bh.consume(substituteCustom("{variable}", VARS));
+    bh.consume(MappingExpr.substitute("{variable}", VARS));
   }
 
   @Benchmark
   public void customReplaceNoMatch(Blackhole bh) {
-    bh.consume(substituteCustom("abcdefghi", VARS));
+    bh.consume(MappingExpr.substitute("abcdefghi", VARS));
   }
 
   @Benchmark

--- a/spectator-ext-jvm/src/main/java/com/netflix/spectator/jvm/MappingExpr.java
+++ b/spectator-ext-jvm/src/main/java/com/netflix/spectator/jvm/MappingExpr.java
@@ -42,6 +42,7 @@ final class MappingExpr {
    *     String with values substituted in. If no matching key is found for a
    *     placeholder, then it will not be modified and left in place.
    */
+  @SuppressWarnings("PMD.NPathComplexity")
   static String substitute(String pattern, Map<String, String> vars) {
     int openBracePos = pattern.indexOf('{');
     if (openBracePos == -1) {

--- a/spectator-ext-jvm/src/main/java/com/netflix/spectator/jvm/MappingExpr.java
+++ b/spectator-ext-jvm/src/main/java/com/netflix/spectator/jvm/MappingExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2023 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,28 @@ final class MappingExpr {
   }
 
   /**
+   * On Java 8, the {@code String.replace} call uses a regex internally which results
+   * in a considerable overhead. This does a simple replace without using regex.
+   */
+  static String replace(String str, String target, String replacement) {
+    int pos = str.indexOf(target);
+    if (pos == -1) {
+      return str;
+    }
+
+    StringBuilder builder = new StringBuilder();
+    String tmp = str;
+    while (pos >= 0) {
+      builder.append(tmp.substring(0, pos)).append(replacement);
+      tmp = tmp.substring(pos + target.length());
+      pos = tmp.indexOf(target);
+    }
+    builder.append(tmp);
+
+    return builder.toString();
+  }
+
+  /**
    * Substitute named variables in the pattern string with the corresponding
    * values in the variables map.
    *
@@ -47,8 +69,8 @@ final class MappingExpr {
     for (Map.Entry<String, String> entry : vars.entrySet()) {
       String raw = entry.getValue();
       String v = Introspector.decapitalize(raw);
-      value = value.replace("{raw:" + entry.getKey() + "}", raw);
-      value = value.replace("{" + entry.getKey() + "}", v);
+      value = replace(value, "{raw:" + entry.getKey() + "}", raw);
+      value = replace(value, "{" + entry.getKey() + "}", v);
     }
     return value;
   }

--- a/spectator-ext-jvm/src/test/java/com/netflix/spectator/jvm/MappingExprTest.java
+++ b/spectator-ext-jvm/src/test/java/com/netflix/spectator/jvm/MappingExprTest.java
@@ -25,34 +25,6 @@ import java.util.Map;
 public class MappingExprTest {
 
   @Test
-  public void replaceSingle() {
-    Assertions.assertEquals("123", MappingExpr.replace("{def}", "{def}", "123"));
-    Assertions.assertEquals("abc123", MappingExpr.replace("abc{def}", "{def}", "123"));
-    Assertions.assertEquals("123abc", MappingExpr.replace("{def}abc", "{def}", "123"));
-  }
-
-  @Test
-  public void replaceMulitple() {
-    String expected = "_a_bc_ghi{de}k_";
-    String actual = MappingExpr.replace("{def}a{def}bc{def}ghi{de}k{def}", "{def}", "_");
-    Assertions.assertEquals(expected, actual);
-  }
-
-  @Test
-  public void replaceNone() {
-    String expected = "abcdef";
-    String actual = MappingExpr.replace("abcdef", "{def}", "_");
-    Assertions.assertSame(expected, actual);
-  }
-
-  @Test
-  public void replaceRecursive() {
-    String expected = "abcdef{def}";
-    String actual = MappingExpr.replace("abc{def}", "{def}", "def{def}");
-    Assertions.assertEquals(expected, actual);
-  }
-
-  @Test
   public void substituteEmpty() {
     Map<String, String> vars = new HashMap<>();
     String actual = MappingExpr.substitute("", vars);
@@ -75,11 +47,43 @@ public class MappingExprTest {
   }
 
   @Test
+  public void substituteSingleEmptyVarName() {
+    Map<String, String> vars = new HashMap<>();
+    vars.put("", "123");
+    String actual = MappingExpr.substitute("abc{}", vars);
+    Assertions.assertEquals("abc123", actual);
+  }
+
+  @Test
+  public void substituteSingleMissingClose() {
+    Map<String, String> vars = new HashMap<>();
+    vars.put("def", "123");
+    String actual = MappingExpr.substitute("abc{def", vars);
+    Assertions.assertEquals("abc{def", actual);
+  }
+
+  @Test
   public void substituteMultiple() {
     Map<String, String> vars = new HashMap<>();
     vars.put("def", "123");
     String actual = MappingExpr.substitute("abc{def}, {def}", vars);
     Assertions.assertEquals("abc123, 123", actual);
+  }
+
+  @Test
+  public void substituteMultipleMissingClose() {
+    Map<String, String> vars = new HashMap<>();
+    vars.put("def", "123");
+    String actual = MappingExpr.substitute("abc{def}, {def", vars);
+    Assertions.assertEquals("abc123, {def", actual);
+  }
+
+  @Test
+  public void substituteMultipleContainsOpenBrace() {
+    Map<String, String> vars = new HashMap<>();
+    vars.put("def, {def", "123");
+    String actual = MappingExpr.substitute("abc{def, {def}", vars);
+    Assertions.assertEquals("abc123", actual);
   }
 
   @Test
@@ -104,6 +108,14 @@ public class MappingExprTest {
     Map<String, String> vars = new HashMap<>();
     vars.put("name", "FooBarBaz");
     String actual = MappingExpr.substitute("abc.def.{raw:name}", vars);
+    Assertions.assertEquals("abc.def.FooBarBaz", actual);
+  }
+
+  @Test
+  public void substituteRawEmtpyVarName() {
+    Map<String, String> vars = new HashMap<>();
+    vars.put("", "FooBarBaz");
+    String actual = MappingExpr.substitute("abc.def.{raw:}", vars);
     Assertions.assertEquals("abc.def.FooBarBaz", actual);
   }
 

--- a/spectator-ext-jvm/src/test/java/com/netflix/spectator/jvm/MappingExprTest.java
+++ b/spectator-ext-jvm/src/test/java/com/netflix/spectator/jvm/MappingExprTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2023 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,34 @@ import java.util.Map;
 
 
 public class MappingExprTest {
+
+  @Test
+  public void replaceSingle() {
+    Assertions.assertEquals("123", MappingExpr.replace("{def}", "{def}", "123"));
+    Assertions.assertEquals("abc123", MappingExpr.replace("abc{def}", "{def}", "123"));
+    Assertions.assertEquals("123abc", MappingExpr.replace("{def}abc", "{def}", "123"));
+  }
+
+  @Test
+  public void replaceMulitple() {
+    String expected = "_a_bc_ghi{de}k_";
+    String actual = MappingExpr.replace("{def}a{def}bc{def}ghi{de}k{def}", "{def}", "_");
+    Assertions.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void replaceNone() {
+    String expected = "abcdef";
+    String actual = MappingExpr.replace("abcdef", "{def}", "_");
+    Assertions.assertSame(expected, actual);
+  }
+
+  @Test
+  public void replaceRecursive() {
+    String expected = "abcdef{def}";
+    String actual = MappingExpr.replace("abc{def}", "{def}", "def{def}");
+    Assertions.assertEquals(expected, actual);
+  }
 
   @Test
   public void substituteEmpty() {


### PR DESCRIPTION
The variable substitution when processing JMX data used the `String.replace` function. On java 8 this internally uses regex which is costly to compile. This change switches it to a custom function for replacing the values. On newer java versions the default is more efficient and doesn't use regex, but the custom version still seems to be a little better for the sample data tested.