### PR TITLE
Add jvm.gc.overhead gauge for OpenJDK 26 and later

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,6 +18,13 @@ jobs:
           distribution: 'zulu'
           cache: 'gradle'
       - run: echo "JDK8=$JAVA_HOME" >> $GITHUB_ENV
+      - name: Set up JDK 26
+        uses: actions/setup-java@v5
+        with:
+          java-version: 26
+          distribution: 'zulu'
+          cache: 'gradle'
+      - run: echo "JDK26=$JAVA_HOME" >> $GITHUB_ENV
       - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,13 @@ jobs:
           distribution: 'zulu'
           cache: 'gradle'
       - run: echo "JDK8=$JAVA_HOME" >> $GITHUB_ENV
+      - name: Set up JDK 26
+        uses: actions/setup-java@v5
+        with:
+          java-version: 26
+          distribution: 'zulu'
+          cache: 'gradle'
+      - run: echo "JDK26=$JAVA_HOME" >> $GITHUB_ENV
       - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -24,6 +24,13 @@ jobs:
           distribution: 'zulu'
           cache: 'gradle'
       - run: echo "JDK8=$JAVA_HOME" >> $GITHUB_ENV
+      - name: Set up JDK 26
+        uses: actions/setup-java@v5
+        with:
+          java-version: 26
+          distribution: 'zulu'
+          cache: 'gradle'
+      - run: echo "JDK26=$JAVA_HOME" >> $GITHUB_ENV
       - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ subprojects {
     useJUnitPlatform()
   }
 
