### PR TITLE
fix HTTP response splitting could lead CRLF Injection

### DIFF
--- a/spectator-ext-ipcservlet/src/main/java/com/netflix/spectator/ipcservlet/IpcServletFilter.java
+++ b/spectator-ext-ipcservlet/src/main/java/com/netflix/spectator/ipcservlet/IpcServletFilter.java
@@ -103,9 +103,15 @@ public class IpcServletFilter implements Filter {
 
   private String getEndpoint(HttpServletRequest httpReq) {
     String servletPath = ServletPathHack.getServletPath(httpReq);
-    return (servletPath == null || servletPath.isEmpty())
+    String endpoint = (servletPath == null || servletPath.isEmpty())
         ? "/"
         : servletPath;
+    return sanitizeHeaderValue(endpoint);
+  }
+
+  private String sanitizeHeaderValue(String value) {
+    // Remove CR and LF characters to prevent HTTP response splitting
+    return value.replaceAll("[\\r\\n]", "");
   }
 
   private void addNetflixHeaders(HttpServletResponse httpRes, String endpoint) {


### PR DESCRIPTION
https://github.com/Netflix/spectator/blob/da48a0bf1ea363739ab6b8ec091a6bff88b84af6/spectator-ext-ipcservlet/src/main/java/com/netflix/spectator/ipcservlet/IpcServletFilter.java#L120-L120

fix the issue need to sanitize the `endpoint` value before it is added to the HTTP response headers. Specifically, we should ensure that the value does not contain any CR (`\r`) or LF (`\n`) characters, which are the primary vectors for HTTP response splitting attacks. This can be achieved by implementing a utility method to validate and sanitize the input.

The fix involves:
1. Adding a utility method to sanitize the `endpoint` value by removing CRLF characters.
2. Applying this sanitization in the `getEndpoint()` method before the `endpoint` value is used in `addNetflixHeaders()`.


Directly writing user input (for example, an HTTP request parameter) to an HTTP header can lead to an HTTP request-splitting or response-splitting vulnerability. HTTP response splitting can lead to vulnerabilities such as XSS and cache poisoning.

HTTP request splitting can allow an attacker to inject an additional HTTP request into a client's outgoing socket connection. This can allow an attacker to perform an SSRF-like attack. In the context of a servlet container, if the user input includes blank lines and the servlet container does not escape the blank lines, then a remote user can cause the response to turn into two separate responses. The remote user can then control one or more responses, which is also HTTP response splitting.

## Recommendation
Guard against HTTP header splitting in the same way as guarding against cross-site scripting. Before passing any data into HTTP headers, either check the data for special characters, or escape any special characters that are present. If the code calls API's directly, ensure that the `validateHeaders` parameter is set to `true`.


## POC
The following shows the 'name' parameter being written to a cookie in two different ways. The first way writes it directly to the cookie, and thus is vulnerable to response-splitting attacks. The second way first removes all special characters, thus avoiding the potential problem.
```java
public class ResponseSplitting extends HttpServlet {
	protected void doGet(HttpServletRequest request, HttpServletResponse response)
	throws ServletException, IOException {
		// BAD: setting a cookie with an unvalidated parameter
		Cookie cookie = new Cookie("name", request.getParameter("name"));
		response.addCookie(cookie);

		// GOOD: remove special characters before putting them in the header
		String name = removeSpecial(request.getParameter("name"));
		Cookie cookie2 = new Cookie("name", name);
		response.addCookie(cookie2);
	}

	private static String removeSpecial(String str) {
		return str.replaceAll("[^a-zA-Z ]", "");
	}
}
```
The following shows the use of the library 'netty' with HTTP response-splitting verification configurations. The second way will verify the parameters before using them to build the HTTP response.
```java
import io.netty.handler.codec.http.DefaultHttpHeaders;

public class ResponseSplitting {
    // BAD: Disables the internal response splitting verification
    private final DefaultHttpHeaders badHeaders = new DefaultHttpHeaders(false);

    // GOOD: Verifies headers passed don't contain CRLF characters
    private final DefaultHttpHeaders goodHeaders = new DefaultHttpHeaders();

    // BAD: Disables the internal response splitting verification
    private final DefaultHttpResponse badResponse = new DefaultHttpResponse(version, httpResponseStatus, false);

    // GOOD: Verifies headers passed don't contain CRLF characters
    private final DefaultHttpResponse goodResponse = new DefaultHttpResponse(version, httpResponseStatus);
}
```
The following shows the use of the netty library with configurations for verification of HTTP request splitting. The second recommended approach in the example verifies the parameters before using them to build the HTTP request.
```java
public class NettyRequestSplitting {
    // BAD: Disables the internal request splitting verification
    private final DefaultHttpHeaders badHeaders = new DefaultHttpHeaders(false);

    // GOOD: Verifies headers passed don't contain CRLF characters
    private final DefaultHttpHeaders goodHeaders = new DefaultHttpHeaders();

    // BAD: Disables the internal request splitting verification
    private final DefaultHttpRequest badRequest = new DefaultHttpRequest(httpVersion, method, uri, false);

    // GOOD: Verifies headers passed don't contain CRLF characters
    private final DefaultHttpRequest goodResponse = new DefaultHttpRequest(httpVersion, method, uri);
}
```
## References
[HTTP response splitting](https://seclists.org/bugtraq/2005/Apr/187)
[HTTP Response Splitting](https://www.owasp.org/index.php/HTTP_Response_Splitting)
[HTTP response splitting](http://en.wikipedia.org/wiki/HTTP_response_splitting)
[CAPEC-105: HTTP Request Splitting](https://capec.mitre.org/data/definitions/105.html)
[CWE-113](https://cwe.mitre.org/data/definitions/113.html)
