### PR TITLE
update benchmark for substitutions

### DIFF
--- a/spectator-ext-jvm/src/jmh/java/com/netflix/spectator/jvm/MappingExprSubstitute.java
+++ b/spectator-ext-jvm/src/jmh/java/com/netflix/spectator/jvm/MappingExprSubstitute.java
@@ -83,7 +83,7 @@ public class MappingExprSubstitute {
 
   @Benchmark
   public void customReplaceMatch(Blackhole bh) {
-    bh.consume(MappingExpr.substitute("{variable}", VARS));
+    bh.consume(MappingExpr.substitute("{keyspace}", VARS));
   }
 
   @Benchmark
@@ -93,7 +93,7 @@ public class MappingExprSubstitute {
 
   @Benchmark
   public void stringReplaceMatch(Blackhole bh) {
-    bh.consume(substituteString("{variable}", VARS));
+    bh.consume(substituteString("{keyspace}", VARS));
   }
 
   @Benchmark


### PR DESCRIPTION
Fix variable name to something that is in the sample map.