### PR TITLE
do not extract endpoint from path for 404s

### DIFF
--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcLogEntry.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcLogEntry.java
@@ -639,7 +639,7 @@ public final class IpcLogEntry {
 
   private String getEndpoint() {
     return (endpoint == null)
-        ? (path == null) ? "unknown" : PathSanitizer.sanitize(path)
+        ? (path == null || httpStatus == 404) ? "unknown" : PathSanitizer.sanitize(path)
         : endpoint;
   }
 

--- a/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/IpcLogEntryTest.java
+++ b/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/IpcLogEntryTest.java
@@ -226,6 +226,17 @@ public class IpcLogEntryTest {
   }
 
   @Test
+  public void endpointViaUri404() {
+    String path = "/api/v1/1234567890";
+    String actual = (String) entry
+        .withUri(URI.create(path))
+        .withHttpStatus(404)
+        .convert(this::toMap)
+        .get("endpoint");
+    Assertions.assertEquals("unknown", actual);
+  }
+
+  @Test
   public void clientNode() {
     String expected = "i-12345";
     String actual = (String) entry


### PR DESCRIPTION
This can lead to a large set of endpoints for things like security scans. Logs should be used to track down those paths.