### PR TITLE
aws2: fix retry header parsing

### DIFF
--- a/spectator-ext-aws2/src/test/java/com/netflix/spectator/aws2/SpectatorExecutionInterceptorTest.java
+++ b/spectator-ext-aws2/src/test/java/com/netflix/spectator/aws2/SpectatorExecutionInterceptorTest.java
@@ -220,7 +220,7 @@ public class SpectatorExecutionInterceptorTest {
     SdkHttpRequest request = SdkHttpRequest.builder()
         .method(SdkHttpMethod.POST)
         .uri(URI.create("https://ec2.us-east-1.amazonaws.com"))
-        .appendHeader("amz-sdk-retry", header)
+        .appendHeader("amz-sdk-request", header)
         .build();
     SdkHttpResponse response = SdkHttpResponse.builder()
         .statusCode(200)
@@ -238,27 +238,27 @@ public class SpectatorExecutionInterceptorTest {
 
   @Test
   public void parseRetryHeaderInitial() {
-    parseRetryHeaderTest("initial", "0/NotUsed");
+    parseRetryHeaderTest("initial", "attempt=1; max=4");
   }
 
   @Test
   public void parseRetryHeaderSecond() {
-    parseRetryHeaderTest("second", "1/NotUsed");
+    parseRetryHeaderTest("second", "attempt=2; max=4");
   }
 
   @Test
   public void parseRetryHeaderThird() {
-    parseRetryHeaderTest("third_up", "2/NotUsed");
+    parseRetryHeaderTest("third_up", "attempt=3; max=4");
   }
 
   @Test
   public void parseRetryHeader50() {
-    parseRetryHeaderTest("third_up", "50/NotUsed");
+    parseRetryHeaderTest("third_up", "attempt=50; max=50");
   }
 
   @Test
   public void parseRetryHeaderInvalidNumber() {
-    parseRetryHeaderTest("unknown", "foo/bar");
+    parseRetryHeaderTest("unknown", "attempt=foo; max=bar");
   }
 
   @Test


### PR DESCRIPTION
The retry header was changed in [2.15.41]. Update the parsing logic to work with the newer version.

[2.15.41]: https://github.com/aws/aws-sdk-java-v2/blob/8aaeeb0a001106db4f6add5bf9517dc130188b4b/.changes/2.15.41.json#L39