### PR TITLE
reduce overhead for cached stat id

### DIFF
--- a/spectator-reg-atlas/src/jmh/java/com/netflix/spectator/atlas/EnsureIdTags.java
+++ b/spectator-reg-atlas/src/jmh/java/com/netflix/spectator/atlas/EnsureIdTags.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Statistic;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * <pre>
+ * Benchmark                          Mode  Cnt         Score        Error   Units
+ * checkMissing                      thrpt    5   7446459.299 ± 236506.306   ops/s
+ * checkMissing:·gc.alloc.rate       thrpt    5      1875.207 ±     59.556  MB/sec
+ * checkMissing:·gc.alloc.rate.norm  thrpt    5       264.062 ±      0.003    B/op
+ * checkMissing:·gc.count            thrpt    5       313.000               counts
+ * checkMissing:·gc.time             thrpt    5       153.000                   ms
+ * checkMissing:·stack               thrpt                NaN                  ---
+ * checkPresent                      thrpt    5  48437646.563 ± 601766.743   ops/s
+ * checkPresent:·gc.alloc.rate       thrpt    5         0.426 ±      0.006  MB/sec
+ * checkPresent:·gc.alloc.rate.norm  thrpt    5         0.009 ±      0.001    B/op
+ * checkPresent:·gc.count            thrpt    5         1.000               counts
+ * checkPresent:·gc.time             thrpt    5         2.000                   ms
+ * checkPresent:·stack               thrpt                NaN                  ---
+ * newIdMissing                      thrpt    5   6415187.273 ± 188476.396   ops/s
+ * newIdMissing:·gc.alloc.rate       thrpt    5      2300.752 ±     67.568  MB/sec
+ * newIdMissing:·gc.alloc.rate.norm  thrpt    5       376.071 ±      0.004    B/op
+ * newIdMissing:·gc.count            thrpt    5       384.000               counts
+ * newIdMissing:·gc.time             thrpt    5       194.000                   ms
+ * newIdMissing:·stack               thrpt                NaN                  ---
+ * newIdPresent                      thrpt    5   7329062.490 ±  67842.114   ops/s
+ * newIdPresent:·gc.alloc.rate       thrpt    5      2740.286 ±     25.401  MB/sec
+ * newIdPresent:·gc.alloc.rate.norm  thrpt    5       392.062 ±      0.001    B/op
+ * newIdPresent:·gc.count            thrpt    5       373.000               counts
+ * newIdPresent:·gc.time             thrpt    5       190.000                   ms
+ * newIdPresent:·stack               thrpt                NaN                  ---
+ * </pre>
+ */
+@State(Scope.Thread)
+public class EnsureIdTags {
+
+  private static final Id BASE_ID = Id.create("ipc.server.call")
+      .withTag("nf.app", "www")
+      .withTag("nf.cluster", "www-main")
+      .withTag("nf.asg", "www-main-v001")
+      .withTag("nf.stack", "main")
+      .withTag("nf.node", "i-1234567890")
+      .withTag("nf.region", "us-east-1")
+      .withTag("nf.zone", "us-east-1c")
+      .withTag("nf.vmtype", "m5.xlarge")
+      .withTag("ipc.client.app", "db")
+      .withTag("ipc.client.cluster", "db-main")
+      .withTag("ipc.client.asg", "db-main-v042")
+      .withTag("ipc.endpoint", "/query")
+      .withTag("ipc.status", "success")
+      .withTag("ipc.status.detail", "200")
+      .withTag("ipc.result", "success");
+
+  private final Id STAT_ID = BASE_ID.withTag(Statistic.count).withTag(DsType.rate);
+
+  @Benchmark
+  public void newIdMissing(Blackhole bh) {
+    Id stat = Id.create(BASE_ID.name())
+        .withTag(Statistic.count)
+        .withTag(DsType.rate)
+        .withTags(BASE_ID.tags());
+    bh.consume(stat);
+  }
+
+  @Benchmark
+  public void newIdPresent(Blackhole bh) {
+    Id stat = Id.create(STAT_ID.name())
+        .withTag(Statistic.count)
+        .withTag(DsType.rate)
+        .withTags(STAT_ID.tags());
+    bh.consume(stat);
+  }
+
+  @Benchmark
+  public void checkMissing(Blackhole bh) {
+    Id stat = AtlasMeter.addIfMissing(BASE_ID, Statistic.count, DsType.rate);
+    bh.consume(stat);
+  }
+
+  @Benchmark
+  public void checkPresent(Blackhole bh) {
+    Id stat = AtlasMeter.addIfMissing(STAT_ID, Statistic.count, DsType.rate);
+    bh.consume(stat);
+  }
+}

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasCounter.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasCounter.java
@@ -37,10 +37,7 @@ class AtlasCounter extends AtlasMeter implements Counter {
     this.value = new StepDouble(0.0, clock, step);
     // Add the statistic for typing. Re-adding the tags from the id is to retain
     // the statistic from the id if it was already set
-    this.stat = Id.create(id.name())
-        .withTag(Statistic.count)
-        .withTag(DsType.rate)
-        .withTags(id.tags());
+    this.stat = AtlasMeter.addIfMissing(id, Statistic.count, DsType.rate);
   }
 
   @Override void measure(long now, MeasurementConsumer consumer) {

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasGauge.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasGauge.java
@@ -18,7 +18,6 @@ package com.netflix.spectator.atlas;
 import com.netflix.spectator.api.Clock;
 import com.netflix.spectator.api.Gauge;
 import com.netflix.spectator.api.Id;
-import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Statistic;
 import com.netflix.spectator.impl.AtomicDouble;
 
@@ -31,7 +30,7 @@ class AtlasGauge extends AtlasMeter implements Gauge {
   private final Id stat;
 
   /** Create a new instance. */
-  AtlasGauge(Registry registry, Id id, Clock clock, long ttl) {
+  AtlasGauge(Id id, Clock clock, long ttl) {
     super(id, clock, ttl);
     this.value = new AtomicDouble(0.0);
     // Add the statistic for typing. Re-adding the tags from the id is to retain

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasGauge.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasGauge.java
@@ -36,10 +36,7 @@ class AtlasGauge extends AtlasMeter implements Gauge {
     this.value = new AtomicDouble(0.0);
     // Add the statistic for typing. Re-adding the tags from the id is to retain
     // the statistic from the id if it was already set
-    this.stat = registry.createId(id.name())
-        .withTag(Statistic.gauge)
-        .withTag(DsType.gauge)
-        .withTags(id.tags());
+    this.stat = AtlasMeter.addIfMissing(id, Statistic.gauge, DsType.gauge);
   }
 
   @Override void measure(long now, MeasurementConsumer consumer) {

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasMaxGauge.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasMaxGauge.java
@@ -18,7 +18,6 @@ package com.netflix.spectator.atlas;
 import com.netflix.spectator.api.Clock;
 import com.netflix.spectator.api.Gauge;
 import com.netflix.spectator.api.Id;
-import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Statistic;
 import com.netflix.spectator.impl.StepDouble;
 
@@ -33,7 +32,7 @@ class AtlasMaxGauge extends AtlasMeter implements Gauge {
   private final Id stat;
 
   /** Create a new instance. */
-  AtlasMaxGauge(Registry registry, Id id, Clock clock, long ttl, long step) {
+  AtlasMaxGauge(Id id, Clock clock, long ttl, long step) {
     super(id, clock, ttl);
     // Initialize to NaN so that it can be used with negative values
     this.value = new StepDouble(Double.NaN, clock, step);

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasMaxGauge.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasMaxGauge.java
@@ -39,10 +39,7 @@ class AtlasMaxGauge extends AtlasMeter implements Gauge {
     this.value = new StepDouble(Double.NaN, clock, step);
     // Add the statistic for typing. Re-adding the tags from the id is to retain
     // the statistic from the id if it was already set
-    this.stat = registry.createId(id.name())
-        .withTag(Statistic.max)
-        .withTag(DsType.gauge)
-        .withTags(id.tags());
+    this.stat = AtlasMeter.addIfMissing(id, Statistic.max, DsType.gauge);
   }
 
   @Override void measure(long now, MeasurementConsumer consumer) {

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasMeter.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasMeter.java
@@ -20,7 +20,6 @@ import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Measurement;
 import com.netflix.spectator.api.Meter;
 import com.netflix.spectator.api.Tag;
-import com.netflix.spectator.api.TagList;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
@@ -434,10 +434,10 @@ public final class AtlasRegistry extends AbstractRegistry implements AutoCloseab
   @Override protected Gauge newGauge(Id id) {
     // Be sure to get StepClock so the measurements will have step aligned
     // timestamps.
-    return new AtlasGauge(this, id, stepClock, meterTTL);
+    return new AtlasGauge(id, stepClock, meterTTL);
   }
 
   @Override protected Gauge newMaxGauge(Id id) {
-    return new AtlasMaxGauge(this, id, clock(), meterTTL, lwcStepMillis);
+    return new AtlasMaxGauge(id, clock(), meterTTL, lwcStepMillis);
   }
 }

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasGaugeTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasGaugeTest.java
@@ -15,10 +15,9 @@
  */
 package com.netflix.spectator.atlas;
 
-import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.ManualClock;
 import com.netflix.spectator.api.Measurement;
-import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Statistic;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -27,9 +26,8 @@ import org.junit.jupiter.api.Test;
 public class AtlasGaugeTest {
 
   private final ManualClock clock = new ManualClock();
-  private final Registry registry = new DefaultRegistry();
   private final long step = 10000L;
-  private final AtlasGauge gauge = new AtlasGauge(registry, registry.createId("test"), clock, step);
+  private final AtlasGauge gauge = new AtlasGauge(Id.create("test"), clock, step);
 
   private void checkValue(long expected) {
     int count = 0;

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasMaxGaugeTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasMaxGaugeTest.java
@@ -15,10 +15,9 @@
  */
 package com.netflix.spectator.atlas;
 
-import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.ManualClock;
 import com.netflix.spectator.api.Measurement;
-import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Statistic;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -27,10 +26,8 @@ import org.junit.jupiter.api.Test;
 public class AtlasMaxGaugeTest {
 
   private final ManualClock clock = new ManualClock();
-  private final Registry registry = new DefaultRegistry();
   private final long step = 10000L;
-  private final AtlasMaxGauge gauge = new AtlasMaxGauge(registry,
-      registry.createId("test"), clock, step, step);
+  private final AtlasMaxGauge gauge = new AtlasMaxGauge(Id.create("test"), clock, step, step);
 
   private void checkValue(double expected) {
     int count = 0;


### PR DESCRIPTION
Updates how the cached stat id used for measurements is computed on simple meter types. Before it would always create a new id and then add back the original tags to overwrite. Now it will check to see if they are present and only add if missing. This ensures that at most a new id will be created once and in some cases not at all.