### PR TITLE
extract trigrams for patterns

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/impl/PatternMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/PatternMatcher.java
@@ -19,6 +19,7 @@ import com.netflix.spectator.impl.matcher.PatternUtils;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.SortedSet;
 
 /**
  * Efficient alternative to using {@link java.util.regex.Pattern} for use cases that just
@@ -118,6 +119,16 @@ public interface PatternMatcher {
    */
   default boolean isContainsMatcher() {
     return false;
+  }
+
+  /**
+   * Returns a set of trigrams for this pattern. A string will only match if it contains
+   * all trigrams in the set. This can be useful for performing an initial filter based on
+   * a trigram index. For complex expressions, expand OR clauses first (see
+   * {@link #expandOrClauses(int)}) and then extract the trigrams for the individual patterns.
+   */
+  default SortedSet<String> trigrams() {
+    return Collections.emptySortedSet();
   }
 
   /**

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/CharSeqMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/CharSeqMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2023 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package com.netflix.spectator.impl.matcher;
 
 import java.io.Serializable;
 import java.util.Objects;
+import java.util.SortedSet;
 
 /** Matcher that checks for a sequence of characters. */
 final class CharSeqMatcher implements Matcher, Serializable {
@@ -45,6 +46,11 @@ final class CharSeqMatcher implements Matcher, Serializable {
   /** Sub-string to look for within the string being checked. */
   String pattern() {
     return pattern;
+  }
+
+  @Override
+  public SortedSet<String> trigrams() {
+    return PatternUtils.computeTrigrams(pattern);
   }
 
   @Override

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/IndexOfMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/IndexOfMatcher.java
@@ -17,6 +17,8 @@ package com.netflix.spectator.impl.matcher;
 
 import java.io.Serializable;
 import java.util.Objects;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.function.Function;
 
 /**
@@ -60,6 +62,14 @@ final class IndexOfMatcher implements GreedyMatcher, Serializable {
   @Override
   public boolean isContainsMatcher() {
     return next == TrueMatcher.INSTANCE;
+  }
+
+  @Override
+  public SortedSet<String> trigrams() {
+    SortedSet<String> ts = new TreeSet<>();
+    ts.addAll(PatternUtils.computeTrigrams(pattern));
+    ts.addAll(next.trigrams());
+    return ts;
   }
 
   private int indexOfIgnoreCase(String str, int offset) {

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/PatternUtils.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/PatternUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2022 Netflix, Inc.
+ * Copyright 2014-2023 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -625,6 +627,20 @@ public final class PatternUtils {
       return pattern.length() <= 1 ? TrueMatcher.INSTANCE : new CharSeqMatcher(pattern.substring(1));
     } else {
       return TrueMatcher.INSTANCE;
+    }
+  }
+
+  /** Compute the set of trigrams for an input string. */
+  public static SortedSet<String> computeTrigrams(String input) {
+    if (input.length() < 3) {
+      return Collections.emptySortedSet();
+    } else {
+      SortedSet<String> trigrams = new TreeSet<>();
+      int n = input.length() - 3;
+      for (int i = 0; i <= n; ++i) {
+        trigrams.add(input.substring(i, i + 3));
+      }
+      return trigrams;
     }
   }
 }

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/RepeatMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/RepeatMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2022 Netflix, Inc.
+ * Copyright 2014-2023 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package com.netflix.spectator.impl.matcher;
 
 import java.io.Serializable;
 import java.util.Objects;
+import java.util.SortedSet;
 import java.util.function.Function;
 
 /** Matcher that looks for a fixed number of repetitions. */
@@ -45,6 +46,11 @@ final class RepeatMatcher implements Matcher, Serializable {
 
   int max() {
     return max;
+  }
+
+  @Override
+  public SortedSet<String> trigrams() {
+    return repeated.trigrams();
   }
 
   @Override

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/SeqMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/SeqMatcher.java
@@ -20,6 +20,8 @@ import com.netflix.spectator.impl.PatternMatcher;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.function.Function;
 
 /**
@@ -79,6 +81,15 @@ final class SeqMatcher implements Matcher, Serializable {
   @Override
   public String containedString() {
     return matchers[0].containedString();
+  }
+
+  @Override
+  public SortedSet<String> trigrams() {
+    SortedSet<String> ts = new TreeSet<>();
+    for (Matcher m : matchers) {
+      ts.addAll(m.trigrams());
+    }
+    return ts;
   }
 
   @Override

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/StartsWithMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/StartsWithMatcher.java
@@ -17,6 +17,7 @@ package com.netflix.spectator.impl.matcher;
 
 import java.io.Serializable;
 import java.util.Objects;
+import java.util.SortedSet;
 
 /**
  * Matcher that checks if the string starts with a given character sequence.
@@ -70,6 +71,11 @@ final class StartsWithMatcher implements Matcher, Serializable {
   @Override
   public boolean isContainsMatcher() {
     return true;
+  }
+
+  @Override
+  public SortedSet<String> trigrams() {
+    return PatternUtils.computeTrigrams(pattern);
   }
 
   @Override

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/ZeroOrMoreMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/ZeroOrMoreMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2022 Netflix, Inc.
+ * Copyright 2014-2023 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@ import com.netflix.spectator.impl.Preconditions;
 
 import java.io.Serializable;
 import java.util.Objects;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.function.Function;
 
 /**
@@ -45,6 +47,14 @@ final class ZeroOrMoreMatcher implements GreedyMatcher, Serializable {
   /** Return the matcher for the portion that follows the sub-string. */
   Matcher next() {
     return next;
+  }
+
+  @Override
+  public SortedSet<String> trigrams() {
+    SortedSet<String> ts = new TreeSet<>();
+    ts.addAll(repeated.trigrams());
+    ts.addAll(next.trigrams());
+    return ts;
   }
 
   @Override

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/ZeroOrOneMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/ZeroOrOneMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2022 Netflix, Inc.
+ * Copyright 2014-2023 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@ import com.netflix.spectator.impl.Preconditions;
 
 import java.io.Serializable;
 import java.util.Objects;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.function.Function;
 
 /**
@@ -45,6 +47,14 @@ final class ZeroOrOneMatcher implements GreedyMatcher, Serializable {
   /** Return the matcher for the portion that follows. */
   Matcher next() {
     return next;
+  }
+
+  @Override
+  public SortedSet<String> trigrams() {
+    SortedSet<String> ts = new TreeSet<>();
+    ts.addAll(repeated.trigrams());
+    ts.addAll(next.trigrams());
+    return ts;
   }
 
   @Override

--- a/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/PatternUtilsTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/PatternUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2023 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,11 @@ package com.netflix.spectator.impl.matcher;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 public class PatternUtilsTest {
 
@@ -178,5 +183,25 @@ public class PatternUtilsTest {
   @Test
   public void escapeDelete() {
     Assertions.assertEquals("\\u007f", PatternUtils.escape("\u007f"));
+  }
+
+  @Test
+  public void computeTrigramsTooShort() {
+    Assertions.assertEquals(Collections.emptySortedSet(), PatternUtils.computeTrigrams(""));
+    Assertions.assertEquals(Collections.emptySortedSet(), PatternUtils.computeTrigrams("a"));
+    Assertions.assertEquals(Collections.emptySortedSet(), PatternUtils.computeTrigrams("ab"));
+  }
+
+  private SortedSet<String> sortedSet(String... items) {
+    return new TreeSet<>(Arrays.asList(items));
+  }
+
+  @Test
+  public void computeTrigrams() {
+    Assertions.assertEquals(sortedSet("abc"), PatternUtils.computeTrigrams("abc"));
+    Assertions.assertEquals(
+        sortedSet("abc", "bcd", "cde", "def", "efg"),
+        PatternUtils.computeTrigrams("abcdefg")
+    );
   }
 }

--- a/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/TrigramsTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/TrigramsTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.impl.matcher;
+
+import com.netflix.spectator.impl.PatternMatcher;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+public class TrigramsTest {
+
+  @Test
+  public void startsWith() {
+    PatternMatcher m = PatternMatcher.compile("^abcd");
+    Assertions.assertEquals(sortedSet("abc", "bcd"), m.trigrams());
+  }
+
+  @Test
+  public void contains() {
+    PatternMatcher m = PatternMatcher.compile(".*abcd");
+    Assertions.assertEquals(sortedSet("abc", "bcd"), m.trigrams());
+  }
+
+  @Test
+  public void endsWith() {
+    PatternMatcher m = PatternMatcher.compile(".*abcd$");
+    Assertions.assertEquals(sortedSet("abc", "bcd"), m.trigrams());
+  }
+
+  @Test
+  public void zeroOrMore() {
+    PatternMatcher m = PatternMatcher.compile("(abc)*def");
+    Assertions.assertEquals(sortedSet("abc", "def"), m.trigrams());
+  }
+
+  @Test
+  public void zeroOrOne() {
+    PatternMatcher m = PatternMatcher.compile("(abc)?def");
+    Assertions.assertEquals(sortedSet("abc", "def"), m.trigrams());
+  }
+
+  @Test
+  public void oneOrMore() {
+    PatternMatcher m = PatternMatcher.compile("(abc)+def");
+    Assertions.assertEquals(sortedSet("abc", "def"), m.trigrams());
+  }
+
+  @Test
+  public void repeat() {
+    PatternMatcher m = PatternMatcher.compile("(abc){0,5}def");
+    Assertions.assertEquals(sortedSet("abc", "def"), m.trigrams());
+  }
+
+  @Test
+  public void partOfSequence() {
+    PatternMatcher m = PatternMatcher.compile(".*[0-9]abcd[efg]hij");
+    Assertions.assertEquals(sortedSet("abc", "bcd", "hij"), m.trigrams());
+  }
+
+  @Test
+  public void multiple() {
+    PatternMatcher m = PatternMatcher.compile("^abc.*def.*ghi");
+    Assertions.assertEquals(sortedSet("abc", "def", "ghi"), m.trigrams());
+  }
+
+  @Test
+  public void orClause() {
+    PatternMatcher matcher = PatternMatcher.compile(".*(abc|def|ghi)");
+    Assertions.assertEquals(Collections.emptySortedSet(), matcher.trigrams());
+
+    List<PatternMatcher> ms = matcher.expandOrClauses(5);
+    Assertions.assertEquals(3, ms.size());
+    SortedSet<String> trigrams = new TreeSet<>();
+    for (PatternMatcher m : ms) {
+      SortedSet<String> ts = m.trigrams();
+      Assertions.assertEquals(1, ts.size());
+      trigrams.addAll(ts);
+    }
+    Assertions.assertEquals(sortedSet("abc", "def", "ghi"), trigrams);
+  }
+
+  private SortedSet<String> sortedSet(String... items) {
+    return new TreeSet<>(Arrays.asList(items));
+  }
+}


### PR DESCRIPTION
Add method to PatternMatcher that can be used to extract a set of trigrams based on the pattern. For the pattern to match, a string must contain all of the trigrams. This only indicates a string might match, the full pattern will still need to be evaluated on the candidates that contain all of the trigrams.