### PR TITLE
aws: check for null values in custom tags

### DIFF
--- a/spectator-ext-aws/src/main/java/com/netflix/spectator/aws/SpectatorRequestMetricCollector.java
+++ b/spectator-ext-aws/src/main/java/com/netflix/spectator/aws/SpectatorRequestMetricCollector.java
@@ -143,18 +143,21 @@ public class SpectatorRequestMetricCollector extends RequestMetricCollector {
     this.customTags = new HashMap<>();
     customTags.forEach((key, value) -> {
       if (ALL_DEFAULT_TAGS.contains(key)) {
-        registry.propagate(new IllegalArgumentException("Invalid custom tag " + key
-              + " - cannot override built-in tag"));
+        registry.propagate(new IllegalArgumentException(
+            "Invalid custom tag " + key + " - cannot override built-in tag"));
+      } else if (value == null) {
+        registry.propagate(new NullPointerException(
+            "Custom tag value for key " + key + " is null"));
       } else {
         this.customTags.put(key, value);
       }
     });
     Preconditions.checkNotNull(handlerContextKey, "handlerContextKey");
     this.handlerContextKey = handlerContextKey;
-    if (ALL_DEFAULT_TAGS.contains(this.handlerContextKey.getName())) {
-      registry.propagate(new IllegalArgumentException("Invalid handler context key "
-                                                      + this.handlerContextKey.getName()
-                                                      + " - cannot override built-in tag"));
+    final String keyName = this.handlerContextKey.getName();
+    if (ALL_DEFAULT_TAGS.contains(keyName)) {
+      registry.propagate(new IllegalArgumentException(
+          "Invalid handler context key " + keyName + " - cannot override built-in tag"));
     }
   }
 

--- a/spectator-ext-aws/src/test/java/com/netflix/spectator/aws/SpectatorRequestMetricCollectorTest.java
+++ b/spectator-ext-aws/src/test/java/com/netflix/spectator/aws/SpectatorRequestMetricCollectorTest.java
@@ -191,6 +191,15 @@ public class SpectatorRequestMetricCollectorTest {
   }
 
   @Test
+  public void testCustomTagsNull() {
+    Map<String, String> customTags = new HashMap<>();
+    customTags.put("tagname", null);
+    collector = new SpectatorRequestMetricCollector(registry, customTags);
+    execRequest("http://monitoring", 503);
+    assertEquals(set(), valueSet("tagname"));
+  }
+
+  @Test
   public void testHandlerContextKey() {
     String contextKeyName = "myContextKey";
     HandlerContextKey<String> handlerContextKey = new HandlerContextKey<>(contextKeyName);


### PR DESCRIPTION
Avoid null values in any custom tags that are passed into the collector.