### PR TITLE
tune prefix tree implementation

### DIFF
--- a/codequality/checkstyle-suppressions.xml
+++ b/codequality/checkstyle-suppressions.xml
@@ -6,4 +6,5 @@
 
 <suppressions>
   <suppress checks="IllegalImport" files="UnsafeUtils.java"/>
+  <suppress checks="VisibilityModifier" files="PrefixTree.java"/>
 </suppressions>

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/PrefixTreeTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/PrefixTreeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2022 Netflix, Inc.
+ * Copyright 2014-2024 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -106,20 +106,101 @@ public class PrefixTreeTest {
   }
 
   @Test
-  public void unsupportedCharInPrefix() {
+  public void unicodeCharInPrefix() {
     PrefixTree<String> tree = new PrefixTree<>();
     tree.put("aβc", "1");
     assertSize(tree, 1);
 
-    Assertions.assertEquals(list("1"), tree.get("abcdef"));
-    Assertions.assertEquals(list("1"), tree.get("abcghi"));
-    Assertions.assertEquals(list("1"), tree.get("abc"));
-    Assertions.assertEquals(list("1"), tree.get("abd"));
-    Assertions.assertEquals(list("1"), tree.get("ab"));
+    Assertions.assertEquals(list("1"), tree.get("aβcdef"));
+    Assertions.assertEquals(list("1"), tree.get("aβcghi"));
+    Assertions.assertEquals(list("1"), tree.get("aβc"));
+    Assertions.assertEquals(Collections.emptyList(), tree.get("abcdef"));
+    Assertions.assertEquals(Collections.emptyList(), tree.get("abcghi"));
+    Assertions.assertEquals(Collections.emptyList(), tree.get("abc"));
+    Assertions.assertEquals(Collections.emptyList(), tree.get("abd"));
+    Assertions.assertEquals(Collections.emptyList(), tree.get("ab"));
+    Assertions.assertEquals(Collections.emptyList(), tree.get("aβ"));
     Assertions.assertEquals(Collections.emptyList(), tree.get("b"));
 
     Assertions.assertTrue(tree.remove("aβc", "1"));
     assertSize(tree, 0);
     Assertions.assertEquals(Collections.emptyList(), tree.get("abcdef"));
+  }
+
+  @Test
+  public void emptyRootPrefix() {
+    PrefixTree<String> tree = new PrefixTree<>();
+    tree.put("ab", "ab");
+    tree.put("cd", "cd");
+
+    Assertions.assertEquals(list("ab"), tree.get("ab"));
+    Assertions.assertEquals(list("cd"), tree.get("cd"));
+    Assertions.assertEquals(Collections.emptyList(), tree.get("ef"));
+
+    Assertions.assertTrue(tree.remove("ab", "ab"));
+    PrefixTree<String> tree2 = new PrefixTree<>();
+    tree2.put("cd", "cd");
+    Assertions.assertEquals(tree2, tree);
+
+    Assertions.assertEquals(Collections.emptyList(), tree.get("ab"));
+    Assertions.assertEquals(list("cd"), tree.get("cd"));
+    Assertions.assertEquals(Collections.emptyList(), tree.get("ef"));
+  }
+
+  @Test
+  public void updateExistingNode() {
+    PrefixTree<String> tree = new PrefixTree<>();
+    tree.put("abcdef", "1");
+    tree.put("abcdef", "2");
+
+    Assertions.assertEquals(list("1", "2"), tree.get("abcdef"));
+  }
+
+  @Test
+  public void addChildNode() {
+    PrefixTree<String> tree = new PrefixTree<>();
+    tree.put("abc", "1");
+    tree.put("abcdefghi", "2");
+    tree.put("abcdef", "3");
+
+    Assertions.assertEquals(list("1", "3"), tree.get("abcdef"));
+    Assertions.assertEquals(list("1", "3", "2"), tree.get("abcdefghi"));
+  }
+
+  @Test
+  public void splitInteriorNode() {
+    PrefixTree<String> tree = new PrefixTree<>();
+    tree.put("abcdef", "abcdef");
+    tree.put("abcghi", "abcghi");
+
+    Assertions.assertEquals(list("abcdef"), tree.get("abcdef"));
+    Assertions.assertEquals(list("abcghi"), tree.get("abcghi"));
+  }
+
+  @Test
+  public void manyDifferentRootPrefixes() {
+    PrefixTree<String> tree = new PrefixTree<>();
+    tree.put("abc", "abc");
+    tree.put("def", "def");
+    tree.put("ghi", "ghi");
+    Assertions.assertEquals(list("abc"), tree.get("abcdef"));
+  }
+
+  @Test
+  public void commonPrefixNoMatch() {
+    Assertions.assertEquals(0, PrefixTree.commonPrefixLength("abcdef", "defghi", 0));
+    Assertions.assertEquals(0, PrefixTree.commonPrefixLength("abcdef", "abcdef", 3));
+  }
+
+  @Test
+  public void commonPrefixEmpty() {
+    Assertions.assertEquals(0, PrefixTree.commonPrefixLength("abcdef", "", 0));
+    Assertions.assertEquals(0, PrefixTree.commonPrefixLength("", "abcdef", 0));
+  }
+
+  @Test
+  public void commonPrefix() {
+    Assertions.assertEquals(3, PrefixTree.commonPrefixLength("abcdef", "abcghi", 0));
+    Assertions.assertEquals(6, PrefixTree.commonPrefixLength("defghi", "abcdefghi", 3));
   }
 }


### PR DESCRIPTION
Updates the prefix tree implementation to improve the performance. Instead of going character by character the nodes will now keep a prefix string for faster matching and less thread contention. Testing on real sample data it reduced the time for matching against the query index by ~6%.