### PR TITLE
gradle jmh 0.7.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'com.github.ben-manes.versions' version '0.44.0'
   id 'com.github.spotbugs' version '5.0.14' apply false
-  id 'me.champeau.jmh' version '0.6.8'
+  id 'me.champeau.jmh' version '0.7.1'
   id 'com.netflix.nebula.dependency-recommender' version '12.2.0'
   id 'com.netflix.nebula.netflixoss' version '11.3.1'
 }
@@ -13,6 +13,12 @@ allprojects {
   apply plugin: 'project-report'
   apply plugin: 'me.champeau.jmh'
   apply plugin: 'com.github.ben-manes.versions'
+
+  // Needs to be here to avoid problems with JMH plugin
+  repositories {
+    mavenCentral()
+    mavenLocal()
+  }
 }
 
 subprojects {
@@ -23,11 +29,6 @@ subprojects {
   apply plugin: 'com.github.spotbugs'
   apply plugin: 'checkstyle'
   apply plugin: 'pmd'
-
-  repositories {
-    mavenCentral()
-    mavenLocal()
-  }
 
   group = "com.netflix.${githubProjectName}"
 


### PR DESCRIPTION
Update to latest gradle jmh plugin for better compatibility with 8.0. Needed to move repository block to avoid errors when loading in intellij.