### PR TITLE
api: Fix duplicate tag bug.

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/ArrayTagSet.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/ArrayTagSet.java
@@ -337,6 +337,7 @@ final class ArrayTagSet implements TagList {
   /**
    * Merge and dedup any entries in {@code ts} that have the same key. The last entry
    * with a given key will get selected.
+   * Note: Each list must be sorted by key before processing.
    */
   private static int merge(String[] dst, String[] srcA, int lengthA, String[] srcB, int lengthB) {
     int i = 0;
@@ -348,6 +349,11 @@ final class ArrayTagSet implements TagList {
       final String av = srcA[ai + 1];
       String bk = srcB[bi];
       String bv = srcB[bi + 1];
+      if (i > 1 && bk.compareTo(dst[i - 2]) == 0) {
+        // skip duplicates in the second array.
+        bi += 2;
+        continue;
+      }
       int cmp = ak.compareTo(bk);
       if (cmp < 0) {
         dst[i++] = ak;

--- a/spectator-api/src/main/java/com/netflix/spectator/api/ArrayTagSet.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/ArrayTagSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2020 Netflix, Inc.
+ * Copyright 2014-2023 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -336,10 +336,9 @@ final class ArrayTagSet implements TagList {
 
   /**
    * Merge and dedup any entries in {@code ts} that have the same key. The last entry
-   * with a given key will get selected.
-   * Note: Each list must be sorted by key before processing.
+   * with a given key will get selected. Each list must be sorted by key before processing.
    */
-  private static int merge(String[] dst, String[] srcA, int lengthA, String[] srcB, int lengthB) {
+  static int merge(String[] dst, String[] srcA, int lengthA, String[] srcB, int lengthB) {
     int i = 0;
     int ai = 0;
     int bi = 0;
@@ -349,20 +348,22 @@ final class ArrayTagSet implements TagList {
       final String av = srcA[ai + 1];
       String bk = srcB[bi];
       String bv = srcB[bi + 1];
-      if (i > 1 && bk.compareTo(dst[i - 2]) == 0) {
-        // skip duplicates in the second array.
-        bi += 2;
-        continue;
-      }
       int cmp = ak.compareTo(bk);
       if (cmp < 0) {
+        // srcA should already have been deduped as it comes from the tag list
         dst[i++] = ak;
         dst[i++] = av;
         ai += 2;
       } else if (cmp > 0) {
+        // Choose last value for a given key if there are duplicates. It is possible srcB
+        // will contain duplicates if the user supplied a type like a list.
+        int j = bi + 2;
+        for (; j < lengthB && bk.equals(srcB[j]); j += 2) {
+          bv = srcB[j + 1];
+        }
         dst[i++] = bk;
         dst[i++] = bv;
-        bi += 2;
+        bi = j;
       } else {
         // Newer tags should override, use source B if there are duplicate keys.
         // If source B has duplicates, then use the last value for the given key.

--- a/spectator-api/src/test/java/com/netflix/spectator/api/ArrayTagSetTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/ArrayTagSetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2020 Netflix, Inc.
+ * Copyright 2014-2023 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -716,6 +716,37 @@ public class ArrayTagSetTest {
     ArrayTagSet tags = ArrayTagSet.create("a", "v1", "b", "v2", "c", "v3");
     ArrayTagSet updated = tags.add("c", "v3");
     Assertions.assertSame(tags, updated);
+  }
+
+  @Test
+  public void mergeDuplicatesTwoKeys() {
+    String[] dst = new String[8];
+    String[] srcA = {"a", "2"};
+    String[] srcB = {"a", "1", "b", "1", "b", "2"};
+
+    int n = ArrayTagSet.merge(dst, srcA, srcA.length, srcB, srcB.length);
+    Assertions.assertArrayEquals(new String[] {"a", "1", "b", "2", null, null, null, null}, dst);
+    Assertions.assertEquals(4, n);
+  }
+
+  @Test
+  public void mergeDuplicatesSrcB() {
+    String[] dst = new String[8];
+    String[] srcA = {"b", "1"};
+    String[] srcB = {"a", "1", "a", "2"};
+    int n = ArrayTagSet.merge(dst, srcA, srcA.length, srcB, srcB.length);
+    Assertions.assertArrayEquals(new String[] {"a", "2", "b", "1", null, null, null, null}, dst);
+    Assertions.assertEquals(4, n);
+  }
+
+  @Test
+  public void mergeDuplicatesBoth() {
+    String[] dst = new String[8];
+    String[] srcA = {"a", "1"};
+    String[] srcB = {"a", "2", "a", "3"};
+    int n = ArrayTagSet.merge(dst, srcA, srcA.length, srcB, srcB.length);
+    Assertions.assertArrayEquals(new String[] {"a", "3", null, null, null, null, null, null}, dst);
+    Assertions.assertEquals(2, n);
   }
 
   @Test


### PR DESCRIPTION
It was possible to provide a list of `Tag`s to an `ArrayTagSet` with duplicate values. The duplicates would not be de-duped at merge time if the duplicate keys in the list were lexically less than that of existing tags. Merge now checks the last written tag value to make sure we don't write a duplicate key.