### PR TITLE
atlas: cleanup stop log message

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
@@ -196,7 +196,7 @@ public final class AtlasRegistry extends AbstractRegistry implements AutoCloseab
       // Shutdown background tasks to collect data
       scheduler.shutdown();
       scheduler = null;
-      logger.info("stopped collecting metrics every {}ms reporting to {}", step, uri);
+      logger.info("stopped collecting metrics every {} reporting to {}", step, uri);
 
       // Flush data to Atlas
       try {


### PR DESCRIPTION
The `step` variable is a duration and the toString indicates the units. Remove the `ms` in the log message which are confusing and lead to message like `PT1Mms`.