### PR TITLE
determine if pattern is starts-with or contains

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/impl/PatternMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/PatternMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2022 Netflix, Inc.
+ * Copyright 2014-2023 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,6 +55,16 @@ public interface PatternMatcher {
   }
 
   /**
+   * Returns a fixed string that is contained within matching results for the pattern if one
+   * is available. This can be used with indexed data to help select a subset of values that
+   * are possible matches. If the pattern does not have a fixed sub-string, then null will be
+   * returned.
+   */
+  default String containedString() {
+    return null;
+  }
+
+  /**
    * The minimum possible length of a matching string. This can be used as a quick check
    * to see if there is any way a given string could match.
    */
@@ -89,6 +99,24 @@ public interface PatternMatcher {
    * to avoid checking for matches.
    */
   default boolean neverMatches() {
+    return false;
+  }
+
+  /**
+   * Returns true if this matcher is equivalent to performing a starts with check on the
+   * prefix. This can be useful when mapping to storage that may have optimized prefix
+   * matching operators.
+   */
+  default boolean isPrefixMatcher() {
+    return false;
+  }
+
+  /**
+   * Returns true if this matcher is equivalent to checking if a string contains a string.
+   * This can be useful when mapping to storage that may have optimized contains matching
+   * operators.
+   */
+  default boolean isContainsMatcher() {
     return false;
   }
 

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/IndexOfMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/IndexOfMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2022 Netflix, Inc.
+ * Copyright 2014-2023 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,6 +50,16 @@ final class IndexOfMatcher implements GreedyMatcher, Serializable {
   /** Return the matcher for the portion that follows the sub-string. */
   Matcher next() {
     return next;
+  }
+
+  @Override
+  public String containedString() {
+    return pattern;
+  }
+
+  @Override
+  public boolean isContainsMatcher() {
+    return next == TrueMatcher.INSTANCE;
   }
 
   private int indexOfIgnoreCase(String str, int offset) {

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/SeqMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/SeqMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2022 Netflix, Inc.
+ * Copyright 2014-2023 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,6 +74,11 @@ final class SeqMatcher implements Matcher, Serializable {
   @Override
   public String prefix() {
     return matchers[0].prefix();
+  }
+
+  @Override
+  public String containedString() {
+    return matchers[0].containedString();
   }
 
   @Override

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/StartsWithMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/StartsWithMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2023 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,6 +55,21 @@ final class StartsWithMatcher implements Matcher, Serializable {
   @Override
   public String prefix() {
     return pattern;
+  }
+
+  @Override
+  public String containedString() {
+    return pattern;
+  }
+
+  @Override
+  public boolean isPrefixMatcher() {
+    return true;
+  }
+
+  @Override
+  public boolean isContainsMatcher() {
+    return true;
   }
 
   @Override

--- a/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/ContainsTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/ContainsTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.impl.matcher;
+
+import com.netflix.spectator.impl.PatternMatcher;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ContainsTest {
+
+  private PatternMatcher re(String pattern) {
+    return PatternMatcher.compile(pattern);
+  }
+
+  private void assertStartsWith(String pattern) {
+    PatternMatcher m = re(pattern);
+    Assertions.assertTrue(m.isPrefixMatcher(), pattern);
+    Assertions.assertTrue(m.isContainsMatcher(), pattern);
+  }
+
+  private void assertContainsOnly(String pattern) {
+    PatternMatcher m = re(pattern);
+    Assertions.assertFalse(m.isPrefixMatcher(), pattern);
+    Assertions.assertTrue(m.isContainsMatcher(), pattern);
+  }
+
+  @Test
+  public void startsWith() {
+    assertStartsWith("^abc");
+    assertStartsWith("^abc[.]def");
+    assertStartsWith("^abc\\.def");
+  }
+
+  @Test
+  public void notStartsWith() {
+    Assertions.assertFalse(re("abc").isPrefixMatcher());
+    Assertions.assertFalse(re("ab[cd]").isPrefixMatcher());
+    Assertions.assertFalse(re("^abc.def").isPrefixMatcher());
+  }
+
+  @Test
+  public void contains() {
+    assertContainsOnly("abc");
+    assertContainsOnly(".*abc");
+    assertContainsOnly("abc\\.def");
+  }
+
+  @Test
+  public void notContains() {
+    Assertions.assertFalse(re("ab[cd]").isContainsMatcher());
+    Assertions.assertFalse(re("abc.def").isContainsMatcher());
+  }
+
+  @Test
+  public void containedString() {
+    Assertions.assertEquals("abc", re("abc").containedString());
+    Assertions.assertEquals("abc", re(".*abc").containedString());
+    Assertions.assertEquals("ab", re(".*ab[cd]").containedString());
+    Assertions.assertEquals("abc", re("abc.def").containedString());
+    Assertions.assertEquals("abc.def", re("abc\\.def").containedString());
+    Assertions.assertEquals("abc", re("^abc.def").containedString());
+    Assertions.assertEquals("abc.def", re("^abc\\.def").containedString());
+  }
+}


### PR DESCRIPTION
Adds support to PatternMatcher to check if a pattern is a strict starts-with or contains check. This can be useful when mapping to some data stores that have optimizations for those operations that will not work with arbitrary regex. Also adds a method to get a contained string that can be used as an initial filter.