### PR TITLE
avoid id mapping for aggregate functions

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Evaluator.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Evaluator.java
@@ -23,6 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -172,8 +173,13 @@ public class Evaluator {
           consolidator.update(timestamp, Double.NaN);
           final double v = consolidator.value(timestamp);
           if (!Double.isNaN(v)) {
-            Map<String, String> tags = idMapper.apply(entry.getKey());
-            tags.putAll(commonTags);
+            Map<String, String> tags = Collections.emptyMap();
+            if (!(expr instanceof DataExpr.AggregateFunction)) {
+              // Aggregation functions only use tags based on the expression. Avoid overhead of
+              // considering the tags for the data.
+              tags = idMapper.apply(entry.getKey());
+              tags.putAll(commonTags);
+            }
             if (delayGaugeAggr && consolidator.isGauge()) {
               // When performing a group by, datapoints missing tag used for the grouping
               // should be ignored


### PR DESCRIPTION
For simple aggregate functions the full set of tags are determined based on the expression. This means we can avoid mapping the id to a tag map.