### PR TITLE
atlas: limit task timer to just the task

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
@@ -253,15 +253,13 @@ public final class AtlasRegistry extends AbstractRegistry implements AutoCloseab
   }
 
   private void timePublishTask(String id, String lockName, Runnable task) {
-    publishTaskTimer(id).recordRunnable(() -> {
-      Lock lock = publishTaskLocks.computeIfAbsent(lockName, n -> new ReentrantLock());
-      lock.lock();
-      try {
-        task.run();
-      } finally {
-        lock.unlock();
-      }
-    });
+    Lock lock = publishTaskLocks.computeIfAbsent(lockName, n -> new ReentrantLock());
+    lock.lock();
+    try {
+      publishTaskTimer(id).recordRunnable(task);
+    } finally {
+      lock.unlock();
+    }
   }
 
   void sendToAtlas() {


### PR DESCRIPTION
Will look at the lock time separately. Helps to avoid confusion about how long the actual work of the task is taking.