### PR TITLE
scheduler will now wait for threads on shutdown

### DIFF
--- a/spectator-api/src/test/java/com/netflix/spectator/impl/SchedulerTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/SchedulerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2024 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Updated the scheduler helper to have the shutdown method block until the threads stop. This makes it easier for callers to ensure they are not competing with in-progress tasks while performing other shutdown work.