### PR TITLE
fix publishing of shadow jars

### DIFF
--- a/spectator-reg-atlas/build.gradle
+++ b/spectator-reg-atlas/build.gradle
@@ -51,6 +51,7 @@ afterEvaluate {
   publishing {
     publications {
       withType(MavenPublication) {
+        artifact(shadowJar)
         pom.withXml {
           asNode()
             .dependencies

--- a/spectator-web-spring/build.gradle
+++ b/spectator-web-spring/build.gradle
@@ -65,6 +65,7 @@ afterEvaluate {
   publishing {
     publications {
       withType(MavenPublication) {
+        artifact(shadowJar)
         pom.withXml {
           asNode()
               .dependencies


### PR DESCRIPTION
Indicate that the shadow jar is an artifact that should be published.