### PR TITLE
switch spark ext to sidecar registry

### DIFF
--- a/spectator-ext-spark/README.md
+++ b/spectator-ext-spark/README.md
@@ -1,7 +1,7 @@
 ## Description
 
 Implementation of `org.apache.spark.metrics.sink.Sink` for reporting Spark system metrics
-to a local sidecar using [spectator-reg-stateless](../spectator-reg-stateless/README.md).
+to a local sidecar using [spectator-reg-sidecar](../spectator-reg-sidecar/README.md).
 
 ## Gradle
 

--- a/spectator-ext-spark/build.gradle
+++ b/spectator-ext-spark/build.gradle
@@ -6,7 +6,7 @@ dependencies {
   api project(':spectator-api')
   implementation project(':spectator-ext-gc')
   implementation project(':spectator-ext-jvm')
-  implementation project(':spectator-reg-stateless')
+  implementation project(':spectator-reg-sidecar')
   implementation "com.typesafe:config"
   implementation 'io.dropwizard.metrics:metrics-core:3.1.2'
   implementation 'org.apache.spark:spark-core_2.10:1.6.1'
@@ -29,7 +29,7 @@ shadowJar {
     include project(':spectator-ext-gc')
     include project(':spectator-ext-ipc')
     include project(':spectator-ext-jvm')
-    include project(':spectator-reg-stateless')
+    include project(':spectator-reg-sidecar')
     include dependency("com.fasterxml.jackson.core:jackson-core")
     include dependency("com.typesafe:config")
   }

--- a/spectator-ext-spark/src/main/java/com/netflix/spectator/spark/SpectatorConfig.java
+++ b/spectator-ext-spark/src/main/java/com/netflix/spectator/spark/SpectatorConfig.java
@@ -15,14 +15,13 @@
  */
 package com.netflix.spectator.spark;
 
-import com.netflix.spectator.stateless.StatelessConfig;
+import com.netflix.spectator.sidecar.SidecarConfig;
 import com.typesafe.config.Config;
 
-import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 
-class SpectatorConfig implements StatelessConfig {
+class SpectatorConfig implements SidecarConfig {
 
   private final Config config;
 
@@ -36,43 +35,13 @@ class SpectatorConfig implements StatelessConfig {
   }
 
   @Override
-  public boolean enabled() {
-    return config.getBoolean("enabled");
-  }
-
-  @Override
-  public Duration meterTTL() {
-    return config.getDuration("meter-ttl");
-  }
-
-  @Override
-  public Duration frequency() {
-    return config.getDuration("frequency");
-  }
-
-  @Override
-  public Duration connectTimeout() {
-    return config.getDuration("connect-timeout");
-  }
-
-  @Override
-  public Duration readTimeout() {
-    return config.getDuration("read-timeout");
-  }
-
-  @Override
-  public String uri() {
-    return config.getString("uri");
-  }
-
-  @Override
-  public int batchSize() {
-    return config.getInt("batch-size");
+  public String outputLocation() {
+    return config.getString("output-location");
   }
 
   @Override
   public Map<String, String> commonTags() {
-    Map<String, String> tags = new HashMap<>();
+    Map<String, String> tags = new HashMap<>(SidecarConfig.super.commonTags());
     for (Config cfg : config.getConfigList("tags")) {
       // These are often populated by environment variables that can sometimes be empty
       // rather than not set when missing. Empty strings are not allowed by Atlas.

--- a/spectator-ext-spark/src/main/resources/reference.conf
+++ b/spectator-ext-spark/src/main/resources/reference.conf
@@ -1,14 +1,8 @@
 
 spectator.spark {
 
-  stateless {
-    enabled = true
-    frequency = 5s
-    meter-ttl = 15m
-    connect-timeout = 1s
-    read-timeout = 10s
-    uri = "http://localhost:7101/api/v4/update"
-    batch-size = 10000
+  sidecar {
+    output-location = "udp://127.0.0.1:1234"
 
     tags = [
       // {

--- a/spectator-ext-spark/src/test/java/com/netflix/spectator/spark/SpectatorConfigTest.java
+++ b/spectator-ext-spark/src/test/java/com/netflix/spectator/spark/SpectatorConfigTest.java
@@ -1,30 +1,17 @@
 package com.netflix.spectator.spark;
 
-import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.time.Duration;
-
 public class SpectatorConfigTest {
 
   private final SpectatorConfig config = new SpectatorConfig(
-      ConfigFactory.load().getConfig("spectator.spark.stateless")
+      ConfigFactory.load().getConfig("spectator.spark.sidecar")
   );
 
   @Test
   public void enabled() {
-    Assertions.assertTrue(config.enabled());
-  }
-
-  @Test
-  public void frequency() {
-    Assertions.assertEquals(Duration.ofSeconds(5), config.frequency());
-  }
-
-  @Test
-  public void meterTTL() {
-    Assertions.assertEquals(Duration.ofMinutes(15), config.meterTTL());
+    Assertions.assertFalse(config.outputLocation().isEmpty());
   }
 }


### PR DESCRIPTION
Spark ext uses stateless registry that is deprecated according to its README.

Switch spark ext to sidecar registry in order to send metrics to the local spectatord.