### PR TITLE
atlas: ignore unknown properties for lwc subs

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/SubscriptionManager.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/SubscriptionManager.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.spectator.atlas;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spectator.api.Clock;
 import com.netflix.spectator.atlas.impl.Subscription;
@@ -58,6 +59,7 @@ class SubscriptionManager {
   /** Create a new instance. */
   SubscriptionManager(ObjectMapper mapper, HttpClient client, Clock clock, AtlasConfig config) {
     this.mapper = mapper;
+    mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     this.client = client;
     this.clock = clock;
     this.uri = URI.create(config.configUri());

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/SubscriptionManagerTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/SubscriptionManagerTest.java
@@ -99,6 +99,15 @@ public class SubscriptionManagerTest {
   }
 
   @Test
+  public void unknownField() {
+    ManualClock clock = new ManualClock();
+    byte[] data = "{\"expressions\":[{\"expression\":\"name,1,:eq,:sum\",\"id\":\"1\",\"frequency\":60000,\"foo\":\"bar\"}]}".getBytes(StandardCharsets.UTF_8);
+    SubscriptionManager mgr = newInstance(clock, ok(data));
+    mgr.refresh();
+    Assertions.assertEquals(set(sub(1)), new HashSet<>(mgr.subscriptions()));
+  }
+
+  @Test
   public void singleExpression() throws Exception {
     ManualClock clock = new ManualClock();
     byte[] data = json(sub(1));


### PR DESCRIPTION
Update the JSON parsing for the LWC subscription manager so that it will ignore unknown fields. This avoids breaking if the server adds some additional metadata to the response. There is the expectation, that new fields can be added as long as it doesn't otherwise break the expected behavior for old clients.