### PR TITLE
always expand in clauses for name key

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Query.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Query.java
@@ -592,7 +592,10 @@ public interface Query {
       // to be indexed more efficiently. The size is limited because if there are
       // multiple large in clauses in an expression the cross product can become really
       // large.
-      if (vs.size() <= 5) {
+      //
+      // The name key is always expanded as it is used as the root of the QueryIndex. Early
+      // filtering at the root has a big impact on matching performance.
+      if ("name".equals(k) || vs.size() <= 5) {
         List<Query> queries = new ArrayList<>(vs.size());
         for (String v : vs) {
           queries.add(new Query.Equal(k, v));


### PR DESCRIPTION
The name is used as the root of the query index and can have a big impact on the performance of matching against the index. Always expand the name when used with an in clause so it will increase the probability of a quick first match.