### PR TITLE
Add Stratum function tagging

### DIFF
--- a/spectator-nflx-tagging/src/main/java/com/netflix/spectator/nflx/tagging/NetflixTagging.java
+++ b/spectator-nflx-tagging/src/main/java/com/netflix/spectator/nflx/tagging/NetflixTagging.java
@@ -57,6 +57,11 @@ public final class NetflixTagging {
     tagKeys.add("nf.stack");
     tagKeys.add("nf.vmtype");
     tagKeys.add("nf.zone");
+    // Stratum function tagging. fnFqName is intentionally excluded — fully-qualified
+    // class names are high-cardinality and churn with refactors, so they are kept for
+    // logs/traces only.
+    tagKeys.add("fnGroup");
+    tagKeys.add("shortFnName");
 
     DEFAULT_ATLAS_TAG_KEYS = Collections.unmodifiableSet(tagKeys);
   }
@@ -139,6 +144,22 @@ public final class NetflixTagging {
     putIfNotEmptyOrNull(getenv, tags, "mantisWorkerNumber", "MANTIS_WORKER_NUMBER");
     putIfNotEmptyOrNull(getenv, tags, "mantisWorkerStageNumber", "MANTIS_WORKER_STAGE_NUMBER");
     putIfNotEmptyOrNull(getenv, tags, "mantisUser", "MANTIS_USER");
+
+    // Stratum function info. shortFnName is composed from group + name to match the
+    // FunctionNameSummarizer used elsewhere in the Stratum stack; it is only emitted
+    // when both pieces are present. fnFqName is included for logs/traces but excluded
+    // from the Atlas tag set (see DEFAULT_ATLAS_TAG_KEYS). isEmptyOrNull treats
+    // whitespace-only values as absent, so the composed value cannot have a leading
+    // or trailing dash from a whitespace-only piece.
+    String fnGroup = getenv.apply("STRATUM_FUNCTION_GROUP");
+    String fnName = getenv.apply("STRATUM_FUNCTION_NAME");
+    if (!isEmptyOrNull(fnGroup)) {
+      tags.put("fnGroup", fnGroup.trim());
+      if (!isEmptyOrNull(fnName)) {
+        tags.put("shortFnName", fnGroup.trim() + "-" + fnName.trim());
+      }
+    }
+    putIfNotEmptyOrNull(getenv, tags, "fnFqName", "STRATUM_FUNCTION_FQNAME");
 
     return tags;
   }

--- a/spectator-nflx-tagging/src/test/java/com/netflix/spectator/nflx/tagging/NetflixTaggingTest.java
+++ b/spectator-nflx-tagging/src/test/java/com/netflix/spectator/nflx/tagging/NetflixTaggingTest.java
@@ -225,4 +225,97 @@ public class NetflixTaggingTest {
     Map<String, String> actual = NetflixTagging.commonTags(vars::get);
     Assertions.assertEquals(expected, actual);
   }
