### PR TITLE
spark: update to versions used internally

### DIFF
--- a/spectator-ext-spark/build.gradle
+++ b/spectator-ext-spark/build.gradle
@@ -8,10 +8,10 @@ dependencies {
   implementation project(':spectator-ext-jvm')
   implementation project(':spectator-reg-sidecar')
   implementation "com.typesafe:config"
-  compileOnly 'io.dropwizard.metrics:metrics-core:3.1.5'
-  compileOnly 'org.apache.spark:spark-core_2.11:2.4.4'
+  compileOnly 'io.dropwizard.metrics:metrics-core:4.2.25'
+  compileOnly 'org.apache.spark:spark-core_2.12:3.3.4'
   testImplementation 'io.dropwizard.metrics:metrics-core:3.1.5'
-  testImplementation 'org.apache.spark:spark-core_2.11:2.4.4'
+  testImplementation 'org.apache.spark:spark-core_2.12:3.3.4'
 }
 
 jar {


### PR DESCRIPTION
Update the spark integration to use the main version of spark and scala in use at Netflix. Metrics version bumped to match what is used in spark 3.3 ([link](https://github.com/apache/spark/blob/27fdf96842ea5a98ea5835bbf78b33b26db1fd3b/pom.xml#L157)).