### PR TITLE
Escape group-by and rollup keys when rendering expressions

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/DataExpr.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/DataExpr.java
@@ -18,6 +18,7 @@ package com.netflix.spectator.atlas.impl;
 import com.netflix.spectator.impl.Preconditions;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -105,6 +106,15 @@ public interface DataExpr {
       aggr.update(p);
     }
     return aggr.result();
+  }
+
+  /**
+   * Escape and comma-join a set of grouping keys for rendering an expression. Keys may
+   * contain special characters such as commas or colons, so each must be escaped to ensure
+   * the rendered string round-trips through {@link Parser}.
+   */
+  static String escapeKeys(Collection<String> keys) {
+    return keys.stream().map(Parser::escape).collect(Collectors.joining(","));
   }
 
   /** Helper for incrementally computing an aggregate of a set of tag values. */
@@ -552,8 +562,7 @@ public interface DataExpr {
     }
 
     @Override public String toString() {
-      final String keyList = String.join(",", keys);
-      return af.toString() + ",(," + keyList + ",),:by";
+      return af.toString() + ",(," + escapeKeys(keys) + ",),:by";
     }
 
     @Override public boolean equals(Object obj) {
@@ -628,8 +637,7 @@ public interface DataExpr {
     }
 
     @Override public String toString() {
-      final String keyList = String.join(",", keys);
-      return af.toString() + ",(," + keyList + ",),:rollup-drop";
+      return af.toString() + ",(," + escapeKeys(keys) + ",),:rollup-drop";
     }
 
     @Override public boolean equals(Object obj) {
@@ -702,8 +710,7 @@ public interface DataExpr {
     }
 
     @Override public String toString() {
-      final String keyList = String.join(",", keys);
-      return af.toString() + ",(," + keyList + ",),:rollup-keep";
+      return af.toString() + ",(," + escapeKeys(keys) + ",),:rollup-keep";
     }
 
     @Override public boolean equals(Object obj) {

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/DataExprTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/DataExprTest.java
@@ -279,6 +279,30 @@ public class DataExprTest {
   }
 
   @Test
+  public void groupByKeyWithEscapeRoundTrips() {
+    // The group-by key contains a comma (escaped on input). Parsing unescapes it, so
+    // toString must re-escape it; otherwise re-parsing would split it into two keys.
+    // The parse helper asserts expr.equals(de.toString()), so this verifies the round-trip.
+    DataExpr.GroupBy expr = (DataExpr.GroupBy) parse("name,sps,:eq,:sum,(,a\\u002cb,),:by");
+    Assertions.assertEquals(Collections.singletonList("a,b"), new ArrayList<>(expr.keys()));
+  }
+
+  @Test
+  public void rollupDropKeyWithEscapeRoundTrips() {
+    // parse() asserts expr.equals(de.toString()), verifying the key round-trips.
+    parse("name,sps,:eq,:sum,(,a\\u002cb,),:rollup-drop");
+  }
+
+  @Test
+  public void rollupKeepKeyWithEscapeIsEscaped() {
+    // KeepRollup stores keys in a HashSet and implicitly adds "name", so a strict
+    // round-trip is not stable. Verify the key needing escaping is rendered escaped
+    // (and so the raw comma is not emitted as a separator).
+    DataExpr expr = Parser.parseDataExpr("name,sps,:eq,:sum,(,a\\u002cb,),:rollup-keep");
+    Assertions.assertTrue(expr.toString().contains("a\\u002cb"), expr.toString());
+  }
+
+  @Test
   public void nestedInClauses() {
     Set<String> values = new TreeSet<>();
     values.add("key");


### PR DESCRIPTION
DataExpr.GroupBy/DropRollup/KeepRollup.toString joined grouping keys with a raw comma, so a key containing a special character (comma, colon, whitespace, or a standalone paren) did not round-trip: re-parsing the rendered expression would split or misinterpret the key. The parser unescapes keys on input, so the render side must re-escape them.

Escape each key via Parser.escape on render, matching Query.In/Query.Equal and the Atlas server (DataExpr.GroupBy.exprString). Factor the shared escape-and-join into DataExpr.escapeKeys.