### PR TITLE
api: add helper methods for Suppliers

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/AbstractTimer.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/AbstractTimer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2023 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,6 @@
  */
 package com.netflix.spectator.api;
 
-import java.util.concurrent.Callable;
-import java.util.concurrent.TimeUnit;
-
-
 /**
  * Base class to simplify implementing a {@link Timer}.
  */
@@ -32,23 +28,7 @@ public abstract class AbstractTimer implements Timer {
     this.clock = clock;
   }
 
-  @Override public <T> T record(Callable<T> f) throws Exception {
-    final long s = clock.monotonicTime();
-    try {
-      return f.call();
-    } finally {
-      final long e = clock.monotonicTime();
-      record(e - s, TimeUnit.NANOSECONDS);
-    }
-  }
-
-  @Override public void record(Runnable f) {
-    final long s = clock.monotonicTime();
-    try {
-      f.run();
-    } finally {
-      final long e = clock.monotonicTime();
-      record(e - s, TimeUnit.NANOSECONDS);
-    }
+  @Override public Clock clock() {
+    return clock;
   }
 }

--- a/spectator-api/src/main/java/com/netflix/spectator/api/CompositeTimer.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/CompositeTimer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2023 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package com.netflix.spectator.api;
 
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 /** Timer implementation for the composite registry. */
@@ -31,29 +30,13 @@ final class CompositeTimer extends CompositeMeter<Timer> implements Timer {
     this.clock = clock;
   }
 
+  @Override public Clock clock() {
+    return clock;
+  }
+
   @Override public void record(long amount, TimeUnit unit) {
     for (Timer t : meters) {
       t.record(amount, unit);
-    }
-  }
-
-  @Override public <T> T record(Callable<T> f) throws Exception {
-    final long s = clock.monotonicTime();
-    try {
-      return f.call();
-    } finally {
-      final long e = clock.monotonicTime();
-      record(e - s, TimeUnit.NANOSECONDS);
-    }
-  }
-
-  @Override public void record(Runnable f) {
-    final long s = clock.monotonicTime();
-    try {
-      f.run();
-    } finally {
-      final long e = clock.monotonicTime();
-      record(e - s, TimeUnit.NANOSECONDS);
     }
   }
 

--- a/spectator-api/src/main/java/com/netflix/spectator/api/NoopTimer.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/NoopTimer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2023 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 package com.netflix.spectator.api;
 
 import java.util.Collections;
