### PR TITLE
atlas: handle OR with multiple matches

### DIFF
--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/QueryIndexTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/QueryIndexTest.java
@@ -317,6 +317,14 @@ public class QueryIndexTest {
   }
 
   @Test
+  public void orMultiMatch() {
+    Query q = Parser.parseQuery("name,a,:eq,name,a,:re,:or");
+    QueryIndex<Query> idx = QueryIndex.newInstance(cacheSupplier);
+    idx.add(q, q);
+    assertEquals(list(q), idx, id("a"));
+  }
+
+  @Test
   public void manyQueries() {
     // CpuUsage for all instances
     Query cpuUsage = Parser.parseQuery("name,cpuUsage,:eq");


### PR DESCRIPTION
Update query index to automatically dedup results to handle the case of OR clauses where both sides match the same data point. Before, the same match would be returned for each OR clause that matched a given data point. If the consumer did not handle that case, then they could aggregate the same value multiple times leading to incorrect results.

This will add some overhead as the set needs to be maintained, but should improve correctness for general usage.