### PR TITLE
add TagListBuilder helper

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -114,7 +114,7 @@ subprojects {
     profilers = ['stack', 'gc']
     includeTests = false
     duplicateClassesStrategy = DuplicatesStrategy.WARN
-    includes = ['.*IdHash.*']
+    includes = ['.*Ids.*']
   }
 
   checkstyle {

--- a/spectator-api/src/jmh/java/com/netflix/spectator/perf/Ids.java
+++ b/spectator-api/src/jmh/java/com/netflix/spectator/perf/Ids.java
@@ -18,6 +18,8 @@ package com.netflix.spectator.perf;
 import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.TagList;
+import com.netflix.spectator.api.TagListBuilder;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
@@ -96,6 +98,8 @@ public class Ids {
       .withTag( "nf.region", "us-east-1")
       .withTag(   "nf.zone", "us-east-1e")
       .withTag(   "nf.node", "i-1234567890");
+
+  private final TagListBuilder builder = TagListBuilder.create();
 
   @Threads(1)
   @Benchmark
@@ -183,6 +187,48 @@ public class Ids {
            "nf.zone", "us-east-1e",
             "status", "200"
     );
+    bh.consume(id);
+  }
+
+  @Threads(1)
+  @Benchmark
+  public void withTagsBuilder(Blackhole bh) {
+    TagList ts = builder
+        .add("nf.app", "test_app")
+        .add("nf.cluster", "test_app-main")
+        .add("nf.asg", "test_app-main-v042")
+        .add("nf.stack", "main")
+        .add("nf.ami", "ami-0987654321")
+        .add("nf.region", "us-east-1")
+        .add("nf.zone", "us-east-1e")
+        .add("nf.node", "i-1234567890")
+        .add("country", "US")
+        .add("device", "xbox")
+        .add("status", "200")
+        .add("client", "ab")
+        .buildAndReset();
+    Id id = registry.createId("http.req.complete").withTags(ts);
+    bh.consume(id);
+  }
+
+  @Threads(1)
+  @Benchmark
+  public void withTagsBuilderSorted(Blackhole bh) {
+    TagList ts = builder
+        .add("client", "ab")
+        .add("country", "US")
+        .add("device", "xbox")
+        .add("nf.ami", "ami-0987654321")
+        .add("nf.app", "test_app")
+        .add("nf.asg", "test_app-main-v042")
+        .add("nf.cluster", "test_app-main")
+        .add("nf.node", "i-1234567890")
+        .add("nf.region", "us-east-1")
+        .add("nf.stack", "main")
+        .add("nf.zone", "us-east-1e")
+        .add("status", "200")
+        .buildAndReset();
+    Id id = registry.createId("http.req.complete").withTags(ts);
     bh.consume(id);
   }
 

--- a/spectator-api/src/main/java/com/netflix/spectator/api/ArrayTagSet.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/ArrayTagSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2023 Netflix, Inc.
+ * Copyright 2014-2025 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -216,7 +216,7 @@ final class ArrayTagSet implements TagList {
   }
 
   /** Add a collection of tags to the set. */
-  private ArrayTagSet addAll(String[] ts, int tsLength, boolean sorted, boolean distinct) {
+  ArrayTagSet addAll(String[] ts, int tsLength, boolean sorted, boolean distinct) {
     if (tsLength == 0) {
       return this;
     } else if (length == 0) {

--- a/spectator-api/src/main/java/com/netflix/spectator/api/TagListBuilder.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/TagListBuilder.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2014-2025 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.api;
+
+import java.util.Arrays;
+
+/**
+ * Builder for creating TagList instances efficiently. This builder can be reused multiple times
+ * and provides optimizations for sorted tag insertion to avoid unnecessary sorting operations
+ * later. A builder instance is not thread safe and should only be used from a single thread at
+ * a time. The user is responsible for managing how to reuse builder instances to avoid initial
+ * allocation of the builder each time.
+ *
+ * <p>The builder tracks whether tags are added in sorted order and passes this information
+ * to the underlying TagList implementation to optimize performance. For best performance,
+ * add tags in lexicographically sorted order by key.</p>
+ *
+ * <p>Example usage:</p>
+ * <pre>{@code
+ * TagListBuilder builder = TagListBuilder.create();
+ * TagList tags = builder
+ *     .add("app", "myapp")
+ *     .add("env", "prod")
+ *     .add("region", "us-east-1")
+ *     .buildAndReset();
+ * }</pre>
+ *
+ * <p>The builder can be reused after calling {@link #buildAndReset()}:</p>
+ * <pre>{@code
+ * TagList tags1 = builder.add("key1", "value1").buildAndReset();
+ * TagList tags2 = builder.add("key2", "value2").buildAndReset();
+ * }</pre>
+ */
+public final class TagListBuilder {
+
+  /**
+   * Creates a new TagListBuilder instance.
+   *
+   * @return a new builder instance
+   */
+  public static TagListBuilder create() {
+    return new TagListBuilder();
+  }
+
+  private String[] tags;
+  private int pos;
+
+  private String lastKey;
+  private boolean sorted;
+
+  /**
+   * Creates a new builder with initial capacity for 10 key-value pairs.
+   */
+  TagListBuilder() {
+    tags = new String[20];
+    pos = 0;
+    lastKey = null;
+    sorted = true;
+  }
+
+  /**
+   * Returns whether the tags added so far are in sorted order by key.
+   * This is used internally to optimize TagList creation.
+   *
+   * @return true if tags are sorted, false otherwise
+   */
+  boolean isSorted() {
+    return sorted;
+  }
+
+  /**
+   * Doubles the capacity of the internal array if needed.
+   */
+  private void resizeIfNeeded() {
+    if (pos >= tags.length) {
+      tags = Arrays.copyOf(tags, tags.length * 2);
+    }
+  }
+
+  /**
+   * Checks if the given key is lexicographically greater than the last added key.
+   *
+   * @param key the key to check
+   * @return true if key is greater than the last key, or if this is the first key
+   */
+  private boolean isGreaterThanLastKey(String key) {
+    return lastKey == null || lastKey.compareTo(key) < 0;
+  }
+
+  /**
+   * Adds a key-value pair to the builder. Null keys or values are ignored.
+   *
+   * <p>For optimal performance, add tags in lexicographically sorted order by key.
+   * The builder tracks sort order and passes this information to the underlying
+   * TagList implementation to avoid unnecessary sorting operations.</p>
+   *
+   * @param key the tag key, must not be null
+   * @param value the tag value, must not be null
+   * @return this builder for method chaining
+   */
+  public TagListBuilder add(String key, String value) {
+    if (key != null && value != null) {
+      resizeIfNeeded();
+      sorted = sorted && isGreaterThanLastKey(key);
+      lastKey = key;
+      tags[pos++] = key;
+      tags[pos++] = value;
+    }
+    return this;
+  }
+
+  /**
+   * Adds a Tag object to the builder. Null keys or values are ignored.
+   *
+   * @param tag the tag to add, must not be null and must have non-null key and value
+   * @return this builder for method chaining
+   */
+  public TagListBuilder add(Tag tag) {
+    return add(tag.key(), tag.value());
+  }
+
+  /**
+   * Resets the builder to its initial empty state, allowing it to be reused.
+   */
+  public void reset() {
+    pos = 0;
+    lastKey = null;
+    sorted = true;
+  }
+
+  /**
+   * Builds a TagList from the accumulated tags and resets the builder for reuse.
+   *
+   * @return a new TagList containing all the added tags
+   */
+  public TagList buildAndReset() {
+    String[] copy = Arrays.copyOf(tags, pos);
+    TagList ts = ArrayTagSet.EMPTY.addAll(copy, pos, sorted, sorted);
+    reset();
+    return ts;
+  }
+}

--- a/spectator-api/src/test/java/com/netflix/spectator/api/TagListBuilderTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/TagListBuilderTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2014-2025 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.api;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TagListBuilderTest {
+
+  @Test
+  public void createEmpty() {
+    TagListBuilder builder = TagListBuilder.create();
+    TagList ts = builder.buildAndReset();
+    Assertions.assertEquals(0, ts.size());
+  }
+
+  @Test
+  public void addSingleTag() {
+    TagListBuilder builder = TagListBuilder.create();
+    TagList ts = builder.add("name", "value").buildAndReset();
+    Assertions.assertEquals(1, ts.size());
+    Assertions.assertEquals("name", ts.getKey(0));
+    Assertions.assertEquals("value", ts.getValue(0));
+  }
+
+  @Test
+  public void addMultipleTags() {
+    TagListBuilder builder = TagListBuilder.create();
+    TagList ts = builder
+        .add("a", "1")
+        .add("b", "2")
+        .add("c", "3")
+        .buildAndReset();
+    Assertions.assertEquals(3, ts.size());
+    Assertions.assertEquals("a", ts.getKey(0));
+    Assertions.assertEquals("1", ts.getValue(0));
+    Assertions.assertEquals("b", ts.getKey(1));
+    Assertions.assertEquals("2", ts.getValue(1));
+    Assertions.assertEquals("c", ts.getKey(2));
+    Assertions.assertEquals("3", ts.getValue(2));
+  }
+
+  @Test
+  public void addTagObject() {
+    TagListBuilder builder = TagListBuilder.create();
+    Tag tag = Tag.of("key", "value");
+    TagList ts = builder.add(tag).buildAndReset();
+    Assertions.assertEquals(1, ts.size());
+    Assertions.assertEquals("key", ts.getKey(0));
+    Assertions.assertEquals("value", ts.getValue(0));
+  }
+
+  @Test
+  public void mixedAddMethods() {
+    TagListBuilder builder = TagListBuilder.create();
+    Tag tag = Tag.of("tag1", "value1");
+    TagList ts = builder
+        .add(tag)
+        .add("tag2", "value2")
+        .buildAndReset();
+    Assertions.assertEquals(2, ts.size());
+    Assertions.assertEquals("tag1", ts.getKey(0));
+    Assertions.assertEquals("value1", ts.getValue(0));
+    Assertions.assertEquals("tag2", ts.getKey(1));
+    Assertions.assertEquals("value2", ts.getValue(1));
+  }
+
+  @Test
+  public void builderReuse() {
+    TagListBuilder builder = TagListBuilder.create();
+    
+    TagList ts1 = builder.add("a", "1").buildAndReset();
+    Assertions.assertEquals(1, ts1.size());
+    Assertions.assertEquals("a", ts1.getKey(0));
+    
+    TagList ts2 = builder.add("b", "2").buildAndReset();
+    Assertions.assertEquals(1, ts2.size());
+    Assertions.assertEquals("b", ts2.getKey(0));
+  }
+
+  @Test
+  public void sortedOrder() {
+    TagListBuilder builder = TagListBuilder.create();
+    builder
+        .add("a", "1")
+        .add("b", "2")
+        .add("c", "3");
+    Assertions.assertTrue(builder.isSorted());
+    builder.buildAndReset();
+  }
+
+  @Test
+  public void unsortedOrder() {
+    TagListBuilder builder = TagListBuilder.create();
+    builder
+        .add("c", "3")
+        .add("a", "1")
+        .add("b", "2");
+    Assertions.assertFalse(builder.isSorted());
+    builder.buildAndReset();
+  }
+
+  @Test
+  public void duplicates() {
+    TagListBuilder builder = TagListBuilder.create();
+    builder
+        .add("a", "1")
+        .add("b", "2")
+        .add("b", "3")
+        .add("c", "4");
+    Assertions.assertFalse(builder.isSorted());
+    builder.buildAndReset();
+  }
+
+  @Test
+  public void expandCapacity() {
+    TagListBuilder builder = TagListBuilder.create();
+    for (int i = 0; i < 15; i++) {
+      builder.add(String.format("key%02d", i), "value" + i);
+    }
+    TagList ts = builder.buildAndReset();
+    Assertions.assertEquals(15, ts.size());
+    for (int i = 0; i < 15; i++) {
+      Assertions.assertEquals(String.format("key%02d", i), ts.getKey(i));
+      Assertions.assertEquals("value" + i, ts.getValue(i));
+    }
+  }
+
+  @Test
+  public void resetClearsState() {
+    TagListBuilder builder = TagListBuilder.create();
+    builder.add("a", "1");
+    builder.reset();
+    TagList ts = builder.buildAndReset();
+    Assertions.assertEquals(0, ts.size());
+  }
+
+  @Test
+  public void nullKey() {
+    TagListBuilder builder = TagListBuilder.create();
+    TagList ts = builder.add(null, "value").buildAndReset();
+    Assertions.assertEquals(0, ts.size());
+  }
+
+  @Test
+  public void nullValue() {
+    TagListBuilder builder = TagListBuilder.create();
+    TagList ts = builder.add("key", null).buildAndReset();
+    Assertions.assertEquals(0, ts.size());
+  }
+
+  @Test
+  public void emptyKeyValue() {
+    TagListBuilder builder = TagListBuilder.create();
+    TagList ts = builder.add("", "").buildAndReset();
+    Assertions.assertEquals(1, ts.size());
+    Assertions.assertEquals("", ts.getKey(0));
+    Assertions.assertEquals("", ts.getValue(0));
+  }
+
+  @Test
+  public void sortedStatePreservedAfterReuse() {
+    TagListBuilder builder = TagListBuilder.create();
+    
+    // First use: add sorted tags
+    builder
+        .add("a", "1")
+        .add("b", "2")
+        .add("c", "3");
+    Assertions.assertTrue(builder.isSorted());
+    builder.buildAndReset();
+    
+    // Second use: add sorted tags again - should still be considered sorted
+    builder
+        .add("x", "1")
+        .add("y", "2")
+        .add("z", "3");
+    Assertions.assertTrue(builder.isSorted());
+    builder.buildAndReset();
+    
+    // Third use: empty builder should be sorted
+    Assertions.assertTrue(builder.isSorted());
+  }
+}


### PR DESCRIPTION
Helper to support more efficient building of tag lists with fewer allocations than relying on varargs `withTags` method. If the builder is reused, then there would only be a single allocation to copy the buffer array for most uses.

The user would be responsible for managing the reuse of the builder instances. This could be a thread local, concurrent queue, or other options that make sense for their use-case.