-import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 /** Counter implementation for the no-op registry. */
@@ -37,14 +36,6 @@ enum NoopTimer implements Timer {
 
   @Override public Iterable<Measurement> measure() {
     return Collections.emptyList();
-  }
-
-  @Override public <T> T record(Callable<T> f) throws Exception {
-    return f.call();
-  }
-
-  @Override public void record(Runnable f) {
-    f.run();
   }
 
   @Override public long count() {

--- a/spectator-api/src/main/java/com/netflix/spectator/api/SwapTimer.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/SwapTimer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2022 Netflix, Inc.
+ * Copyright 2014-2023 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package com.netflix.spectator.api;
 
 import com.netflix.spectator.impl.SwapMeter;
 
-import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.LongSupplier;
@@ -35,28 +34,12 @@ final class SwapTimer extends SwapMeter<Timer> implements Timer {
     return registry.timer(id);
   }
 
+  @Override public Clock clock() {
+    return registry.clock();
+  }
+
   @Override public void record(long amount, TimeUnit unit) {
     get().record(amount, unit);
-  }
-
-  @Override public <T> T record(Callable<T> f) throws Exception {
-    final long s = registry.clock().monotonicTime();
-    try {
-      return f.call();
-    } finally {
-      final long e = registry.clock().monotonicTime();
-      record(e - s, TimeUnit.NANOSECONDS);
-    }
-  }
-
-  @Override public void record(Runnable f) {
-    final long s = registry.clock().monotonicTime();
-    try {
-      f.run();
-    } finally {
-      final long e = registry.clock().monotonicTime();
-      record(e - s, TimeUnit.NANOSECONDS);
-    }
   }
 
   @Override public long count() {

--- a/spectator-api/src/main/java/com/netflix/spectator/api/Timer.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/Timer.java
@@ -173,7 +173,7 @@ public interface Timer extends Meter {
   }
 
   /**
-   * Executes the callable `f` and records the time taken.
+   * Executes the supplier `f` and records the time taken.
    *
    * @param f
    *     Function to execute and measure the execution time.
@@ -192,7 +192,7 @@ public interface Timer extends Meter {
   }
 
   /**
-   * Executes the callable `f` and records the time taken.
+   * Executes the supplier `f` and records the time taken.
    *
    * @param f
    *     Function to execute and measure the execution time.
@@ -211,7 +211,7 @@ public interface Timer extends Meter {
   }
 
   /**
-   * Executes the callable `f` and records the time taken.
+   * Executes the supplier `f` and records the time taken.
    *
    * @param f
    *     Function to execute and measure the execution time.
@@ -230,7 +230,7 @@ public interface Timer extends Meter {
   }
 
   /**
-   * Executes the callable `f` and records the time taken.
+   * Executes the supplier `f` and records the time taken.
    *
    * @param f
    *     Function to execute and measure the execution time.
@@ -249,7 +249,7 @@ public interface Timer extends Meter {
   }
 
   /**
-   * Executes the callable `f` and records the time taken.
+   * Executes the supplier `f` and records the time taken.
    *
    * @param f
    *     Function to execute and measure the execution time.

--- a/spectator-api/src/main/java/com/netflix/spectator/api/histogram/BucketTimer.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/histogram/BucketTimer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2021 Netflix, Inc.
+ * Copyright 2014-2023 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@ import com.netflix.spectator.api.Timer;
 import com.netflix.spectator.api.Utils;
 
 import java.util.Collections;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -76,31 +75,13 @@ public final class BucketTimer implements Timer {
     return false;
   }
 
+  @Override public Clock clock() {
+    return registry.clock();
+  }
+
   @Override public void record(long amount, TimeUnit unit) {
     final long nanos = unit.toNanos(amount);
     timer(f.apply(nanos)).record(amount, unit);
-  }
-
-  @Override public <T> T record(Callable<T> rf) throws Exception {
-    final Clock clock = registry.clock();
-    final long s = clock.monotonicTime();
-    try {
-      return rf.call();
-    } finally {
-      final long e = clock.monotonicTime();
-      record(e - s, TimeUnit.NANOSECONDS);
-    }
-  }
-
-  @Override public void record(Runnable rf) {
-    final Clock clock = registry.clock();
-    final long s = clock.monotonicTime();
-    try {
-      rf.run();
-    } finally {
-      final long e = clock.monotonicTime();
-      record(e - s, TimeUnit.NANOSECONDS);
-    }
   }
 
   /** Return the timer for a given bucket. */

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/Scheduler.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/Scheduler.java
@@ -486,7 +486,7 @@ public class Scheduler {
             final long delay = clock.wallTime() - task.getNextExecutionTime();
             stats.taskExecutionDelay().record(delay, TimeUnit.MILLISECONDS);
 
-            stats.taskExecutionTime().record(() -> task.runAndReschedule(queue, stats));
+            stats.taskExecutionTime().recordRunnable(() -> task.runAndReschedule(queue, stats));
           } catch (InterruptedException e) {
             LOGGER.debug("task interrupted", e);
             break;

--- a/spectator-api/src/test/java/com/netflix/spectator/api/DefaultTimerTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/DefaultTimerTest.java
@@ -113,7 +113,7 @@ public class DefaultTimerTest {
   public void testRecordCallable() throws Exception {
     Timer t = new DefaultTimer(clock, NoopId.INSTANCE);
     clock.setMonotonicTime(100L);
-    int v = t.record(() -> {
+    int v = t.recordCallable(() -> {
       clock.setMonotonicTime(500L);
       return 42;
     });
@@ -128,7 +128,7 @@ public class DefaultTimerTest {
     clock.setMonotonicTime(100L);
     boolean seen = false;
     try {
-      t.record(() -> {
+      t.recordCallable(() -> {
         clock.setMonotonicTime(500L);
         throw new Exception("foo");
       });
@@ -144,18 +144,173 @@ public class DefaultTimerTest {
   public void testRecordRunnable() throws Exception {
     Timer t = new DefaultTimer(clock, NoopId.INSTANCE);
     clock.setMonotonicTime(100L);
-    t.record(() -> clock.setMonotonicTime(500L));
+    t.recordRunnable(() -> clock.setMonotonicTime(500L));
     Assertions.assertEquals(t.count(), 1L);
     Assertions.assertEquals(t.totalTime(), 400L);
   }
 
   @Test
-  public void testRecordRunnableException() throws Exception {
+  public void testRecordRunnableException() {
     Timer t = new DefaultTimer(clock, NoopId.INSTANCE);
     clock.setMonotonicTime(100L);
     boolean seen = false;
     try {
-      t.record(() -> {
+      t.recordRunnable(() -> {
+        clock.setMonotonicTime(500L);
+        throw new RuntimeException("foo");
+      });
+    } catch (Exception e) {
+      seen = true;
+    }
+    Assertions.assertTrue(seen);
+    Assertions.assertEquals(t.count(), 1L);
+    Assertions.assertEquals(t.totalTime(), 400L);
+  }
+
+  @Test
+  public void testRecordSupplier() throws Exception {
+    Timer t = new DefaultTimer(clock, NoopId.INSTANCE);
+    clock.setMonotonicTime(100L);
+    String value = t.recordSupplier(() -> {
+      clock.setMonotonicTime(500L);
+      return "foo";
+    });
+    Assertions.assertEquals(value, "foo");
+    Assertions.assertEquals(t.count(), 1L);
+    Assertions.assertEquals(t.totalTime(), 400L);
+  }
+
+  @Test
+  public void testRecordSupplierException() {
+    Timer t = new DefaultTimer(clock, NoopId.INSTANCE);
+    clock.setMonotonicTime(100L);
+    boolean seen = false;
+    try {
+      t.recordSupplier(() -> {
+        clock.setMonotonicTime(500L);
+        throw new RuntimeException("foo");
+      });
+    } catch (Exception e) {
+      seen = true;
+    }
+    Assertions.assertTrue(seen);
+    Assertions.assertEquals(t.count(), 1L);
+    Assertions.assertEquals(t.totalTime(), 400L);
+  }
+
+  @Test
+  public void testRecordBooleanSupplier() throws Exception {
+    Timer t = new DefaultTimer(clock, NoopId.INSTANCE);
+    clock.setMonotonicTime(100L);
+    boolean value = t.recordBooleanSupplier(() -> {
+      clock.setMonotonicTime(500L);
+      return true;
+    });
+    Assertions.assertTrue(value);
+    Assertions.assertEquals(t.count(), 1L);
+    Assertions.assertEquals(t.totalTime(), 400L);
+  }
+
+  @Test
+  public void testRecordBooleanSupplierException() {
+    Timer t = new DefaultTimer(clock, NoopId.INSTANCE);
+    clock.setMonotonicTime(100L);
+    boolean seen = false;
+    try {
+      t.recordBooleanSupplier(() -> {
+        clock.setMonotonicTime(500L);
+        throw new RuntimeException("foo");
+      });
+    } catch (Exception e) {
+      seen = true;
+    }
+    Assertions.assertTrue(seen);
+    Assertions.assertEquals(t.count(), 1L);
+    Assertions.assertEquals(t.totalTime(), 400L);
+  }
+
+  @Test
+  public void testRecordIntSupplier() throws Exception {
+    Timer t = new DefaultTimer(clock, NoopId.INSTANCE);
+    clock.setMonotonicTime(100L);
+    int value = t.recordIntSupplier(() -> {
+      clock.setMonotonicTime(500L);
+      return 42;
+    });
+    Assertions.assertEquals(value, 42);
+    Assertions.assertEquals(t.count(), 1L);
+    Assertions.assertEquals(t.totalTime(), 400L);
+  }
+
+  @Test
+  public void testRecordIntSupplierException() {
+    Timer t = new DefaultTimer(clock, NoopId.INSTANCE);
+    clock.setMonotonicTime(100L);
+    boolean seen = false;
+    try {
+      t.recordIntSupplier(() -> {
+        clock.setMonotonicTime(500L);
+        throw new RuntimeException("foo");
+      });
+    } catch (Exception e) {
+      seen = true;
+    }
+    Assertions.assertTrue(seen);
+    Assertions.assertEquals(t.count(), 1L);
+    Assertions.assertEquals(t.totalTime(), 400L);
+  }
+
+  @Test
+  public void testRecordLongSupplier() throws Exception {
+    Timer t = new DefaultTimer(clock, NoopId.INSTANCE);
+    clock.setMonotonicTime(100L);
+    long value = t.recordLongSupplier(() -> {
+      clock.setMonotonicTime(500L);
+      return 42L;
+    });
+    Assertions.assertEquals(value, 42L);
+    Assertions.assertEquals(t.count(), 1L);
+    Assertions.assertEquals(t.totalTime(), 400L);
+  }
+
+  @Test
+  public void testRecordLongSupplierException() {
+    Timer t = new DefaultTimer(clock, NoopId.INSTANCE);
+    clock.setMonotonicTime(100L);
+    boolean seen = false;
+    try {
+      t.recordLongSupplier(() -> {
+        clock.setMonotonicTime(500L);
+        throw new RuntimeException("foo");
+      });
+    } catch (Exception e) {
+      seen = true;
+    }
+    Assertions.assertTrue(seen);
+    Assertions.assertEquals(t.count(), 1L);
+    Assertions.assertEquals(t.totalTime(), 400L);
+  }
+
+  @Test
+  public void testRecordDoubleSupplier() throws Exception {
+    Timer t = new DefaultTimer(clock, NoopId.INSTANCE);
+    clock.setMonotonicTime(100L);
+    double value = t.recordDoubleSupplier(() -> {
+      clock.setMonotonicTime(500L);
+      return 42.5;
+    });
+    Assertions.assertEquals(value, 42.5);
+    Assertions.assertEquals(t.count(), 1L);
+    Assertions.assertEquals(t.totalTime(), 400L);
+  }
+
+  @Test
+  public void testRecordDoubleSupplierException() {
+    Timer t = new DefaultTimer(clock, NoopId.INSTANCE);
+    clock.setMonotonicTime(100L);
+    boolean seen = false;
+    try {
+      t.recordDoubleSupplier(() -> {
         clock.setMonotonicTime(500L);
         throw new RuntimeException("foo");
       });
@@ -174,7 +329,7 @@ public class DefaultTimerTest {
   @Test
   public void testCallable() throws Exception {
     Timer t = new DefaultTimer(clock, NoopId.INSTANCE);
-    int v2 = t.record(() -> square(42));
+    int v2 = t.recordCallable(() -> square(42));
   }
 
   @Test

--- a/spectator-ext-sandbox/src/main/java/com/netflix/spectator/sandbox/BucketTimer.java
+++ b/spectator-ext-sandbox/src/main/java/com/netflix/spectator/sandbox/BucketTimer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2023 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,13 @@
  */
 package com.netflix.spectator.sandbox;
 
+import com.netflix.spectator.api.Clock;
 import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Measurement;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Spectator;
 import com.netflix.spectator.api.Timer;
 
-import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -85,16 +85,12 @@ public final class BucketTimer implements Timer {
     return t.hasExpired();
   }
 
+  @Override public Clock clock() {
+    return t.clock();
+  }
+
   @Override public void record(long amount, TimeUnit unit) {
     t.record(amount, unit);
-  }
-
-  @Override public <T> T record(Callable<T> rf) throws Exception {
-    return t.record(rf);
-  }
-
-  @Override public void record(Runnable rf) {
-    t.record(rf);
   }
 
   @Override public long count() {

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasTimer.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasTimer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2023 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ import com.netflix.spectator.impl.StepLong;
 import com.netflix.spectator.impl.StepValue;
 
 import java.time.Duration;
-import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -95,6 +94,10 @@ class AtlasTimer extends AtlasMeter implements Timer {
     consumer.accept(mid, timestamp, maxValue);
   }
 
+  @Override public Clock clock() {
+    return clock;
+  }
+
   @Override public void record(long amount, TimeUnit unit) {
     long now = clock.wallTime();
     count.getCurrent(now).incrementAndGet();
@@ -163,24 +166,6 @@ class AtlasTimer extends AtlasMeter implements Timer {
     long p = maxValue.get();
     while (v > p && !maxValue.compareAndSet(p, v)) {
       p = maxValue.get();
-    }
-  }
-
-  @Override public <T> T record(Callable<T> f) throws Exception {
-    final long start = clock.monotonicTime();
-    try {
-      return f.call();
-    } finally {
-      record(clock.monotonicTime() - start, TimeUnit.NANOSECONDS);
-    }
-  }
-
-  @Override public void record(Runnable f) {
-    final long start = clock.monotonicTime();
-    try {
-      f.run();
-    } finally {
-      record(clock.monotonicTime() - start, TimeUnit.NANOSECONDS);
     }
   }
 

--- a/spectator-reg-micrometer/src/main/java/com/netflix/spectator/micrometer/MicrometerRegistry.java
+++ b/spectator-reg-micrometer/src/main/java/com/netflix/spectator/micrometer/MicrometerRegistry.java
@@ -44,12 +44,14 @@ import java.util.stream.Collectors;
 public final class MicrometerRegistry implements Registry {
 
   private final MeterRegistry impl;
+  private final Clock clock;
 
   private final ConcurrentHashMap<Id, Object> state = new ConcurrentHashMap<>();
 
   /** Create a new instance. */
   public MicrometerRegistry(MeterRegistry impl) {
     this.impl = impl;
+    this.clock = new MicrometerClock(impl.config().clock());
   }
 
   private io.micrometer.core.instrument.Tag convert(Tag t) {
@@ -88,7 +90,7 @@ public final class MicrometerRegistry implements Registry {
   }
 
   @Override public Clock clock() {
-    return new MicrometerClock(impl.config().clock());
+    return clock;
   }
 
   @Override public Id createId(String name) {
@@ -116,7 +118,7 @@ public final class MicrometerRegistry implements Registry {
   }
 
   @Override public Timer timer(Id id) {
-    return new MicrometerTimer(id, impl.timer(id.name(), convert(id.tags())));
+    return new MicrometerTimer(id, impl.timer(id.name(), convert(id.tags())), clock);
   }
 
   @Override public Gauge gauge(Id id) {

--- a/spectator-reg-micrometer/src/main/java/com/netflix/spectator/micrometer/MicrometerTimer.java
+++ b/spectator-reg-micrometer/src/main/java/com/netflix/spectator/micrometer/MicrometerTimer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2023 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Measurement;
 import com.netflix.spectator.api.Timer;
 
-import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -37,14 +36,6 @@ class MicrometerTimer extends MicrometerMeter implements Timer {
 
   @Override public void record(long amount, TimeUnit unit) {
     impl.record(amount, unit);
-  }
-
-  @Override public <T> T record(Callable<T> f) throws Exception {
-    return impl.recordCallable(f);
-  }
-
-  @Override public void record(Runnable f) {
-    impl.record(f);
   }
 
   @Override public long count() {

--- a/spectator-reg-micrometer/src/main/java/com/netflix/spectator/micrometer/MicrometerTimer.java
+++ b/spectator-reg-micrometer/src/main/java/com/netflix/spectator/micrometer/MicrometerTimer.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.spectator.micrometer;
 
+import com.netflix.spectator.api.Clock;
 import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Measurement;
 import com.netflix.spectator.api.Timer;
@@ -27,11 +28,17 @@ import java.util.concurrent.TimeUnit;
 class MicrometerTimer extends MicrometerMeter implements Timer {
 
   private final io.micrometer.core.instrument.Timer impl;
+  private final Clock clock;
 
   /** Create a new instance. */
-  MicrometerTimer(Id id, io.micrometer.core.instrument.Timer impl) {
+  MicrometerTimer(Id id, io.micrometer.core.instrument.Timer impl, Clock clock) {
     super(id);
     this.impl = impl;
+    this.clock = clock;
+  }
+
+  @Override public Clock clock() {
+    return clock;
   }
 
   @Override public void record(long amount, TimeUnit unit) {

--- a/spectator-reg-sidecar/src/main/java/com/netflix/spectator/sidecar/SidecarTimer.java
+++ b/spectator-reg-sidecar/src/main/java/com/netflix/spectator/sidecar/SidecarTimer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2022 Netflix, Inc.
+ * Copyright 2014-2023 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ import com.netflix.spectator.api.Clock;
 import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Timer;
 
-import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -37,28 +36,14 @@ class SidecarTimer extends SidecarMeter implements Timer {
     this.writer = writer;
   }
 
+  @Override public Clock clock() {
+    return clock;
+  }
+
   @Override public void record(long amount, TimeUnit unit) {
     final double seconds = unit.toNanos(amount) / 1e9;
     if (seconds >= 0.0) {
       writer.write(idString, seconds);
-    }
-  }
-
-  @Override public <T> T record(Callable<T> f) throws Exception {
-    final long start = clock.monotonicTime();
-    try {
-      return f.call();
-    } finally {
-      record(clock.monotonicTime() - start, TimeUnit.NANOSECONDS);
-    }
-  }
-
-  @Override public void record(Runnable f) {
-    final long start = clock.monotonicTime();
-    try {
-      f.run();
-    } finally {
-      record(clock.monotonicTime() - start, TimeUnit.NANOSECONDS);
     }
   }
 


### PR DESCRIPTION
Adds methods to the Timer interface to make it easier to work with the Supplier types in the JDK. There is already a method that works with Callable, but since that throws Exception it can be cumbersome to use in code. Methods have also been added for the suppliers with primitive types to avoid boxing.

Overload resolution can be messy with lambdas. To avoid those issues record methods have been added with a different name for each interface. The existing record methods for Callable and Runnable have been deprecated in favor of the more specifically named method.

Fixes #566.