### PR TITLE
Fix User-controlled data in numeric cast

### DIFF
--- a/spectator-reg-metrics5/src/main/java/com/netflix/spectator/metrics5/MetricsCounter.java
+++ b/spectator-reg-metrics5/src/main/java/com/netflix/spectator/metrics5/MetricsCounter.java
@@ -51,6 +51,9 @@ class MetricsCounter implements Counter {
   }
 
   @Override public void add(double amount) {
+    if (amount < Long.MIN_VALUE || amount > Long.MAX_VALUE) {
+      throw new IllegalArgumentException("Amount is out of range for a long: " + amount);
+    }
     impl.mark((long) amount);
   }
 


### PR DESCRIPTION
https://github.com/Netflix/spectator/blob/0b10cbe6ba80d32dd0ebbd271a3e096462140d2c/spectator-reg-metrics5/src/main/java/com/netflix/spectator/metrics5/MetricsCounter.java#L54-L54

fix the issue need to validate the `amount` parameter before casting it to a `long`. Specifically:
1. Ensure that the `amount` is within the range of values that can be safely represented as a `long` without truncation.
2. If the value is outside the acceptable range, throw an exception or handle the error appropriately.

The fix will involve adding a guard condition in the `add` method of the `MetricsCounter` class to check the range of the `amount` parameter before performing the cast.

## References
[NUM12-J. Ensure conversions of numeric types to narrower types do not result in lost or misinterpreted data](https://wiki.sei.cmu.edu/confluence/display/java/NUM12-J.+Ensure+conversions+of+numeric+types+to+narrower+types+do+not+result+in+lost+or+misinterpreted+data)
CWE-197
CWE-681