### PR TITLE
Hash64: hybrid inline/getBytes UTF-8 path in updateString

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,6 +99,11 @@ subprojects {
     includeTests = false
     duplicateClassesStrategy = DuplicatesStrategy.WARN
     includes = ['.*Ids.*']
+    // Run benchmarks on a modern JDK rather than the project's JDK 8 toolchain;
+    // JDK 8 compatibility is a library-source constraint, not a perf target.
+    javaLauncher = javaToolchains.launcherFor {
+      languageVersion = JavaLanguageVersion.of(25)
+    }
   }
 
   checkstyle {

--- a/spectator-api/src/jmh/java/com/netflix/spectator/perf/IdHash.java
+++ b/spectator-api/src/jmh/java/com/netflix/spectator/perf/IdHash.java
@@ -24,15 +24,27 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.infra.Blackhole;
 
 /**
- * Benchmark                             Mode  Cnt        Score        Error   Units
- * IdHash.hash64                        thrpt    5  2379245.474 ±   7379.034   ops/s
- * IdHash.hash64_2                      thrpt    5  4817014.307 ±   5704.027   ops/s
- * IdHash.openhft                       thrpt    5  4910133.221 ± 100296.076   ops/s
+ * JDK 25, M1 Mac, fork=1, 2 warmup × 5 iter. All ops/s.
  *
- * Benchmark                             Mode  Cnt        Score        Error   Units
- * IdHash.hash64:·gc.alloc.rate.norm    thrpt    5        0.188 ±      0.002    B/op
- * IdHash.hash64_2:·gc.alloc.rate.norm  thrpt    5     1152.095 ±      0.001    B/op
- * IdHash.openhft:·gc.alloc.rate.norm   thrpt    5     1128.095 ±      0.002    B/op
+ * Three versions of Hash64.updateString compared:
+ *   - Before:  String.getBytes(UTF_8) + Unsafe long-stride updateBytes (always).
+ *   - Inline:  inline UTF-8 char loop (always); no allocation.
+ *   - Hybrid:  inline loop for length ≤ 128 or non-String CharSequence;
+ *              falls back to getBytes path above the threshold.
+ *
+ *   Benchmark              Before      Inline      Hybrid   Notes
+ *   hash64              1,251,106   2,080,744   2,045,902   per-tag Id hashing
+ *   shortAsciiString   19,988,867  22,450,113  22,488,509   18 chars
+ *   unicodeString      11,785,066  13,864,127  13,991,804   17 chars, mixed UTF-8
+ *   hash64_2            2,984,101   1,478,570   2,729,695   ~310 chars (id.toString)
+ *   longAsciiString     4,149,357   1,306,378   4,199,309   368 chars
+ *   openhft             4,401,361   4,401,036   4,349,151   reference impl
+ *
+ * Hybrid keeps the small-string wins (+64% on hash64, +13% on shortAsciiString,
+ * +19% on unicodeString) and recovers essentially all of the long-string perf
+ * (longAsciiString back to baseline; hash64_2 within ~9%). Below the threshold the
+ * inline path is structurally non-allocating; above it the getBytes byte[] is
+ * typically JIT-scalar-replaced and gc.alloc.rate stays ~zero in JMH.
  */
 @State(Scope.Thread)
 public class IdHash {
@@ -54,6 +66,22 @@ public class IdHash {
   private final Hash64 h64 = new Hash64();
   private final LongHashFunction xx = LongHashFunction.xx();
 
+  // Short ASCII tag-style string (~16 chars) — common metric tag case.
+  private final String shortAscii = "i-0123456789abcdef";
+
+  // Long ASCII string (~256 chars) — stresses the long-string path.
+  private final String longAscii;
+  {
+    StringBuilder sb = new StringBuilder(256);
+    for (int j = 0; j < 16; ++j) {
+      sb.append("/api/v1/users/abcd1234/");
+    }
+    longAscii = sb.toString();
+  }
+
+  // Mixed ASCII + Latin-1 + CJK to exercise the 2-byte and 3-byte UTF-8 branches.
+  private final String unicode = "user-42-héllo-世界";
+
   @Benchmark
   public void hash64(Blackhole bh) {
     h64.updateString(id.name());
@@ -74,5 +102,20 @@ public class IdHash {
   @Benchmark
   public void openhft(Blackhole bh) {
     bh.consume(xx.hashChars(id.toString()));
+  }
+
+  @Benchmark
+  public void shortAsciiString(Blackhole bh) {
+    bh.consume(h64.updateString(shortAscii).computeAndReset());
+  }
+
+  @Benchmark
+  public void longAsciiString(Blackhole bh) {
+    bh.consume(h64.updateString(longAscii).computeAndReset());
+  }
+
+  @Benchmark
+  public void unicodeString(Blackhole bh) {
+    bh.consume(h64.updateString(unicode).computeAndReset());
   }
 }

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/Hash64.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/Hash64.java
@@ -122,60 +122,86 @@ public final class Hash64 {
     return updateChars(values, 0, values.length);
   }
 
-  /** Update the hash with the specified character sequence value. */
+  /**
+   * Threshold above which {@link #updateString(CharSequence)} hands a {@code String} off
+   * to {@code getBytes(UTF_8) + updateBytes}. Below this length the inline char-loop is
+   * faster (no per-call setup amortization) and structurally non-allocating; above it,
+   * the intrinsified UTF-8 encoder plus Unsafe long-stride writes pull ahead. 128 chars
+   * is the empirical crossover on JDK 25 — see IdHash JMH numbers.
+   */
+  static final int LONG_STRING_THRESHOLD = 128;
+
+  /**
+   * Update the hash with the specified character sequence value. The string is hashed
+   * as its UTF-8 byte sequence. The result matches
+   * {@code updateBytes(s.getBytes(UTF_8))} bit-for-bit, so output is portable to other
+   * languages that hash UTF-8 bytes.
+   *
+   * <p>For short strings (length ≤ {@value #LONG_STRING_THRESHOLD}) and any non-String
+   * {@code CharSequence}, encodes in-place via a char loop with no transient byte
+   * array. For longer {@code String} inputs, falls back to {@code getBytes(UTF_8)}
+   * followed by the Unsafe long-stride {@code updateBytes} path — that one allocates a
+   * transient byte[] (typically JIT-scalar-replaced) but throughput is 2–3× higher on
+   * long strings.</p>
+   */
   public Hash64 updateString(CharSequence str) {
-    if (str instanceof String) {
-      updateBytes(((String) str).getBytes(StandardCharsets.UTF_8));
-    } else {
-      updateCharSequence(str);
+    final int len = str.length();
+    if (len > LONG_STRING_THRESHOLD && str instanceof String) {
+      return updateBytes(((String) str).getBytes(StandardCharsets.UTF_8));
+    }
+    int i = 0;
+    while (i < len) {
+      char c = str.charAt(i++);
+      if (c < 0x80) {
+        // 1-byte ASCII (hot path)
+        writeByte((byte) c);
+      } else if (c < 0x800) {
+        // 2-byte encoding
+        writeByte((byte) (0xC0 | (c >>> 6)));
+        writeByte((byte) (0x80 | (c & 0x3F)));
+      } else if (Character.isHighSurrogate(c)) {
+        if (i < len && Character.isLowSurrogate(str.charAt(i))) {
+          char low = str.charAt(i++);
+          int cp = Character.toCodePoint(c, low);
+          writeByte((byte) (0xF0 | (cp >>> 18)));
+          writeByte((byte) (0x80 | ((cp >>> 12) & 0x3F)));
+          writeByte((byte) (0x80 | ((cp >>> 6) & 0x3F)));
+          writeByte((byte) (0x80 | (cp & 0x3F)));
+        } else {
+          // Unpaired high surrogate → '?'
+          writeByte((byte) 0x3F);
+        }
+      } else if (Character.isLowSurrogate(c)) {
+        // Unpaired low surrogate → '?'
+        writeByte((byte) 0x3F);
+      } else {
+        // 3-byte encoding
+        writeByte((byte) (0xE0 | (c >>> 12)));
+        writeByte((byte) (0x80 | ((c >>> 6) & 0x3F)));
+        writeByte((byte) (0x80 | (c & 0x3F)));
+      }
     }
     return this;
   }
 
-  private void updateCharSequence(CharSequence str) {
-    for (int i = 0; i < str.length(); ++i) {
-      char c = str.charAt(i);
-
-      if (c < 0x80) {
-        // 1-byte ASCII
-        updateByte((byte) c);
-
-      } else if (c < 0x800) {
-        // 2-byte encoding
-        updateByte((byte) (0xC0 | (c >>> 6)));
-        updateByte((byte) (0x80 | (c & 0x3F)));
-
-      } else if (Character.isHighSurrogate(c)) {
-        // Check for valid surrogate pair
-        if (i + 1 < str.length() && Character.isLowSurrogate(str.charAt(i + 1))) {
-          char low = str.charAt(++i);
-          int cp = Character.toCodePoint(c, low);
-          updateByte((byte) (0xF0 | (cp >>> 18)));
-          updateByte((byte) (0x80 | ((cp >>> 12) & 0x3F)));
-          updateByte((byte) (0x80 | ((cp >>> 6) & 0x3F)));
-          updateByte((byte) (0x80 | (cp & 0x3F)));
-        } else {
-          // Unpaired high surrogate → '?'
-          updateByte((byte) 0x3F);
-        }
-
-      } else if (Character.isLowSurrogate(c)) {
-        // Unpaired low surrogate → '?'
-        updateByte((byte) 0x3F);
-
-      } else {
-        // 3-byte encoding
-        updateByte((byte) (0xE0 | (c >>> 12)));
-        updateByte((byte) (0x80 | ((c >>> 6) & 0x3F)));
-        updateByte((byte) (0x80 | (c & 0x3F)));
+  // Tight check-and-write for a single byte. Used by updateString's hot loop directly
+  // (so the JIT keeps the per-char path small) and by updateByte (which previously
+  // duplicated this logic via checkSpace + updateByteImpl).
+  private void writeByte(byte value) {
+    if (bitPos == Long.SIZE) {
+      if (++stripePos == stripe.length) {
+        processStripe();
       }
+      bitPos = 0;
+      stripe[stripePos] = 0L;
     }
+    stripe[stripePos] |= ((long) value & 0xFFL) << bitPos;
+    bitPos += Byte.SIZE;
   }
 
   /** Update the hash with the specified byte value. */
   public Hash64 updateByte(byte value) {
-    checkSpace(Byte.SIZE);
-    updateByteImpl(value);
+    writeByte(value);
     return this;
   }
 


### PR DESCRIPTION
Replaces the previous single-path updateString with a length-based hybrid:

- For length ≤ 128 (typical metric tag values) or any non-String CharSequence: inline UTF-8 char loop, no allocation, no per-call encoder setup overhead.
- For longer String inputs: fall back to getBytes(UTF_8) + Unsafe long-stride updateBytes, where the intrinsified UTF-8 encoder and 8-byte-per-iter writes win on throughput.

Output is bit-identical to updateBytes(s.getBytes(UTF_8)) regardless of which path is taken; the existing Hash64Test.checkString assertions cover both sides of the threshold (random strings of length 0-999).

Other changes:
- New private writeByte helper handles per-byte stripe writes and rollover; updateByte delegates to it to avoid duplicate logic.
- build.gradle: pin the jmh task to JDK 25 so benchmarks reflect the modern JIT, independent of the JDK 8 source toolchain.

JMH on JDK 25 (M1; see IdHash.java javadoc for the full table):

```
  IdHash.hash64             1.25M -> 2.05M ops/s   (+64%)
  IdHash.shortAsciiString     20M -> 22M           (+13%)
  IdHash.unicodeString        12M -> 14M           (+19%)
  IdHash.longAsciiString    4.15M -> 4.20M         (+1%)
  IdHash.hash64_2           2.98M -> 2.73M         (-9%)
```