### PR TITLE
atlas: limit LWC subs to time series exprs

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/SubscriptionManager.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/SubscriptionManager.java
@@ -112,10 +112,10 @@ class SubscriptionManager {
   private Subscriptions filterByStep(Subscriptions subs) {
     List<Subscription> filtered = new ArrayList<>(subs.getExpressions().size());
     for (Subscription sub : subs.getExpressions()) {
-      if (isSupportedFrequency(sub.getFrequency())) {
+      if (sub.isTimeSeries() && isSupportedFrequency(sub.getFrequency())) {
         filtered.add(sub);
       } else {
-        LOGGER.trace("ignored subscription with invalid frequency: {}", sub);
+        LOGGER.trace("ignored subscription with unsupported type or invalid step: {}", sub);
       }
     }
     return new Subscriptions().withExpressions(filtered);

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Subscription.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Subscription.java
@@ -24,6 +24,7 @@ package com.netflix.spectator.atlas.impl;
 public final class Subscription {
 
   private String id;
+  private String exprType;
   private String expression;
   private long frequency;
 
@@ -42,6 +43,12 @@ public final class Subscription {
     return expr;
   }
 
+  /** Return true if it is a time series expression. */
+  public boolean isTimeSeries() {
+    // Null is for legacy endpoints that do not indicate the type.
+    return exprType == null || "TIME_SERIES".equals(exprType);
+  }
+
   /** Id for a subscription.  */
   public String getId() {
     return id;
@@ -55,6 +62,22 @@ public final class Subscription {
   /** Set the subscription id. */
   public Subscription withId(String id) {
     this.id = id;
+    return this;
+  }
+
+  /** Expression type for the subscription. */
+  public String getExprType() {
+    return exprType;
+  }
+
+  /** Set the expression for the subscription. */
+  public void setExprType(String exprType) {
+    this.exprType = exprType;
+  }
+
+  /** Set the expression for the subscription. */
+  public Subscription withExprType(String exprType) {
+    setExprType(exprType);
     return this;
   }
 
@@ -97,6 +120,7 @@ public final class Subscription {
     Subscription that = (Subscription) o;
     return frequency == that.frequency
         && equalsOrNull(id, that.id)
+        && equalsOrNull(exprType, that.exprType)
         && equalsOrNull(expression, that.expression);
   }
 
@@ -106,6 +130,7 @@ public final class Subscription {
 
   @Override public int hashCode() {
     int result = hashCodeOrZero(id);
+    result = 31 * result + hashCodeOrZero(exprType);
     result = 31 * result + hashCodeOrZero(expression);
     result = 31 * result + (int) (frequency ^ (frequency >>> 32));
     return result;
@@ -116,6 +141,6 @@ public final class Subscription {
   }
 
   @Override public String toString() {
-    return "Subscription(" + id + ",[" + expression + "]," + frequency + ")";
+    return "Subscription(" + id + "," + exprType + ",[" + expression + "]," + frequency + ")";
   }
 }

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/SubscriptionTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/SubscriptionTest.java
@@ -42,4 +42,19 @@ public class SubscriptionTest {
     Assertions.assertThrows(IllegalArgumentException.class,
         () -> new Subscription().withExpression(":true").dataExpr());
   }
+
+  @Test
+  public void timeSeries() {
+    Subscription sub = new Subscription().withExpression(":true,:sum");
+    Assertions.assertTrue(sub.isTimeSeries());
+
+    sub.setExprType("TIME_SERIES");
+    Assertions.assertTrue(sub.isTimeSeries());
+
+    sub.setExprType("EVENTS");
+    Assertions.assertFalse(sub.isTimeSeries());
+
+    sub.setExprType("TRACE_TIME_SERIES");
+    Assertions.assertFalse(sub.isTimeSeries());
+  }
 }


### PR DESCRIPTION
This registry only supports forwarding data for time series. Ignore other expression types if present.