### PR TITLE
include slf4j in spark shadow jar

### DIFF
--- a/spectator-ext-spark/build.gradle
+++ b/spectator-ext-spark/build.gradle
@@ -39,7 +39,8 @@ shadowJar {
     include project(':spectator-ext-ipc')
     include project(':spectator-ext-jvm')
     include project(':spectator-reg-sidecar')
-    include dependency("com.typesafe:config")
+    include dependency('com.typesafe:config')
+    include dependency('org.slf4j:slf4j-api')
   }
   minimize()
 


### PR DESCRIPTION
We are relocating to avoid conflicts, but the jar wasn't added to the dependency list so it results in a class not found error.