### PR TITLE
add utility for computing 64-bit hash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,6 +102,7 @@ subprojects {
     toolVersion = '9.3'
     ignoreFailures = false 
     configFile = rootProject.file('codequality/checkstyle.xml')
+    configDirectory = rootProject.file("codequality")
     sourceSets = [sourceSets.main]
   }
   

--- a/codequality/checkstyle-suppressions.xml
+++ b/codequality/checkstyle-suppressions.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE suppressions PUBLIC
+    "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+    "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+
+<suppressions>
+  <suppress checks="IllegalImport" files="UnsafeUtils.java"/>
+</suppressions>

--- a/codequality/checkstyle.xml
+++ b/codequality/checkstyle.xml
@@ -170,4 +170,7 @@
         <module name="SuppressWarningsHolder"/>
     </module>
     <module name="SuppressWarningsFilter"/>
+    <module name="SuppressionFilter">
+      <property name="file" value="${config_loc}/checkstyle-suppressions.xml"/>
+    </module>
 </module>

--- a/codequality/findbugs-exclude.xml
+++ b/codequality/findbugs-exclude.xml
@@ -7,6 +7,12 @@
     </And>
   </Match>
   <Match>
+    <And>
+      <Class name="com.netflix.spectator.impl.UnsafeUtils"/>
+      <Bug pattern="REC_CATCH_EXCEPTION"/>
+    </And>
+  </Match>
+  <Match>
     <Bug pattern="EI_EXPOSE_REP"/>
   </Match>
   <Match>

--- a/dependencies.properties
+++ b/dependencies.properties
@@ -18,6 +18,7 @@ com.typesafe:config = 1.4.2
 io.dropwizard.metrics5:metrics-core = 5.0.0-rc15 # 5.0.0 is a bad version do not use
 io.micrometer:micrometer-core = 1.10.6
 javax.inject:javax.inject = 1
+net.openhft:zero-allocation-hashing = 0.16
 nl.jqno.equalsverifier:equalsverifier = 3.14.1
 org.apache.logging.log4j:log4j-api = 2.20.0
 org.apache.logging.log4j:log4j-core = 2.20.0

