### PR TITLE
IpcServletFilter: fix HTTP Request Splitting could lead cache poisoning

### DIFF
--- a/spectator-ext-ipcservlet/src/main/java/com/netflix/spectator/ipcservlet/IpcServletFilter.java
+++ b/spectator-ext-ipcservlet/src/main/java/com/netflix/spectator/ipcservlet/IpcServletFilter.java
@@ -104,9 +104,18 @@ public class IpcServletFilter implements Filter {
 
   private String getEndpoint(HttpServletRequest httpReq) {
     String servletPath = ServletPathHack.getServletPath(httpReq);
+    servletPath = sanitizePath(servletPath);
     return (servletPath == null || servletPath.isEmpty())
         ? "/"
         : servletPath;
+  }
+
+  private String sanitizePath(String path) {
+    if (path == null) {
+      return null;
+    }
+    // Remove CRLF characters to prevent HTTP response splitting
+    return path.replaceAll("[\\r\\n]", "");
   }
 
   private void addNetflixHeaders(HttpServletResponse httpRes, String endpoint) {


### PR DESCRIPTION


https://github.com/Netflix/spectator/blob/7b7fb5f86ef51bee1621312127aa23b3df02a5a0/spectator-ext-ipcservlet/src/main/java/com/netflix/spectator/ipcservlet/IpcServletFilter.java#L121-L121

Fix the issue need to ensure that the user-provided servlet path is properly sanitized before being used as a header value. This involves:
1. Implementing a stricter sanitization mechanism that explicitly removes or escapes CRLF characters (`\r` and `\n`) from the servlet path.
2. Updating the `getEndpoint()` method in `IpcServletFilter.java` to sanitize the servlet path before returning it.
3. Ensuring that the sanitization logic is applied consistently across all paths where user input is used in HTTP headers.

---

#### References
[HTTP response splitting](https://seclists.org/bugtraq/2005/Apr/187)
[HTTP Response Splitting](https://www.owasp.org/index.php/HTTP_Response_Splitting)
[HTTP response splitting](http://en.wikipedia.org/wiki/HTTP_response_splitting)
[CAPEC-105: HTTP Request Splitting](https://capec.mitre.org/data/definitions/105.html)
