### PR TITLE
Remove unintentional return

### DIFF
--- a/spectator-ext-jvm/src/main/java/com/netflix/spectator/jvm/Jmx.java
+++ b/spectator-ext-jvm/src/main/java/com/netflix/spectator/jvm/Jmx.java
@@ -50,7 +50,6 @@ public final class Jmx {
         return t;
       });
       JavaFlightRecorder.monitorDefaultEvents(registry, executor);
-      return;
     } else {
       monitorClassLoadingMXBean(registry);
       monitorThreadMXBean(registry);


### PR DESCRIPTION
When I added the condition for ensuring we were still registering memory pools, I missed dropping the short-circuit return, so we accidentally dropped these.