### PR TITLE
api: add helpers to wrap lambdas with a timer

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/Timer.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/Timer.java
@@ -18,11 +18,48 @@ package com.netflix.spectator.api;
 import java.time.Duration;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
+import java.util.function.BinaryOperator;
 import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
+import java.util.function.DoubleBinaryOperator;
+import java.util.function.DoubleConsumer;
+import java.util.function.DoublePredicate;
 import java.util.function.DoubleSupplier;
+import java.util.function.DoubleToIntFunction;
+import java.util.function.DoubleToLongFunction;
+import java.util.function.DoubleUnaryOperator;
+import java.util.function.Function;
+import java.util.function.IntBinaryOperator;
+import java.util.function.IntConsumer;
+import java.util.function.IntFunction;
+import java.util.function.IntPredicate;
 import java.util.function.IntSupplier;
+import java.util.function.IntToDoubleFunction;
+import java.util.function.IntToLongFunction;
+import java.util.function.IntUnaryOperator;
+import java.util.function.LongBinaryOperator;
+import java.util.function.LongConsumer;
+import java.util.function.LongFunction;
+import java.util.function.LongPredicate;
 import java.util.function.LongSupplier;
+import java.util.function.LongToDoubleFunction;
+import java.util.function.LongToIntFunction;
+import java.util.function.LongUnaryOperator;
+import java.util.function.ObjDoubleConsumer;
+import java.util.function.ObjIntConsumer;
+import java.util.function.ObjLongConsumer;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.util.function.ToDoubleBiFunction;
+import java.util.function.ToDoubleFunction;
+import java.util.function.ToIntBiFunction;
+import java.util.function.ToIntFunction;
+import java.util.function.ToLongBiFunction;
+import java.util.function.ToLongFunction;
+import java.util.function.UnaryOperator;
 
 /**
  * Timer intended to track a large number of short running events. Example would be something like
@@ -265,6 +302,951 @@ public interface Timer extends Meter {
       long e = clock.monotonicTime();
       record(e - s, TimeUnit.NANOSECONDS);
     }
+  }
+
+  /**
+   * Wraps the lambda `f` to update this timer each time the wrapper is invoked.
+   *
+   * @param f
+   *     Function to execute and measure the execution time.
+   * @return
+   *     Wrapper that invokes `f` and records the time taken.
+   */
+  default <V> Callable<V> wrapCallable(Callable<V> f) {
+    return () -> {
+      final Clock clock = clock();
+      long s = clock.monotonicTime();
+      try {
+        return f.call();
+      } finally {
+        long e = clock.monotonicTime();
+        record(e - s, TimeUnit.NANOSECONDS);
+      }
+    };
+  }
+
+  /**
+   * Wraps the lambda `f` to update this timer each time the wrapper is invoked.
+   *
+   * @param f
+   *     Function to execute and measure the execution time.
+   * @return
+   *     Wrapper that invokes `f` and records the time taken.
+   */
+  default Runnable wrapRunnable(Runnable f) {
+    return () -> {
+      final Clock clock = clock();
+      long s = clock.monotonicTime();
+      try {
+        f.run();
+      } finally {
+        long e = clock.monotonicTime();
+        record(e - s, TimeUnit.NANOSECONDS);
+      }
+    };
+  }
+
+  /**
+   * Wraps the lambda `f` to update this timer each time the wrapper is invoked.
+   *
+   * @param f
+   *     Function to execute and measure the execution time.
+   * @return
+   *     Wrapper that invokes `f` and records the time taken.
+   */
+  default <T, U> BiConsumer<T, U> wrapBiConsumer(BiConsumer<T, U> f) {
+    return (t, u) -> {
+      final Clock clock = clock();
+      long s = clock.monotonicTime();
+      try {
+        f.accept(t, u);
+      } finally {
+        long e = clock.monotonicTime();
+        record(e - s, TimeUnit.NANOSECONDS);
+      }
+    };
+  }
+
+  /**
+   * Wraps the lambda `f` to update this timer each time the wrapper is invoked.
+   *
+   * @param f
+   *     Function to execute and measure the execution time.
+   * @return
+   *     Wrapper that invokes `f` and records the time taken.
+   */
+  default <T, U, R> BiFunction<T, U, R> wrapBiFunction(BiFunction<T, U, R> f) {
+    return (t, u) -> {
+      final Clock clock = clock();
+      long s = clock.monotonicTime();
+      try {
+        return f.apply(t, u);
+      } finally {
+        long e = clock.monotonicTime();
+        record(e - s, TimeUnit.NANOSECONDS);
+      }
+    };
+  }
+
+  /**
+   * Wraps the lambda `f` to update this timer each time the wrapper is invoked.
+   *
+   * @param f
+   *     Function to execute and measure the execution time.
+   * @return
+   *     Wrapper that invokes `f` and records the time taken.
+   */
+  default <T> BinaryOperator<T> wrapBinaryOperator(BinaryOperator<T> f) {
+    return (t, u) -> {
+      final Clock clock = clock();
+      long s = clock.monotonicTime();
+      try {
+        return f.apply(t, u);
+      } finally {
+        long e = clock.monotonicTime();
+        record(e - s, TimeUnit.NANOSECONDS);
+      }
+    };
+  }
+
+  /**
+   * Wraps the lambda `f` to update this timer each time the wrapper is invoked.
+   *
+   * @param f
+   *     Function to execute and measure the execution time.
+   * @return
+   *     Wrapper that invokes `f` and records the time taken.
+   */
+  default <T, U> BiPredicate<T, U> wrapBiPredicate(BiPredicate<T, U> f) {
+    return (t, u) -> {
+      final Clock clock = clock();
+      long s = clock.monotonicTime();
+      try {
+        return f.test(t, u);
+      } finally {
+        long e = clock.monotonicTime();
+        record(e - s, TimeUnit.NANOSECONDS);
+      }
+    };
+  }
+
+  /**
+   * Wraps the lambda `f` to update this timer each time the wrapper is invoked.
+   *
+   * @param f
+   *     Function to execute and measure the execution time.
+   * @return
+   *     Wrapper that invokes `f` and records the time taken.
+   */
+  default BooleanSupplier wrapBooleanSupplier(BooleanSupplier f) {
+    return () -> {
+      final Clock clock = clock();
+      long s = clock.monotonicTime();
+      try {
+        return f.getAsBoolean();
+      } finally {
+        long e = clock.monotonicTime();
+        record(e - s, TimeUnit.NANOSECONDS);
+      }
+    };
+  }
+
+  /**
+   * Wraps the lambda `f` to update this timer each time the wrapper is invoked.
+   *
+   * @param f
+   *     Function to execute and measure the execution time.
+   * @return
+   *     Wrapper that invokes `f` and records the time taken.
+   */
+  default <T> Consumer<T> wrapConsumer(Consumer<T> f) {
+    return (t) -> {
+      final Clock clock = clock();
+      long s = clock.monotonicTime();
+      try {
+        f.accept(t);
+      } finally {
+        long e = clock.monotonicTime();
+        record(e - s, TimeUnit.NANOSECONDS);
+      }
+    };
+  }
+
+  /**
+   * Wraps the lambda `f` to update this timer each time the wrapper is invoked.
+   *
+   * @param f
+   *     Function to execute and measure the execution time.
+   * @return
+   *     Wrapper that invokes `f` and records the time taken.
+   */
+  default DoubleBinaryOperator wrapDoubleBinaryOperator(DoubleBinaryOperator f) {
+    return (t, u) -> {
+      final Clock clock = clock();
+      long s = clock.monotonicTime();
+      try {
+        return f.applyAsDouble(t, u);
+      } finally {
+        long e = clock.monotonicTime();
+        record(e - s, TimeUnit.NANOSECONDS);
+      }
+    };
+  }
+
+  /**
+   * Wraps the lambda `f` to update this timer each time the wrapper is invoked.
+   *
+   * @param f
+   *     Function to execute and measure the execution time.
+   * @return
+   *     Wrapper that invokes `f` and records the time taken.
+   */
+  default DoubleConsumer wrapDoubleConsumer(DoubleConsumer f) {
+    return (t) -> {
+      final Clock clock = clock();
+      long s = clock.monotonicTime();
+      try {
+        f.accept(t);
+      } finally {
+        long e = clock.monotonicTime();
+        record(e - s, TimeUnit.NANOSECONDS);
+      }
+    };
+  }
+
+  /**
+   * Wraps the lambda `f` to update this timer each time the wrapper is invoked.
+   *
+   * @param f
+   *     Function to execute and measure the execution time.
+   * @return
+   *     Wrapper that invokes `f` and records the time taken.
+   */
+  default <R> java.util.function.DoubleFunction<R> wrapDoubleFunction(java.util.function.DoubleFunction<R> f) {
+    return (t) -> {
+      final Clock clock = clock();
+      long s = clock.monotonicTime();
+      try {
+        return f.apply(t);
+      } finally {
+        long e = clock.monotonicTime();
+        record(e - s, TimeUnit.NANOSECONDS);
+      }
+    };
+  }
+
+  /**
+   * Wraps the lambda `f` to update this timer each time the wrapper is invoked.
+   *
+   * @param f
+   *     Function to execute and measure the execution time.
+   * @return
+   *     Wrapper that invokes `f` and records the time taken.
+   */
+  default DoublePredicate wrapDoublePredicate(DoublePredicate f) {
+    return (t) -> {
+      final Clock clock = clock();
+      long s = clock.monotonicTime();
+      try {
+        return f.test(t);
+      } finally {
+        long e = clock.monotonicTime();
+        record(e - s, TimeUnit.NANOSECONDS);
+      }
+    };
+  }
+
+  /**
+   * Wraps the lambda `f` to update this timer each time the wrapper is invoked.
+   *
+   * @param f
+   *     Function to execute and measure the execution time.
+   * @return
+   *     Wrapper that invokes `f` and records the time taken.
+   */
+  default DoubleSupplier wrapDoubleSupplier(DoubleSupplier f) {
+    return () -> {
+      final Clock clock = clock();
+      long s = clock.monotonicTime();
+      try {
+        return f.getAsDouble();
+      } finally {
+        long e = clock.monotonicTime();
+        record(e - s, TimeUnit.NANOSECONDS);
+      }
+    };
+  }
+
+  /**
+   * Wraps the lambda `f` to update this timer each time the wrapper is invoked.
+   *
+   * @param f
+   *     Function to execute and measure the execution time.
+   * @return
+   *     Wrapper that invokes `f` and records the time taken.
+   */
+  default DoubleToIntFunction wrapDoubleToIntFunction(DoubleToIntFunction f) {
+    return (t) -> {
+      final Clock clock = clock();
+      long s = clock.monotonicTime();
+      try {
+        return f.applyAsInt(t);
+      } finally {
+        long e = clock.monotonicTime();
+        record(e - s, TimeUnit.NANOSECONDS);
+      }
+    };
+  }
+
+  /**
+   * Wraps the lambda `f` to update this timer each time the wrapper is invoked.
+   *
+   * @param f
+   *     Function to execute and measure the execution time.
+   * @return
+   *     Wrapper that invokes `f` and records the time taken.
+   */
+  default DoubleToLongFunction wrapDoubleToLongFunction(DoubleToLongFunction f) {
+    return (t) -> {
+      final Clock clock = clock();
+      long s = clock.monotonicTime();
+      try {
+        return f.applyAsLong(t);
+      } finally {
+        long e = clock.monotonicTime();
+        record(e - s, TimeUnit.NANOSECONDS);
+      }
+    };
+  }
+
+  /**
+   * Wraps the lambda `f` to update this timer each time the wrapper is invoked.
+   *
+   * @param f
+   *     Function to execute and measure the execution time.
+   * @return
+   *     Wrapper that invokes `f` and records the time taken.
+   */
+  default DoubleUnaryOperator wrapDoubleUnaryOperator(DoubleUnaryOperator f) {
+    return (t) -> {
+      final Clock clock = clock();
+      long s = clock.monotonicTime();
+      try {
+        return f.applyAsDouble(t);
+      } finally {
+        long e = clock.monotonicTime();
+        record(e - s, TimeUnit.NANOSECONDS);
+      }
+    };
+  }
+
+  /**
+   * Wraps the lambda `f` to update this timer each time the wrapper is invoked.
+   *
+   * @param f
+   *     Function to execute and measure the execution time.
+   * @return
+   *     Wrapper that invokes `f` and records the time taken.
+   */
+  default <T, R> Function<T, R> wrapFunction(Function<T, R> f) {
+    return (t) -> {
+      final Clock clock = clock();
+      long s = clock.monotonicTime();
+      try {
+        return f.apply(t);
+      } finally {
+        long e = clock.monotonicTime();
+        record(e - s, TimeUnit.NANOSECONDS);
+      }
+    };
+  }
+
+  /**
+   * Wraps the lambda `f` to update this timer each time the wrapper is invoked.
+   *
+   * @param f
+   *     Function to execute and measure the execution time.
+   * @return
+   *     Wrapper that invokes `f` and records the time taken.
+   */
+  default IntBinaryOperator wrapIntBinaryOperator(IntBinaryOperator f) {
+    return (t, u) -> {
+      final Clock clock = clock();
+      long s = clock.monotonicTime();
+      try {
+        return f.applyAsInt(t, u);
+      } finally {
+        long e = clock.monotonicTime();
+        record(e - s, TimeUnit.NANOSECONDS);
+      }
+    };
+  }
+
+  /**
+   * Wraps the lambda `f` to update this timer each time the wrapper is invoked.
+   *
+   * @param f
+   *     Function to execute and measure the execution time.
+   * @return
+   *     Wrapper that invokes `f` and records the time taken.
+   */
+  default IntConsumer wrapIntConsumer(IntConsumer f) {
+    return (t) -> {
+      final Clock clock = clock();
+      long s = clock.monotonicTime();
+      try {
+        f.accept(t);
+      } finally {
+        long e = clock.monotonicTime();
+        record(e - s, TimeUnit.NANOSECONDS);
+      }
+    };
+  }
+
+  /**
+   * Wraps the lambda `f` to update this timer each time the wrapper is invoked.
+   *
+   * @param f
+   *     Function to execute and measure the execution time.
+   * @return
+   *     Wrapper that invokes `f` and records the time taken.
+   */
+  default <R> IntFunction<R> wrapIntFunction(IntFunction<R> f) {
+    return (t) -> {
+      final Clock clock = clock();
+      long s = clock.monotonicTime();
+      try {
+        return f.apply(t);
+      } finally {
+        long e = clock.monotonicTime();
+        record(e - s, TimeUnit.NANOSECONDS);
+      }
+    };
+  }
+
+  /**
+   * Wraps the lambda `f` to update this timer each time the wrapper is invoked.
+   *
+   * @param f
+   *     Function to execute and measure the execution time.
+   * @return
+   *     Wrapper that invokes `f` and records the time taken.
+   */
+  default IntPredicate wrapIntPredicate(IntPredicate f) {
+    return (t) -> {
+      final Clock clock = clock();
+      long s = clock.monotonicTime();
+      try {
+        return f.test(t);
+      } finally {
+        long e = clock.monotonicTime();
+        record(e - s, TimeUnit.NANOSECONDS);
+      }
+    };
+  }
+
+  /**
+   * Wraps the lambda `f` to update this timer each time the wrapper is invoked.
+   *
+   * @param f
+   *     Function to execute and measure the execution time.
+   * @return
+   *     Wrapper that invokes `f` and records the time taken.
+   */
+  default IntSupplier wrapIntSupplier(IntSupplier f) {
+    return () -> {
+      final Clock clock = clock();
+      long s = clock.monotonicTime();
+      try {
+        return f.getAsInt();
+      } finally {
+        long e = clock.monotonicTime();
+        record(e - s, TimeUnit.NANOSECONDS);
+      }
+    };
+  }
+
+  /**
+   * Wraps the lambda `f` to update this timer each time the wrapper is invoked.
+   *
+   * @param f
+   *     Function to execute and measure the execution time.
+   * @return
+   *     Wrapper that invokes `f` and records the time taken.
+   */
+  default IntToDoubleFunction wrapIntToDoubleFunction(IntToDoubleFunction f) {
+    return (t) -> {
+      final Clock clock = clock();
+      long s = clock.monotonicTime();
+      try {
+        return f.applyAsDouble(t);
+      } finally {
+        long e = clock.monotonicTime();
+        record(e - s, TimeUnit.NANOSECONDS);
+      }
+    };
+  }
+
+  /**
+   * Wraps the lambda `f` to update this timer each time the wrapper is invoked.
+   *
+   * @param f
+   *     Function to execute and measure the execution time.
+   * @return
+   *     Wrapper that invokes `f` and records the time taken.
+   */
+  default IntToLongFunction wrapIntToLongFunction(IntToLongFunction f) {
+    return (t) -> {
+      final Clock clock = clock();
+      long s = clock.monotonicTime();
+      try {
+        return f.applyAsLong(t);
+      } finally {
+        long e = clock.monotonicTime();
+        record(e - s, TimeUnit.NANOSECONDS);
+      }
+    };
+  }
+
+  /**
+   * Wraps the lambda `f` to update this timer each time the wrapper is invoked.
+   *
+   * @param f
+   *     Function to execute and measure the execution time.
+   * @return
+   *     Wrapper that invokes `f` and records the time taken.
+   */
+  default IntUnaryOperator wrapIntUnaryOperator(IntUnaryOperator f) {
+    return (t) -> {
+      final Clock clock = clock();
+      long s = clock.monotonicTime();
+      try {
+        return f.applyAsInt(t);
+      } finally {
+        long e = clock.monotonicTime();
+        record(e - s, TimeUnit.NANOSECONDS);
+      }
+    };
+  }
+
+  /**
+   * Wraps the lambda `f` to update this timer each time the wrapper is invoked.
+   *
+   * @param f
+   *     Function to execute and measure the execution time.
+   * @return
+   *     Wrapper that invokes `f` and records the time taken.
+   */
+  default LongBinaryOperator wrapLongBinaryOperator(LongBinaryOperator f) {
+    return (t, u) -> {
+      final Clock clock = clock();
+      long s = clock.monotonicTime();
+      try {
+        return f.applyAsLong(t, u);
+      } finally {
+        long e = clock.monotonicTime();
+        record(e - s, TimeUnit.NANOSECONDS);
+      }
+    };
+  }
+
+  /**
+   * Wraps the lambda `f` to update this timer each time the wrapper is invoked.
+   *
+   * @param f
+   *     Function to execute and measure the execution time.
+   * @return
+   *     Wrapper that invokes `f` and records the time taken.
+   */
+  default LongConsumer wrapLongConsumer(LongConsumer f) {
+    return (t) -> {
+      final Clock clock = clock();
+      long s = clock.monotonicTime();
+      try {
+        f.accept(t);
+      } finally {
+        long e = clock.monotonicTime();
+        record(e - s, TimeUnit.NANOSECONDS);
+      }
+    };
+  }
+
+  /**
+   * Wraps the lambda `f` to update this timer each time the wrapper is invoked.
+   *
+   * @param f
+   *     Function to execute and measure the execution time.
+   * @return
+   *     Wrapper that invokes `f` and records the time taken.
+   */
+  default <R> LongFunction<R> wrapLongFunction(LongFunction<R> f) {
+    return (t) -> {
+      final Clock clock = clock();
+      long s = clock.monotonicTime();
+      try {
+        return f.apply(t);
+      } finally {
+        long e = clock.monotonicTime();
+        record(e - s, TimeUnit.NANOSECONDS);
+      }
+    };
+  }
+
+  /**
+   * Wraps the lambda `f` to update this timer each time the wrapper is invoked.
+   *
+   * @param f
+   *     Function to execute and measure the execution time.
+   * @return
+   *     Wrapper that invokes `f` and records the time taken.
+   */
+  default LongPredicate wrapLongPredicate(LongPredicate f) {
+    return (t) -> {
+      final Clock clock = clock();
+      long s = clock.monotonicTime();
+      try {
+        return f.test(t);
+      } finally {
+        long e = clock.monotonicTime();
+        record(e - s, TimeUnit.NANOSECONDS);
+      }
+    };
+  }
+
+  /**
+   * Wraps the lambda `f` to update this timer each time the wrapper is invoked.
+   *
+   * @param f
+   *     Function to execute and measure the execution time.
+   * @return
+   *     Wrapper that invokes `f` and records the time taken.
+   */
+  default LongSupplier wrapLongSupplier(LongSupplier f) {
+    return () -> {
+      final Clock clock = clock();
+      long s = clock.monotonicTime();
+      try {
+        return f.getAsLong();
+      } finally {
+        long e = clock.monotonicTime();
+        record(e - s, TimeUnit.NANOSECONDS);
+      }
+    };
+  }
+
+  /**
+   * Wraps the lambda `f` to update this timer each time the wrapper is invoked.
+   *
+   * @param f
+   *     Function to execute and measure the execution time.
+   * @return
+   *     Wrapper that invokes `f` and records the time taken.
+   */
+  default LongToIntFunction wrapLongToIntFunction(LongToIntFunction f) {
+    return (t) -> {
+      final Clock clock = clock();
+      long s = clock.monotonicTime();
+      try {
+        return f.applyAsInt(t);
+      } finally {
+        long e = clock.monotonicTime();
+        record(e - s, TimeUnit.NANOSECONDS);
+      }
+    };
+  }
+
+  /**
+   * Wraps the lambda `f` to update this timer each time the wrapper is invoked.
+   *
+   * @param f
+   *     Function to execute and measure the execution time.
+   * @return
+   *     Wrapper that invokes `f` and records the time taken.
+   */
+  default LongToDoubleFunction wrapLongToDoubleFunction(LongToDoubleFunction f) {
+    return (t) -> {
+      final Clock clock = clock();
+      long s = clock.monotonicTime();
+      try {
+        return f.applyAsDouble(t);
+      } finally {
+        long e = clock.monotonicTime();
+        record(e - s, TimeUnit.NANOSECONDS);
+      }
+    };
+  }
+
+  /**
+   * Wraps the lambda `f` to update this timer each time the wrapper is invoked.
+   *
+   * @param f
+   *     Function to execute and measure the execution time.
+   * @return
+   *     Wrapper that invokes `f` and records the time taken.
+   */
+  default LongUnaryOperator wrapLongUnaryOperator(LongUnaryOperator f) {
+    return (t) -> {
+      final Clock clock = clock();
+      long s = clock.monotonicTime();
+      try {
+        return f.applyAsLong(t);
+      } finally {
+        long e = clock.monotonicTime();
+        record(e - s, TimeUnit.NANOSECONDS);
+      }
+    };
+  }
+
+  /**
+   * Wraps the lambda `f` to update this timer each time the wrapper is invoked.
+   *
+   * @param f
+   *     Function to execute and measure the execution time.
+   * @return
+   *     Wrapper that invokes `f` and records the time taken.
+   */
+  default <T> ObjDoubleConsumer<T> wrapObjDoubleConsumer(ObjDoubleConsumer<T> f) {
+    return (t, u) -> {
+      final Clock clock = clock();
+      long s = clock.monotonicTime();
+      try {
+        f.accept(t, u);
+      } finally {
+        long e = clock.monotonicTime();
+        record(e - s, TimeUnit.NANOSECONDS);
+      }
+    };
+  }
+
+  /**
+   * Wraps the lambda `f` to update this timer each time the wrapper is invoked.
+   *
+   * @param f
+   *     Function to execute and measure the execution time.
+   * @return
+   *     Wrapper that invokes `f` and records the time taken.
+   */
+  default <T> ObjIntConsumer<T> wrapObjIntConsumer(ObjIntConsumer<T> f) {
+    return (t, u) -> {
+      final Clock clock = clock();
+      long s = clock.monotonicTime();
+      try {
+        f.accept(t, u);
+      } finally {
+        long e = clock.monotonicTime();
+        record(e - s, TimeUnit.NANOSECONDS);
+      }
+    };
+  }
+
+  /**
+   * Wraps the lambda `f` to update this timer each time the wrapper is invoked.
+   *
+   * @param f
+   *     Function to execute and measure the execution time.
+   * @return
+   *     Wrapper that invokes `f` and records the time taken.
+   */
+  default <T> ObjLongConsumer<T> wrapObjLongConsumer(ObjLongConsumer<T> f) {
+    return (t, u) -> {
+      final Clock clock = clock();
+      long s = clock.monotonicTime();
+      try {
+        f.accept(t, u);
+      } finally {
+        long e = clock.monotonicTime();
+        record(e - s, TimeUnit.NANOSECONDS);
+      }
+    };
+  }
+
+  /**
+   * Wraps the lambda `f` to update this timer each time the wrapper is invoked.
+   *
+   * @param f
+   *     Function to execute and measure the execution time.
+   * @return
+   *     Wrapper that invokes `f` and records the time taken.
+   */
+  default <T> Predicate<T> wrapPredicate(Predicate<T> f) {
+    return (t) -> {
+      final Clock clock = clock();
+      long s = clock.monotonicTime();
+      try {
+        return f.test(t);
+      } finally {
+        long e = clock.monotonicTime();
+        record(e - s, TimeUnit.NANOSECONDS);
+      }
+    };
+  }
+
+  /**
+   * Wraps the lambda `f` to update this timer each time the wrapper is invoked.
+   *
+   * @param f
+   *     Function to execute and measure the execution time.
+   * @return
+   *     Wrapper that invokes `f` and records the time taken.
+   */
+  default <T> Supplier<T> wrapSupplier(Supplier<T> f) {
+    return () -> {
+      final Clock clock = clock();
+      long s = clock.monotonicTime();
+      try {
+        return f.get();
+      } finally {
+        long e = clock.monotonicTime();
+        record(e - s, TimeUnit.NANOSECONDS);
+      }
+    };
+  }
+
+  /**
+   * Wraps the lambda `f` to update this timer each time the wrapper is invoked.
+   *
+   * @param f
+   *     Function to execute and measure the execution time.
+   * @return
+   *     Wrapper that invokes `f` and records the time taken.
+   */
+  default <T, U> ToDoubleBiFunction<T, U> wrapToDoubleBiFunction(ToDoubleBiFunction<T, U> f) {
+    return (t, u) -> {
+      final Clock clock = clock();
+      long s = clock.monotonicTime();
+      try {
+        return f.applyAsDouble(t, u);
+      } finally {
+        long e = clock.monotonicTime();
+        record(e - s, TimeUnit.NANOSECONDS);
+      }
+    };
+  }
+
+  /**
+   * Wraps the lambda `f` to update this timer each time the wrapper is invoked.
+   *
+   * @param f
+   *     Function to execute and measure the execution time.
+   * @return
+   *     Wrapper that invokes `f` and records the time taken.
+   */
+  default <T> ToDoubleFunction<T> wrapToDoubleFunction(ToDoubleFunction<T> f) {
+    return (t) -> {
+      final Clock clock = clock();
+      long s = clock.monotonicTime();
+      try {
+        return f.applyAsDouble(t);
+      } finally {
+        long e = clock.monotonicTime();
+        record(e - s, TimeUnit.NANOSECONDS);
+      }
+    };
+  }
+
+  /**
+   * Wraps the lambda `f` to update this timer each time the wrapper is invoked.
+   *
+   * @param f
+   *     Function to execute and measure the execution time.
+   * @return
+   *     Wrapper that invokes `f` and records the time taken.
+   */
+  default <T, U> ToIntBiFunction<T, U> wrapToIntBiFunction(ToIntBiFunction<T, U> f) {
+    return (t, u) -> {
+      final Clock clock = clock();
+      long s = clock.monotonicTime();
+      try {
+        return f.applyAsInt(t, u);
+      } finally {
+        long e = clock.monotonicTime();
+        record(e - s, TimeUnit.NANOSECONDS);
+      }
+    };
+  }
+
+  /**
+   * Wraps the lambda `f` to update this timer each time the wrapper is invoked.
+   *
+   * @param f
+   *     Function to execute and measure the execution time.
+   * @return
+   *     Wrapper that invokes `f` and records the time taken.
+   */
+  default <T> ToIntFunction<T> wrapToIntFunction(ToIntFunction<T> f) {
+    return (t) -> {
+      final Clock clock = clock();
+      long s = clock.monotonicTime();
+      try {
+        return f.applyAsInt(t);
+      } finally {
+        long e = clock.monotonicTime();
+        record(e - s, TimeUnit.NANOSECONDS);
+      }
+    };
+  }
+
+  /**
+   * Wraps the lambda `f` to update this timer each time the wrapper is invoked.
+   *
+   * @param f
+   *     Function to execute and measure the execution time.
+   * @return
+   *     Wrapper that invokes `f` and records the time taken.
+   */
+  default <T, U> ToLongBiFunction<T, U> wrapToLongBiFunction(ToLongBiFunction<T, U> f) {
+    return (t, u) -> {
+      final Clock clock = clock();
+      long s = clock.monotonicTime();
+      try {
+        return f.applyAsLong(t, u);
+      } finally {
+        long e = clock.monotonicTime();
+        record(e - s, TimeUnit.NANOSECONDS);
+      }
+    };
+  }
+
+  /**
+   * Wraps the lambda `f` to update this timer each time the wrapper is invoked.
+   *
+   * @param f
+   *     Function to execute and measure the execution time.
+   * @return
+   *     Wrapper that invokes `f` and records the time taken.
+   */
+  default <T> ToLongFunction<T> wrapToLongFunction(ToLongFunction<T> f) {
+    return (t) -> {
+      final Clock clock = clock();
+      long s = clock.monotonicTime();
+      try {
+        return f.applyAsLong(t);
+      } finally {
+        long e = clock.monotonicTime();
+        record(e - s, TimeUnit.NANOSECONDS);
+      }
+    };
+  }
+
+  /**
+   * Wraps the lambda `f` to update this timer each time the wrapper is invoked.
+   *
+   * @param f
+   *     Function to execute and measure the execution time.
+   * @return
+   *     Wrapper that invokes `f` and records the time taken.
+   */
+  default <T> UnaryOperator<T> wrapUnaryOperator(UnaryOperator<T> f) {
+    return (t) -> {
+      final Clock clock = clock();
+      long s = clock.monotonicTime();
+      try {
+        return f.apply(t);
+      } finally {
+        long e = clock.monotonicTime();
+        record(e - s, TimeUnit.NANOSECONDS);
+      }
+    };
   }
 
   /**


### PR DESCRIPTION
Adds helpers to the Timer interface to wrap the common lambda types in `java.util.function`. This can be useful to wrap a lambda that is passed to another class in order to measure each invocation. For example:

```java
Timer t = registry.timer(id);
int sum = Arrays
    .stream(new String[] {"foo", "bar", "baz"})
    .mapToInt(t.wrapToIntFunction(String::length))
    .sum();
```

Caller should ensure that the lambda does sufficient work that timing an invocatino will not be more costly than executing the lambda body.