### PR TITLE
Avoid boxing in GcEvent.TIME_ORDER comparator

### DIFF
--- a/spectator-ext-gc/src/main/java/com/netflix/spectator/gc/GcEvent.java
+++ b/spectator-ext-gc/src/main/java/com/netflix/spectator/gc/GcEvent.java
@@ -109,7 +109,7 @@ public class GcEvent {
   }
 
   /** Order events from oldest to newest. */
-  public static final Comparator<GcEvent> TIME_ORDER = Comparator.comparing(GcEvent::getStartTime);
+  public static final Comparator<GcEvent> TIME_ORDER = Comparator.comparingLong(GcEvent::getStartTime);
 
   /** Order events from newest to oldest. */
   public static final Comparator<GcEvent> REVERSE_TIME_ORDER = TIME_ORDER.reversed();


### PR DESCRIPTION
Using Comparator.comparingLong to avoid boxing of longs in GcEvent.TIME_ORDER.