### PR TITLE
Go back to com.github.johnrengelman.shadow and upgrade ASM to 9.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,16 @@
+// Needed until shadow plugin is updated for JDK21. For more details see
+// https://github.com/Netflix/spectator/issues/1113
 buildscript {
-    configurations.configureEach { configuration ->
-        configuration.resolutionStrategy {
-            eachDependency { DependencyResolveDetails details ->
-                if (details.requested.group == 'org.ow2.asm') {
-                    details.useVersion '9.6'
-                    details.because "Asm 9.6 is required for JDK 21+ support"
-                }
-            }
+  configurations.configureEach { configuration ->
+    configuration.resolutionStrategy {
+      eachDependency { DependencyResolveDetails details ->
+        if (details.requested.group == 'org.ow2.asm') {
+          details.useVersion '9.6'
+          details.because "Asm 9.6 is required for JDK 21+ support"
         }
+      }
     }
+  }
 }
 
 plugins {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,20 @@
+buildscript {
+    configurations.configureEach { configuration ->
+        configuration.resolutionStrategy {
+            eachDependency { DependencyResolveDetails details ->
+                if (details.requested.group == 'org.ow2.asm') {
+                    details.useVersion '9.6'
+                    details.because "Asm 9.6 is required for JDK 21+ support"
+                }
+            }
+        }
+    }
+}
+
 plugins {
   id 'com.github.ben-manes.versions' version '0.50.0'
   id 'com.github.spotbugs' version '5.2.5' apply false
+  id "com.github.johnrengelman.shadow" version "8.1.1" apply false
   id 'me.champeau.jmh' version '0.7.2'
   id 'com.netflix.nebula.dependency-recommender' version '12.2.0'
   id 'com.netflix.nebula.netflixoss' version '11.4.0'

--- a/spectator-agent/build.gradle
+++ b/spectator-agent/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'io.github.goooler.shadow' version '8.1.3'
+  id "com.github.johnrengelman.shadow"
 }
 
 dependencies {

--- a/spectator-ext-spark/build.gradle
+++ b/spectator-ext-spark/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'io.github.goooler.shadow' version '8.1.3'
+  id "com.github.johnrengelman.shadow"
 }
 
 dependencies {

--- a/spectator-reg-atlas/build.gradle
+++ b/spectator-reg-atlas/build.gradle
@@ -1,7 +1,7 @@
 import java.util.zip.ZipFile
 
 plugins {
-  id 'io.github.goooler.shadow' version '8.1.3'
+    id "com.github.johnrengelman.shadow"
 }
 
 dependencies {
@@ -51,7 +51,6 @@ afterEvaluate {
   publishing {
     publications {
       withType(MavenPublication) {
-        artifact(shadowJar)
         pom.withXml {
           asNode()
             .dependencies

--- a/spectator-web-spring/build.gradle
+++ b/spectator-web-spring/build.gradle
@@ -16,7 +16,7 @@
 import java.util.zip.ZipFile
 
 plugins {
-  id 'io.github.goooler.shadow' version '8.1.3'
+  id "com.github.johnrengelman.shadow"
 }
 
 dependencies {
@@ -65,7 +65,6 @@ afterEvaluate {
   publishing {
     publications {
       withType(MavenPublication) {
-        artifact(shadowJar)
         pom.withXml {
           asNode()
               .dependencies


### PR DESCRIPTION
This should restore the old behavior and upgrading ASM to 9.6 adds support for JDK 21 

Sample POM:

```
<?xml version="1.0" encoding="UTF-8"?>
<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <modelVersion>4.0.0</modelVersion>
  <groupId>com.netflix.spectator</groupId>
  <artifactId>spectator-reg-atlas</artifactId>
  <version>1.8.0-SNAPSHOT</version>
  <name>spectator-reg-atlas</name>
  <description>spectator-reg-atlas</description>
  <url>https://github.com/netflix/spectator</url>
  <licenses>
    <license>
      <name>The Apache Software License, Version 2.0</name>
      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
      <distribution>repo</distribution>
    </license>
  </licenses>
  <developers>
    <developer>
      <id>netflixgithub</id>
      <name>Netflix Open Source Development</name>
      <email>netflixoss@netflix.com</email>
    </developer>
  </developers>
  <scm>
    <url>ssh://git@github.com/netflix/spectator.git</url>
  </scm>
  <dependencies>
    <dependency>
      <groupId>com.netflix.spectator</groupId>
      <artifactId>spectator-api</artifactId>
      <version>1.8.0-SNAPSHOT</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>com.netflix.spectator</groupId>
      <artifactId>spectator-ext-ipc</artifactId>
      <version>1.8.0-SNAPSHOT</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>org.slf4j</groupId>
      <artifactId>slf4j-api</artifactId>
      <version>1.7.36</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>javax.inject</groupId>
      <artifactId>javax.inject</artifactId>
      <version>1</version>
      <scope>runtime</scope>
    </dependency>
  </dependencies>

</project>

```