### PR TITLE
Implement missing overrides in NoopDistributionSummary

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/NoopDistributionSummary.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/NoopDistributionSummary.java
@@ -34,6 +34,9 @@ enum NoopDistributionSummary implements DistributionSummary {
   @Override public void record(long amount) {
   }
 
+  @Override public void record(long[] amounts, int n) {
+  }
+
   @Override public Iterable<Measurement> measure() {
     return Collections.emptyList();
   }
@@ -44,5 +47,23 @@ enum NoopDistributionSummary implements DistributionSummary {
 
   @Override public long totalAmount() {
     return 0L;
+  }
+
+  @Override
+  public BatchUpdater batchUpdater(int batchSize) {
+    return NoopBatchUpdater.INSTANCE;
+  }
+
+  private enum NoopBatchUpdater implements BatchUpdater {
+    INSTANCE;
+
+    @Override public void flush() {
+    }
+
+    @Override public void record(long amount) {
+    }
+
+    @Override public void close() {
+    }
   }
 }

--- a/spectator-api/src/test/java/com/netflix/spectator/api/NoopDistributionSummaryTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/NoopDistributionSummaryTest.java
@@ -38,6 +38,18 @@ public class NoopDistributionSummaryTest {
     NoopDistributionSummary t = NoopDistributionSummary.INSTANCE;
     t.record(42);
     Assertions.assertFalse(t.measure().iterator().hasNext());
+    t.record(new long[] { 1L, 2L, 3L }, 3);
+    Assertions.assertFalse(t.measure().iterator().hasNext());
   }
 
+  @Test
+  public void testBatchUpdate() throws Exception {
+    NoopDistributionSummary t = NoopDistributionSummary.INSTANCE;
+    try (DistributionSummary.BatchUpdater batchUpdater = t.batchUpdater(10)) {
+      for (long i = 0; i < 100; i++) {
+        batchUpdater.record(i);
+      }
+    }
+    Assertions.assertFalse(t.measure().iterator().hasNext());
+  }
 }


### PR DESCRIPTION
Implement overrides for batchUpdater and record in NoopDistributionSummary that do nothing and avoid allocating.