### PR TITLE
reduce overhead for expiration pass

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/AbstractRegistry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/AbstractRegistry.java
@@ -291,11 +291,10 @@ public abstract class AbstractRegistry implements Registry {
   protected void removeExpiredMeters() {
     int total = 0;
     int expired = 0;
-    Iterator<Map.Entry<Id, Meter>> it = meters.entrySet().iterator();
+    Iterator<Meter> it = meters.values().iterator();
     while (it.hasNext()) {
       ++total;
-      Map.Entry<Id, Meter> entry = it.next();
-      Meter m = entry.getValue();
+      Meter m = it.next();
       if (m.hasExpired()) {
         ++expired;
         it.remove();
@@ -309,7 +308,7 @@ public abstract class AbstractRegistry implements Registry {
    * Cleanup any expired meter patterns stored in the state. It should only be used as
    * a cache so the entry should get recreated if needed.
    */
-  private void cleanupCachedState() {
+  protected void cleanupCachedState() {
     int total = 0;
     int expired = 0;
     Iterator<Map.Entry<Id, Object>> it = state.entrySet().iterator();

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasMeter.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasMeter.java
@@ -59,7 +59,11 @@ abstract class AtlasMeter implements Meter {
   }
 
   @Override public boolean hasExpired() {
-    return clock.wallTime() - lastUpdated > ttl;
+    return hasExpired(clock.wallTime());
+  }
+
+  boolean hasExpired(long now) {
+    return now - lastUpdated > ttl;
   }
 
   @Override public Iterable<Measurement> measure() {

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
@@ -344,8 +344,20 @@ public final class AtlasRegistry extends AbstractRegistry implements AutoCloseab
    */
   @SuppressWarnings("PMD.UselessOverridingMethod")
   @Override public void removeExpiredMeters() {
-    // Overridden to increase visibility from protected in base class to public
-    super.removeExpiredMeters();
+    long now = clock().wallTime();
+    int total = 0;
+    int expired = 0;
+    Iterator<Meter> it = iterator();
+    while (it.hasNext()) {
+      ++total;
+      AtlasMeter m = (AtlasMeter) it.next();
+      if (m.hasExpired(now)) {
+        ++expired;
+        it.remove();
+      }
+    }
+    logger.debug("removed {} expired meters out of {} total", expired, total);
+    cleanupCachedState();
   }
 
   private void fetchSubscriptions() {


### PR DESCRIPTION
Tune the `removeExpiredMeters` method to make it a bit more efficient. Uses the values iterator rather than entries so Entry objects are not needed. For the Atlas registry, the timestamp for the expiration check will now be computed once rather than once per meter.