### PR TITLE
atlas: remove inject dependency

### DIFF
--- a/spectator-nflx-plugin/src/main/java/com/netflix/spectator/nflx/SpectatorModule.java
+++ b/spectator-nflx-plugin/src/main/java/com/netflix/spectator/nflx/SpectatorModule.java
@@ -89,7 +89,7 @@ public final class SpectatorModule extends AbstractModule {
         .toInstance(Clock.SYSTEM);
     OptionalBinder.newOptionalBinder(binder(), Registry.class)
         .setDefault()
-        .to(AtlasRegistry.class)
+        .toProvider(RegistryProvider.class)
         .in(Scopes.SINGLETON);
   }
 
@@ -113,6 +113,20 @@ public final class SpectatorModule extends AbstractModule {
         atlasConfig = NetflixConfig.createConfig(config);
       }
       return atlasConfig;
+    }
+  }
+
+  @Singleton
+  private static class RegistryProvider implements Provider<Registry> {
+
+    @Inject
+    private Clock clock;
+
+    @Inject
+    private AtlasConfig config;
+
+    @Override public Registry get() {
+      return new AtlasRegistry(clock, config);
     }
   }
 

--- a/spectator-reg-atlas/build.gradle
+++ b/spectator-reg-atlas/build.gradle
@@ -10,7 +10,6 @@ dependencies {
   implementation 'com.fasterxml.jackson.core:jackson-core'
   implementation 'com.fasterxml.jackson.core:jackson-databind'
   implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-smile'
-  implementation 'javax.inject:javax.inject'
   jmh project(':spectator-api')
 }
 

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
@@ -36,8 +36,6 @@ import com.netflix.spectator.atlas.impl.PublishPayload;
 import com.netflix.spectator.impl.Scheduler;
 import com.netflix.spectator.ipc.http.HttpClient;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
 import java.net.URI;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -56,7 +54,6 @@ import java.util.stream.StreamSupport;
 /**
  * Registry for reporting metrics to Atlas.
  */
-@Singleton
 public final class AtlasRegistry extends AbstractRegistry implements AutoCloseable {
 
   private static final String PUBLISH_TASK_TIMER = "spectator.atlas.publishTaskTime";
@@ -98,7 +95,6 @@ public final class AtlasRegistry extends AbstractRegistry implements AutoCloseab
   private final ConcurrentHashMap<String, Lock> publishTaskLocks = new ConcurrentHashMap<>();
 
   /** Create a new instance. */
-  @Inject
   public AtlasRegistry(Clock clock, AtlasConfig config) {
     this(clock, config, null);
   }


### PR DESCRIPTION
Most things have now moved to the jakarta annotations. If using the module it will still work as expected via a provider.