### PR TITLE
FirstLimiter race

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/patterns/CardinalityLimiters.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/patterns/CardinalityLimiters.java
@@ -193,8 +193,7 @@ public final class CardinalityLimiters {
         // Lock to keep hashmap consistent with counter for remaining
         lock.lock();
         try {
-          if (remaining.get() > 0) {
-            values.put(s, s);
+          if (remaining.get() > 0 && values.put(s, s) == null) {
             remaining.decrementAndGet();
           }
         } finally {

--- a/spectator-api/src/test/java/com/netflix/spectator/api/patterns/CardinalityLimitersConcurrencyTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/patterns/CardinalityLimitersConcurrencyTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2014-2024 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.api.patterns;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static com.netflix.spectator.api.patterns.CardinalityLimiters.OTHERS;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CardinalityLimitersConcurrencyTest {
+
+  private final ExecutorService pool = Executors.newFixedThreadPool(100);
+
+  @Test
+  void firstLimiterWhenContentionSizeIsRespected() throws InterruptedException, ExecutionException {
+    Function<String, String> limiter = CardinalityLimiters.first(100);
+
+    // when: 100 threads try to register the same 1..100 numbers with contention
+    Callable<List<String>> task = () -> IntStream
+        .rangeClosed(1, 100)
+        .mapToObj(j -> limiter.apply(String.valueOf(j))).collect(Collectors.toList());
+    List<Future<List<String>>> handles = IntStream.rangeClosed(1, 100)
+        .mapToObj(i -> pool.submit(task))
+        .collect(Collectors.toList());
+    for (Future<List<String>> handle : handles) {
+      handle.get();
+    }
+
+    // then: expect each number to have been registered despite the contention
+    //  since the bound has not been reached. (i.e OTHERS must not be present)
+    List<String> appliedNumbers = new ArrayList<>();
+    for (int i = 1; i <= 100; i++) {
+      String applied = limiter.apply(String.valueOf(i));
+      appliedNumbers.add(applied);
+    }
+
+    assertTrue(appliedNumbers.stream().noneMatch(n -> n.equals(OTHERS)),
+        () -> "at least one number was not registered in the limiter, "
+            + String.join(",", appliedNumbers));
+  }
+}


### PR DESCRIPTION
### Description
Under contention the `CardinalityLimiters.FirstLimiter` will stop accepting values *before* its limit has been reached. 
This behavior happens when more than one thread add the same value to the limiter value registry and the `remaining` property is decremented even though no new entry has been added. 

### Steps to reproduce

I added a test in `CardinalityLimitersConcurrencyTest` that reproduces the issue fairly consistently. It simulates threads submitting the same series of numbers and expect all numbers to be registered. A failing test example output is below, note the `--others--` entries that should not be present.

```
at least one number was not registered in the limiter, 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,--others--,--others--,--others--,--others--,--others--
```

### Fix proposal

After acquiring the lock, we can check if the limiter value registry contains the key before inserting the entry and decrementing `remaining`.

