### PR TITLE
Fix deprecated method in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ public class Server {
 
   public Response handle(Request req) {
     final long s = System.nanoTime();
-    requestLatency.record(() -> {
+    requestLatency.recordRunnable(() -> {
       try {
         Response res = doSomething(req);
 


### PR DESCRIPTION
Switch to recordRunnable for the timer example.