### PR TITLE
ipc: reset disable flag when reusing entries

### DIFF
--- a/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/IpcLogEntryTest.java
+++ b/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/IpcLogEntryTest.java
@@ -778,6 +778,28 @@ public class IpcLogEntryTest {
   }
 
   @Test
+  public void serverMetricsDisabledReuseEntry() {
+    Registry registry = new DefaultRegistry();
+    IpcLogger logger = new IpcLogger(registry, clock, LoggerFactory.getLogger(getClass()));
+
+    logger.createServerEntry()
+        .withOwner("test")
+        .addRequestHeader("netflix-ingress-common-ipc-metrics", "true")
+        .markStart()
+        .markEnd()
+        .log();
+    Assertions.assertEquals(0, registry.stream().count());
+
+    logger.createServerEntry()
+        .withOwner("test")
+        .addRequestHeader("netflix-ingress-common-ipc-metrics", "false")
+        .markStart()
+        .markEnd()
+        .log();
+    Assertions.assertEquals(3, registry.stream().count());
+  }
+
+  @Test
   public void endpointUnknownIfNotSet() {
     Registry registry = new DefaultRegistry();
     IpcLogger logger = new IpcLogger(registry, clock, LoggerFactory.getLogger(getClass()));


### PR DESCRIPTION
Before if there was a disabled request that was successful, then all subsequent requests that reuse the entry would also be disabled. Also moves the finalization of some of the fields to a helper that is always called to avoid different values going to the access log if metrics are disabled.