--- a/spectator-api/build.gradle
+++ b/spectator-api/build.gradle
@@ -2,9 +2,11 @@
 dependencies {
   testImplementation files("$projectDir/src/test/lib/compatibility-0.68.0.jar")
   testImplementation "com.google.re2j:re2j"
+  testImplementation "net.openhft:zero-allocation-hashing"
   testImplementation "org.hsqldb:hsqldb"
   jmh "com.google.re2j:re2j"
   jmh "com.github.ben-manes.caffeine:caffeine"
+  jmh "net.openhft:zero-allocation-hashing"
 }
 
 javadoc {

--- a/spectator-api/src/jmh/java/com/netflix/spectator/perf/IdHash.java
+++ b/spectator-api/src/jmh/java/com/netflix/spectator/perf/IdHash.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.perf;
+
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.impl.Hash64;
+import net.openhft.hashing.LongHashFunction;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * Benchmark                             Mode  Cnt        Score        Error   Units
+ * IdHash.hash64                        thrpt    5  2379245.474 ±   7379.034   ops/s
+ * IdHash.hash64_2                      thrpt    5  4817014.307 ±   5704.027   ops/s
+ * IdHash.openhft                       thrpt    5  4910133.221 ± 100296.076   ops/s
+ *
+ * Benchmark                             Mode  Cnt        Score        Error   Units
+ * IdHash.hash64:·gc.alloc.rate.norm    thrpt    5        0.188 ±      0.002    B/op
+ * IdHash.hash64_2:·gc.alloc.rate.norm  thrpt    5     1152.095 ±      0.001    B/op
+ * IdHash.openhft:·gc.alloc.rate.norm   thrpt    5     1128.095 ±      0.002    B/op
+ */
+@State(Scope.Thread)
+public class IdHash {
+
+  private final Id id = Id.create("http.req.complete")
+      .withTag(    "nf.app", "test_app")
+      .withTag("nf.cluster", "test_app-main")
+      .withTag(    "nf.asg", "test_app-main-v042")
+      .withTag(  "nf.stack", "main")
+      .withTag(    "nf.ami", "ami-0987654321")
+      .withTag( "nf.region", "us-east-1")
+      .withTag(   "nf.zone", "us-east-1e")
+      .withTag(   "nf.node", "i-1234567890")
+      .withTag(   "country", "US")
+      .withTag(    "device", "xbox")
+      .withTag(    "status", "200")
+      .withTag(    "client", "ab");
+
+  private final Hash64 h64 = new Hash64();
+  private final LongHashFunction xx = LongHashFunction.xx();
+
+  @Benchmark
+  public void hash64(Blackhole bh) {
+    h64.updateString(id.name());
+    for (int i = 1; i < id.size(); ++i) {
+      h64.updateChar(':');
+      h64.updateString(id.getKey(i));
+      h64.updateChar('=');
+      h64.updateString(id.getValue(i));
+    }
+    bh.consume(h64.computeAndReset());
+  }
+
+  @Benchmark
+  public void hash64_2(Blackhole bh) {
+    bh.consume(h64.updateString(id.toString()).computeAndReset());
+  }
+
+  @Benchmark
+  public void openhft(Blackhole bh) {
+    bh.consume(xx.hashChars(id.toString()));
+  }
+}

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/Hash64.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/Hash64.java
@@ -1,0 +1,405 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.impl;
+
+/**
+ * Helper to compute a 64-bit hash incrementally based on a set of primitives and primitive
+ * arrays. It is currently using the XXH64 algorithm. See the
+ * <a href="https://github.com/Cyan4973/xxHash/blob/dev/doc/xxhash_spec.md">spec</a> for more
+ * details.
+ *
+ * <p><b>This class is an internal implementation detail only intended for use within spectator.
+ * It is subject to change without notice.</b></p>
+ */
+@SuppressWarnings("PMD")
+public final class Hash64 {
+
+  private static final long PRIME64_1 = 0x9E3779B185EBCA87L;
+  private static final long PRIME64_2 = 0xC2B2AE3D27D4EB4FL;
+  private static final long PRIME64_3 = 0x165667B19E3779F9L;
+  private static final long PRIME64_4 = 0x85EBCA77C2B2AE63L;
+  private static final long PRIME64_5 = 0x27D4EB2F165667C5L;
+
+  private final long[] stripe;
+  private int stripePos;
+  private int bitPos;
+
+  private final long seed;
+  private long acc1;
+  private long acc2;
+  private long acc3;
+  private long acc4;
+  private long inputLength;
+
+  /** Create a new instance with a seed of zero. */
+  public Hash64() {
+    this(0L);
+  }
+
+  /** Create a new instance. */
+  public Hash64(long seed) {
+    this.seed = seed;
+    this.stripe = new long[4];
+    reset();
+  }
+
+  /** Reset so it can be reused for computing another hash. */
+  public void reset() {
+    stripePos = 0;
+    bitPos = 0;
+    stripe[0] = 0L;
+    acc1 = seed + PRIME64_1 + PRIME64_2;
+    acc2 = seed + PRIME64_2;
+    acc3 = seed;
+    acc4 = seed - PRIME64_1;
+    inputLength = 0L;
+  }
+
+  private void checkSpace(int size) {
+    // Ensure there is enough space to write the primitive in the current
+    // long value, otherwise move to the next
+    if (size > Long.SIZE - bitPos) {
+      if (++stripePos == stripe.length) {
+        processStripe();
+      }
+      bitPos = 0;
+      stripe[stripePos] = 0L;
+    }
+  }
+
+  /** Update the hash with the specified boolean value. */
+  public Hash64 updateBoolean(boolean value) {
+    return updateByte((byte) (value ? 1 : 0));
+  }
+
+  /** Update the hash with the specified boolean values. */
+  public Hash64 updateBooleans(boolean[] values, int offset, int length) {
+    for (int i = offset; i < offset + length; ++i) {
+      updateBoolean(values[i]);
+    }
+    return this;
+  }
+
+  /** Update the hash with the specified boolean values. */
+  public Hash64 updateBooleans(boolean[] values) {
+    return updateBooleans(values, 0, values.length);
+  }
+
+  /** Update the hash with the specified character value. */
+  public Hash64 updateChar(char value) {
+    checkSpace(Character.SIZE);
+    final long c = ((long) value) << bitPos;
+    stripe[stripePos] |= c;
+    bitPos += Character.SIZE;
+    return this;
+  }
+
+  /** Update the hash with the specified character values. */
+  public Hash64 updateChars(char[] values, int offset, int length) {
+    for (int i = offset; i < offset + length; ++i) {
+      updateChar(values[i]);
+    }
+    return this;
+  }
+
+  /** Update the hash with the specified character values. */
+  public Hash64 updateChars(char[] values) {
+    return updateChars(values, 0, values.length);
+  }
+
+  /** Update the hash with the specified character sequence value. */
+  public Hash64 updateString(CharSequence str) {
+    if (str instanceof String && UnsafeUtils.stringValueSupported()) {
+      if (UnsafeUtils.stringValueBytes()) {
+        byte[] vs = UnsafeUtils.getStringValueBytes((String) str);
+        updateBytes(vs, 0, vs.length);
+      } else {
+        char[] vs = UnsafeUtils.getStringValueChars((String) str);
+        updateChars(vs, 0, vs.length);
+      }
+    } else {
+      for (int i = 0; i < str.length(); ++i) {
+        updateChar(str.charAt(i));
+      }
+    }
+    return this;
+  }
+
+  /** Update the hash with the specified byte value. */
+  public Hash64 updateByte(byte value) {
+    checkSpace(Byte.SIZE);
+    final long v = ((long) value & 0xFFL) << bitPos;
+    stripe[stripePos] |= v;
+    bitPos += Byte.SIZE;
+    return this;
+  }
+
+  /** Update the hash with the specified byte values. */
+  public Hash64 updateBytes(byte[] values, int offset, int length) {
+    if (UnsafeUtils.supported() && length >= 8) {
+      final int bytesInStripe = (Long.SIZE - bitPos) / Byte.SIZE;
+      final int s = offset + bytesInStripe;
+      final int e = s + (length - bytesInStripe) / Long.BYTES * Long.BYTES;
+
+      // Complete current stripe
+      for (int i = offset; i < s; ++i) {
+        updateByte(values[i]);
+      }
+
+      // Write long values
+      for (int i = s; i < e; i += Long.BYTES) {
+        updateLong(UnsafeUtils.getLong(values, i));
+      }
+
+      // Write remaining bytes
+      for (int i = e; i < offset + length; ++i) {
+        updateByte(values[i]);
+      }
+    } else {
+      for (int i = offset; i < offset + length; ++i) {
+        updateByte(values[i]);
+      }
+    }
+    return this;
+  }
+
+  /** Update the hash with the specified byte values. */
+  public Hash64 updateBytes(byte[] values) {
+    return updateBytes(values, 0, values.length);
+  }
+
+  /** Update the hash with the specified short value. */
+  public Hash64 updateShort(short value) {
+    checkSpace(Short.SIZE);
+    final long v = ((long) value & 0xFFFFL) << bitPos;
+    stripe[stripePos] |= v;
+    bitPos += Short.SIZE;
+    return this;
+  }
+
+  /** Update the hash with the specified short values. */
+  public Hash64 updateShorts(short[] values, int offset, int length) {
+    for (int i = offset; i < offset + length; ++i) {
+      updateShort(values[i]);
+    }
+    return this;
+  }
+
+  /** Update the hash with the specified short values. */
+  public Hash64 updateShorts(short[] values) {
+    return updateShorts(values, 0, values.length);
+  }
+
+  /** Update the hash with the specified int value. */
+  public Hash64 updateInt(int value) {
+    checkSpace(Integer.SIZE);
+    final long v = ((long) value & 0xFFFFFFFFL) << bitPos;
+    stripe[stripePos] |= v;
+    bitPos += Integer.SIZE;
+    return this;
+  }
+
+  /** Update the hash with the specified int values. */
+  public Hash64 updateInts(int[] values, int offset, int length) {
+    for (int i = offset; i < offset + length; ++i) {
+      updateInt(values[i]);
+    }
+    return this;
+  }
+
+  /** Update the hash with the specified int values. */
+  public Hash64 updateInts(int[] values) {
+    return updateInts(values, 0, values.length);
+  }
+
+  /** Update the hash with the specified long value. */
+  public Hash64 updateLong(long value) {
+    checkSpace(Long.SIZE);
+    stripe[stripePos] = value;
+    bitPos += Long.SIZE;
+    return this;
+  }
+
+  /** Update the hash with the specified long values. */
+  public Hash64 updateLongs(long[] values, int offset, int length) {
+    checkSpace(Long.SIZE);
+
+    // Fill current stripe
+    final int prefixLength = Math.min(length, stripe.length - stripePos);
+    System.arraycopy(values, offset, stripe, stripePos, prefixLength);
+    stripePos += prefixLength;
+    if (stripePos == stripe.length) {
+      processStripe();
+    }
+
+    // Copy the remainder, one stripe at a time
+    final int start = offset + prefixLength;
+    final int end = offset + length;
+    for (int i = start; i < end; i += stripe.length) {
+      final int copyLength = Math.min(stripe.length, end - i);
+      System.arraycopy(values, i, stripe, 0, copyLength);
+      stripePos = copyLength;
+      if (stripePos == stripe.length) {
+        processStripe();
+      } else {
+        stripe[stripePos] = 0L;
+      }
+    }
+    return this;
+  }
+
+  /** Update the hash with the specified long values. */
+  public Hash64 updateLongs(long[] values) {
+    return updateLongs(values, 0, values.length);
+  }
+
+  /** Update the hash with the specified float value. */
+  public Hash64 updateFloat(float value) {
+    return updateInt(Float.floatToIntBits(value));
+  }
+
+  /** Update the hash with the specified float values. */
+  public Hash64 updateFloats(float[] values, int offset, int length) {
+    for (int i = offset; i < offset + length; ++i) {
+      updateFloat(values[i]);
+    }
+    return this;
+  }
+
+  /** Update the hash with the specified float values. */
+  public Hash64 updateFloats(float[] values) {
+    return updateFloats(values, 0, values.length);
+  }
+
+  /** Update the hash with the specified double value. */
+  public Hash64 updateDouble(double value) {
+    return updateLong(Double.doubleToLongBits(value));
+  }
+
+  /** Update the hash with the specified double values. */
+  public Hash64 updateDoubles(double[] values, int offset, int length) {
+    for (int i = offset; i < offset + length; ++i) {
+      updateDouble(values[i]);
+    }
+    return this;
+  }
+
+  /** Update the hash with the specified double values. */
+  public Hash64 updateDoubles(double[] values) {
+    return updateDoubles(values, 0, values.length);
+  }
+
+  private void processStripe() {
+    inputLength += 32;
+    acc1 = round(acc1, stripe[0]);
+    acc2 = round(acc2, stripe[1]);
+    acc3 = round(acc3, stripe[2]);
+    acc4 = round(acc4, stripe[3]);
+    stripePos = 0;
+    bitPos = 0;
+    stripe[0] = 0L;
+  }
+
+  private long round(long acc, long lane) {
+    acc += lane * PRIME64_2;
+    acc = Long.rotateLeft(acc, 31);
+    return acc * PRIME64_1;
+  }
+
+  private long mergeAccumulator(long acc, long accN) {
+    acc ^= round(0L, accN);
+    acc *= PRIME64_1;
+    return acc + PRIME64_4;
+  }
+
+  private long consumeRemainingInput(long acc) {
+
+    for (int i = 0; i < stripePos; ++i) {
+      long lane = stripe[i];
+      acc ^= round(0, lane);
+      acc = Long.rotateLeft(acc, 27) * PRIME64_1;
+      acc += PRIME64_4;
+    }
+
+    long buffer = stripe[stripePos];
+    if (bitPos >= 4) {
+      long lane = buffer & 0xFFFFFFFFL;
+      acc ^= (lane * PRIME64_1);
+      acc = Long.rotateLeft(acc, 23) * PRIME64_2;
+      acc += PRIME64_3;
+      buffer >>>= 32;
+      bitPos -= 4;
+    }
+
+    while (bitPos >= 1) {
+      long lane = buffer & 0xFFL;
+      acc ^= (lane * PRIME64_5);
+      acc = Long.rotateLeft(acc, 11) * PRIME64_1;
+      buffer >>>= 8;
+      bitPos -= 1;
+    }
+
+    return acc;
+  }
+
+  private long avalanche(long acc) {
+    acc ^= acc >>> 33;
+    acc *= PRIME64_2;
+    acc ^= acc >>> 29;
+    acc *= PRIME64_3;
+    acc ^= acc >>> 32;
+    return acc;
+  }
+
+  /** Compute and return the final hash value. */
+  public long compute() {
+    // Write final stripe if it is full
+    checkSpace(Byte.SIZE);
+
+    long acc;
+    if (inputLength < 32L) {
+      // Special case: input is less than 32 bytes
+      acc = seed + PRIME64_5;
+    } else {
+      // Step 3. Accumulator convergence
+      acc = Long.rotateLeft(acc1, 1)
+          + Long.rotateLeft(acc2, 7)
+          + Long.rotateLeft(acc3, 12)
+          + Long.rotateLeft(acc4, 18);
+      acc = mergeAccumulator(acc, acc1);
+      acc = mergeAccumulator(acc, acc2);
+      acc = mergeAccumulator(acc, acc3);
+      acc = mergeAccumulator(acc, acc4);
+    }
+
+    // Step 4. Add input length
+    inputLength += stripePos * 8L + bitPos / 8L;
+    acc += inputLength;
+
+    // Step 5. Consume remaining input
+    acc = consumeRemainingInput(acc);
+
+    // Step 6. Final mix (avalanche)
+    return avalanche(acc);
+  }
+
+  /** Compute the final hash value and reset the hash accumulator. */
+  public long computeAndReset() {
+    long h = compute();
+    reset();
+    return h;
+  }
+}

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/UnsafeUtils.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/UnsafeUtils.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.impl;
+
+import sun.misc.Unsafe; // NOPMD
+
+import java.lang.reflect.Field;
+
+/**
+ * Utility class for using {@code sun.misc.Unsafe} to access some internal details to get
+ * better performance.
+ *
+ * <p><b>This class is an internal implementation detail only intended for use within spectator.
+ * It is subject to change without notice.</b></p>
+ */
+@SuppressWarnings("PMD")
+public final class UnsafeUtils {
+
+  private static final Unsafe UNSAFE;
+
+  private static final long STRING_VALUE_OFFSET;
+  private static final boolean STRING_VALUE_BYTES;
+
+  static {
+    Unsafe instance;
+    try {
+      final Field theUnsafe = Unsafe.class.getDeclaredField("theUnsafe");
+      theUnsafe.setAccessible(true);
+      instance = (Unsafe) theUnsafe.get(null);
+    } catch (Exception e) {
+      instance = null;
+    }
+    UNSAFE = instance;
+
+    if (UNSAFE != null) {
+      long stringValueOffset;
+      boolean stringValueBytes;
+      try {
+        final Field value = String.class.getDeclaredField("value");
+        stringValueOffset = UNSAFE.objectFieldOffset(value);
+        Object obj = UNSAFE.getObject("value", stringValueOffset);
+        stringValueBytes = obj instanceof byte[];
+      } catch (Exception e) {
+        stringValueOffset = -1L;
+        stringValueBytes = false;
+      }
+      STRING_VALUE_OFFSET = stringValueOffset;
+      STRING_VALUE_BYTES = stringValueBytes;
+    } else {
+      STRING_VALUE_OFFSET =  -1L;
+      STRING_VALUE_BYTES = false;
+    }
+  }
+
+  private UnsafeUtils() {
+  }
+
+  /**
+   * Returns true if unsafe operations are supported. Code should have a fallback that
+   * works when it is not available.
+   */
+  public static boolean supported() {
+    return UNSAFE != null;
+  }
+
+  /** Returns true if extracting the underlying value array for a String is supported. */
+  public static boolean stringValueSupported() {
+    return STRING_VALUE_OFFSET > 0L;
+  }
+
+  /** Returns true if it is a newer JDK that uses a byte array for the characters. */
+  public static boolean stringValueBytes() {
+    return STRING_VALUE_BYTES;
+  }
+
+  /** Get the value array for a String as an array of bytes. */
+  public static byte[] getStringValueBytes(String str) {
+    return (byte[]) UNSAFE.getObject(str, STRING_VALUE_OFFSET);
+  }
+
+  /** Get the value array for a String as an array of characters. */
+  public static char[] getStringValueChars(String str) {
+    return (char[]) UNSAFE.getObject(str, STRING_VALUE_OFFSET);
+  }
+
+  /** Treat a seq of 8 bytes at the given offset as a long value. */
+  public static long getLong(byte[] bytes, int offset) {
+    long idx = Unsafe.ARRAY_BYTE_BASE_OFFSET + offset;
+    return UNSAFE.getLong(bytes, idx);
+  }
+}

--- a/spectator-api/src/test/java/com/netflix/spectator/impl/Hash64Test.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/Hash64Test.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.impl;
+
+import net.openhft.hashing.LongHashFunction;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+
+public class Hash64Test {
+
+  private final Random random = new Random(42L);
+
+
+  private boolean[] randomBooleanArray(int length) {
+    boolean[] vs = new boolean[length];
+    for (int i = 0; i < length; ++i) {
+      vs[i] = random.nextBoolean();
+    }
+    return vs;
+  }
+
+  private long checkBooleans(boolean[] vs) {
+    Hash64 h64 = new Hash64();
+    for (boolean v : vs)
+      h64.updateBoolean(v);
+    long a = h64.computeAndReset();
+    long b = h64.updateBooleans(vs).compute();
+    Assertions.assertEquals(a, b);
+    return a;
+  }
+
+  @Test
+  public void hashBooleans() {
+    Set<Long> hashes = new HashSet<>();
+    for (int i = 0; i < 1000; ++i) {
+      boolean[] vs = randomBooleanArray(i);
+      long h = checkBooleans(vs);
+      Assertions.assertFalse(hashes.contains(h));
+      hashes.add(h);
+    }
+  }
+
+  private String randomString(int length) {
+    StringBuilder builder = new StringBuilder(length);
+    for (int i = 0; i < length; ++i) {
+      char c = (char) random.nextInt(Character.MAX_VALUE);
+      builder.append(c);
+    }
+    return builder.toString();
+  }
+
+  private long checkBytes(String str) {
+    byte[] bytes = str.getBytes(StandardCharsets.UTF_8);
+    Hash64 h64 = new Hash64();
+    for (byte b : bytes)
+      h64.updateByte(b);
+    long a = h64.computeAndReset();
+    long b = h64.updateBytes(bytes).computeAndReset();
+    Assertions.assertEquals(a, b, "input: " + str+ ", " + bytes.length);
+
+    for (int i = 0; i < bytes.length; i += 7) {
+      int length = Math.min(7, bytes.length - i);
+      h64.updateBytes(bytes, i, length);
+    }
+    long c = h64.compute();
+    Assertions.assertEquals(a, c);
+
+    return a;
+  }
+
+  @Test
+  public void hashBytes() {
+    Map<Long, String> hashes = new HashMap<>();
+    for (int i = 0; i < 1000; ++i) {
+      String str = randomString(i);
+      long h = checkBytes(str);
+      Assertions.assertFalse(hashes.containsKey(h), () ->
+          "[" + str + "] and [" + hashes.get(h) +  "] have same hash value, h = " + h
+      );
+      hashes.put(h, str);
+    }
+  }
+
+  private long checkString(String str) {
+    long a = new Hash64().updateString(str).compute();
+    long b = new Hash64().updateChars(str.toCharArray()).compute();
+    long c = new Hash64()
+        .updateString(new StringBuilder().append(str))
+        .compute();
+    Assertions.assertEquals(a, b);
+    Assertions.assertEquals(a, c);
+    return a;
+  }
+
+  @Test
+  public void hashString() {
+    Map<Long, String> hashes = new HashMap<>();
+    for (int i = 0; i < 1000; ++i) {
+      String str = randomString(i);
+      long h = checkString(str);
+      Assertions.assertFalse(hashes.containsKey(h), () ->
+        "[" + str + "] and [" + hashes.get(h) +  "] have same hash value, h = " + h
+      );
+      hashes.put(h, str);
+    }
+  }
+
+  private short[] randomShortArray(int length) {
+    short[] vs = new short[length];
+    for (int i = 0; i < length; ++i) {
+      vs[i] = (short) random.nextInt(Short.MAX_VALUE);
+    }
+    return vs;
+  }
+
+  private long checkShorts(short[] vs) {
+    Hash64 h64 = new Hash64();
+    for (short v : vs)
+      h64.updateShort(v);
+    long a = h64.computeAndReset();
+    long b = h64.updateShorts(vs).compute();
+    Assertions.assertEquals(a, b);
+    return a;
+  }
+
+  @Test
+  public void hashShorts() {
+    Set<Long> hashes = new HashSet<>();
+    for (int i = 0; i < 1000; ++i) {
+      short[] vs = randomShortArray(i);
+      long h = checkShorts(vs);
+      Assertions.assertFalse(hashes.contains(h));
+      hashes.add(h);
+    }
+  }
+
+  private int[] randomIntArray(int length) {
+    int[] vs = new int[length];
+    for (int i = 0; i < length; ++i) {
+      vs[i] = random.nextInt();
+    }
+    return vs;
+  }
+
+  private long checkInts(int[] vs) {
+    Hash64 h64 = new Hash64();
+    for (int v : vs)
+      h64.updateInt(v);
+    long a = h64.computeAndReset();
+    long b = h64.updateInts(vs).compute();
+    Assertions.assertEquals(a, b);
+    return a;
+  }
+
+  @Test
+  public void hashInts() {
+    Set<Long> hashes = new HashSet<>();
+    for (int i = 0; i < 1000; ++i) {
+      int[] vs = randomIntArray(i);
+      long h = checkInts(vs);
+      Assertions.assertFalse(hashes.contains(h));
+      hashes.add(h);
+    }
+  }
+
+  @Test
+  public void hashLong() {
+    // Sanity check implementation with openhft version
+    final LongHashFunction xx64 = LongHashFunction.xx();
+    final Hash64 h64 = new Hash64();
+    for (int i = 0; i < 1; ++i) {
+      long v = random.nextLong();
+      long h = h64.updateLong(v).computeAndReset();
+      Assertions.assertEquals(xx64.hashLong(v), h);
+    }
+  }
+
+  private long[] randomLongArray(int length) {
+    long[] vs = new long[length];
+    for (int i = 0; i < length; ++i) {
+      vs[i] = random.nextLong();
+    }
+    return vs;
+  }
+
+  @Test
+  public void hashLongs() {
+    // Sanity check implementation with openhft version
+    final LongHashFunction xx64 = LongHashFunction.xx();
+    final Hash64 h64 = new Hash64();
+    for (int i = 0; i < 1000; ++i) {
+      long[] vs = randomLongArray(i);
+      long h = h64.updateLongs(vs).computeAndReset();
+      Assertions.assertEquals(xx64.hashLongs(vs), h);
+    }
+  }
+
+  private float[] randomFloatArray(int length) {
+    float[] vs = new float[length];
+    for (int i = 0; i < length; ++i) {
+      vs[i] = random.nextFloat();
+    }
+    return vs;
+  }
+
+  private long checkFloats(float[] vs) {
+    Hash64 h64 = new Hash64();
+    for (float v : vs)
+      h64.updateFloat(v);
+    long a = h64.computeAndReset();
+    long b = h64.updateFloats(vs).compute();
+    Assertions.assertEquals(a, b);
+    return a;
+  }
+
+  @Test
+  public void hashFloats() {
+    Set<Long> hashes = new HashSet<>();
+    for (int i = 0; i < 1000; ++i) {
+      float[] vs = randomFloatArray(i);
+      long h = checkFloats(vs);
+      Assertions.assertFalse(hashes.contains(h));
+      hashes.add(h);
+    }
+  }
+
+  private double[] randomDoubleArray(int length) {
+    double[] vs = new double[length];
+    for (int i = 0; i < length; ++i) {
+      vs[i] = random.nextDouble();
+    }
+    return vs;
+  }
+
+  private long checkDoubles(double[] vs) {
+    Hash64 h64 = new Hash64();
+    for (double v : vs)
+      h64.updateDouble(v);
+    long a = h64.computeAndReset();
+    long b = h64.updateDoubles(vs).compute();
+    Assertions.assertEquals(a, b);
+    return a;
+  }
+
+  @Test
+  public void hashDoubles() {
+    Set<Long> hashes = new HashSet<>();
+    for (int i = 0; i < 1000; ++i) {
+      double[] vs = randomDoubleArray(i);
+      long h = checkDoubles(vs);
+      Assertions.assertFalse(hashes.contains(h));
+      hashes.add(h);
+    }
+  }
+}


### PR DESCRIPTION
Currently based on XXH64. Allows for data to be incrementally fed to the hash accumulator to make it more convenient to use and avoid allocations creating the structure needed to pass into the hash. Though in some cases the incremental processing is slower than just passing in something like a precomputed string.