### PR TITLE
make spark deps compileOnly

### DIFF
--- a/spectator-ext-spark/build.gradle
+++ b/spectator-ext-spark/build.gradle
@@ -8,8 +8,8 @@ dependencies {
   implementation project(':spectator-ext-jvm')
   implementation project(':spectator-reg-sidecar')
   implementation "com.typesafe:config"
-  implementation 'io.dropwizard.metrics:metrics-core:3.1.5'
-  implementation 'org.apache.spark:spark-core_2.11:2.4.4'
+  compileOnly 'io.dropwizard.metrics:metrics-core:3.1.5'
+  compileOnly 'org.apache.spark:spark-core_2.11:2.4.4'
 }
 
 jar {

--- a/spectator-ext-spark/build.gradle
+++ b/spectator-ext-spark/build.gradle
@@ -10,6 +10,8 @@ dependencies {
   implementation "com.typesafe:config"
   compileOnly 'io.dropwizard.metrics:metrics-core:3.1.5'
   compileOnly 'org.apache.spark:spark-core_2.11:2.4.4'
+  testImplementation 'io.dropwizard.metrics:metrics-core:3.1.5'
+  testImplementation 'org.apache.spark:spark-core_2.11:2.4.4'
 }
 
 jar {


### PR DESCRIPTION
This should avoid changing the spark version used if someone is pulling this in with maven or gradle.