### PR TITLE
ipc: sanitize header values

### DIFF
--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/http/HeaderSanitizer.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/http/HeaderSanitizer.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014-2025 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.ipc.http;
+
+/**
+ * Helper for sanitizing string values before using as a header. Guards against
+ * <a href="https://cwe.mitre.org/data/definitions/93.html">CRLF injection</a>
+ * in header values.
+ */
+public final class HeaderSanitizer {
+
+  private HeaderSanitizer() {
+  }
+
+  /** Returns a sanitized value that is safe to use as a header. */
+  public static String sanitize(String value) {
+    return value == null
+        ? value
+        : value.replace("\r", "").replace("\n", "");
+  }
+}

--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/http/HttpRequestBuilder.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/http/HttpRequestBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2023 Netflix, Inc.
+ * Copyright 2014-2025 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -123,7 +123,7 @@ public class HttpRequestBuilder {
    */
   public HttpRequestBuilder addHeader(String name, String value) {
     if (value != null) {
-      reqHeaders.put(name, value);
+      reqHeaders.put(name, HeaderSanitizer.sanitize(value));
     }
     return this;
   }

--- a/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/http/HeaderSanitizerTest.java
+++ b/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/http/HeaderSanitizerTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2014-2025 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.ipc.http;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class HeaderSanitizerTest {
+
+  @Test
+  public void okValue() {
+    String value = "foo\tbar baz";
+    Assertions.assertEquals(value, HeaderSanitizer.sanitize(value));
+  }
+
+  @Test
+  public void removeCR() {
+    String value = "foo\rbar";
+    Assertions.assertEquals("foobar", HeaderSanitizer.sanitize(value));
+  }
+
+  @Test
+  public void removeLF() {
+    String value = "foo\nbar";
+    Assertions.assertEquals("foobar", HeaderSanitizer.sanitize(value));
+  }
+
+  @Test
+  public void removeCRLF() {
+    String value = "foo\r\nbar";
+    Assertions.assertEquals("foobar", HeaderSanitizer.sanitize(value));
+  }
+
+  @Test
+  public void removeMisc() {
+    String value = "foo\r\nbar\nbaz\r";
+    Assertions.assertEquals("foobarbaz", HeaderSanitizer.sanitize(value));
+  }
+}

--- a/spectator-ext-ipcservlet/src/main/java/com/netflix/spectator/ipcservlet/IpcServletFilter.java
+++ b/spectator-ext-ipcservlet/src/main/java/com/netflix/spectator/ipcservlet/IpcServletFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2025 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import com.netflix.spectator.ipc.IpcLogEntry;
 import com.netflix.spectator.ipc.IpcLogger;
 import com.netflix.spectator.ipc.NetflixHeader;
 import com.netflix.spectator.ipc.NetflixHeaders;
+import com.netflix.spectator.ipc.http.HeaderSanitizer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -117,7 +118,7 @@ public class IpcServletFilter implements Filter {
 
   private void addIfNotPresent(HttpServletResponse httpRes, String name, String value) {
     if (httpRes.getHeader(name) == null) {
-      httpRes.addHeader(name, value);
+      httpRes.addHeader(name, HeaderSanitizer.sanitize(value));
     }
   }
 


### PR DESCRIPTION
Remove CR or LF in header values to avoid possible header injection.