### PR TITLE
fix NPE for missing tag with group by

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Evaluator.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Evaluator.java
@@ -197,7 +197,7 @@ public class Evaluator {
                 double acc = expr.isCount() ? 1.0 : v;
                 metrics.add(new EvalPayload.Metric(subId, tags, acc));
               }
-            } else {
+            } else if (tags != null) {
               TagsValuePair p = new TagsValuePair(tags, v);
               aggregator.update(p);
               LOGGER.trace("aggregating: {}: {}", timestamp, p);

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/EvaluatorTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/EvaluatorTest.java
@@ -124,6 +124,19 @@ public class EvaluatorTest {
   }
 
   @Test
+  public void missingTagGroupBy() {
+    List<Subscription> subs = new ArrayList<>();
+    subs.add(newSubscription("sum", ":true,:sum,(,app,),:by"));
+
+    Evaluator evaluator = newEvaluator();
+    evaluator.sync(subs);
+    EvalPayload payload = evaluator.eval(0L, data("foo", 1.0, 2.0, 3.0));
+
+    EvalPayload expected = new EvalPayload(0L, Collections.emptyList());
+    Assertions.assertEquals(expected, sort(payload));
+  }
+
+  @Test
   public void updateSub() {
 
     // Eval with sum


### PR DESCRIPTION
The change in #1120 can result in a NullPointerException if a group by is used and one of the required dimensions is missing.