### PR TITLE
atlas: disable in clause expansion

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Query.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Query.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2024 Netflix, Inc.
+ * Copyright 2014-2025 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -588,25 +588,6 @@ public interface Query {
 
     @Override public boolean matches(String value) {
       return value != null && vs.contains(value);
-    }
-
-    @Override public List<Query> dnfList() {
-      // For smaller sets expand to a disjunction of equal clauses. This allows them
-      // to be indexed more efficiently. The size is limited because if there are
-      // multiple large in clauses in an expression the cross product can become really
-      // large.
-      //
-      // The name key is always expanded as it is used as the root of the QueryIndex. Early
-      // filtering at the root has a big impact on matching performance.
-      if ("name".equals(k) || vs.size() <= 5) {
-        List<Query> queries = new ArrayList<>(vs.size());
-        for (String v : vs) {
-          queries.add(new Query.Equal(k, v));
-        }
-        return queries;
-      } else {
-        return Collections.singletonList(this);
-      }
     }
 
     @Override public String toString() {

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/QueryIndex.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/QueryIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2023 Netflix, Inc.
+ * Copyright 2014-2025 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -400,7 +400,8 @@ public final class QueryIndex<T> {
 
       boolean keyPresent = false;
 
-      for (int j = i; j < tags.size(); ++j) {
+      final int tagsSize = tags.size();
+      for (int j = i; j < tagsSize; ++j) {
         String k = tags.getKey(j);
         String v = tags.getValue(j);
         int cmp = compare(k, keyRef);
@@ -435,7 +436,7 @@ public final class QueryIndex<T> {
           } else {
             // Enhanced for loop typically results in iterator being allocated. Using
             // size/get avoids the allocation and has better throughput.
-            int n = otherMatches.size();
+            final int n = otherMatches.size();
             for (int p = 0; p < n; ++p) {
               otherMatches.get(p).forEachMatch(tags, nextPos, consumer);
             }
@@ -536,7 +537,7 @@ public final class QueryIndex<T> {
         } else {
           // Enhanced for loop typically results in iterator being allocated. Using
           // size/get avoids the allocation and has better throughput.
-          int n = otherMatches.size();
+          final int n = otherMatches.size();
           for (int p = 0; p < n; ++p) {
             otherMatches.get(p).forEachMatch(tags, consumer);
           }

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/QueryIndexTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/QueryIndexTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2023 Netflix, Inc.
+ * Copyright 2014-2025 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -504,8 +504,8 @@ public class QueryIndexTest {
         "    - [b]\n" +
         "        matches:\n" +
         "        - [name,a,:eq,key,b,:eq,:and]\n" +
-        "        - [name,a,:eq,key,(,b,c,),:in,:and]\n" +
-        "    - [c]\n" +
+        "    other checks:\n" +
+        "    - [key,(,b,c,),:in]\n" +
         "        matches:\n" +
         "        - [name,a,:eq,key,(,b,c,),:in,:and]\n" +
         "    other keys:\n" +

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/QueryTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/QueryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2024 Netflix, Inc.
+ * Copyright 2014-2025 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,10 +22,8 @@ import nl.jqno.equalsverifier.Warning;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -428,14 +426,12 @@ public class QueryTest {
 
   @Test
   public void dnfListIn() {
-    List<Query> expected = new ArrayList<>();
     Set<String> values = new TreeSet<>();
     for (int i = 0; i < 5; ++i) {
       values.add("" + i);
-      expected.add(new Query.Equal("k", "" + i));
     }
     Query q = new Query.In("k", values);
-    Assertions.assertEquals(expected, q.dnfList());
+    Assertions.assertEquals(Collections.singletonList(q), q.dnfList());
 
     values.add("5");
     Assertions.assertEquals(Collections.singletonList(q), q.dnfList());


### PR DESCRIPTION
Disable expansion of `:in` queries when used with the query index. Since the prefix tree matches exactly now the overhead of multiple branches is higher than savings.