### PR TITLE
support parallel polling of measurements

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/EvaluatorConfig.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/EvaluatorConfig.java
@@ -67,4 +67,13 @@ public interface EvaluatorConfig {
   default <T> QueryIndex.CacheSupplier<T> indexCacheSupplier() {
     return new QueryIndex.DefaultCacheSupplier<>(new NoopRegistry());
   }
+
+  /**
+   * Returns true if the measurements should be polled in parallel using the default
+   * common fork join pool. For apps that are mostly just reporting metrics this can be
+   * useful to more quickly process them. Default is false.
+   */
+  default boolean parallelMeasurementPolling() {
+    return false;
+  }
 }


### PR DESCRIPTION
Add option to poll measurements concurrently. This can be useful for apps that mostly just report metrics and are not doing other work. It is disabled by default to ensure there isn't heavy load for other apps.