### PR TITLE
aws: deprecate classes

### DIFF
--- a/spectator-ext-aws/src/main/java/com/netflix/spectator/aws/SpectatorMetricCollector.java
+++ b/spectator-ext-aws/src/main/java/com/netflix/spectator/aws/SpectatorMetricCollector.java
@@ -23,7 +23,11 @@ import com.netflix.spectator.impl.Preconditions;
 
 /**
  * A MetricCollector that captures SDK metrics.
+ *
+ * @deprecated Users should migrate to AWS SDK for Java V2. AWS will drop support
+ * for V1 after 2025.
  */
+@Deprecated
 public class SpectatorMetricCollector extends MetricCollector {
     private final RequestMetricCollector requestMetricCollector;
     private final ServiceMetricCollector serviceMetricCollector;

--- a/spectator-ext-aws/src/main/java/com/netflix/spectator/aws/SpectatorRequestMetricCollector.java
+++ b/spectator-ext-aws/src/main/java/com/netflix/spectator/aws/SpectatorRequestMetricCollector.java
@@ -37,7 +37,11 @@ import java.util.stream.Stream;
 
 /**
  * A {@link RequestMetricCollector} that captures request level metrics for AWS clients.
+ *
+ * @deprecated Users should migrate to AWS SDK for Java V2. AWS will drop support
+ * for V1 after 2025.
  */
+@Deprecated
 public class SpectatorRequestMetricCollector extends RequestMetricCollector {
 
   /**

--- a/spectator-ext-aws/src/main/java/com/netflix/spectator/aws/SpectatorServiceMetricCollector.java
+++ b/spectator-ext-aws/src/main/java/com/netflix/spectator/aws/SpectatorServiceMetricCollector.java
@@ -27,7 +27,11 @@ import java.util.concurrent.TimeUnit;
 /**
  * A {@link ServiceMetricCollector} that captures the time it takes to get a connection
  * from the pool.
+ *
+ * @deprecated Users should migrate to AWS SDK for Java V2. AWS will drop support
+ * for V1 after 2025.
  */
+@Deprecated
 class SpectatorServiceMetricCollector extends ServiceMetricCollector {
 
   private final Timer clientGetConnectionTime;


### PR DESCRIPTION
Deprecate these classe to encourage users to transition to V2 before [AWS support for V1] ends.

[AWS support for V1]: https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-java-v1-x-on-december-31-2025/