### PR TITLE
add deprecation notices to readmes

### DIFF
--- a/spectator-ext-aws/README.md
+++ b/spectator-ext-aws/README.md
@@ -1,4 +1,10 @@
 # spectator-ext-aws
+
+**DEPRECATED:** AWS SDK for Java V1 will no longer be supported [after 2025]. Users
+should move to AWS SDK for Java V2.
+
+[after 2025]: https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-java-v1-x-on-december-31-2025/
+
 Use Spectator as the Metrics backend for AWS SDK Request Metrics.
 
 # Usage

--- a/spectator-ext-log4j1/README.md
+++ b/spectator-ext-log4j1/README.md
@@ -1,5 +1,9 @@
 ## Description
 
+**DEPRECATED:** Log4J 1.x has reached [end of life]. Users should move to Log4J 2.x.
+
+[end of life]: https://news.apache.org/foundation/entry/apache_logging_services_project_announces
+
 Report basic metrics summarizing the log volume. See [docs] for more information.
 
 [docs]: https://netflix.github.io/spectator/en/latest/ext/log4j1/

--- a/spectator-nflx-plugin/README.md
+++ b/spectator-nflx-plugin/README.md
@@ -1,5 +1,7 @@
 ## Description
 
+**DEPRECATED:** Internal users should move to SBN.
+
 Provides a module for use with Guice based applications running at Netflix.
 See [docs] for more information.
 

--- a/spectator-reg-metrics3/README.md
+++ b/spectator-reg-metrics3/README.md
@@ -1,5 +1,8 @@
 ## Description
 
+**DEPRECATED:** Use `spectator-reg-micrometer` for integration with other
+systems not supported directly via a Spectator registry implementation.
+
 Registry implementation that wraps the [Dropwizard Metrics] library.
 
 [Dropwizard Metrics]: https://metrics.dropwizard.io/3.1.0/

--- a/spectator-reg-metrics5/README.md
+++ b/spectator-reg-metrics5/README.md
@@ -1,5 +1,8 @@
 ## Description
 
+**DEPRECATED:** Use `spectator-reg-micrometer` for integration with other
+systems not supported directly via a Spectator registry implementation.
+
 Registry implementation that wraps the [Dropwizard Metrics] 5.x library.
 
 [Dropwizard Metrics]: https://metrics.dropwizard.io/5.0.0-rc11/


### PR DESCRIPTION
Update readmes for some sub-projects to indicate they are deprecated and usage should be phased out.