### PR TITLE
Remove ReentrantLock usage in HttpRequestBuilder

### DIFF
--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/http/HttpRequestBuilder.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/http/HttpRequestBuilder.java
@@ -42,8 +42,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.zip.Deflater;
@@ -62,12 +60,6 @@ public class HttpRequestBuilder {
 
   private static final StreamHelper STREAM_HELPER = new StreamHelper();
 
-  private static final Lock LOCK = new ReentrantLock();
-
-  // Should not be used directly, use the method of the same name that will create the
-  // executor if needed on the first access.
-  private static volatile ExecutorService defaultExecutor;
-
   private static ThreadFactory newThreadFactory() {
     return new ThreadFactory() {
       private final AtomicInteger next = new AtomicInteger();
@@ -82,18 +74,12 @@ public class HttpRequestBuilder {
   }
 
   private static ExecutorService defaultExecutor() {
-    ExecutorService executor = defaultExecutor;
-    if (executor != null) {
-      return executor;
-    }
-    LOCK.lock();
-    try {
-      defaultExecutor = Executors.newFixedThreadPool(
-          Runtime.getRuntime().availableProcessors(), newThreadFactory());
-      return defaultExecutor;
-    } finally {
-      LOCK.unlock();
-    }
+    return DefaultExecutorHolder.DEFAULT_EXECUTOR;
+  }
+
+  private static final class DefaultExecutorHolder {
+    private static final ExecutorService DEFAULT_EXECUTOR = Executors.newFixedThreadPool(
+            Runtime.getRuntime().availableProcessors(), newThreadFactory());
   }
 
   private final URI uri;


### PR DESCRIPTION
Switch to a static holder class for lazily initializing the default executor to avoid needing to use an explicit lock. Also technically fixes a race condition where multiple executors could get initialized.