+
+  @Test
+  public void commonTagsStratumAllPresent() {
+    Map<String, String> vars = sampleEnvironmentVars();
+    vars.put("STRATUM_FUNCTION_GROUP", "foo-group");
+    vars.put("STRATUM_FUNCTION_NAME", "bar");
+    vars.put("STRATUM_FUNCTION_FQNAME", "com.example.foo.BarFn");
+    Map<String, String> expected = sampleExpectedTags();
+    expected.put("fnGroup", "foo-group");
+    expected.put("shortFnName", "foo-group-bar");
+    expected.put("fnFqName", "com.example.foo.BarFn");
+    Map<String, String> actual = NetflixTagging.commonTags(vars::get);
+    Assertions.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void commonTagsStratumGroupOnly() {
+    // Only the group is present; shortFnName requires both group and name, so it
+    // should not be emitted. fnGroup still is.
+    Map<String, String> vars = sampleEnvironmentVars();
+    vars.put("STRATUM_FUNCTION_GROUP", "foo-group");
+    Map<String, String> expected = sampleExpectedTags();
+    expected.put("fnGroup", "foo-group");
+    Map<String, String> actual = NetflixTagging.commonTags(vars::get);
+    Assertions.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void commonTagsStratumNameOnly() {
+    // Only the name is present; neither shortFnName nor fnGroup should appear.
+    Map<String, String> vars = sampleEnvironmentVars();
+    vars.put("STRATUM_FUNCTION_NAME", "bar");
+    Map<String, String> expected = sampleExpectedTags();
+    Map<String, String> actual = NetflixTagging.commonTags(vars::get);
+    Assertions.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void commonTagsStratumNonePresent() {
+    // None of the Stratum vars set — no Stratum tags emitted.
+    Map<String, String> vars = sampleEnvironmentVars();
+    Map<String, String> expected = sampleExpectedTags();
+    Map<String, String> actual = NetflixTagging.commonTags(vars::get);
+    Assertions.assertEquals(expected, actual);
+    Assertions.assertFalse(actual.containsKey("shortFnName"));
+    Assertions.assertFalse(actual.containsKey("fnGroup"));
+    Assertions.assertFalse(actual.containsKey("fnFqName"));
+  }
+
+  @Test
+  public void commonTagsStratumWhitespaceTrimmed() {
+    // Leading/trailing whitespace in either var must be trimmed before composing
+    // shortFnName so we don't end up with "  group  -  name  ".
+    Map<String, String> vars = sampleEnvironmentVars();
+    vars.put("STRATUM_FUNCTION_GROUP", "  foo-group  ");
+    vars.put("STRATUM_FUNCTION_NAME", "\tbar\n");
+    Map<String, String> expected = sampleExpectedTags();
+    expected.put("fnGroup", "foo-group");
+    expected.put("shortFnName", "foo-group-bar");
+    Map<String, String> actual = NetflixTagging.commonTags(vars::get);
+    Assertions.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void commonTagsForAtlasStratum() {
+    // Atlas filter: shortFnName and fnGroup are included; fnFqName is excluded
+    // because it is not in DEFAULT_ATLAS_TAG_KEYS (high-cardinality FQ class name).
+    Map<String, String> vars = sampleEnvironmentVars();
+    vars.put("STRATUM_FUNCTION_GROUP", "foo-group");
+    vars.put("STRATUM_FUNCTION_NAME", "bar");
+    vars.put("STRATUM_FUNCTION_FQNAME", "com.example.foo.BarFn");
+    Map<String, String> expected = atlasExpectedTags();
+    expected.put("fnGroup", "foo-group");
+    expected.put("shortFnName", "foo-group-bar");
+    Map<String, String> actual = NetflixTagging.commonTagsForAtlas(vars::get);
+    Assertions.assertEquals(expected, actual);
+    Assertions.assertFalse(actual.containsKey("fnFqName"));
+  }
+
+  @Test
+  public void commonTagsForAtlasStratumSanitizes() {
+    // Group/name values containing characters outside the Atlas-safe set should be
+    // sanitized by fixTagString when filtered through commonTagsForAtlas. Colons
+    // and slashes are not in [-._A-Za-z0-9~^] and should become underscores.
+    Map<String, String> vars = sampleEnvironmentVars();
+    vars.put("STRATUM_FUNCTION_GROUP", "foo:group");
+    vars.put("STRATUM_FUNCTION_NAME", "bar/v2");
+    Map<String, String> expected = atlasExpectedTags();
+    expected.put("fnGroup", "foo_group");
+    expected.put("shortFnName", "foo_group-bar_v2");
+    Map<String, String> actual = NetflixTagging.commonTagsForAtlas(vars::get);
+    Assertions.assertEquals(expected, actual);
+  }
 }


### PR DESCRIPTION
Promote three Stratum function env vars to common tags so per-function breakdowns are available alongside the existing nf.* dimensions:

```
- fnGroup       ← STRATUM_FUNCTION_GROUP
- shortFnName   ← ${STRATUM_FUNCTION_GROUP}-${STRATUM_FUNCTION_NAME}
                  (only emitted when both pieces are present, matching
                  the existing FunctionNameSummarizer convention)
- fnFqName      ← STRATUM_FUNCTION_FQNAME (kept out of the Atlas
                  default tag set because FQ class names are
                  high-cardinality and churn with refactors;
                  available for logs/traces)
```

Tests cover: all three vars present, group-only, name-only, none present, whitespace trimming, Atlas filter (confirms fnFqName is excluded), and Atlas sanitization of values containing characters outside the safe set.