### PR TITLE
cache hash code for Query.In

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Query.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Query.java
@@ -567,11 +567,14 @@ public interface Query {
     private final String k;
     private final Set<String> vs;
 
+    private final int cachedHashCode;
+
     /** Create a new instance. */
     In(String k, Set<String> vs) {
       Preconditions.checkArg(!vs.isEmpty(), "list of values for :in cannot be empty");
       this.k = Preconditions.checkNotNull(k, "k");
       this.vs = Preconditions.checkNotNull(vs, "vs");
+      this.cachedHashCode = calculateHashCode();
     }
 
     @Override public String key() {
@@ -618,6 +621,10 @@ public interface Query {
     }
 
     @Override public int hashCode() {
+      return cachedHashCode;
+    }
+
+    private int calculateHashCode() {
       int result = k.hashCode();
       result = 31 * result + vs.hashCode();
       return result;

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/QueryTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/QueryTest.java
@@ -116,6 +116,10 @@ public class QueryTest {
     EqualsVerifier
         .forClass(Query.In.class)
         .suppress(Warning.NULL_FIELDS)
+        .withCachedHashCode(
+            "cachedHashCode",
+            "calculateHashCode",
+            new Query.In("k", Collections.singleton("v")))
         .verify();
   }
 


### PR DESCRIPTION
In some cases it can be a big set of values and recomputing in the query index to do map looks has a high overhead.