### PR TITLE
fix bug for p100 percentile approximation

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/histogram/PercentileBuckets.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/histogram/PercentileBuckets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2024 Netflix, Inc.
+ * Copyright 2014-2025 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -185,10 +185,14 @@ public final class PercentileBuckets {
     Preconditions.checkArg(pcts.length == results.length,
         "pcts is not the same size as results array");
 
+    int lastNonZeroIdx = 0;
     double total = 0.0;
-    for (double c : counts) {
-      if (c > 0.0 && Double.isFinite(c))
+    for (int i = 0; i < counts.length; ++i) {
+      double c = counts[i];
+      if (c > 0.0 && Double.isFinite(c)) {
         total += c;
+        lastNonZeroIdx = i;
+      }
     }
 
     int pctIdx = 0;
@@ -196,7 +200,7 @@ public final class PercentileBuckets {
     double prev = 0.0;
     double prevP = 0.0;
     long prevB = 0;
-    for (int i = 0; i < BUCKET_VALUES.length; ++i) {
+    for (int i = 0; i <= lastNonZeroIdx; ++i) {
       double next = prev + counts[i];
       double nextP = 100.0 * next / total;
       long nextB = BUCKET_VALUES[i];
@@ -215,7 +219,7 @@ public final class PercentileBuckets {
     }
 
     double nextP = 100.0;
-    long nextB = Long.MAX_VALUE;
+    long nextB = BUCKET_VALUES[lastNonZeroIdx];
     while (pctIdx < pcts.length) {
       double f = (pcts[pctIdx] - prevP) / (nextP - prevP);
       results[pctIdx] = f * (nextB - prevB) + prevB;

--- a/spectator-api/src/test/java/com/netflix/spectator/api/histogram/PercentileBucketsTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/histogram/PercentileBucketsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2024 Netflix, Inc.
+ * Copyright 2014-2025 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -165,5 +165,25 @@ public class PercentileBucketsTest {
       double threshold = 0.1 * expected + 1e-12;
       Assertions.assertEquals(expected, PercentileBuckets.percentile(counts, pct), threshold);
     }
+  }
+
+  @Test
+  public void maxLongForP100() {
+    double[] counts = new double[PercentileBuckets.length()];
+    counts[128] = 0.03416666826233268;
+    counts[129] = 0.031666668225079776;
+    counts[130] = 0.008333333767950535;
+    counts[131] = 0.005833333637565375;
+    counts[132] = 0.013333334028720856;
+    counts[133] = 0.015000000689178707;
+    counts[134] = 0.005000000260770321;
+    counts[135] = 0.006666667014360428;
+    counts[136] = 0.0008333333767950535;
+    counts[137] = 0.0025000001303851606;
+    counts[138] = 0.0;
+    counts[139] = 0.0008333333767950535;
+    double v = PercentileBuckets.percentile(counts, 100.0) / 1e9;
+    Assertions.assertTrue(v < 3.94);
+    Assertions.assertTrue(v > 3.93);
   }
 }


### PR DESCRIPTION
In some cases the floating point math would result in it going to the end of the buckets and treating the max value as `Long.MAX_VALUE` rather than the end boundary for the last bucket with a non-zero count.