### PR TITLE
Avoid 0 duration GC event times

### DIFF
--- a/spectator-ext-gc/src/main/java/com/netflix/spectator/gc/GcLogger.java
+++ b/spectator-ext-gc/src/main/java/com/netflix/spectator/gc/GcLogger.java
@@ -252,7 +252,8 @@ public final class GcLogger {
       .withTag("action", info.getGcAction())
       .withTag("cause", info.getGcCause());
     Timer timer = Spectator.globalRegistry().timer(eventId);
-    timer.record(info.getGcInfo().getDuration(), TimeUnit.MILLISECONDS);
+    long duration = Math.max(1, info.getGcInfo().getDuration());
+    timer.record(duration, TimeUnit.MILLISECONDS);
 
     // Update promotion and allocation counters
     updateMetrics(info.getGcName(), info.getGcInfo());


### PR DESCRIPTION
We noticed `:dist-avg` under 1ms for ZGC and `getDuration` is in milliseconds, so we must be regularly seeing events that start and end in the same millisecond:

https://github.com/openjdk/jdk/blob/3b283543c33df8c225e10b9186b7bc3cefd1a347/src/jdk.management/share/classes/com/sun/management/GcInfo.java#L140-L147

There are few other problems with these metrics and the concurrent garbage collectors, but I'm intentionally avoiding looking at those because we expect to have better ways of measuring GC overhead/pressure in upcoming releases.