### PR TITLE
Avoid boxing in Measurment.hashCode

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/Measurement.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/Measurement.java
@@ -63,8 +63,8 @@ public final class Measurement {
     final int prime = 31;
     int hc = prime;
     hc = prime * hc + id.hashCode();
-    hc = prime * hc + Long.valueOf(timestamp).hashCode();
-    hc = prime * hc + Double.valueOf(value).hashCode();
+    hc = prime * hc + Long.hashCode(timestamp);
+    hc = prime * hc + Double.hashCode(value);
     return hc;
   }
 


### PR DESCRIPTION
Use Long.hashCode / Double.hashCode to avoid boxing in Measurment.hashCode.