### PR TITLE
only consider grouping keys for id mapping

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/DataExpr.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/DataExpr.java
@@ -471,13 +471,17 @@ public interface DataExpr {
   final class GroupBy implements DataExpr {
 
     private final AggregateFunction af;
-    private final List<String> keys;
+    private final Set<String> keys;
 
     /** Create a new instance. */
-    GroupBy(AggregateFunction af, List<String> keys) {
+    GroupBy(AggregateFunction af, Set<String> keys) {
       Preconditions.checkArg(!keys.isEmpty(), "key list for group by cannot be empty");
       this.af = af;
       this.keys = keys;
+    }
+
+    Set<String> keys() {
+      return keys;
     }
 
     @SuppressWarnings("PMD.ReturnEmptyCollectionRatherThanNull")

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/EvaluatorConfig.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/EvaluatorConfig.java
@@ -20,6 +20,8 @@ import com.netflix.spectator.api.NoopRegistry;
 import com.netflix.spectator.atlas.AtlasConfig;
 
 import java.util.Map;
+import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 /**
@@ -45,7 +47,7 @@ public interface EvaluatorConfig {
           return config.commonTags();
         }
 
-        @Override public Function<Id, Map<String, String>> idMapper() {
+        @Override public BiFunction<Id, Set<String>, Map<String, String>> idMapper() {
           return new IdMapper(JsonUtils.createReplacementFunction(config.validTagCharacters()));
         }
       };
@@ -59,7 +61,7 @@ public interface EvaluatorConfig {
   Map<String, String> commonTags();
 
   /** Function to convert an id to a map of key/value pairs. */
-  default Function<Id, Map<String, String>> idMapper() {
+  default BiFunction<Id, Set<String>, Map<String, String>> idMapper() {
     return new IdMapper(Function.identity());
   }
 

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Parser.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Parser.java
@@ -21,6 +21,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 
 /**
@@ -196,7 +197,7 @@ public final class Parser {
         case ":by":
           tmp = (List<String>) stack.pop();
           af = (DataExpr.AggregateFunction) stack.pop();
-          stack.push(new DataExpr.GroupBy(af, tmp));
+          stack.push(new DataExpr.GroupBy(af, new LinkedHashSet<>(tmp)));
           break;
         case ":rollup-drop":
           tmp = (List<String>) stack.pop();


### PR DESCRIPTION
When using a group by expression, only consider the tags that are part of the grouping rather than the full set when mapping the id.