### PR TITLE
Fix typo in README.md

### DIFF
--- a/spectator-ext-aws/README.md
+++ b/spectator-ext-aws/README.md
@@ -5,7 +5,7 @@ Use Spectator as the Metrics backend for AWS SDK Request Metrics.
 The spectator-ext-aws module can be plugged into the SDK globally using:
 
 `````java
-SpectatorMetricsCollector collector = new SpectatorMetricsCollector(Spectator.globalRegistry());
+SpectatorMetricCollector collector = new SpectatorMetricCollector(Spectator.globalRegistry());
 AwsSdkMetrics.setMetricCollector(collector);
 `````
 


### PR DESCRIPTION
I've found a small typo in the readme. Causes importing the wrong class when the correct would be `com.netflix.spectator.aws.SpectatorMetricCollector`.