### PR TITLE
Override createId methods in AbstractRegistry and CompositeRegistry

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/AbstractRegistry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/AbstractRegistry.java
@@ -161,6 +161,24 @@ public abstract class AbstractRegistry implements Registry {
     }
   }
 
+  @Override public Id createId(String name, String... tags) {
+    try {
+      return new DefaultId(name, ArrayTagSet.create(tags));
+    } catch (Exception e) {
+      propagate(e);
+      return NoopId.INSTANCE;
+    }
+  }
+
+  @Override public Id createId(String name, Map<String, String> tags) {
+    try {
+      return new DefaultId(name, ArrayTagSet.create(tags));
+    } catch (Exception e) {
+      propagate(e);
+      return NoopId.INSTANCE;
+    }
+  }
+
   /**
    * Ensure a the id type is correct. While not recommended, nothing stops users from using a
    * custom implementation of the {@link Id} interface. This can create unexpected and strange

--- a/spectator-api/src/main/java/com/netflix/spectator/api/CompositeRegistry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/CompositeRegistry.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -119,6 +120,14 @@ public final class CompositeRegistry implements Registry {
   }
 
   @Override public Id createId(String name, Iterable<Tag> tags) {
+    return new DefaultId(name, ArrayTagSet.create(tags));
+  }
+
+  @Override public Id createId(String name, String... tags) {
+    return new DefaultId(name, ArrayTagSet.create(tags));
+  }
+
+  @Override public Id createId(String name, Map<String, String> tags) {
     return new DefaultId(name, ArrayTagSet.create(tags));
   }
 


### PR DESCRIPTION
The default implementation for some of the createId overloads in Registry don't create an ArrayTagSet directly and do some extra copying of tags.