### PR TITLE
ipc: avoid exception for empty paths

### DIFF
--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/http/PathSanitizer.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/http/PathSanitizer.java
@@ -40,7 +40,7 @@ public final class PathSanitizer {
 
   /** Returns a sanitized path string for use as an endpoint tag value. */
   public static String sanitize(String path) {
-    return sanitizeSegments(removeParameters(path), Collections.emptySet());
+    return sanitize(path, Collections.emptySet());
   }
 
   /**
@@ -55,7 +55,8 @@ public final class PathSanitizer {
    *     Sanitized path that can be used as an endpoint tag value.
    */
   public static String sanitize(String path, Set<String> allowed) {
-    return sanitizeSegments(removeParameters(path), allowed);
+    String tmp = sanitizeSegments(removeParameters(path), allowed);
+    return tmp.isEmpty() ? "none" : tmp;
   }
 
   private static String removeParameters(String path) {
@@ -64,13 +65,13 @@ public final class PathSanitizer {
 
   private static String removeParameters(String path, char c) {
     int i = path.indexOf(c);
-    return i > 0 ? path.substring(0, i) : path;
+    return i >= 0 ? path.substring(0, i) : path;
   }
 
   private static String sanitizeSegments(String path, Set<String> allowed) {
     StringBuilder builder = new StringBuilder();
     int length = path.length();
-    int pos = path.charAt(0) == '/' ? 1 : 0;
+    int pos = path.isEmpty() || path.charAt(0) != '/' ? 0 : 1;
     int segmentsAdded = 0;
 
     while (pos < length && segmentsAdded < 5) {

--- a/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/http/PathSanitizerTest.java
+++ b/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/http/PathSanitizerTest.java
@@ -38,6 +38,14 @@ public class PathSanitizerTest {
   }
 
   @Test
+  public void emptyPath() {
+    Assertions.assertEquals("none", sanitize("/"));
+    Assertions.assertEquals("none", sanitize(""));
+    Assertions.assertEquals("none", sanitize("/?a=1"));
+    Assertions.assertEquals("none", sanitize("?a=1"));
+  }
+
+  @Test
   public void uuids() {
     String path = "/api/v1/foo/" + UUID.randomUUID();
     Assertions.assertEquals("_api_v1_foo_-", sanitize(path));


### PR DESCRIPTION
Fix StringIndexOutOfBoundsException if sanitize is called with an empty path string. Also updates the logic for `/` to be consistent with an empty path string. Both will now get sanitized to `none` as tag values cannot be empty.