### PR TITLE
atlas: support dropping data in rollup policy

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/RollupPolicy.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/RollupPolicy.java
@@ -72,12 +72,38 @@ public interface RollupPolicy extends Function<List<Measurement>, List<RollupPol
     return Rollups.fromRules(commonTags, rules);
   }
 
+  /** Operation associated with a rule. */
+  enum Operation {
+    /** Rollup data by removing specified dimensions. */
+    ROLLUP,
+
+    /** Drop the data that matches the query. */
+    DROP
+  }
+
   /**
    * Rule for matching a set of measurements and removing specified dimensions.
    */
   final class Rule {
     private final String query;
     private final List<String> rollup;
+    private final Operation operation;
+
+    /**
+     * Create a new instance.
+     *
+     * @param query
+     *     Atlas query expression that indicates the set of measurements matching this rule.
+     * @param rollup
+     *     Set of dimensions to remove from the matching measurements.
+     * @param operation
+     *     Operation to perform if there is a match to the query.
+     */
+    public Rule(String query, List<String> rollup, Operation operation) {
+      this.query = Preconditions.checkNotNull(query, "query");
+      this.rollup = Preconditions.checkNotNull(rollup, "rollup");
+      this.operation = Preconditions.checkNotNull(operation, "operation");
+    }
 
     /**
      * Create a new instance.
@@ -88,8 +114,7 @@ public interface RollupPolicy extends Function<List<Measurement>, List<RollupPol
      *     Set of dimensions to remove from the matching measurements.
      */
     public Rule(String query, List<String> rollup) {
-      this.query = Preconditions.checkNotNull(query, "query");
-      this.rollup = Preconditions.checkNotNull(rollup, "rollup");
+      this(query, rollup, Operation.ROLLUP);
     }
 
     /** Return the query expression string. */
@@ -102,18 +127,24 @@ public interface RollupPolicy extends Function<List<Measurement>, List<RollupPol
       return rollup;
     }
 
+    /** Return the operation to perform if the query matches. */
+    public Operation operation() {
+      return operation;
+    }
+
     @Override
     public boolean equals(Object o) {
       if (this == o) return true;
       if (!(o instanceof Rule)) return false;
       Rule rule = (Rule) o;
       return query.equals(rule.query)
-          && rollup.equals(rule.rollup);
+          && rollup.equals(rule.rollup)
+          && operation == rule.operation;
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(query, rollup);
+      return Objects.hash(query, rollup, operation);
     }
   }
 

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/Rollups.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/Rollups.java
@@ -58,11 +58,16 @@ final class Rollups {
       for (Measurement m : ms) {
         List<RollupPolicy.Rule> matches = index.findMatches(m.id());
         if (matches.isEmpty()) {
-          // No matches for the id, but we sill need to treat as an aggregate because
+          // No matches for the id, but we still need to treat as an aggregate because
           // rollup on another id could cause a collision
           Map<Id, Aggregator> idMap = aggregates.computeIfAbsent(commonTags, k -> new HashMap<>());
           updateAggregate(idMap, m.id(), m);
         } else {
+          // Skip measurement if one of the rules indicates it should be dropped
+          if (shouldDrop(matches)) {
+            continue;
+          }
+
           // For matching rules, find dimensions from common tags and others that are part
           // of the id
           Set<String> commonDimensions = new HashSet<>();
@@ -77,7 +82,7 @@ final class Rollups {
             }
           }
 
-          // Peform rollup by removing the dimensions
+          // Perform rollup by removing the dimensions
           Map<String, String> tags = commonDimensions.isEmpty()
               ? commonTags
               : rollup(commonTags, commonDimensions);
@@ -96,6 +101,15 @@ final class Rollups {
       }
       return results;
     };
+  }
+
+  private static boolean shouldDrop(List<RollupPolicy.Rule> rules) {
+    for (RollupPolicy.Rule rule : rules) {
+      if (rule.operation() == RollupPolicy.Operation.DROP) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private static Map<String, String> rollup(Map<String, String> tags, Set<String> dimensions) {


### PR DESCRIPTION
Add an operation to the rule that can be used to indicate data should be dropped entirely.