### PR TITLE
api: percentile approximations from doubles

### DIFF
--- a/spectator-api/src/test/java/com/netflix/spectator/api/histogram/PercentileBucketsTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/histogram/PercentileBucketsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2024 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -117,6 +117,46 @@ public class PercentileBucketsTest {
     long[] counts = new long[PercentileBuckets.length()];
     for (int i = 0; i < 100_000; ++i) {
       ++counts[PercentileBuckets.indexOf(i)];
+    }
+
+    double[] pcts = new double[] {0.0, 25.0, 50.0, 75.0, 90.0, 95.0, 98.0, 99.0, 99.5, 100.0};
+    for (double pct : pcts) {
+      double expected = pct * 1e3;
+      double threshold = 0.1 * expected + 1e-12;
+      Assertions.assertEquals(expected, PercentileBuckets.percentile(counts, pct), threshold);
+    }
+  }
+
+  @Test
+  public void percentilesDouble() {
+    double[] counts = new double[PercentileBuckets.length()];
+    for (int i = 0; i < 100_000; ++i) {
+      // simulate it as a rate per minute
+      counts[PercentileBuckets.indexOf(i)] += 1.0 / 60.0;
+    }
+
+    double[] pcts = new double[] {0.0, 25.0, 50.0, 75.0, 90.0, 95.0, 98.0, 99.0, 99.5, 100.0};
+    double[] results = new double[pcts.length];
+
+    PercentileBuckets.percentiles(counts, pcts, results);
+
+    double[] expected = new double[] {0.0, 25e3, 50e3, 75e3, 90e3, 95e3, 98e3, 99e3, 99.5e3, 100e3};
+    double threshold = 0.1 * 100_000; // quick check, should be within 10% of total
+    Assertions.assertArrayEquals(expected, results, threshold);
+
+    // Further check each value is within 10% of actual percentile
+    for (int i = 0 ; i < results.length; ++i) {
+      threshold = 0.1 * expected[i] + 1e-12;
+      Assertions.assertEquals(expected[i], results[i], threshold);
+    }
+  }
+
+  @Test
+  public void percentileDouble() {
+    double[] counts = new double[PercentileBuckets.length()];
+    for (int i = 0; i < 100_000; ++i) {
+      // simulate it as a rate per minute
+      counts[PercentileBuckets.indexOf(i)] += 1.0 / 60.0;
     }
 
     double[] pcts = new double[] {0.0, 25.0, 50.0, 75.0, 90.0, 95.0, 98.0, 99.0, 99.5, 100.0};


### PR DESCRIPTION
Update the buckets helper to allow for computing the approximations using floating point counts. Avoids the need for conversion to integer which can be tricky to do correctly in some cases.