### PR TITLE
Hash64: fix non-spec output and add allocation-free static helpers

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/impl/Hash64.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/Hash64.java
@@ -385,13 +385,13 @@ public final class Hash64 {
     stripe[0] = 0L;
   }
 
-  private long round(long acc, long lane) {
+  private static long round(long acc, long lane) {
     acc += lane * PRIME64_2;
     acc = Long.rotateLeft(acc, 31);
     return acc * PRIME64_1;
   }
 
-  private long mergeAccumulator(long acc, long accN) {
+  private static long mergeAccumulator(long acc, long accN) {
     acc ^= round(0L, accN);
     acc *= PRIME64_1;
     return acc + PRIME64_4;
@@ -407,27 +407,31 @@ public final class Hash64 {
     }
 
     long buffer = stripe[stripePos];
-    if (bitPos >= 4) {
+    // bitPos is in bits; 32 bits = 4 bytes, 8 bits = 1 byte. Prior versions used
+    // 4 and 1 here directly, which made the byte-by-byte loop run 8x too many
+    // times on non-multiple-of-8 inputs and produced a deterministic but
+    // non-spec-compliant hash. Cross-validated against net.openhft xxHash64.
+    if (bitPos >= 32) {
       long lane = buffer & 0xFFFFFFFFL;
       acc ^= (lane * PRIME64_1);
       acc = Long.rotateLeft(acc, 23) * PRIME64_2;
       acc += PRIME64_3;
       buffer >>>= 32;
-      bitPos -= 4;
+      bitPos -= 32;
     }
 
-    while (bitPos >= 1) {
+    while (bitPos >= 8) {
       long lane = buffer & 0xFFL;
       acc ^= (lane * PRIME64_5);
       acc = Long.rotateLeft(acc, 11) * PRIME64_1;
       buffer >>>= 8;
-      bitPos -= 1;
+      bitPos -= 8;
     }
 
     return acc;
   }
 
-  private long avalanche(long acc) {
+  private static long avalanche(long acc) {
     acc ^= acc >>> 33;
     acc *= PRIME64_2;
     acc ^= acc >>> 29;
@@ -473,6 +477,293 @@ public final class Hash64 {
     long h = compute();
     reset();
     return h;
+  }
+
+  // ------------------------------------------------------------------------
+  // Allocation-free static helpers for hashing a single value.
+  //
+  // The instance API (new Hash64().updateX(...)...compute()) is the right fit
+  // when composing the hash of multiple values, but for the common "hash one
+  // long / string / byte[]" case the instance allocation and the per-call
+  // ThreadLocal pattern that callers reach for are both undesirable —
+  // ThreadLocals are particularly bad on virtual threads. These statics
+  // compute the same xxHash64 output as the instance API with no allocation
+  // (except hashString on inputs longer than LONG_STRING_THRESHOLD, which
+  // routes through getBytes(UTF_8) + hashBytes for throughput).
+  // ------------------------------------------------------------------------
+
+  /** xxHash64 of a single {@code long} value with seed 0. Allocation-free. */
+  public static long hashLong(long value) {
+    return hashLong(value, 0L);
+  }
+
+  /** xxHash64 of a single {@code long} value with the given seed. Allocation-free. */
+  public static long hashLong(long value, long seed) {
+    long acc = seed + PRIME64_5 + 8L;
+    acc ^= round(0L, value);
+    acc = Long.rotateLeft(acc, 27) * PRIME64_1 + PRIME64_4;
+    return avalanche(acc);
+  }
+
+  /** xxHash64 of a single {@code int} value with seed 0. Allocation-free. */
+  public static long hashInt(int value) {
+    return hashInt(value, 0L);
+  }
+
+  /** xxHash64 of a single {@code int} value with the given seed. Allocation-free. */
+  public static long hashInt(int value, long seed) {
+    long acc = seed + PRIME64_5 + 4L;
+    acc ^= (((long) value) & 0xFFFFFFFFL) * PRIME64_1;
+    acc = Long.rotateLeft(acc, 23) * PRIME64_2 + PRIME64_3;
+    return avalanche(acc);
+  }
+
+  /** xxHash64 of {@code bytes} with seed 0. Allocation-free. */
+  public static long hashBytes(byte[] bytes) {
+    return hashBytes(bytes, 0, bytes.length, 0L);
+  }
+
+  /** xxHash64 of {@code bytes} with the given seed. Allocation-free. */
+  public static long hashBytes(byte[] bytes, long seed) {
+    return hashBytes(bytes, 0, bytes.length, seed);
+  }
+
+  /** xxHash64 of {@code bytes[offset, offset+length)} with seed 0. Allocation-free. */
+  public static long hashBytes(byte[] bytes, int offset, int length) {
+    return hashBytes(bytes, offset, length, 0L);
+  }
+
+  /**
+   * xxHash64 of {@code bytes[offset, offset+length)} with the given seed.
+   * Allocation-free.
+   */
+  public static long hashBytes(byte[] bytes, int offset, int length, long seed) {
+    long acc;
+    int i = offset;
+    final int end = offset + length;
+
+    if (length >= 32) {
+      long acc1 = seed + PRIME64_1 + PRIME64_2;
+      long acc2 = seed + PRIME64_2;
+      long acc3 = seed;
+      long acc4 = seed - PRIME64_1;
+      final int stripeEnd = offset + (length & ~31);
+      while (i < stripeEnd) {
+        acc1 = round(acc1, readLongLE(bytes, i));
+        acc2 = round(acc2, readLongLE(bytes, i + 8));
+        acc3 = round(acc3, readLongLE(bytes, i + 16));
+        acc4 = round(acc4, readLongLE(bytes, i + 24));
+        i += 32;
+      }
+      acc = Long.rotateLeft(acc1, 1) + Long.rotateLeft(acc2, 7)
+          + Long.rotateLeft(acc3, 12) + Long.rotateLeft(acc4, 18);
+      acc = mergeAccumulator(acc, acc1);
+      acc = mergeAccumulator(acc, acc2);
+      acc = mergeAccumulator(acc, acc3);
+      acc = mergeAccumulator(acc, acc4);
+    } else {
+      acc = seed + PRIME64_5;
+    }
+
+    acc += length;
+    return avalanche(consumeBytesTail(acc, bytes, i, end));
+  }
+
+  // Consume up to 31 trailing bytes: as many 8-byte chunks as fit, then one
+  // 4-byte chunk if possible, then byte-by-byte.
+  private static long consumeBytesTail(long acc, byte[] bytes, int i, int end) {
+    while (end - i >= 8) {
+      acc ^= round(0L, readLongLE(bytes, i));
+      acc = Long.rotateLeft(acc, 27) * PRIME64_1 + PRIME64_4;
+      i += 8;
+    }
+    if (end - i >= 4) {
+      acc ^= readIntLE(bytes, i) * PRIME64_1;
+      acc = Long.rotateLeft(acc, 23) * PRIME64_2 + PRIME64_3;
+      i += 4;
+    }
+    while (i < end) {
+      acc ^= ((long) bytes[i] & 0xFFL) * PRIME64_5;
+      acc = Long.rotateLeft(acc, 11) * PRIME64_1;
+      ++i;
+    }
+    return acc;
+  }
+
+  private static long readLongLE(byte[] bytes, int offset) {
+    if (UnsafeUtils.supported()) {
+      return UnsafeUtils.getLong(bytes, offset);
+    }
+    return ((long) bytes[offset]     & 0xFFL)
+        | (((long) bytes[offset + 1] & 0xFFL) << 8)
+        | (((long) bytes[offset + 2] & 0xFFL) << 16)
+        | (((long) bytes[offset + 3] & 0xFFL) << 24)
+        | (((long) bytes[offset + 4] & 0xFFL) << 32)
+        | (((long) bytes[offset + 5] & 0xFFL) << 40)
+        | (((long) bytes[offset + 6] & 0xFFL) << 48)
+        | (((long) bytes[offset + 7] & 0xFFL) << 56);
+  }
+
+  private static long readIntLE(byte[] bytes, int offset) {
+    return ((long) bytes[offset]     & 0xFFL)
+        | (((long) bytes[offset + 1] & 0xFFL) << 8)
+        | (((long) bytes[offset + 2] & 0xFFL) << 16)
+        | (((long) bytes[offset + 3] & 0xFFL) << 24);
+  }
+
+  /**
+   * xxHash64 of the UTF-8 byte sequence of {@code str} with seed 0.
+   *
+   * <p>Allocation behavior: a {@code String} longer than {@value #LONG_STRING_THRESHOLD}
+   * chars routes through {@code getBytes(UTF_8) + hashBytes} for throughput (allocates
+   * a transient byte[], matches {@link #updateString(CharSequence)}'s hybrid). All other
+   * inputs — short {@code String}s and any non-{@code String} {@link CharSequence}
+   * regardless of length — take the inline UTF-8 encoder and allocate nothing. Long
+   * non-{@code String} {@code CharSequence}s pay the inline path's throughput cost
+   * since {@code getBytes} is not available on them.</p>
+   */
+  public static long hashString(CharSequence str) {
+    return hashString(str, 0L);
+  }
+
+  /**
+   * xxHash64 of the UTF-8 byte sequence of {@code str} with the given seed. See
+   * {@link #hashString(CharSequence)} for allocation behavior.
+   */
+  public static long hashString(CharSequence str, long seed) {
+    if (str.length() > LONG_STRING_THRESHOLD && str instanceof String) {
+      return hashBytes(((String) str).getBytes(StandardCharsets.UTF_8), seed);
+    }
+    return hashStringInline(str, seed);
+  }
+
+  // Inline xxHash64 of the UTF-8 byte sequence of str with no byte[] allocation.
+  // Buffers up to a 32-byte stripe in local state; full stripes are folded into
+  // the four accumulators; partial trailing input is consumed at finalize.
+  private static long hashStringInline(CharSequence str, long seed) {
+    long acc1 = seed + PRIME64_1 + PRIME64_2;
+    long acc2 = seed + PRIME64_2;
+    long acc3 = seed;
+    long acc4 = seed - PRIME64_1;
+    // Stripe buffer kept as four named locals (not a long[4]) so the method is
+    // structurally non-allocating regardless of JIT escape analysis.
+    long s0 = 0L, s1 = 0L, s2 = 0L;
+    long currentLane = 0L;
+    int bitPos = 0;
+    int laneIdx = 0;
+    long inputLength = 0L;
+
+    final int charLen = str.length();
+    for (int ci = 0; ci < charLen; ++ci) {
+      char c = str.charAt(ci);
+
+      // Encode one char into 1-4 UTF-8 bytes packed into bytesPacked (low-to-high).
+      int numBytes;
+      long bytesPacked;
+      if (c < 0x80) {
+        bytesPacked = c;
+        numBytes = 1;
+      } else if (c < 0x800) {
+        bytesPacked = (0xC0L | (c >>> 6))
+            | ((0x80L | (c & 0x3F)) << 8);
+        numBytes = 2;
+      } else if (Character.isHighSurrogate(c)) {
+        if (ci + 1 < charLen && Character.isLowSurrogate(str.charAt(ci + 1))) {
+          int cp = Character.toCodePoint(c, str.charAt(++ci));
+          bytesPacked = (0xF0L | (cp >>> 18))
+              | ((0x80L | ((cp >>> 12) & 0x3F)) << 8)
+              | ((0x80L | ((cp >>> 6) & 0x3F)) << 16)
+              | ((0x80L | (cp & 0x3F)) << 24);
+          numBytes = 4;
+        } else {
+          bytesPacked = 0x3F; // unpaired high surrogate → '?'
+          numBytes = 1;
+        }
+      } else if (Character.isLowSurrogate(c)) {
+        bytesPacked = 0x3F; // unpaired low surrogate → '?'
+        numBytes = 1;
+      } else {
+        bytesPacked = (0xE0L | (c >>> 12))
+            | ((0x80L | ((c >>> 6) & 0x3F)) << 8)
+            | ((0x80L | (c & 0x3F)) << 16);
+        numBytes = 3;
+      }
+
+      // Append bytes into the stripe buffer; on lane fill, advance laneIdx;
+      // on full 32-byte stripe, apply rounds and reset.
+      for (int bi = 0; bi < numBytes; ++bi) {
+        currentLane |= (bytesPacked & 0xFFL) << bitPos;
+        bytesPacked >>>= 8;
+        bitPos += 8;
+        if (bitPos == 64) {
+          if (laneIdx == 3) {
+            // 4th lane just filled — fold the whole stripe into the accumulators.
+            acc1 = round(acc1, s0);
+            acc2 = round(acc2, s1);
+            acc3 = round(acc3, s2);
+            acc4 = round(acc4, currentLane);
+            inputLength += 32;
+            laneIdx = 0;
+          } else {
+            switch (laneIdx) {
+              case 0: s0 = currentLane; break;
+              case 1: s1 = currentLane; break;
+              default: s2 = currentLane; break;  // laneIdx == 2
+            }
+            ++laneIdx;
+          }
+          currentLane = 0L;
+          bitPos = 0;
+        }
+      }
+    }
+
+    final long tailBytes = laneIdx * 8L + bitPos / 8L;
+    final long totalBytes = inputLength + tailBytes;
+    long acc;
+    if (totalBytes < 32L) {
+      acc = seed + PRIME64_5;
+    } else {
+      acc = Long.rotateLeft(acc1, 1) + Long.rotateLeft(acc2, 7)
+          + Long.rotateLeft(acc3, 12) + Long.rotateLeft(acc4, 18);
+      acc = mergeAccumulator(acc, acc1);
+      acc = mergeAccumulator(acc, acc2);
+      acc = mergeAccumulator(acc, acc3);
+      acc = mergeAccumulator(acc, acc4);
+    }
+    acc += totalBytes;
+
+    // Consume buffered complete lanes (laneIdx of them, in order) as 8-byte tail
+    // chunks. Unrolled to keep the lane state in named locals.
+    if (laneIdx >= 1) {
+      acc ^= round(0L, s0);
+      acc = Long.rotateLeft(acc, 27) * PRIME64_1 + PRIME64_4;
+    }
+    if (laneIdx >= 2) {
+      acc ^= round(0L, s1);
+      acc = Long.rotateLeft(acc, 27) * PRIME64_1 + PRIME64_4;
+    }
+    if (laneIdx >= 3) {
+      acc ^= round(0L, s2);
+      acc = Long.rotateLeft(acc, 27) * PRIME64_1 + PRIME64_4;
+    }
+    // Then partial-lane bytes from currentLane (bitPos in bits, multiple of 8).
+    long buffer = currentLane;
+    int remainingBits = bitPos;
+    if (remainingBits >= 32) {
+      long lane = buffer & 0xFFFFFFFFL;
+      acc ^= lane * PRIME64_1;
+      acc = Long.rotateLeft(acc, 23) * PRIME64_2 + PRIME64_3;
+      buffer >>>= 32;
+      remainingBits -= 32;
+    }
+    while (remainingBits >= 8) {
+      acc ^= (buffer & 0xFFL) * PRIME64_5;
+      acc = Long.rotateLeft(acc, 11) * PRIME64_1;
+      buffer >>>= 8;
+      remainingBits -= 8;
+    }
+    return avalanche(acc);
   }
 
   /**

--- a/spectator-api/src/test/java/com/netflix/spectator/impl/Hash64Test.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/Hash64Test.java
@@ -287,4 +287,203 @@ public class Hash64Test {
       Assertions.assertTrue(delta < 1000);
     }
   }
+
+  @Test
+  public void hashBytesMatchesXxHashSpec() {
+    // Cross-validate against the openhft xxHash64 reference across input lengths
+    // 0..256. Prior versions of consumeRemainingInput produced non-spec output
+    // for any length that wasn't a multiple of 8 bytes; this guards against
+    // regressions to that bug and verifies cross-language portability of the
+    // hash values.
+    final LongHashFunction xx64 = LongHashFunction.xx();
+    final byte[] data = new byte[256];
+    for (int i = 0; i < data.length; ++i) {
+      data[i] = (byte) i;
+    }
+    for (int len = 0; len <= data.length; ++len) {
+      long expected = xx64.hashBytes(data, 0, len);
+      long actual = new Hash64().updateBytes(data, 0, len).compute();
+      Assertions.assertEquals(expected, actual, "length=" + len);
+    }
+  }
+
+  @Test
+  public void hashStringMatchesXxHashSpec() {
+    // updateString hashes the UTF-8 byte sequence; openhft.hashBytes on the
+    // same UTF-8 bytes should match exactly for any length and any character
+    // (1-, 2-, 3-, or 4-byte UTF-8 sequences).
+    final LongHashFunction xx64 = LongHashFunction.xx();
+    final String[] samples = {
+        "", "a", "ab", "abc", "abcd", "abcde", "abcdef", "abcdefg",
+        "abcdefgh", "abcdefghi", "abcdefghijklmno", "abcdefghijklmnop",
+        "héllo", "世界", "user-42-héllo-世界",
+        repeat("x", 127), repeat("x", 128), repeat("x", 129),
+        repeat("x", 1024)
+    };
+    for (String s : samples) {
+      byte[] utf8 = s.getBytes(StandardCharsets.UTF_8);
+      long expected = xx64.hashBytes(utf8);
+      long actual = new Hash64().updateString(s).compute();
+      Assertions.assertEquals(expected, actual, "input=\"" + s + "\" (utf8 length=" + utf8.length + ")");
+    }
+  }
+
+  private static String repeat(String s, int n) {
+    StringBuilder sb = new StringBuilder(s.length() * n);
+    for (int i = 0; i < n; ++i) sb.append(s);
+    return sb.toString();
+  }
+
+  // ------------------------------------------------------------------------
+  // Static-helper tests: assert the allocation-free static methods produce
+  // identical output to (a) the instance builder API and (b) openhft xxHash64.
+  // ------------------------------------------------------------------------
+
+  @Test
+  public void staticHashLong() {
+    LongHashFunction xx = LongHashFunction.xx();
+    long[] values = {0L, 1L, -1L, Long.MIN_VALUE, Long.MAX_VALUE, 42L, 0xDEADBEEFCAFEBABEL};
+    for (long v : values) {
+      long fromBuilder = new Hash64().updateLong(v).compute();
+      long fromStatic = Hash64.hashLong(v);
+      long fromXx = xx.hashLong(v);
+      Assertions.assertEquals(fromBuilder, fromStatic, "builder vs static, value=" + v);
+      Assertions.assertEquals(fromXx, fromStatic, "openhft vs static, value=" + v);
+    }
+  }
+
+  @Test
+  public void staticHashLongWithSeed() {
+    long[] values = {0L, 1L, -1L, 42L};
+    long[] seeds = {0L, 1L, -1L, 0xCAFEBABECAFEBABEL};
+    for (long seed : seeds) {
+      LongHashFunction xx = LongHashFunction.xx(seed);
+      for (long v : values) {
+        long fromStatic = Hash64.hashLong(v, seed);
+        long fromXx = xx.hashLong(v);
+        Assertions.assertEquals(fromXx, fromStatic,
+            "openhft vs static, value=" + v + ", seed=" + seed);
+      }
+    }
+  }
+
+  @Test
+  public void staticHashInt() {
+    LongHashFunction xx = LongHashFunction.xx();
+    int[] values = {0, 1, -1, Integer.MIN_VALUE, Integer.MAX_VALUE, 42};
+    for (int v : values) {
+      long fromBuilder = new Hash64().updateInt(v).compute();
+      long fromStatic = Hash64.hashInt(v);
+      long fromXx = xx.hashInt(v);
+      Assertions.assertEquals(fromBuilder, fromStatic, "builder vs static, value=" + v);
+      Assertions.assertEquals(fromXx, fromStatic, "openhft vs static, value=" + v);
+    }
+  }
+
+  @Test
+  public void staticHashBytes() {
+    LongHashFunction xx = LongHashFunction.xx();
+    byte[] data = new byte[256];
+    for (int i = 0; i < data.length; ++i) {
+      data[i] = (byte) i;
+    }
+    for (int len = 0; len <= data.length; ++len) {
+      long fromBuilder = new Hash64().updateBytes(data, 0, len).compute();
+      long fromStatic = Hash64.hashBytes(data, 0, len);
+      long fromXx = xx.hashBytes(data, 0, len);
+      Assertions.assertEquals(fromBuilder, fromStatic, "builder vs static, length=" + len);
+      Assertions.assertEquals(fromXx, fromStatic, "openhft vs static, length=" + len);
+    }
+  }
+
+  @Test
+  public void staticHashBytesWithSeed() {
+    long seed = 0xCAFEBABEL;
+    LongHashFunction xx = LongHashFunction.xx(seed);
+    byte[] data = new byte[128];
+    for (int i = 0; i < data.length; ++i) {
+      data[i] = (byte) (i * 7);
+    }
+    for (int len = 0; len <= data.length; ++len) {
+      long fromStatic = Hash64.hashBytes(data, 0, len, seed);
+      long fromXx = xx.hashBytes(data, 0, len);
+      Assertions.assertEquals(fromXx, fromStatic, "length=" + len);
+    }
+  }
+
+  @Test
+  public void staticHashBytesOffset() {
+    // Same payload viewed via different offsets must produce the same hash.
+    byte[] padded = new byte[300];
+    byte[] payload = "hello world this is a test string".getBytes(StandardCharsets.UTF_8);
+    System.arraycopy(payload, 0, padded, 50, payload.length);
+
+    long fromPayload = Hash64.hashBytes(payload);
+    long fromOffset = Hash64.hashBytes(padded, 50, payload.length);
+    Assertions.assertEquals(fromPayload, fromOffset);
+  }
+
+  @Test
+  public void staticHashString() {
+    LongHashFunction xx = LongHashFunction.xx();
+    String[] samples = {
+        "", "a", "ab", "abc", "abcdefgh", "abcdefghi",
+        "héllo", "世界", "user-42-héllo-世界",
+        repeat("x", 31), repeat("x", 32), repeat("x", 33),
+        repeat("x", 127), repeat("x", 128), repeat("x", 129),
+        repeat("abc", 100)
+    };
+    for (String s : samples) {
+      byte[] utf8 = s.getBytes(StandardCharsets.UTF_8);
+      long fromBuilder = new Hash64().updateString(s).compute();
+      long fromStatic = Hash64.hashString(s);
+      long fromXx = xx.hashBytes(utf8);
+      Assertions.assertEquals(fromBuilder, fromStatic,
+          "builder vs static, input=\"" + s + "\" (utf8 len=" + utf8.length + ")");
+      Assertions.assertEquals(fromXx, fromStatic,
+          "openhft vs static, input=\"" + s + "\" (utf8 len=" + utf8.length + ")");
+    }
+  }
+
+  @Test
+  public void staticHashStringCharSequence() {
+    // Non-String CharSequence takes the inline path even for long inputs;
+    // verify the same byte sequence still produces the same hash.
+    String base = repeat("abc", 100);
+    StringBuilder sb = new StringBuilder(base);
+    long fromString = Hash64.hashString(base);
+    long fromBuilder = Hash64.hashString(sb);
+    Assertions.assertEquals(fromString, fromBuilder);
+  }
+
+  @Test
+  public void staticHashStringCharSequenceMultibyte() {
+    // Long non-String CharSequence (which stays on the inline encoder regardless
+    // of length) with 2-, 3-, and 4-byte UTF-8 code points, sized to cross 8-byte
+    // lane and 32-byte stripe boundaries in the inline encoder.
+    LongHashFunction xx = LongHashFunction.xx();
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < 50; ++i) {
+      sb.append("a")        // 1-byte
+        .append("é")       // 2-byte (Latin-1)
+        .append("世")       // 3-byte (CJK)
+        .append("😀");  // 4-byte (surrogate pair, U+1F600 grinning face)
+    }
+    byte[] utf8 = sb.toString().getBytes(StandardCharsets.UTF_8);
+    long fromStatic = Hash64.hashString(sb);
+    long fromXx = xx.hashBytes(utf8);
+    Assertions.assertEquals(fromXx, fromStatic, "utf8 length=" + utf8.length);
+  }
+
+  @Test
+  public void staticHashStringWithSeed() {
+    long seed = 0xC0FFEEL;
+    LongHashFunction xx = LongHashFunction.xx(seed);
+    String[] samples = {"", "a", "abcdefgh", "héllo", repeat("x", 200)};
+    for (String s : samples) {
+      long fromStatic = Hash64.hashString(s, seed);
+      long fromXx = xx.hashBytes(s.getBytes(StandardCharsets.UTF_8));
+      Assertions.assertEquals(fromXx, fromStatic, "input=\"" + s + "\"");
+    }
+  }
 }


### PR DESCRIPTION
Two related changes that together let Hash64 be used for spec-correct, allocation-free, single-value xxHash64 computation.

1) Fix non-spec output for non-8-byte-multiple inputs.

   consumeRemainingInput treated bitPos as bytes for its loop bounds
   and decrements, but elsewhere in the class bitPos is in bits
   (incremented by Byte.SIZE = 8, compared to Long.SIZE = 64, used as
   a left-shift amount). The mismatch meant the 4-byte chunk path
   fired whenever any partial bytes were present, folding phantom
   zero bytes into the hash, and the byte-by-byte loop then ran
   bitPos times instead of bitPos / 8 times.

   Result: Hash64 produced a deterministic but non-xxHash64-spec
   value for any input length that wasn't a multiple of 8 bytes.
   Internal tests passed because they only asserted self-consistency
   (updateString(s) == updateBytes(s.getBytes(UTF_8))), not
   equivalence to a reference xxHash64.

   Fix: use 32 (bits in 4 bytes) and 8 (bits in 1 byte) in the loop
   bounds and decrements, matching the bit semantics used everywhere
   else.

2) Add allocation-free static helpers.

   The instance API is the right shape for composing hashes of
   complex objects, but for the common "hash one value" case it
   forces callers into either per-call allocation or a
   ThreadLocal<Hash64>. ThreadLocal is increasingly a footgun: each
   virtual thread gets its own copy, and at Loom-scale millions of
   copies add up. Project Loom guidance is to avoid ThreadLocal for
   resources like this.

   API (all with optional seed overloads):
   - hashLong(long), hashLong(long, long seed)
   - hashInt(int),   hashInt(int, long seed)
   - hashBytes(byte[]),
     hashBytes(byte[], long seed),
     hashBytes(byte[], int off, int len),
     hashBytes(byte[], int off, int len, long seed)
   - hashString(CharSequence), hashString(CharSequence, long seed)

   Allocation:
   - hashLong/hashInt: pure local arithmetic, never allocates.
   - hashBytes: streaming with four local long accumulators; never allocates.
   - hashString: inline UTF-8 encode with the stripe buffer held in four named long locals (not a long[4]), so the method is structurally non-allocating regardless of JIT escape analysis. For String inputs longer than LONG_STRING_THRESHOLD (128 chars), matches updateString's hybrid and routes through getBytes(UTF_8)
     + hashBytes — that path allocates a transient byte[]. Long non-String CharSequences stay on the inline path since getBytes is not available on them.

   Implementation: round/mergeAccumulator/avalanche promoted to
   private static (they were already stateless). Some streaming-logic
   duplication with the instance API; mitigated by the test suite.

Tests assert each static helper's output equals BOTH the builder API and net.openhft xxHash64 across input lengths 0..256 bytes / 0..1024 chars, seeded and unseeded variants, and a long non-String CharSequence with mixed 1/2/3/4-byte UTF-8 code points crossing 8- and 32-byte stripe boundaries in the inline encoder.