-  [17, 21, 25].each { additionalJDK ->
+  [17, 21, 25, 26].each { additionalJDK ->
     def additionalTestTask = tasks.register("testJDK$additionalJDK", Test) {
       description = "Runs tests against JDK $additionalJDK."
       group = 'verification'

--- a/spectator-ext-jvm/src/main/java/com/netflix/spectator/jvm/Jmx.java
+++ b/spectator-ext-jvm/src/main/java/com/netflix/spectator/jvm/Jmx.java
@@ -20,12 +20,9 @@ import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.patterns.PolledMeter;
 import com.typesafe.config.Config;
 
-import java.lang.management.BufferPoolMXBean;
-import java.lang.management.ClassLoadingMXBean;
-import java.lang.management.CompilationMXBean;
-import java.lang.management.ManagementFactory;
-import java.lang.management.MemoryPoolMXBean;
-import java.lang.management.ThreadMXBean;
+import java.lang.management.*;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
@@ -55,13 +52,37 @@ public final class Jmx {
       monitorThreadMXBean(registry);
       monitorCompilationMXBean(registry);
     }
-
+    monitorGcOverhead(registry);
     for (MemoryPoolMXBean mbean : ManagementFactory.getMemoryPoolMXBeans()) {
       registry.register(new MemoryPoolMeter(registry, mbean));
     }
     for (BufferPoolMXBean mbean : ManagementFactory.getPlatformMXBeans(BufferPoolMXBean.class)) {
       registry.register(new BufferPoolMeter(registry, mbean));
     }
+  }
+
+  private static void monitorGcOverhead(Registry registry) {
+    PolledMeter.using(registry)
+            .withName("jvm.gc.overhead")
+            .monitorStaticMethodValue(Jmx::getGcOverhead);
+  }
+
+  @SuppressWarnings("PMD.EmptyCatchBlock")
+  private static double getGcOverhead() {
+    try {
+      com.sun.management.OperatingSystemMXBean os = (com.sun.management.OperatingSystemMXBean)
+              ManagementFactory.getOperatingSystemMXBean();
+      MemoryMXBean memory = ManagementFactory.getMemoryMXBean();
+      Method getTotalGcCpuTime = MemoryMXBean.class.getMethod("getTotalGcCpuTime");
+        long gcCpuTime = (long) getTotalGcCpuTime.invoke(memory);
+        long processCpuTime = os.getProcessCpuTime();
+        return processCpuTime <= 0 ? Double.NaN : (double) gcCpuTime / processCpuTime;
+    } catch (ClassCastException | NoSuchMethodException ignore) {
+      // OpenJDK 26 and later - see https://bugs.openjdk.org/browse/JDK-8368529
+    } catch (InvocationTargetException | IllegalAccessException e) {
+        throw new RuntimeException(e);
+    }
+    return Double.NaN;
   }
 
   private static void monitorClassLoadingMXBean(Registry registry) {

--- a/spectator-ext-jvm/src/main/java/com/netflix/spectator/jvm/Jmx.java
+++ b/spectator-ext-jvm/src/main/java/com/netflix/spectator/jvm/Jmx.java
@@ -72,7 +72,6 @@ public final class Jmx {
             .monitorStaticMethodValue(Jmx::getGcOverhead);
   }
 
-  @SuppressWarnings("PMD.EmptyCatchBlock")
   private static Method getGcCpuTimeMethod() {
     try {
       // OpenJDK 26 and later - see https://bugs.openjdk.org/browse/JDK-8368529

--- a/spectator-ext-jvm/src/main/java/com/netflix/spectator/jvm/Jmx.java
+++ b/spectator-ext-jvm/src/main/java/com/netflix/spectator/jvm/Jmx.java
@@ -32,9 +32,9 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public final class Jmx {
 
-  private static final AtomicLong prevGcCpuTime = new AtomicLong(-1L);
-  private static final AtomicLong prevProcessCpuTime = new AtomicLong(-1L);
-  private static final Method gcCpuTimeMethod = getGcCpuTimeMethod();
+  private static final AtomicLong PREV_GC_CPU_TIME = new AtomicLong(-1L);
+  private static final AtomicLong PREV_PROCESS_CPU_TIME = new AtomicLong(-1L);
+  private static final Method GC_CPU_TIME_METHOD = getGcCpuTimeMethod();
 
   private Jmx() {
   }
@@ -83,17 +83,17 @@ public final class Jmx {
   }
 
   private static double getGcOverhead() {
-    if (gcCpuTimeMethod == null) {
+    if (GC_CPU_TIME_METHOD == null) {
       return Double.NaN;
     }
     try {
       com.sun.management.OperatingSystemMXBean os = (com.sun.management.OperatingSystemMXBean)
               ManagementFactory.getOperatingSystemMXBean();
       MemoryMXBean memory = ManagementFactory.getMemoryMXBean();
-      long gcCpuTime = (long) gcCpuTimeMethod.invoke(memory);
+      long gcCpuTime = (long) GC_CPU_TIME_METHOD.invoke(memory);
       long processCpuTime = os.getProcessCpuTime();
-      long prevGc = prevGcCpuTime.getAndSet(gcCpuTime);
-      long prevProcess = prevProcessCpuTime.getAndSet(processCpuTime);
+      long prevGc = PREV_GC_CPU_TIME.getAndSet(gcCpuTime);
+      long prevProcess = PREV_PROCESS_CPU_TIME.getAndSet(processCpuTime);
       if (prevGc < 0 || prevProcess < 0) {
         return Double.NaN;
       }

--- a/spectator-ext-jvm/src/main/java/com/netflix/spectator/jvm/Jmx.java
+++ b/spectator-ext-jvm/src/main/java/com/netflix/spectator/jvm/Jmx.java
@@ -25,11 +25,16 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Helpers for working with JMX mbeans.
  */
 public final class Jmx {
+
+  private static final AtomicLong prevGcCpuTime = new AtomicLong(-1L);
+  private static final AtomicLong prevProcessCpuTime = new AtomicLong(-1L);
+  private static final Method gcCpuTimeMethod = getGcCpuTimeMethod();
 
   private Jmx() {
   }
@@ -68,21 +73,36 @@ public final class Jmx {
   }
 
   @SuppressWarnings("PMD.EmptyCatchBlock")
+  private static Method getGcCpuTimeMethod() {
+    try {
+      // OpenJDK 26 and later - see https://bugs.openjdk.org/browse/JDK-8368529
+      return MemoryMXBean.class.getMethod("getTotalGcCpuTime");
+    } catch (NoSuchMethodException ignore) {
+      return null;
+    }
+  }
+
   private static double getGcOverhead() {
+    if (gcCpuTimeMethod == null) {
+      return Double.NaN;
+    }
     try {
       com.sun.management.OperatingSystemMXBean os = (com.sun.management.OperatingSystemMXBean)
               ManagementFactory.getOperatingSystemMXBean();
       MemoryMXBean memory = ManagementFactory.getMemoryMXBean();
-      Method getTotalGcCpuTime = MemoryMXBean.class.getMethod("getTotalGcCpuTime");
-        long gcCpuTime = (long) getTotalGcCpuTime.invoke(memory);
-        long processCpuTime = os.getProcessCpuTime();
-        return processCpuTime <= 0 ? Double.NaN : (double) gcCpuTime / processCpuTime;
-    } catch (ClassCastException | NoSuchMethodException ignore) {
-      // OpenJDK 26 and later - see https://bugs.openjdk.org/browse/JDK-8368529
+      long gcCpuTime = (long) gcCpuTimeMethod.invoke(memory);
+      long processCpuTime = os.getProcessCpuTime();
+      long prevGc = prevGcCpuTime.getAndSet(gcCpuTime);
+      long prevProcess = prevProcessCpuTime.getAndSet(processCpuTime);
+      if (prevGc < 0 || prevProcess < 0) {
+        return Double.NaN;
+      }
+      long deltaProcess = processCpuTime - prevProcess;
+      long deltaGc = gcCpuTime - prevGc;
+      return deltaProcess <= 0 ? Double.NaN : (double) deltaGc / deltaProcess;
     } catch (InvocationTargetException | IllegalAccessException e) {
-        throw new RuntimeException(e);
+      throw new RuntimeException(e);
     }
-    return Double.NaN;
   }
 
   private static void monitorClassLoadingMXBean(Registry registry) {

--- a/spectator-ext-jvm/src/test/java/com/netflix/spectator/jvm/JmxGcOverheadTest.java
+++ b/spectator-ext-jvm/src/test/java/com/netflix/spectator/jvm/JmxGcOverheadTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2014-2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.jvm;
+
+import com.netflix.spectator.api.*;
+import com.netflix.spectator.api.patterns.PolledMeter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class JmxGcOverheadTest {
+
+  @Test
+  @EnabledForJreRange(min = JRE.JAVA_26)
+  public void gcOverheadMeterRegistered() {
+    Registry registry = new DefaultRegistry();
+    Jmx.registerStandardMXBeans(registry);
+    Meter meter = registry.get(Id.create("jvm.gc.overhead"));
+    assertNotNull(meter, "jvm.gc.overhead should be registered");
+  }
+
+  @Test
+  @EnabledForJreRange(min = JRE.JAVA_26)
+  public void gcOverheadMeterMeasure() {
+    Registry registry = new DefaultRegistry();
+    Jmx.registerStandardMXBeans(registry);
+    System.gc();
+    PolledMeter.update(registry);
+    assertTrue(registry.gauge(Id.create("jvm.gc.overhead")).value() > 0);
+  }
+
+}

--- a/spectator-ext-jvm/src/test/java/com/netflix/spectator/jvm/JmxGcOverheadTest.java
+++ b/spectator-ext-jvm/src/test/java/com/netflix/spectator/jvm/JmxGcOverheadTest.java
@@ -39,7 +39,11 @@ public class JmxGcOverheadTest {
   public void gcOverheadMeterMeasure() {
     Registry registry = new DefaultRegistry();
     Jmx.registerStandardMXBeans(registry);
+    // First poll establishes the baseline, value will be NaN
+    PolledMeter.update(registry);
+    // Trigger GC activity between polls
     System.gc();
+    // Second poll computes the delta from the baseline
     PolledMeter.update(registry);
     assertTrue(registry.gauge(Id.create("jvm.gc.overhead")).value() > 0);
   }


### PR DESCRIPTION
This adds a new `jvm.gc.overhead` gauge that finally gives us an accurate measurement of GC versus application CPU utilisation, rather than using `jvm.gc.pause` as a proxy, which only works for the collectors that do no work concurrently.