### PR TITLE
Avoid allocating lambda in PercentileTimer.computeIfAbsent

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,7 +113,7 @@ subprojects {
     profilers = ['stack', 'gc']
     includeTests = false
     duplicateClassesStrategy = DuplicatesStrategy.WARN
-    includes = ['.*Caching.*']
+    includes = ['.*PercentileTimers.*']
   }
 
   checkstyle {

--- a/spectator-api/src/main/java/com/netflix/spectator/api/histogram/PercentileTimer.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/histogram/PercentileTimer.java
@@ -72,8 +72,14 @@ public final class PercentileTimer implements Timer {
    * site.
    */
   private static PercentileTimer computeIfAbsent(Registry registry, Id id, long min, long max) {
-    Object timer = Utils.computeIfAbsent(
-        registry.state(), id, i -> new PercentileTimer(registry, id, min, max));
+    Object timer = registry.state().get(id);
+    if (timer == null) {
+      PercentileTimer newTimer = new PercentileTimer(registry, id, min, max);
+      timer = registry.state().putIfAbsent(id, newTimer);
+      if (timer == null) {
+        return newTimer;
+      }
+    }
     return (timer instanceof PercentileTimer)
         ? ((PercentileTimer) timer).withRange(min, max)
         : new PercentileTimer(registry, id, min, max);

--- a/spectator-api/src/main/java/com/netflix/spectator/api/histogram/PercentileTimer.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/histogram/PercentileTimer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2023 Netflix, Inc.
+ * Copyright 2014-2024 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@ import com.netflix.spectator.api.Measurement;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Statistic;
 import com.netflix.spectator.api.Timer;
-import com.netflix.spectator.api.Utils;
 import com.netflix.spectator.api.patterns.IdBuilder;
 import com.netflix.spectator.api.patterns.TagsBuilder;
 
@@ -72,6 +71,12 @@ public final class PercentileTimer implements Timer {
    * site.
    */
   private static PercentileTimer computeIfAbsent(Registry registry, Id id, long min, long max) {
+    // Inlined:
+    // Object timer = Utils.computeIfAbsent(
+    //        registry.state(), id, i -> new PercentileTimer(registry, id, min, max));
+    //
+    // The lambda needs to capture the parameters for registry, min, and max which can lead to
+    // a high allocation rate for the lambda instance.
     Object timer = registry.state().get(id);
     if (timer == null) {
       PercentileTimer newTimer = new PercentileTimer(registry, id, min, max);


### PR DESCRIPTION
PercentileTimer.computeIfAbsent would delegate to Utils.computeIfAbsent, which actually eagerly calls get and then putIfAbsent if the timer is not in the underlying map. Just directly do that to avoid needing to allocate a lambda in the case the timer is present.