### PR TITLE
support more customization for evaluator

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Consolidator.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Consolidator.java
@@ -125,7 +125,7 @@ public interface Consolidator {
   }
 
   /**
-   * Placeholder implementation used when the the primary and consolidated step sizes are
+   * Placeholder implementation used when the primary and consolidated step sizes are
    * the same.
    */
   final class None implements Consolidator {

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/EvaluatorConfig.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/EvaluatorConfig.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas.impl;
+
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.NoopRegistry;
+import com.netflix.spectator.atlas.AtlasConfig;
+
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Additional interface that can be implemented by the AtlasConfig instance providing knobs
+ * for internal registry details.
+ *
+ * <p><b>Classes in this package are only intended for use internally within spectator. They may
+ * change at any time and without notice.</b>
+ */
+public interface EvaluatorConfig {
+
+  /** Create a new instance from an AtlasConfig. */
+  static EvaluatorConfig fromAtlasConfig(AtlasConfig config) {
+    if (config instanceof EvaluatorConfig) {
+      return (EvaluatorConfig) config;
+    } else {
+      return new EvaluatorConfig() {
+        @Override public long evaluatorStepSize() {
+          return config.lwcStep().toMillis();
+        }
+
+        @Override public Map<String, String> commonTags() {
+          return config.commonTags();
+        }
+
+        @Override public Function<Id, Map<String, String>> idMapper() {
+          return new IdMapper(JsonUtils.createReplacementFunction(config.validTagCharacters()));
+        }
+      };
+    }
+  }
+
+  /** Step size used for the raw measurements. */
+  long evaluatorStepSize();
+
+  /** Returns the common tags to apply to all metrics reported to Atlas. */
+  Map<String, String> commonTags();
+
+  /** Function to convert an id to a map of key/value pairs. */
+  default Function<Id, Map<String, String>> idMapper() {
+    return new IdMapper(Function.identity());
+  }
+
+  /** Supplier for cache to use within the evaluator query index. */
+  default <T> QueryIndex.CacheSupplier<T> indexCacheSupplier() {
+    return new QueryIndex.DefaultCacheSupplier<>(new NoopRegistry());
+  }
+}

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/IdMapper.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/IdMapper.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas.impl;
+
+import com.netflix.spectator.api.Id;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Default mapping function from an Id to a Map.
+ *
+ * <p><b>Classes in this package are only intended for use internally within spectator. They may
+ * change at any time and without notice.</b>
+ */
+public final class IdMapper implements Function<Id, Map<String, String>> {
+
+  private final Function<String, String> fixTagString;
+
+  /** Create a new instance using the provided function to fix invalid characters in the tags. */
+  public IdMapper(Function<String, String> fixTagString) {
+    this.fixTagString = fixTagString;
+  }
+
+  @Override
+  public Map<String, String> apply(Id id) {
+    int size = id.size();
+    Map<String, String> tags = new HashMap<>(size);
+
+    // Start at 1 as name will be added last
+    for (int i = 1; i < size; ++i) {
+      String k = fixTagString.apply(id.getKey(i));
+      String v = fixTagString.apply(id.getValue(i));
+      tags.put(k, v);
+    }
+
+    // Add the name, it is added last so it will have precedence if the user tried to
+    // use a tag key of "name".
+    String name = fixTagString.apply(id.name());
+    tags.put("name", name);
+
+    return tags;
+  }
+}

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/EvaluatorTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/EvaluatorTest.java
@@ -19,8 +19,8 @@ import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.ManualClock;
 import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.NoopRegistry;
 import com.netflix.spectator.api.Registry;
-import com.netflix.spectator.api.Tag;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -30,6 +30,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 
 public class EvaluatorTest {
@@ -47,26 +48,17 @@ public class EvaluatorTest {
     return ms;
   }
 
-  private TagsValuePair newTagsValuePair(Measurement m) {
-    Map<String, String> tags = new HashMap<>();
-    for (Tag t : m.id().tags()) {
-      tags.put(t.key(), t.value());
-    }
-    tags.put("name", m.id().name());
-    return new TagsValuePair(tags, m.value());
-  }
-
-  private Map<String, String> toMap(Id id) {
-    Map<String, String> tags = new HashMap<>();
-    for (Tag t : id.tags()) {
-      tags.put(t.key(), t.value());
-    }
-    tags.put("name", id.name());
-    return tags;
-  }
-
   private Evaluator newEvaluator(String... commonTags) {
-    return new Evaluator(tags(commonTags), this::toMap, 5000);
+    EvaluatorConfig config = new EvaluatorConfig() {
+      @Override public long evaluatorStepSize() {
+        return 5000L;
+      }
+
+      @Override public Map<String, String> commonTags() {
+        return tags(commonTags);
+      }
+    };
+    return new Evaluator(config);
   }
 
   private Map<String, String> tags(String... ts) {


### PR DESCRIPTION
For some internal uses under heavy load, such as aggregators, it is desirable to have more control over some of the settings used with the LWC evaluator. In particular, this allows for tuning the cache behavior used with the index. Later it can be extended to support parallelism for matching against the index.