### PR TITLE
atlas: fix bug in PrefixTree

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/PrefixTree.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/PrefixTree.java
@@ -475,7 +475,7 @@ final class PrefixTree {
       } else if (inQueries.isEmpty() && otherQueries.isEmpty() && cs.size() == 1) {
         Node c = cs.get(0);
         String p = prefix + c.prefix;
-        return new Node(p, EMPTY, c.inQueries, c.otherQueries);
+        return new Node(p, c.children, c.inQueries, c.otherQueries);
       } else {
         return new Node(prefix, cs.toArray(EMPTY), inQueries, otherQueries);
       }

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/PrefixTreeTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/PrefixTreeTest.java
@@ -203,6 +203,31 @@ public class PrefixTreeTest {
   }
 
   @Test
+  public void compressWithSingleChildHavingNoDirectMatches() {
+    PrefixTree tree = new PrefixTree();
+    tree.put(re("abcdef"));
+    tree.put(re("abcghi"));
+    tree.put(re("xyz"));
+    Assertions.assertEquals(3, tree.size());
+
+    tree.remove(re("xyz"));
+    Assertions.assertEquals(2, tree.size());
+  }
+
+  @Test
+  public void compressWithSingleChildHavingDirectMatches() {
+    PrefixTree tree = new PrefixTree();
+    tree.put(re("abc"));
+    tree.put(re("abcdef"));
+    tree.put(re("abcghi"));
+    tree.put(re("xyz"));
+    Assertions.assertEquals(4, tree.size());
+
+    tree.remove(re("xyz"));
+    Assertions.assertEquals(3, tree.size());
+  }
+
+  @Test
   public void commonPrefixNoMatch() {
     Assertions.assertEquals(0, PrefixTree.commonPrefixLength("abcdef", "defghi", 0));
     Assertions.assertEquals(0, PrefixTree.commonPrefixLength("abcdef", "abcdef", 3));

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/QueryIndexTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/QueryIndexTest.java
@@ -636,4 +636,34 @@ public class QueryIndexTest {
       }
     });
   }
+
+  @Test
+  public void otherChecksBug() {
+    Query q1 = Parser.parseQuery("name,foo,:eq,path,abcdef,:re,:and");
+    Query q2 = Parser.parseQuery("name,foo,:eq,path,abcghi,:re,:and");
+    Query q3 = Parser.parseQuery("name,foo,:eq,path,xyz,:re,:and");
+
+    QueryIndex<Integer> idx = QueryIndex.newInstance(new NoopRegistry());
+    idx.add(q1, 1);
+    idx.add(q2, 2);
+    idx.add(q3, 3);
+    Assertions.assertEquals(
+        Collections.singletonList(1),
+        idx.findMatches(id("foo", "path", "abcdef")));
+    Assertions.assertEquals(
+        Collections.singletonList(2),
+        idx.findMatches(id("foo", "path", "abcghijkl")));
+    Assertions.assertEquals(
+        Collections.singletonList(3),
+        idx.findMatches(id("foo", "path", "xyz")));
+
+    idx.remove(q3, 3);
+    Assertions.assertEquals(
+        Collections.singletonList(1),
+        idx.findMatches(id("foo", "path", "abcdef")));
+    Assertions.assertEquals(
+        Collections.singletonList(2),
+        idx.findMatches(id("foo", "path", "abcghijkl")));
+    Assertions.assertTrue(idx.findMatches(id("foo", "path", "xyz")).isEmpty());
+  }
 }


### PR DESCRIPTION
If a node only had a single child after a removal, it would get compressed by merging the prefix. However the children of the merged child node were getting dropped.