### PR TITLE
ipc: add option to disable inflight

### DIFF
--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcLogEntry.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcLogEntry.java
@@ -156,7 +156,7 @@ public final class IpcLogEntry {
    * the request completes it is recommended to call {@link #markEnd()}.
    */
   public IpcLogEntry markStart() {
-    if (registry != null && !disableMetrics) {
+    if (registry != null && !disableMetrics && logger.inflightEnabled()) {
       inflightId = getInflightId();
       int n = logger.inflightRequests(inflightId).incrementAndGet();
       registry.distributionSummary(inflightId).record(n);

--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcLogger.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2024 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,32 +47,40 @@ public class IpcLogger {
   private final Registry registry;
   private final Clock clock;
   private final Logger logger;
+  private final IpcLoggerConfig config;
 
+  private final boolean inflightEnabled;
   private final ConcurrentHashMap<Id, AtomicInteger> inflightRequests;
   private final ConcurrentHashMap<String, Function<String, String>> limiters;
 
   private final LinkedBlockingQueue<IpcLogEntry> entries;
 
   /**
-   * Create a new instance. Allows the clock to be explicitly set for unit tests.
+   * Create a new instance.
    */
-  IpcLogger(Registry registry, Clock clock, Logger logger) {
+  IpcLogger(Registry registry, Logger logger, IpcLoggerConfig config) {
     this.registry = registry;
-    this.clock = clock;
+    this.clock = registry.clock();
     this.logger = logger;
+    this.config = config;
+    this.inflightEnabled = config.inflightMetricsEnabled();
     this.inflightRequests = new ConcurrentHashMap<>();
     this.limiters = new ConcurrentHashMap<>();
-    this.entries = new LinkedBlockingQueue<>(1000);
+    this.entries = new LinkedBlockingQueue<>(config.entryQueueSize());
   }
 
   /** Create a new instance. */
   public IpcLogger(Registry registry, Logger logger) {
-    this(registry, registry.clock(), logger);
+    this(registry, logger, k -> null);
   }
 
   /** Create a new instance. */
   public IpcLogger(Registry registry) {
-    this(registry, registry.clock(), LoggerFactory.getLogger(IpcLogger.class));
+    this(registry, LoggerFactory.getLogger(IpcLogger.class), k -> null);
+  }
+
+  boolean inflightEnabled() {
+    return inflightEnabled;
   }
 
   /** Return the number of inflight requests associated with the given id. */
@@ -85,7 +93,10 @@ public class IpcLogger {
    * backend from a metrics explosion if some dimensions have a high cardinality.
    */
   Function<String, String> limiterForKey(String key) {
-    return Utils.computeIfAbsent(limiters, key, k -> CardinalityLimiters.rollup(25));
+    return Utils.computeIfAbsent(limiters, key, k -> {
+      final int n = config.cardinalityLimit(k);
+      return CardinalityLimiters.rollup(n);
+    });
   }
 
   private IpcLogEntry newEntry() {

--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcLoggerConfig.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcLoggerConfig.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2014-2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.ipc;
+
+/**
+ * Configuration settings for IpcLogger.
+ */
+public interface IpcLoggerConfig {
+
+  /**
+   * Get the value for a given key or return null if it is not present.
+   */
+  String get(String key);
+
+  /**
+   * Get the value for a given key or return the specified default if it is not present.
+   */
+  default String get(String key, String dflt) {
+    String v = get(key);
+    return v == null ? dflt : v;
+  }
+
+  /**
+   * Get the value for a given key or return the specified default if it is not present.
+   */
+  default int getInt(String key, int dflt) {
+    int n = dflt;
+    String v = get(key, Integer.toString(n));
+    try {
+      n = Integer.parseInt(v);
+    } catch (NumberFormatException ignored) {
+    }
+    return n;
+  }
+
+  /**
+   * Determines whether the metrics for number of in flight requests will be generated.
+   * These metrics are poorly modeled and often lead to confusion. To estimate number
+   * of in flight requests for a given scope, Little's law can be used along with the
+   * latency metrics. Defaults to true for backwards compatibility.
+   */
+  default boolean inflightMetricsEnabled() {
+    String v = get("spectator.ipc.inflight-metrics-enabled", "true");
+    return "true".equals(v);
+  }
+
+  /**
+   * Limit to use for the cardinality limiter applied on a given tag key. IPC metrics
+   * have many dimensions and a high volume, be careful with increasing the limit as
+   * it can easily cause a large increase.
+   */
+  default int cardinalityLimit(String tagKey) {
+    String propKey = "spectator.ipc.cardinality-limit." + tagKey;
+    return getInt(propKey, 25);
+  }
+
+  /**
+   * Size to use for the queue of reusable logger entries.
+   */
+  default int entryQueueSize() {
+    return getInt("spectator.ipc.entry-queue-size", 1000);
+  }
+}


### PR DESCRIPTION
The inflight metrics are poorly modeled and can often be confusing. They do not aggregate as expected so aren't really meaningful unless you understand the full set of dimensions used. Add option to disable them. Cannot remove for now due to backwards compatibility.