### PR TITLE
Use JMH 'jvm' option to fork benchmarks on JDK 25

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,10 +100,12 @@ subprojects {
     duplicateClassesStrategy = DuplicatesStrategy.WARN
     includes = ['.*Ids.*']
     // Run benchmarks on a modern JDK rather than the project's JDK 8 toolchain;
-    // JDK 8 compatibility is a library-source constraint, not a perf target.
-    javaLauncher = javaToolchains.launcherFor {
+    // JDK 8 compatibility is a library-source constraint, not a perf target. The
+    // jmh extension's javaLauncher does not steer the forked benchmark JVM, so
+    // point the JMH 'jvm' option directly at the JDK 25 launcher.
+    jvm = javaToolchains.launcherFor {
       languageVersion = JavaLanguageVersion.of(25)
-    }
+    }.get().executablePath.asFile.absolutePath
   }
 
   checkstyle {


### PR DESCRIPTION
The `jmh` extension's `javaLauncher` does not steer the forked benchmark
JVM, so benchmarks were silently running on the JDK 8 toolchain rather
than the intended modern JDK. Point the JMH `jvm` option directly at the
JDK 25 launcher instead.

JDK 8 compatibility is a constraint on library sources only, not a
performance target, so running the benchmarks on a current JDK better
reflects real-world performance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)