### PR TITLE
ERROR vs WARN for registry/publisher errors

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
@@ -217,7 +217,7 @@ public final class AtlasRegistry extends AbstractRegistry implements AutoCloseab
         overridableClock.setWallTime(now / stepMillis * stepMillis + stepMillis);
         sendToAtlas();
       } catch (Exception e) {
-        logger.warn("failed to flush data to Atlas", e);
+        logger.error("failed to flush data to Atlas", e);
       }
 
       // Shutdown publisher used for sending metrics
@@ -317,7 +317,7 @@ public final class AtlasRegistry extends AbstractRegistry implements AutoCloseab
             CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
           }
         } catch (Exception e) {
-          logger.warn("failed to send metrics for subscriptions (uri={})", evalUri, e);
+          logger.error("failed to send metrics for subscriptions (uri={})", evalUri, e);
         }
       } else {
         logger.debug("lwc is disabled, skipping subscriptions");

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/DefaultPublisher.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/DefaultPublisher.java
@@ -170,7 +170,7 @@ public final class DefaultPublisher implements Publisher {
         recordClockSkew((date == null) ? 0L : date.toEpochMilli());
         validationHelper.recordResults(payload.getMetrics().size(), res);
       } catch (Exception e) {
-        logger.warn("failed to send metrics (uri={})", uri, e);
+        logger.error("failed to send metrics (uri={})", uri, e);
         validationHelper.incrementDroppedHttp(payload.getMetrics().size());
       }
     };
@@ -191,7 +191,7 @@ public final class DefaultPublisher implements Publisher {
             .withJsonContent(json)
             .send();
       } catch (Exception e) {
-        logger.warn("failed to send metrics for subscriptions (uri={})", evalUri, e);
+        logger.error("failed to send metrics for subscriptions (uri={})", evalUri, e);
       }
     };
     return CompletableFuture.runAsync(task, senderPool);

--- a/spectator-reg-stateless/src/main/java/com/netflix/spectator/stateless/StatelessRegistry.java
+++ b/spectator-reg-stateless/src/main/java/com/netflix/spectator/stateless/StatelessRegistry.java
@@ -123,12 +123,12 @@ public final class StatelessRegistry extends AbstractRegistry {
             .compress(Deflater.BEST_SPEED)
             .send();
         if (res.status() != 200) {
-          logger.warn("failed to send metrics, status {}: {}", res.status(), res.entityAsString());
+          logger.error("failed to send metrics, status {}: {}", res.status(), res.entityAsString());
         }
       }
       removeExpiredMeters();
     } catch (Exception e) {
-      logger.warn("failed to send metrics", e);
+      logger.error("failed to send metrics", e);
     }
   }
 


### PR DESCRIPTION
This should help expose Atlas reporting errors more quickly to systems that harvest and expose ERRORs