### PR TITLE
Simplify comparators in GcEvent

### DIFF
--- a/spectator-ext-gc/src/main/java/com/netflix/spectator/gc/GcEvent.java
+++ b/spectator-ext-gc/src/main/java/com/netflix/spectator/gc/GcEvent.java
@@ -109,10 +109,8 @@ public class GcEvent {
   }
 
   /** Order events from oldest to newest. */
-  public static final Comparator<GcEvent> TIME_ORDER =
-      (e1, e2) -> (int) (e1.getStartTime() - e2.getStartTime());
+  public static final Comparator<GcEvent> TIME_ORDER = Comparator.comparing(GcEvent::getStartTime);
 
   /** Order events from newest to oldest. */
-  public static final Comparator<GcEvent> REVERSE_TIME_ORDER =
-      (e1, e2) -> (int) (e2.getStartTime() - e1.getStartTime());
+  public static final Comparator<GcEvent> REVERSE_TIME_ORDER = TIME_ORDER.reversed();
 }


### PR DESCRIPTION
Simplify TIME_ORDER and REVERSE_TIME_ORDER comparators by leveraging Comparator.comparing and .reversed.