### PR TITLE
atlas: fix npe for grouped lwc gauges

### DIFF
--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/EvaluatorTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/EvaluatorTest.java
@@ -272,6 +272,18 @@ public class EvaluatorTest {
   }
 
   @Test
+  public void delayAggrGaugeGroupByMissingKey() {
+    List<Subscription> subs = new ArrayList<>();
+    subs.add(newSubscription("sum", ":true,:sum,(,foo,),:by"));
+
+    Evaluator evaluator = newEvaluator(true);
+    evaluator.sync(subs);
+    EvalPayload payload = evaluator.eval(0L, data("foo", 1.0, 2.0, 3.0));
+
+    Assertions.assertEquals(0, payload.getMetrics().size());
+  }
+
+  @Test
   public void delayAggrGaugeMax() {
     List<Subscription> subs = new ArrayList<>();
     subs.add(newSubscription("max", ":true,:max"));


### PR DESCRIPTION
When performing a group by, if there is a datapoint that does not have all of the keys used in the grouping there would be an NPE. They will now get ignored similar to the behavior for counters or when not delaying the gauge aggregation.