### PR TITLE
ci: use Temurin distributions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,21 +15,21 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 19
-          distribution: 'zulu'
+          distribution: 'temurin'
           cache: 'gradle'
       - run: echo "JDK19=$JAVA_HOME" >> $GITHUB_ENV
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           java-version: 17
-          distribution: 'zulu'
+          distribution: 'temurin'
           cache: 'gradle'
       - run: echo "JDK17=$JAVA_HOME" >> $GITHUB_ENV
       - name: Set up JDK 8
         uses: actions/setup-java@v3
         with:
           java-version: 8
-          distribution: 'zulu'
+          distribution: 'temurin'
           cache: 'gradle'
       - run: echo "JDK8=$JAVA_HOME" >> $GITHUB_ENV
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,21 +18,21 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 19
-          distribution: 'zulu'
+          distribution: 'temurin'
           cache: 'gradle'
       - run: echo "JDK19=$JAVA_HOME" >> $GITHUB_ENV
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           java-version: 17
-          distribution: 'zulu'
+          distribution: 'temurin'
           cache: 'gradle'
       - run: echo "JDK17=$JAVA_HOME" >> $GITHUB_ENV
       - name: Set up JDK 8
         uses: actions/setup-java@v3
         with:
           java-version: 8
-          distribution: 'zulu'
+          distribution: 'temurin'
           cache: 'gradle'
       - run: echo "JDK8=$JAVA_HOME" >> $GITHUB_ENV
       - name: Build candidate

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -20,21 +20,21 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 19
-          distribution: 'zulu'
+          distribution: 'temurin'
           cache: 'gradle'
       - run: echo "JDK19=$JAVA_HOME" >> $GITHUB_ENV
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           java-version: 17
-          distribution: 'zulu'
+          distribution: 'temurin'
           cache: 'gradle'
       - run: echo "JDK17=$JAVA_HOME" >> $GITHUB_ENV
       - name: Set up JDK 8
         uses: actions/setup-java@v3
         with:
           java-version: 8
-          distribution: 'zulu'
+          distribution: 'temurin'
           cache: 'gradle'
       - run: echo "JDK8=$JAVA_HOME" >> $GITHUB_ENV
       - name: Build


### PR DESCRIPTION
Host runners include Temurin by default as part of the [hosted tool cache](https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#hosted-tool-cache). Using Temurin speeds up builds as there is no need to download and configure the Java SDK with every build.