### PR TITLE
reduce allocations for refreshing subscriptions

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/impl/StreamHelper.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/StreamHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2021 Netflix, Inc.
+ * Copyright 2014-2023 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.spectator.atlas.impl;
+package com.netflix.spectator.impl;
 
 import java.io.ByteArrayOutputStream;
 
@@ -21,16 +21,19 @@ import java.io.ByteArrayOutputStream;
  * Caches ByteArrayOutputStream objects in a thread local to allow for reuse. This can be
  * useful to reduce the allocations for growing the buffer. It will hold onto the streams
  * so it should only be used for use-cases where the data written to the stream is bounded.
+ *
+ * <p><b>This class is an internal implementation detail only intended for use within spectator.
+ * It is subject to change without notice.</b></p>
  */
-final class StreamHelper {
+public final class StreamHelper {
 
   private final ThreadLocal<ByteArrayOutputStream> streams;
 
-  StreamHelper() {
+  public StreamHelper() {
     streams = new ThreadLocal<>();
   }
 
-  ByteArrayOutputStream getOrCreateStream() {
+  public ByteArrayOutputStream getOrCreateStream() {
     ByteArrayOutputStream baos = streams.get();
     if (baos == null) {
       baos = new ByteArrayOutputStream();

--- a/spectator-api/src/test/java/com/netflix/spectator/impl/StreamHelperTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/StreamHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2021 Netflix, Inc.
+ * Copyright 2014-2023 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.spectator.atlas.impl;
+package com.netflix.spectator.impl;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/SubscriptionManager.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/SubscriptionManager.java
@@ -83,6 +83,7 @@ class SubscriptionManager {
           .withReadTimeout(readTimeout)
           .acceptGzip()
           .addHeader("If-None-Match", etag)
+          .reuseResponseBuffers(true)
           .send();
       if (res.status() == 304) {
         LOGGER.debug("no modification to subscriptions");

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/DefaultPublisher.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/DefaultPublisher.java
@@ -23,6 +23,7 @@ import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.atlas.AtlasConfig;
 import com.netflix.spectator.atlas.AtlasRegistry;
 import com.netflix.spectator.atlas.Publisher;
+import com.netflix.spectator.impl.StreamHelper;
 import com.netflix.spectator.ipc.http.HttpClient;
 import com.netflix.spectator.ipc.http.HttpResponse;
 import org.slf4j.Logger;


### PR DESCRIPTION
If there are a large number of subscriptions, then there can be a significant number of allocations from growing the ByteArrayOutputStream when consuming the response. Adds an option to the request builder to enable reusing the buffers.