### PR TITLE
ipc: make constructor with logger config public

### DIFF
--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcLogger.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcLogger.java
@@ -58,7 +58,7 @@ public class IpcLogger {
   /**
    * Create a new instance.
    */
-  IpcLogger(Registry registry, Logger logger, IpcLoggerConfig config) {
+  public IpcLogger(Registry registry, Logger logger, IpcLoggerConfig config) {
     this.registry = registry;
     this.clock = registry.clock();
     this.logger = logger;

--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/http/Defaults.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/http/Defaults.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2014-2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.ipc.http;
+
+import com.netflix.spectator.api.Spectator;
+import com.netflix.spectator.ipc.IpcLogger;
+import com.netflix.spectator.ipc.IpcLoggerConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Default instances for IPC loggers used with HTTP client wrapper. */
+final class Defaults {
+
+  private Defaults() {
+  }
+
+  /** Use HttpClient for the slf4j logger instance. */
+  static final Logger LOGGER = LoggerFactory.getLogger(HttpClient.class);
+
+  /** Logger config that delegates to system properties. */
+  static final IpcLoggerConfig IPC_LOGGER_CONFIG = Defaults::getProperty;
+
+  /** IPC logger using global registry and with default config. */
+  static final IpcLogger IPC_LOGGER =
+      new IpcLogger(Spectator.globalRegistry(), LOGGER, IPC_LOGGER_CONFIG);
+
+  /** Delegate to system properties and change default to disable inflight metrics. */
+  private static String getProperty(String key) {
+    String dflt = "spectator.ipc.inflight-metrics-enabled".equals(key) ? "false" : null;
+    return System.getProperty(key, dflt);
+  }
+}

--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/http/HttpClient.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/http/HttpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2024 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package com.netflix.spectator.ipc.http;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Spectator;
 import com.netflix.spectator.ipc.IpcLogger;
-import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 
@@ -49,9 +48,7 @@ public interface HttpClient {
    * Default {@link IpcLogger} instance. It will report metrics to
    * {@link Spectator#globalRegistry()}.
    */
-  IpcLogger DEFAULT_LOGGER = new IpcLogger(
-      Spectator.globalRegistry(),
-      LoggerFactory.getLogger(HttpClient.class));
+  IpcLogger DEFAULT_LOGGER = Defaults.IPC_LOGGER;
 
   /**
    * Default client instance that can be used in static contexts where it is not
@@ -68,7 +65,7 @@ public interface HttpClient {
    *     Client instance based on {@link java.net.HttpURLConnection}.
    */
   static HttpClient create(Registry registry) {
-    return create(new IpcLogger(registry, LoggerFactory.getLogger(HttpClient.class)));
+    return create(new IpcLogger(registry, Defaults.LOGGER));
   }
 
   /**

--- a/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/http/DefaultsTest.java
+++ b/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/http/DefaultsTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2014-2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.ipc.http;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class DefaultsTest {
+
+  private static final String infightProp = "spectator.ipc.inflight-metrics-enabled";
+
+  @Test
+  public void inflightDefaultsFalse() {
+    System.clearProperty(infightProp);
+    Assertions.assertFalse(Defaults.IPC_LOGGER_CONFIG.inflightMetricsEnabled());
+  }
+
+  @Test
+  public void inflightSetFalse() {
+    System.setProperty(infightProp, "false");
+    Assertions.assertFalse(Defaults.IPC_LOGGER_CONFIG.inflightMetricsEnabled());
+  }
+
+  @Test
+  public void inflightSetTrue() {
+    System.setProperty(infightProp, "true");
+    Assertions.assertTrue(Defaults.IPC_LOGGER_CONFIG.inflightMetricsEnabled());
+  }
+}


### PR DESCRIPTION
Update the visibility to allow the config to be customized. The default http client wrapper now sets up the config to delegate to system properties.