### PR TITLE
atlas: support delayed gauge aggregation

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/EvaluatorConfig.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/EvaluatorConfig.java
@@ -76,4 +76,15 @@ public interface EvaluatorConfig {
   default boolean parallelMeasurementPolling() {
     return false;
   }
+
+  /**
+   * Returns true if gauge aggregation should be delayed until downstream in the final eval
+   * step. In some cases such as running with an inline aggregator, the same gauge value may
+   * be reported to multiple instances resulting in it contributing to the aggregate multiple
+   * times. When delayed, the downstream eval step will receive all datapoints and dedup based
+   * on a hash to mimic all datapoints being at a single aggregator.
+   */
+  default boolean delayGaugeAggregation() {
+    return false;
+  }
 }

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/ConsolidatorTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/ConsolidatorTest.java
@@ -108,7 +108,7 @@ public class ConsolidatorTest {
 
   @Test
   public void noneEmpty() {
-    Consolidator consolidator = new Consolidator.None();
+    Consolidator consolidator = new Consolidator.None(false);
     Assertions.assertTrue(consolidator.isEmpty());
     consolidator.update(30000, 12.0);
     Assertions.assertFalse(consolidator.isEmpty());
@@ -205,7 +205,7 @@ public class ConsolidatorTest {
     Counter primary = registry(clock, CONSOLIDATED_STEP).counter(id);
     Counter consolidated = registry(clock, CONSOLIDATED_STEP).counter(id);
 
-    Consolidator consolidator = new Consolidator.None();
+    Consolidator consolidator = new Consolidator.None(false);
 
     consolidateRandomData(
         measurementId,

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/DataExprTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/DataExprTest.java
@@ -66,7 +66,7 @@ public class DataExprTest {
   }
 
   private Iterable<TagsValuePair> evalNoCheck(DataExpr expr, Iterable<TagsValuePair> input) {
-    DataExpr.Aggregator aggr = expr.aggregator(expr.query().exactTags(), false);
+    DataExpr.Aggregator aggr = expr.aggregator(false);
     for (TagsValuePair p : input) {
       aggr.update(p);
     }
@@ -192,7 +192,7 @@ public class DataExprTest {
         Assertions.assertEquals("foo", v.tags().get("name"));
       }
       double tv = Double.parseDouble(v.tags().get("v"));
-      Assertions.assertEquals((tv < 2.0) ? 2.0 : tv, v.value(), 1e-12);
+      Assertions.assertEquals(Math.max(tv, 2.0), v.value(), 1e-12);
     }
     Assertions.assertEquals(shouldCheckQuery ? 3 : 4, count);
   }


### PR DESCRIPTION
Add support for delaying gauge aggregation when pushing data to LWC. In some cases, the registry will be used on an intermediate cluster that aggregates results and can receive updates more frequently than the consumption step size. This can lead to the same gauge value coming from multiple aggregators leading to skewed values for accumulating aggregation types like sum and count.

To avoid this problem, the gauge aggregation can be delayed until the evaluator consuming the data so that the corresponding values can be deduped before computing the final aggregation. The deduping is based on the `atlas.aggr` dimension which is a hash of the id.