### PR TITLE
atlas: fix duplicate flush on shutdown

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
@@ -244,7 +244,7 @@ public final class AtlasRegistry extends AbstractRegistry implements AutoCloseab
     return debugRegistry.timer(PUBLISH_TASK_TIMER, "id", id);
   }
 
-  void sendToAtlas() {
+  synchronized void sendToAtlas() {
     publishTaskTimer("sendToAtlas").record(() -> {
       if (config.enabled()) {
         long t = lastCompletedTimestamp(stepMillis);
@@ -272,7 +272,7 @@ public final class AtlasRegistry extends AbstractRegistry implements AutoCloseab
     });
   }
 
-  void sendToLWC() {
+  synchronized void sendToLWC() {
     publishTaskTimer("sendToLWC").record(() -> {
       long t = lastCompletedTimestamp(lwcStepMillis);
       //if (config.enabled() || config.lwcEnabled()) {


### PR DESCRIPTION
If it was in the process of sending data when the registry is shutdown, then it could result in the same time interval getting sent multiple times. Synchronizing the methods is a simple solution for now as only a single thread should be performing a send at a given time.