### PR TITLE
support checking for match after the prefix

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/impl/PatternMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/PatternMatcher.java
@@ -47,6 +47,15 @@ public interface PatternMatcher {
   boolean matches(String str);
 
   /**
+   * Returns true if the passed in string matches the pattern after the prefix. This method
+   * can be used to more efficiently check the value if the {@link #prefix()} was already
+   * verified.
+   */
+  default boolean matchesAfterPrefix(String str) {
+    return matches(str);
+  }
+
+  /**
    * Returns a fixed string prefix for the pattern if one is available. This can be used
    * with indexed data to help select a subset of values that are possible matches. If the
    * pattern does not have a fixed string prefix, then null will be returned.

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/SeqMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/SeqMatcher.java
@@ -74,6 +74,20 @@ final class SeqMatcher implements Matcher, Serializable {
   }
 
   @Override
+  public boolean matchesAfterPrefix(String str) {
+    if (matchers[0] instanceof StartsWithMatcher) {
+      final int end = str.length();
+      int pos = matchers[0].prefix().length();
+      for (int i = 1; i < matchers.length && pos >= 0; ++i) {
+        pos = matchers[i].matches(str, pos, end - pos);
+      }
+      return pos >= 0;
+    } else {
+      return matches(str);
+    }
+  }
+
+  @Override
   public String prefix() {
     return matchers[0].prefix();
   }

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/StartsWithMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/StartsWithMatcher.java
@@ -54,6 +54,11 @@ final class StartsWithMatcher implements Matcher, Serializable {
   }
 
   @Override
+  public boolean matchesAfterPrefix(String str) {
+    return true;
+  }
+
+  @Override
   public String prefix() {
     return pattern;
   }

--- a/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/AbstractPatternMatcherTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/AbstractPatternMatcherTest.java
@@ -66,6 +66,18 @@ public abstract class AbstractPatternMatcherTest {
   }
 
   @Test
+  public void matchesAfterPrefix() {
+    // StartsWithMatcher, bar case should match because it will not get checked and we trust
+    // that the caller has already verified the prefix.
+    Assertions.assertTrue(PatternMatcher.compile("^abc").matchesAfterPrefix("abcdef"));
+    Assertions.assertTrue(PatternMatcher.compile("^abc").matchesAfterPrefix("bardef"));
+
+    // SeqMatcher
+    Assertions.assertTrue(PatternMatcher.compile("^abc").matchesAfterPrefix("abc[d-f]"));
+    Assertions.assertTrue(PatternMatcher.compile("^abc").matchesAfterPrefix("bar[d-f]"));
+  }
+
+  @Test
   public void startAnchor() {
     testRE("^abc", "abcdef");
     testRE("^abc", "123456");

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/QueryIndex.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/QueryIndex.java
@@ -499,7 +499,7 @@ public final class QueryIndex<T> {
           if (!otherChecks.isEmpty()) {
             List<QueryIndex<T>> tmp = new ArrayList<>();
             otherChecksTree.forEach(v, kq -> {
-              if (kq.matches(v)) {
+              if (matches(kq, v)) {
                 QueryIndex<T> idx = otherChecks.get(kq);
                 if (idx != null) {
                   tmp.add(idx);
@@ -533,6 +533,15 @@ public final class QueryIndex<T> {
     // Check matches with missing keys
     if (missingKeysIdx != null && !keyPresent) {
       missingKeysIdx.forEachMatch(tags, consumer);
+    }
+  }
+
+  private boolean matches(Query.KeyQuery kq, String value) {
+    if (kq instanceof Query.Regex) {
+      Query.Regex re = (Query.Regex) kq;
+      return re.pattern().matchesAfterPrefix(value);
+    } else {
+      return kq.matches(value);
     }
   }
 


### PR DESCRIPTION
For patterns where the prefix is extracted and verified before values are checked against the full matcher, we do not need to recheck the prefix. This change adds a method to the pattern matcher to allow bypassing the prefix and just matching against the remaining part of the pattern.