### PR TITLE
[WIP] Add new IPC tags from IPC Metrics v2 spec

### DIFF
--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcAttemptReason.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcAttemptReason.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.ipc;
+
+import com.netflix.spectator.api.Tag;
+
+public enum IpcAttemptReason implements Tag {
+
+    /**
+     * Represents the initial attempt for the request.
+     */
+    initial,
+
+    /**
+     * Represents a retry attempt for the request.
+     */
+    retry,
+
+    /**
+     * Represents a hedge attempt for the request.
+     */
+    hedge;
+
+    @Override public String key() {
+        return IpcTagKey.attemptFinal.key();
+    }
+
+    @Override public String value() {
+        return name();
+    }
+}

--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcLogEntry.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcLogEntry.java
@@ -56,14 +56,17 @@ public final class IpcLogEntry {
   private String protocol;
 
   private IpcStatus status;
+  private String statusCode;
   private String statusDetail;
   private Throwable exception;
 
   private IpcAttempt attempt;
+  private String attemptReason;
   private IpcAttemptFinal attemptFinal;
 
   private String vip;
   private String endpoint;
+  private String method;
 
   private String clientRegion;
   private String clientZone;
@@ -218,6 +221,14 @@ public final class IpcLogEntry {
   }
 
   /**
+   * Set the implementation specific status code for the request.
+   */
+  public IpcLogEntry withStatusCode(String statusCode) {
+    this.statusCode = statusCode;
+    return this;
+  }
+
+  /**
    * Set the detailed implementation specific status for the request. In most cases it
    * is preferable to use {@link #withException(Throwable)} or {@link #withHttpStatus(int)}
    * instead of calling this directly.
@@ -283,6 +294,22 @@ public final class IpcLogEntry {
   }
 
   /**
+   * Set the reason for the attempt for the request.
+   * See {@link IpcAttemptReason} for possible values.
+   */
+  public IpcLogEntry withAttemptReason(IpcAttemptReason attemptReason) {
+    return withAttemptReason(attemptReason.value());
+  }
+
+  /**
+   * Set the reason for the attempt for the request.
+   */
+  public IpcLogEntry withAttemptReason(String attemptReason) {
+    this.attemptReason = attemptReason;
+    return this;
+  }
+
+  /**
    * Set whether or not this is the final attempt for the request.
    */
   public IpcLogEntry withAttemptFinal(boolean isFinal) {
@@ -304,6 +331,22 @@ public final class IpcLogEntry {
    */
   public IpcLogEntry withEndpoint(String endpoint) {
     this.endpoint = endpoint;
+    return this;
+  }
+
+  /**
+   * Set the method used for this request.
+   * See {@link IpcMethod} for possible values.
+   */
+  public IpcLogEntry withMethod(IpcMethod method) {
+    return withMethod(method.value());
+  }
+
+  /**
+   * Set the method used for this request.
+   */
+  public IpcLogEntry withMethod(String method) {
+    this.method = method;
     return this;
   }
 
@@ -899,6 +942,7 @@ public final class IpcLogEntry {
         .addField("protocol", protocol)
         .addField("uri", uri)
         .addField("path", path)
+        .addField("method", method)
         .addField("endpoint", endpoint)
         .addField("vip", vip)
         .addField("clientRegion", clientRegion)
@@ -916,9 +960,11 @@ public final class IpcLogEntry {
         .addField("remoteAddress", remoteAddress)
         .addField("remotePort", remotePort)
         .addField("attempt", attempt)
+        .addField("attemptReason", attemptReason)
         .addField("attemptFinal", attemptFinal)
         .addField("result", result)
         .addField("status", status)
+        .addField("statusCode", statusCode)
         .addField("statusDetail", statusDetail)
         .addField("exceptionClass", getExceptionClass())
         .addField("exceptionMessage", getExceptionMessage())

--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcMethod.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcMethod.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.ipc;
+
+import com.netflix.spectator.api.Tag;
+
+public enum IpcMethod implements Tag {
+
+    /**
+     * Represents a unary gRPC method.
+     */
+    unary,
+
+    /**
+     * Represents a client streaming gRPC method.
+     */
+    client_streaming,
+
+    /**
+     * Represents a server streaming gRPC method.
+     */
+    server_streaming,
+
+    /**
+     * Represents a bidirectional streaming gRPC method.
+     */
+    bidi_streaming,
+
+    /**
+     * Represents an HTTP GET request.
+     */
+    get,
+
+    /**
+     * Represents an HTTP POST request.
+     */
+    post,
+
+    /**
+     * Represents an HTTP PUT request.
+     */
+    put,
+
+    /**
+     * Represents an HTTP PATCH request.
+     */
+    patch,
+
+    /**
+     * Represents an HTTP DELETE request.
+     */
+    delete,
+
+    /**
+     * Represents an HTTP OPTIONS request.
+     */
+    options,
+
+    /**
+     * Represents a GraphQL query.
+     */
+    query,
+
+    /**
+     * Represents a GraphQL mutation.
+     */
+    mutation,
+
+    /**
+     * Represents a GraphQL subscription.
+     */
+    subscription;
+
+    @Override public String key() {
+        return IpcTagKey.method.key();
+    }
+
+    @Override public String value() {
+        return name();
+    }
+}

--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcMetric.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcMetric.java
@@ -49,7 +49,9 @@ public enum IpcMetric {
           IpcTagKey.status
       ),
       EnumSet.of(
+          IpcTagKey.attemptReason,
           IpcTagKey.endpoint,
+          IpcTagKey.method,
           IpcTagKey.failureInjected,
           IpcTagKey.httpMethod,
           IpcTagKey.httpStatus,
@@ -58,6 +60,7 @@ public enum IpcMetric {
           IpcTagKey.serverApp,
           IpcTagKey.serverCluster,
           IpcTagKey.serverAsg,
+          IpcTagKey.statusCode,
           IpcTagKey.statusDetail,
           IpcTagKey.vip
       )
@@ -75,6 +78,7 @@ public enum IpcMetric {
       ),
       EnumSet.of(
           IpcTagKey.endpoint,
+          IpcTagKey.method,
           IpcTagKey.clientApp,
           IpcTagKey.clientCluster,
           IpcTagKey.clientAsg,
@@ -83,6 +87,7 @@ public enum IpcMetric {
           IpcTagKey.httpStatus,
           IpcTagKey.id,
           IpcTagKey.protocol,
+          IpcTagKey.statusCode,
           IpcTagKey.statusDetail,
           IpcTagKey.vip
       )

--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcTagKey.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcTagKey.java
@@ -33,6 +33,12 @@ public enum IpcTagKey {
   result("ipc.result"),
 
   /**
+   * Indicates where the result was ultimately sourced from such as cache, direct,
+   * proxy, fallback, etc.
+   */
+  source("ipc.source"),
+
+  /**
    * Dimension indicating a high level status for the request. These values are the same
    * for all implementations to make it easier to query across services. See {@link IpcStatus}
    * for permitted values.
@@ -40,9 +46,17 @@ public enum IpcTagKey {
   status("ipc.status"),
 
   /**
+   * Dimension indicating the transport-specific code that aligns to the IPC status.
+   * The values for this are implementation specific. For example with HTTP,
+   * the status code value would be used here.
+   */
+  statusCode("ipc.status.code"),
+
+  /**
    * Optional dimension indicating a more detailed status. The values for this are
-   * implementation specific. For example with HTTP, the status code would be a likely
-   * value used here.
+   * implementation specific. For example, the {@link #status} may be
+   * {@code connection_error} and {@code statusDetail} would be {@code no_servers},
+   * {@code connect_timeout}, {@code ssl_handshake_failure}, etc.
    */
   statusDetail("ipc.status.detail"),
 
@@ -71,6 +85,11 @@ public enum IpcTagKey {
    * Indicates the attempt number for the request.
    */
   attempt("ipc.attempt"),
+
+  /**
+   * Indicates the reason for the attempt. See {@link IpcAttemptReason} for possible values.
+   */
+  attemptReason("ipc.attempt.reason"),
 
   /**
    * Indicates if this is the final attempt for the request. For example, if the client
@@ -102,6 +121,11 @@ public enum IpcTagKey {
    * Protocol used for the request. For example {@code http_1} or {@code http_2}.
    */
   protocol("ipc.protocol"),
+
+  /**
+   * Method used to make the IPC request. See {@link IpcMethod} for possible values.
+   */
+  method("ipc.method"),
 
   /**
    * Region where the client is located.

--- a/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/IpcLogEntryTest.java
+++ b/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/IpcLogEntryTest.java
@@ -147,6 +147,16 @@ public class IpcLogEntryTest {
   }
 
   @Test
+  public void statusCode() {
+    String expected = "deadline_exceeded";
+    String actual = (String) entry
+            .withStatusCode(expected)
+            .convert(this::toMap)
+            .get("statusCode");
+    Assertions.assertEquals(expected, actual);
+  }
+
+  @Test
   public void statusDetail() {
     String expected = "connection_failed";
     String actual = (String) entry
@@ -185,6 +195,26 @@ public class IpcLogEntryTest {
         .withAttempt(7)
         .convert(this::toMap)
         .get("attempt");
+    Assertions.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void attemptReason() {
+    String expected = IpcAttemptReason.retry.value();
+    String actual = (String) entry
+            .withAttemptReason(IpcAttemptReason.retry)
+            .convert(this::toMap)
+            .get("attemptReason");
+    Assertions.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void customAttemptReason() {
+    String expected = "unknown";
+    String actual = (String) entry
+            .withAttemptReason(expected)
+            .convert(this::toMap)
+            .get("attemptReason");
     Assertions.assertEquals(expected, actual);
   }
 
@@ -238,6 +268,27 @@ public class IpcLogEntryTest {
         .get("endpoint");
     Assertions.assertEquals("unknown", actual);
   }
+
+  @Test
+  public void method() {
+    String expected = IpcMethod.get.value();
+    String actual = (String) entry
+            .withMethod(IpcMethod.get)
+            .convert(this::toMap)
+            .get("method");
+    Assertions.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void customMethod() {
+    String expected = "websocket";
+    String actual = (String) entry
+            .withMethod(expected)
+            .convert(this::toMap)
+            .get("method");
+    Assertions.assertEquals(expected, actual);
+  }
+
 
   @Test
   public void clientNode() {


### PR DESCRIPTION
Added new IPC tags as per the V2 spec:
 - ipc.source (To be used for api metrics)
 - ipc.method
 - ipc.source.code
 - ipc.attempt.reason
 
 Open questions for discussion:
 - Should we create a new Enum for `ApiMetric` (Similar to IpcMetric)
 - Do we need validations for `IpcAttemptReason` and `IpcMethod` enums? The values present in the enum classes aren't supposed to be exhaustive hence I didn't put in a strict validation rule (As opposed to ipc.status which has a fixed set of allowed values).
  - Should we deprecate `HttpMethod` and `HttpStatus` from IpcTags?
  