### PR TITLE
api: minor optimization for LongTaskTimer.stop

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/patterns/LongTaskTimer.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/patterns/LongTaskTimer.java
@@ -99,9 +99,8 @@ public final class LongTaskTimer implements com.netflix.spectator.api.LongTaskTi
   }
 
   @Override public long stop(long task) {
-    Long startTime = tasks.get(task);
+    Long startTime = tasks.remove(task);
     if (startTime != null) {
-      tasks.remove(task);
       return clock.monotonicTime() - startTime;
     } else {
       return -1L;


### PR DESCRIPTION
Avoid looking up the task twice in the map.