### PR TITLE
reduce allocations for group by result tags

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/DataExpr.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/DataExpr.java
@@ -480,6 +480,10 @@ public interface DataExpr {
       this.keys = keys;
     }
 
+    AggregateFunction aggregateFunction() {
+      return af;
+    }
+
     Set<String> keys() {
       return keys;
     }


### PR DESCRIPTION
Avoid copying to new map for the group by.