### PR TITLE
ipc: Fix NPE from #1150 if IPC logger is not configured.

### DIFF
--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcLogEntry.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcLogEntry.java
@@ -156,7 +156,7 @@ public final class IpcLogEntry {
    * the request completes it is recommended to call {@link #markEnd()}.
    */
   public IpcLogEntry markStart() {
-    if (registry != null && !disableMetrics && logger.inflightEnabled()) {
+    if (registry != null && !disableMetrics && logger != null && logger.inflightEnabled()) {
       inflightId = getInflightId();
       int n = logger.inflightRequests(inflightId).incrementAndGet();
       registry.distributionSummary(inflightId).record(n);

--- a/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/IpcLogEntryTest.java
+++ b/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/IpcLogEntryTest.java
@@ -20,6 +20,7 @@ import com.netflix.spectator.api.BasicTag;
 import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.DistributionSummary;
 import com.netflix.spectator.api.ManualClock;
+import com.netflix.spectator.api.NoopRegistry;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Utils;
 import com.netflix.spectator.api.patterns.CardinalityLimiters;
@@ -35,6 +36,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class IpcLogEntryTest {
 
@@ -888,5 +891,13 @@ public class IpcLogEntryTest {
     registry.counters().forEach(c -> {
       Assertions.assertEquals("unknown", Utils.getTagValue(c.id(), "ipc.endpoint"));
     });
+  }
+
+  @Test
+  public void markNullLogger() {
+    IpcLogEntry entry = new IpcLogEntry(clock)
+        .withRegistry(new NoopRegistry());
+    entry.markStart();
+    assertSame(entry, entry.markEnd());
   }
 }


### PR DESCRIPTION
Results in a
`java.lang.NullPointerException: Cannot invoke "com.netflix.spectator.ipc.IpcLogger.inflightEnabled()" because "this.logger" is null`