### PR TITLE
atlas: support parallel evaluation

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
@@ -305,7 +305,7 @@ public final class AtlasRegistry extends AbstractRegistry implements AutoCloseab
       if (config.lwcEnabled()) {
         logger.debug("sending to LWC for time: {}", t);
         try {
-          EvalPayload payload = evaluator.eval(t);
+          EvalPayload payload = evaluator.eval(t, parallelPolling);
           if (!payload.getMetrics().isEmpty()) {
             List<CompletableFuture<Void>> futures = new ArrayList<>();
             payload.consumeBatches(batchSize, p -> futures.add(publisher.publish(p)));


### PR DESCRIPTION
Update evaluator for streaming expressions to allow them to be evaluated in parallel. This can be useful when run as a centralized service with thousands of expressions.