### PR TITLE
additional tests for contains and trigrams

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/CharSeqMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/CharSeqMatcher.java
@@ -49,6 +49,11 @@ final class CharSeqMatcher implements Matcher, Serializable {
   }
 
   @Override
+  public String containedString() {
+    return pattern;
+  }
+
+  @Override
   public SortedSet<String> trigrams() {
     return PatternUtils.computeTrigrams(pattern);
   }

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/RepeatMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/RepeatMatcher.java
@@ -16,6 +16,7 @@
 package com.netflix.spectator.impl.matcher;
 
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.Objects;
 import java.util.SortedSet;
 import java.util.function.Function;
@@ -49,8 +50,13 @@ final class RepeatMatcher implements Matcher, Serializable {
   }
 
   @Override
+  public String containedString() {
+    return min == 0 ? null : repeated.containedString();
+  }
+
+  @Override
   public SortedSet<String> trigrams() {
-    return repeated.trigrams();
+    return min == 0 ? Collections.emptySortedSet() : repeated.trigrams();
   }
 
   @Override

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/SeqMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/SeqMatcher.java
@@ -80,7 +80,12 @@ final class SeqMatcher implements Matcher, Serializable {
 
   @Override
   public String containedString() {
-    return matchers[0].containedString();
+    String str = null;
+    for (Matcher m : matchers) {
+      str = m.containedString();
+      if (str != null) break;
+    }
+    return str;
   }
 
   @Override

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/ZeroOrMoreMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/ZeroOrMoreMatcher.java
@@ -50,11 +50,13 @@ final class ZeroOrMoreMatcher implements GreedyMatcher, Serializable {
   }
 
   @Override
+  public String containedString() {
+    return next.containedString();
+  }
+
+  @Override
   public SortedSet<String> trigrams() {
-    SortedSet<String> ts = new TreeSet<>();
-    ts.addAll(repeated.trigrams());
-    ts.addAll(next.trigrams());
-    return ts;
+    return next.trigrams();
   }
 
   @Override

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/ZeroOrMoreMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/ZeroOrMoreMatcher.java
@@ -20,7 +20,6 @@ import com.netflix.spectator.impl.Preconditions;
 import java.io.Serializable;
 import java.util.Objects;
 import java.util.SortedSet;
-import java.util.TreeSet;
 import java.util.function.Function;
 
 /**

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/ZeroOrOneMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/ZeroOrOneMatcher.java
@@ -50,11 +50,13 @@ final class ZeroOrOneMatcher implements GreedyMatcher, Serializable {
   }
 
   @Override
+  public String containedString() {
+    return next.containedString();
+  }
+
+  @Override
   public SortedSet<String> trigrams() {
-    SortedSet<String> ts = new TreeSet<>();
-    ts.addAll(repeated.trigrams());
-    ts.addAll(next.trigrams());
-    return ts;
+    return next.trigrams();
   }
 
   @Override

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/ZeroOrOneMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/ZeroOrOneMatcher.java
@@ -20,7 +20,6 @@ import com.netflix.spectator.impl.Preconditions;
 import java.io.Serializable;
 import java.util.Objects;
 import java.util.SortedSet;
-import java.util.TreeSet;
 import java.util.function.Function;
 
 /**

--- a/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/AbstractPatternMatcherTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/AbstractPatternMatcherTest.java
@@ -422,6 +422,14 @@ public abstract class AbstractPatternMatcherTest {
   }
 
   @Test
+  public void repeatZero() {
+    testRE("(abc){0,3}def", "def");
+    testRE("(abc){0,3}def", "abcdef");
+    testRE("(abc){1,3}def", "def");
+    testRE("(abc){1,3}def", "abcdef");
+  }
+
+  @Test
   public void repeatWithOr() {
     testRE("(a|b|c){1,3}d", "aaad");
     testRE("(a|b|c){1,3}d", "aaa");

--- a/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/ContainsPatternMatcherTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/ContainsPatternMatcherTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.impl.matcher;
+
+import com.netflix.spectator.impl.PatternMatcher;
+import org.junit.jupiter.api.Assertions;
+
+public class ContainsPatternMatcherTest extends AbstractPatternMatcherTest {
+
+  @Override
+  protected void testRE(String regex, String value) {
+    PatternMatcher matcher = PatternMatcher.compile(regex);
+    String str = matcher.containedString();
+
+    // Contains should be more lenient than the actual pattern, so anything that is matched
+    // by the pattern must be a possible match with the trigrams.
+    if (str != null && matcher.matches(value)) {
+      Assertions.assertTrue(value.contains(str));
+    }
+  }
+}

--- a/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/ContainsTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/ContainsTest.java
@@ -68,10 +68,46 @@ public class ContainsTest {
   public void containedString() {
     Assertions.assertEquals("abc", re("abc").containedString());
     Assertions.assertEquals("abc", re(".*abc").containedString());
+    Assertions.assertEquals("abc", re(".*abc$").containedString());
     Assertions.assertEquals("ab", re(".*ab[cd]").containedString());
     Assertions.assertEquals("abc", re("abc.def").containedString());
     Assertions.assertEquals("abc.def", re("abc\\.def").containedString());
     Assertions.assertEquals("abc", re("^abc.def").containedString());
     Assertions.assertEquals("abc.def", re("^abc\\.def").containedString());
+  }
+
+  @Test
+  public void containsZeroOrMore() {
+    Assertions.assertEquals("def", re("(abc)*def").containedString());
+  }
+
+  @Test
+  public void containsZeroOrOne() {
+    Assertions.assertEquals("def", re("(abc)?def").containedString());
+  }
+
+  @Test
+  public void containsOneOrMore() {
+    Assertions.assertEquals("abc", re("(abc)+def").containedString());
+  }
+
+  @Test
+  public void containsRepeat() {
+    Assertions.assertEquals("def", re("(abc){0,5}def").containedString());
+  }
+
+  @Test
+  public void containsRepeatAtLeastOne() {
+    Assertions.assertEquals("abc", re("(abc){1,5}def").containedString());
+  }
+
+  @Test
+  public void containsPartOfSequence() {
+    Assertions.assertEquals("abcd", re(".*[0-9]abcd[efg]hij").containedString());
+  }
+
+  @Test
+  public void containsMultiple() {
+    Assertions.assertEquals("abc", re("^abc.*def.*ghi").containedString());
   }
 }

--- a/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/TrigramsPatternMatcherTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/TrigramsPatternMatcherTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.impl.matcher;
+
+import com.netflix.spectator.impl.PatternMatcher;
+import org.junit.jupiter.api.Assertions;
+
+import java.util.SortedSet;
+
+public class TrigramsPatternMatcherTest extends AbstractPatternMatcherTest {
+
+  @Override
+  protected void testRE(String regex, String value) {
+    PatternMatcher matcher = PatternMatcher.compile(regex);
+    SortedSet<String> trigrams = matcher.trigrams();
+
+    // Trigrams should be more lenient than the actual pattern, so anything that is matched
+    // by the pattern must be a possible match with the trigrams.
+    if (matcher.matches(value)) {
+      Assertions.assertTrue(couldMatch(trigrams, value));
+    }
+  }
+
+  private boolean couldMatch(SortedSet<String> trigrams, String value) {
+    return trigrams.stream().allMatch(value::contains);
+  }
+}

--- a/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/TrigramsTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/TrigramsTest.java
@@ -48,13 +48,13 @@ public class TrigramsTest {
   @Test
   public void zeroOrMore() {
     PatternMatcher m = PatternMatcher.compile("(abc)*def");
-    Assertions.assertEquals(sortedSet("abc", "def"), m.trigrams());
+    Assertions.assertEquals(sortedSet("def"), m.trigrams());
   }
 
   @Test
   public void zeroOrOne() {
     PatternMatcher m = PatternMatcher.compile("(abc)?def");
-    Assertions.assertEquals(sortedSet("abc", "def"), m.trigrams());
+    Assertions.assertEquals(sortedSet("def"), m.trigrams());
   }
 
   @Test
@@ -66,6 +66,12 @@ public class TrigramsTest {
   @Test
   public void repeat() {
     PatternMatcher m = PatternMatcher.compile("(abc){0,5}def");
+    Assertions.assertEquals(sortedSet("def"), m.trigrams());
+  }
+
+  @Test
+  public void repeatAtLeastOne() {
+    PatternMatcher m = PatternMatcher.compile("(abc){1,5}def");
     Assertions.assertEquals(sortedSet("abc", "def"), m.trigrams());
   }
 


### PR DESCRIPTION
Put in some additional test cases for extracting contained strings and trigrams from patterns. Fixes some cases with trigram extraction for repeats that can be absent from the string and still match.