### PR TITLE
support matching without structuring as an id

### DIFF
--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/QueryIndexTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/QueryIndexTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2022 Netflix, Inc.
+ * Copyright 2014-2023 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,21 +19,70 @@ import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.NoopRegistry;
 import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.impl.Cache;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.function.Function;
 
 public class QueryIndexTest {
 
   private final Registry registry = new DefaultRegistry();
+
+  private final QueryIndex.CacheSupplier<Query> cacheSupplier = new QueryIndex.CacheSupplier<Query>() {
+    @Override
+    public Cache<String, List<QueryIndex<Query>>> get() {
+      return new Cache<String, List<QueryIndex<Query>>>() {
+        private final Map<String, List<QueryIndex<Query>>> data = new HashMap<>();
+
+        @Override
+        public List<QueryIndex<Query>> get(String key) {
+          // Cache for a single call
+          return data.remove(key);
+        }
+
+        @Override
+        public List<QueryIndex<Query>> peek(String key) {
+          return null;
+        }
+
+        @Override
+        public void put(String key, List<QueryIndex<Query>> value) {
+          data.put(key, value);
+        }
+
+        @Override
+        public List<QueryIndex<Query>> computeIfAbsent(String key, Function<String, List<QueryIndex<Query>>> f) {
+          return data.computeIfAbsent(key, f);
+        }
+
+        @Override
+        public void clear() {
+          data.clear();
+        }
+
+        @Override
+        public int size() {
+          return data.size();
+        }
+
+        @Override
+        public Map<String, List<QueryIndex<Query>>> asMap() {
+          return new HashMap<>(data);
+        }
+      };
+    }
+  };
 
   private Id id(String name, String... tags) {
     return registry.createId(name, tags);
@@ -48,40 +97,46 @@ public class QueryIndexTest {
     return sort(Arrays.asList(vs));
   }
 
-  private List<Query> findMatches(QueryIndex<Query> idx, Id id) {
-    return sort(idx.findMatches(id));
-  }
-
   @Test
   public void empty() {
-    QueryIndex<Integer> idx = QueryIndex.newInstance(registry);
-    Assertions.assertTrue(idx.findMatches(id("a")).isEmpty());
+    QueryIndex<Query> idx = QueryIndex.newInstance(cacheSupplier);
+    assertEquals(Collections.emptyList(), idx, id("a"));
   }
 
   private static final Query SIMPLE_QUERY = Parser.parseQuery("name,a,:eq,key,b,:eq,:and");
 
   private QueryIndex<Query> simpleIdx() {
-    return QueryIndex.<Query>newInstance(registry).add(SIMPLE_QUERY, SIMPLE_QUERY);
+    return QueryIndex.newInstance(cacheSupplier).add(SIMPLE_QUERY, SIMPLE_QUERY);
+  }
+
+  private void assertEquals(List<Query> expected, QueryIndex<Query> idx, Id id) {
+    // Do multiple iterations just to exercise caching and cache expiration paths
+    for (int i = 0; i < 4; ++i) {
+      Assertions.assertEquals(expected, sort(idx.findMatches(id)));
+    }
+    for (int i = 0; i < 4; ++i) {
+      Assertions.assertEquals(expected, sort(idx.findMatches(Query.toMap(id)::get)));
+    }
   }
 
   @Test
   public void simpleMissingKey() {
     Id id = id("a", "foo", "bar");
-    Assertions.assertTrue(simpleIdx().findMatches(id).isEmpty());
+    assertEquals(Collections.emptyList(), simpleIdx(), id);
   }
 
   @Test
   public void simpleMatches() {
     Id id1 = id("a", "key", "b");
     Id id2 = id("a", "foo", "bar", "key", "b");
-    Assertions.assertEquals(list(SIMPLE_QUERY), simpleIdx().findMatches(id1));
-    Assertions.assertEquals(list(SIMPLE_QUERY), simpleIdx().findMatches(id2));
+    assertEquals(list(SIMPLE_QUERY), simpleIdx(), id1);
+    assertEquals(list(SIMPLE_QUERY), simpleIdx(),id2);
   }
 
   @Test
   public void simpleNameDoesNotMatch() {
     Id id = id("b", "foo", "bar");
-    Assertions.assertTrue(simpleIdx().findMatches(id).isEmpty());
+    assertEquals(Collections.emptyList(), simpleIdx(), id);
   }
 
   @Test
@@ -97,21 +152,21 @@ public class QueryIndexTest {
   private static final Query HASKEY_QUERY = Parser.parseQuery("name,a,:eq,key,b,:eq,:and,c,:has,:and");
 
   private QueryIndex<Query> hasKeyIdx() {
-    return QueryIndex.<Query>newInstance(registry).add(HASKEY_QUERY, HASKEY_QUERY);
+    return QueryIndex.newInstance(cacheSupplier).add(HASKEY_QUERY, HASKEY_QUERY);
   }
 
   @Test
   public void hasKeyMissingKey() {
     Id id = id("a", "key", "b", "foo", "bar");
-    Assertions.assertTrue(hasKeyIdx().findMatches(id).isEmpty());
+    assertEquals(Collections.emptyList(), hasKeyIdx(), id);
   }
 
   @Test
   public void hasKeyMatches() {
     Id id1 = id("a", "key", "b", "c", "12345");
     Id id2 = id("a", "foo", "bar", "key", "b", "c", "foobar");
-    Assertions.assertEquals(list(HASKEY_QUERY), hasKeyIdx().findMatches(id1));
-    Assertions.assertEquals(list(HASKEY_QUERY), hasKeyIdx().findMatches(id2));
+    assertEquals(list(HASKEY_QUERY), hasKeyIdx(), id1);
+    assertEquals(list(HASKEY_QUERY), hasKeyIdx(), id2);
   }
 
   @Test
@@ -120,77 +175,77 @@ public class QueryIndexTest {
     QueryIndex<Query> idx = hasKeyIdx();
     for (int i = 0; i < 10; ++i) {
       // Subsequent checks for :has operation should come from cache
-      Assertions.assertEquals(list(HASKEY_QUERY), idx.findMatches(id1));
+      assertEquals(list(HASKEY_QUERY), idx, id1);
     }
   }
 
   private static final Query IN_QUERY = Parser.parseQuery("name,a,:eq,key,(,b,c,),:in,:and");
 
   private QueryIndex<Query> inIdx() {
-    return QueryIndex.<Query>newInstance(registry).add(IN_QUERY, IN_QUERY);
+    return QueryIndex.newInstance(cacheSupplier).add(IN_QUERY, IN_QUERY);
   }
 
   @Test
   public void inMissingKey() {
     Id id = id("a", "key2", "b", "foo", "bar");
-    Assertions.assertTrue(inIdx().findMatches(id).isEmpty());
+    assertEquals(Collections.emptyList(), inIdx(), id);
   }
 
   @Test
   public void inMatches() {
     Id id1 = id("a", "key", "b", "c", "12345");
     Id id2 = id("a", "foo", "bar", "key", "c", "c", "foobar");
-    Assertions.assertEquals(list(IN_QUERY), inIdx().findMatches(id1));
-    Assertions.assertEquals(list(IN_QUERY), inIdx().findMatches(id2));
+    assertEquals(list(IN_QUERY), inIdx(), id1);
+    assertEquals(list(IN_QUERY), inIdx(), id2);
   }
 
   @Test
   public void inValueNotInSet() {
     Id id = id("a", "key", "d", "c", "12345");
-    Assertions.assertTrue(inIdx().findMatches(id).isEmpty());
+    assertEquals(Collections.emptyList(), inIdx(), id);
   }
 
   @Test
   public void trueMatches() {
-    QueryIndex<Query> idx = QueryIndex.<Query>newInstance(registry).add(Query.TRUE, Query.TRUE);
+    QueryIndex<Query> idx = QueryIndex.newInstance(cacheSupplier).add(Query.TRUE, Query.TRUE);
     Id id1 = id("a", "key", "b", "c", "12345");
     Id id2 = id("a", "foo", "bar", "key", "b", "c", "foobar");
-    Assertions.assertEquals(list(Query.TRUE), idx.findMatches(id1));
-    Assertions.assertEquals(list(Query.TRUE), idx.findMatches(id2));
+    assertEquals(list(Query.TRUE), idx, id1);
+    assertEquals(list(Query.TRUE), idx, id2);
   }
 
   @Test
   public void falseDoesNotMatch() {
-    QueryIndex<Query> idx = QueryIndex.<Query>newInstance(registry).add(Query.FALSE, Query.FALSE);
+    QueryIndex<Query> idx = QueryIndex.newInstance(cacheSupplier).add(Query.FALSE, Query.FALSE);
     Assertions.assertTrue(idx.isEmpty());
   }
 
   @Test
   public void removals() {
-    QueryIndex<Query> idx = QueryIndex.newInstance(registry);
+    QueryIndex<Query> idx = QueryIndex.newInstance(cacheSupplier);
     idx.add(SIMPLE_QUERY, SIMPLE_QUERY);
     idx.add(HASKEY_QUERY, HASKEY_QUERY);
     idx.add(IN_QUERY, IN_QUERY);
 
     Id id1 = id("a", "key", "b", "c", "12345");
-    Assertions.assertEquals(list(SIMPLE_QUERY, IN_QUERY, HASKEY_QUERY), findMatches(idx, id1));
+    assertEquals(list(SIMPLE_QUERY, IN_QUERY, HASKEY_QUERY), idx, id1);
 
     Query q = Parser.parseQuery("name,a,:eq");
     Assertions.assertFalse(idx.remove(q, q));
-    Assertions.assertEquals(list(SIMPLE_QUERY, IN_QUERY, HASKEY_QUERY), findMatches(idx, id1));
+    assertEquals(list(SIMPLE_QUERY, IN_QUERY, HASKEY_QUERY), idx, id1);
 
     Assertions.assertTrue(idx.remove(IN_QUERY, IN_QUERY));
-    Assertions.assertEquals(list(SIMPLE_QUERY, HASKEY_QUERY), findMatches(idx, id1));
+    assertEquals(list(SIMPLE_QUERY, HASKEY_QUERY), idx, id1);
 
     Assertions.assertTrue(idx.remove(SIMPLE_QUERY, SIMPLE_QUERY));
-    Assertions.assertEquals(list(HASKEY_QUERY), findMatches(idx, id1));
+    assertEquals(list(HASKEY_QUERY), idx, id1);
 
     Assertions.assertTrue(idx.remove(HASKEY_QUERY, HASKEY_QUERY));
     Assertions.assertTrue(idx.isEmpty());
-    Assertions.assertTrue(idx.findMatches(id1).isEmpty());
+    assertEquals(Collections.emptyList(), idx, id1);
 
     idx.add(SIMPLE_QUERY, SIMPLE_QUERY);
-    Assertions.assertEquals(list(SIMPLE_QUERY), findMatches(idx, id1));
+    assertEquals(list(SIMPLE_QUERY), idx, id1);
   }
 
   private boolean remove(QueryIndex<Query> idx, Query value) {
@@ -199,29 +254,29 @@ public class QueryIndexTest {
 
   @Test
   public void removalsUsingQuery() {
-    QueryIndex<Query> idx = QueryIndex.newInstance(registry);
+    QueryIndex<Query> idx = QueryIndex.newInstance(cacheSupplier);
     idx.add(SIMPLE_QUERY, SIMPLE_QUERY);
     idx.add(HASKEY_QUERY, HASKEY_QUERY);
     idx.add(IN_QUERY, IN_QUERY);
 
     Id id1 = id("a", "key", "b", "c", "12345");
-    Assertions.assertEquals(list(SIMPLE_QUERY, IN_QUERY, HASKEY_QUERY), findMatches(idx, id1));
+    assertEquals(list(SIMPLE_QUERY, IN_QUERY, HASKEY_QUERY), idx, id1);
 
     Assertions.assertFalse(remove(idx, Parser.parseQuery("name,a,:eq")));
-    Assertions.assertEquals(list(SIMPLE_QUERY, IN_QUERY, HASKEY_QUERY), findMatches(idx, id1));
+    assertEquals(list(SIMPLE_QUERY, IN_QUERY, HASKEY_QUERY), idx, id1);
 
     Assertions.assertTrue(remove(idx, IN_QUERY));
-    Assertions.assertEquals(list(SIMPLE_QUERY, HASKEY_QUERY), findMatches(idx, id1));
+    assertEquals(list(SIMPLE_QUERY, HASKEY_QUERY), idx, id1);
 
     Assertions.assertTrue(remove(idx, SIMPLE_QUERY));
-    Assertions.assertEquals(list(HASKEY_QUERY), findMatches(idx, id1));
+    assertEquals(list(HASKEY_QUERY), idx, id1);
 
     Assertions.assertTrue(remove(idx, HASKEY_QUERY));
     Assertions.assertTrue(idx.isEmpty());
-    Assertions.assertTrue(idx.findMatches(id1).isEmpty());
+    assertEquals(Collections.emptyList(), idx, id1);
 
     idx.add(SIMPLE_QUERY, SIMPLE_QUERY);
-    Assertions.assertEquals(list(SIMPLE_QUERY), idx.findMatches(id1));
+    assertEquals(list(SIMPLE_QUERY), idx, id1);
   }
 
   private Set<String> set(int n) {
@@ -235,10 +290,10 @@ public class QueryIndexTest {
   @Test
   public void queryNormalization() {
     Query q = Parser.parseQuery("name,a,:eq,name,b,:eq,:or,key,b,:eq,:and");
-    QueryIndex<Query> idx = QueryIndex.newInstance(registry);
+    QueryIndex<Query> idx = QueryIndex.newInstance(cacheSupplier);
     idx.add(q, q);
-    Assertions.assertEquals(list(q), idx.findMatches(id("a", "key", "b")));
-    Assertions.assertEquals(list(q), idx.findMatches(id("b", "key", "b")));
+    assertEquals(list(q), idx, id("a", "key", "b"));
+    assertEquals(list(q), idx, id("b", "key", "b"));
   }
 
   @Test
@@ -249,10 +304,10 @@ public class QueryIndexTest {
     Query q2 = new Query.In("b", set(10000));
     Query q3 = new Query.In("c", set(10000));
     Query query = q1.and(q2).and(q3);
-    QueryIndex<Query> idx = QueryIndex.<Query>newInstance(registry).add(query, query);
+    QueryIndex<Query> idx = QueryIndex.newInstance(cacheSupplier).add(query, query);
 
     Id id1 = id("cpu", "a", "1", "b", "9999", "c", "727");
-    Assertions.assertEquals(list(query), idx.findMatches(id1));
+    assertEquals(list(query), idx, id1);
   }
 
   @Test
@@ -269,7 +324,7 @@ public class QueryIndexTest {
       diskUsagePerNode.add(q);
     }
 
-    QueryIndex<Query> idx = QueryIndex.<Query>newInstance(registry)
+    QueryIndex<Query> idx = QueryIndex.newInstance(cacheSupplier)
         .add(cpuUsage, cpuUsage)
         .add(diskUsage, diskUsage);
     for (Query q : diskUsagePerNode) {
@@ -277,115 +332,121 @@ public class QueryIndexTest {
     }
 
     // Matching
-    Assertions.assertEquals(
+    assertEquals(
         list(cpuUsage),
-        idx.findMatches(id("cpuUsage", "nf.node", "unknown")));
-    Assertions.assertEquals(
+        idx,
+        id("cpuUsage", "nf.node", "unknown"));
+    assertEquals(
         list(cpuUsage),
-        idx.findMatches(id("cpuUsage", "nf.node", "i-00099")));
-    Assertions.assertEquals(
+        idx,
+        id("cpuUsage", "nf.node", "i-00099"));
+    assertEquals(
         list(diskUsage),
-        idx.findMatches(id("diskUsage", "nf.node", "unknown")));
-    Assertions.assertEquals(
+        idx,
+        id("diskUsage", "nf.node", "unknown"));
+    assertEquals(
         list(diskUsage, diskUsagePerNode.get(diskUsagePerNode.size() - 1)),
-        idx.findMatches(id("diskUsage", "nf.node", "i-00099")));
+        idx,
+        id("diskUsage", "nf.node", "i-00099"));
 
     // Shouldn't match
-    Assertions.assertTrue(
-        idx.findMatches(id("memoryUsage", "nf.node", "i-00099")).isEmpty());
+    assertEquals(
+        Collections.emptyList(),
+        idx,
+        id("memoryUsage", "nf.node", "i-00099"));
   }
 
   @Test
   public void multipleClausesForSameKey() {
     Query q = Parser.parseQuery("name,abc.*,:re,name,.*def,:re,:and");
-    QueryIndex<Query> idx = QueryIndex.<Query>newInstance(registry).add(q, q);
+    QueryIndex<Query> idx = QueryIndex.newInstance(cacheSupplier).add(q, q);
 
     // Doesn't match prefix check
-    Assertions.assertTrue(idx.findMatches(id("foodef")).isEmpty());
+    assertEquals(Collections.emptyList(), idx, id("foodef"));
 
     // Doesn't match suffix check
-    Assertions.assertTrue(idx.findMatches(id("abcbar")).isEmpty());
+    assertEquals(Collections.emptyList(), idx, id("abcbar"));
 
     // Matches both
-    Assertions.assertFalse(idx.findMatches(id("abcdef")).isEmpty());
-    Assertions.assertFalse(idx.findMatches(id("abc def")).isEmpty());
+    assertEquals(list(q), idx, id("abcdef"));
+    assertEquals(list(q), idx, id("abc def"));
   }
 
   @Test
   public void notEqClause() {
     Query q = Parser.parseQuery("name,cpu,:eq,id,user,:eq,:not,:and");
-    QueryIndex<Query> idx = QueryIndex.<Query>newInstance(registry).add(q, q);
+    QueryIndex<Query> idx = QueryIndex.newInstance(cacheSupplier).add(q, q);
 
-    Assertions.assertFalse(idx.findMatches(id("cpu", "id", "system")).isEmpty());
-    Assertions.assertTrue(idx.findMatches(id("cpu", "id", "user")).isEmpty());
+    assertEquals(list(q), idx, id("cpu", "id", "system"));
+    assertEquals(Collections.emptyList(), idx, id("cpu", "id", "user"));
   }
 
   @Test
   public void notEqMissingKey() {
     Query q = Parser.parseQuery("name,cpu,:eq,id,user,:eq,:not,:and");
-    QueryIndex<Query> idx = QueryIndex.<Query>newInstance(registry).add(q, q);
-    Assertions.assertFalse(idx.findMatches(id("cpu")).isEmpty());
+    QueryIndex<Query> idx = QueryIndex.newInstance(cacheSupplier).add(q, q);
+    assertEquals(list(q), idx, id("cpu"));
   }
 
   @Test
   public void notEqMissingKeyMiddle() {
     Query q = Parser.parseQuery("name,cpu,:eq,mm,foo,:eq,:not,:and,zz,bar,:eq,:and");
-    QueryIndex<Query> idx = QueryIndex.<Query>newInstance(registry).add(q, q);
+    QueryIndex<Query> idx = QueryIndex.newInstance(cacheSupplier).add(q, q);
 
-    Assertions.assertFalse(idx.findMatches(id("cpu", "zz", "bar")).isEmpty());
+    assertEquals(list(q), idx, id("cpu", "zz", "bar"));
   }
 
   @Test
   public void notEqMissingKeyEnd() {
     Query q = Parser.parseQuery("name,cpu,:eq,zz,foo,:eq,:not,:and");
-    QueryIndex<Query> idx = QueryIndex.<Query>newInstance(registry).add(q, q);
+    QueryIndex<Query> idx = QueryIndex.newInstance(cacheSupplier).add(q, q);
 
-    Assertions.assertFalse(idx.findMatches(id("cpu")).isEmpty());
+    assertEquals(list(q), idx, id("cpu"));
   }
 
   @Test
   public void multiNotEqClause() {
     Query q = Parser.parseQuery("name,cpu,:eq,id,system,:eq,:and,id,user,:eq,:not,:and");
-    QueryIndex<Query> idx = QueryIndex.<Query>newInstance(registry).add(q, q);
+    QueryIndex<Query> idx = QueryIndex.newInstance(cacheSupplier).add(q, q);
 
-    Assertions.assertFalse(idx.findMatches(id("cpu", "id", "system")).isEmpty());
-    Assertions.assertTrue(idx.findMatches(id("cpu", "id", "user")).isEmpty());
+    assertEquals(list(q), idx, id("cpu", "id", "system"));
+    assertEquals(Collections.emptyList(), idx, id("cpu", "id", "user"));
   }
 
   @Test
   public void notInClause() {
     Query q = Parser.parseQuery("name,cpu,:eq,id,(,user,iowait,),:in,:not,:and");
-    QueryIndex<Query> idx = QueryIndex.<Query>newInstance(registry).add(q, q);
+    QueryIndex<Query> idx = QueryIndex.newInstance(cacheSupplier).add(q, q);
 
-    Assertions.assertFalse(idx.findMatches(id("cpu", "id", "system")).isEmpty());
-    Assertions.assertTrue(idx.findMatches(id("cpu", "id", "user")).isEmpty());
-    Assertions.assertTrue(idx.findMatches(id("cpu", "id", "iowait")).isEmpty());
+    assertEquals(list(q), idx, id("cpu", "id", "system"));
+    assertEquals(Collections.emptyList(), idx, id("cpu", "id", "user"));
+    assertEquals(Collections.emptyList(), idx, id("cpu", "id", "iowait"));
   }
 
   @Test
   public void multiNotInClause() {
     Query q = Parser.parseQuery("name,cpu,:eq,id,system,:eq,:and,id,(,user,iowait,),:in,:not,:and");
-    QueryIndex<Query> idx = QueryIndex.<Query>newInstance(registry).add(q, q);
+    QueryIndex<Query> idx = QueryIndex.newInstance(cacheSupplier).add(q, q);
 
-    Assertions.assertFalse(idx.findMatches(id("cpu", "id", "system")).isEmpty());
-    Assertions.assertTrue(idx.findMatches(id("cpu", "id", "user")).isEmpty());
-    Assertions.assertTrue(idx.findMatches(id("cpu", "id", "iowait")).isEmpty());
+    assertEquals(list(q), idx, id("cpu", "id", "system"));
+    assertEquals(Collections.emptyList(), idx, id("cpu", "id", "user"));
+    assertEquals(Collections.emptyList(), idx, id("cpu", "id", "iowait"));
   }
 
   @Test
   public void doubleNotsSameKey() {
     Query q = Parser.parseQuery("a,1,:eq,b,2,:eq,:and,c,3,:eq,:not,:and,c,4,:eq,:not,:and");
-    QueryIndex<Query> idx = QueryIndex.<Query>newInstance(registry).add(q, q);
-    Assertions.assertFalse(idx.findMatches(id("cpu", "a", "1", "b", "2", "c", "5")).isEmpty());
-    Assertions.assertTrue(idx.findMatches(id("cpu", "a", "1", "b", "2", "c", "3")).isEmpty());
-    Assertions.assertTrue(idx.findMatches(id("cpu", "a", "1", "b", "2", "c", "4")).isEmpty());
-    Assertions.assertFalse(idx.findMatches(id("cpu", "a", "1", "b", "2")).isEmpty());
+    QueryIndex<Query> idx = QueryIndex.newInstance(cacheSupplier).add(q, q);
+    assertEquals(list(q), idx, id("cpu", "a", "1", "b", "2", "c", "5"));
+    assertEquals(Collections.emptyList(), idx, id("cpu", "a", "1", "b", "2", "c", "3"));
+    assertEquals(Collections.emptyList(), idx, id("cpu", "a", "1", "b", "2", "c", "4"));
+    assertEquals(list(q), idx, id("cpu", "a", "1", "b", "2"));
   }
 
   @Test
   public void removalOfNotQuery() {
     Query q = Parser.parseQuery("name,cpu,:eq,id,user,:eq,:not,:and");
-    QueryIndex<Query> idx = QueryIndex.<Query>newInstance(registry).add(q, q);
+    QueryIndex<Query> idx = QueryIndex.newInstance(cacheSupplier).add(q, q);
     Assertions.assertTrue(idx.remove(q, q));
     Assertions.assertTrue(idx.isEmpty());
   }
@@ -393,7 +454,7 @@ public class QueryIndexTest {
   @Test
   public void removalOfNotQueryUsingQuery() {
     Query q = Parser.parseQuery("name,cpu,:eq,id,user,:eq,:not,:and");
-    QueryIndex<Query> idx = QueryIndex.<Query>newInstance(registry).add(q, q);
+    QueryIndex<Query> idx = QueryIndex.newInstance(cacheSupplier).add(q, q);
     Assertions.assertTrue(remove(idx, q));
     Assertions.assertTrue(idx.isEmpty());
   }
@@ -402,25 +463,21 @@ public class QueryIndexTest {
   public void removalPrefixRegexSubtree() {
     Query q1 = Parser.parseQuery("name,test,:eq,a,foo,:re,:and,b,bar,:eq,:and");
     Query q2 = Parser.parseQuery("name,test,:eq,a,foo,:re,:and");
-    QueryIndex<Query> idx = QueryIndex.<Query>newInstance(registry)
+    QueryIndex<Query> idx = QueryIndex.newInstance(cacheSupplier)
         .add(q1, q1)
         .add(q2, q2);
 
     Id id = id("test", "a", "foo", "b", "bar");
 
-    Set<Query> expected = new HashSet<>();
-    expected.add(q1);
-    expected.add(q2);
-    Assertions.assertEquals(expected, new HashSet<>(idx.findMatches(id)));
+    assertEquals(list(q2, q1), idx, id);
 
     idx.remove(q1, q1);
-    expected.remove(q1);
-    Assertions.assertEquals(expected, new HashSet<>(idx.findMatches(id)));
+    assertEquals(list(q2), idx, id);
   }
 
   @Test
   public void toStringMethod() {
-    QueryIndex<Query> idx = QueryIndex.newInstance(registry);
+    QueryIndex<Query> idx = QueryIndex.newInstance(cacheSupplier);
     idx.add(SIMPLE_QUERY, SIMPLE_QUERY);
     idx.add(HASKEY_QUERY, HASKEY_QUERY);
     idx.add(IN_QUERY, IN_QUERY);


### PR DESCRIPTION
Add `forEachMatch` overloads to the `QueryIndex` that takes a function to supply the value for a tag key. For use-cases where the tags are not already structured as an id, this avoids the overhead of converting. Since it is just a simple function, there is a lot of flexibility for the actual data structure used.