### PR TITLE
Guard SpectatorAppender against re-entrant append

### DIFF
--- a/spectator-ext-log4j1/src/main/java/com/netflix/spectator/log4j/SpectatorAppender.java
+++ b/spectator-ext-log4j1/src/main/java/com/netflix/spectator/log4j/SpectatorAppender.java
@@ -28,10 +28,9 @@ import org.apache.log4j.spi.ThrowableInformation;
  */
 public final class SpectatorAppender extends AppenderSkeleton {
 
-  // Recording a message can fail inside the registry (see Registry#propagate), which logs a
-  // warning that routes back through the root logger and re-enters this appender on the same
-  // thread. Skip the re-entrant call to avoid an infinite recursion.
-  private static final ThreadLocal<Boolean> APPENDING = ThreadLocal.withInitial(() -> false);
+  // Registry warnings can route through the root logger while this appender is recording.
+  // Drop nested calls on the same thread to avoid appender recursion.
+  private static final ThreadLocal<Boolean> APPENDING = new ThreadLocal<>();
 
   private final Registry registry;
   private final Id[] numMessages;
@@ -59,10 +58,10 @@ public final class SpectatorAppender extends AppenderSkeleton {
   }
 
   @Override protected void append(LoggingEvent event) {
-    if (APPENDING.get()) {
+    if (Boolean.TRUE.equals(APPENDING.get())) {
       return;
     }
-    APPENDING.set(true);
+    APPENDING.set(Boolean.TRUE);
     try {
       final LevelTag level = LevelTag.get(event.getLevel());
       registry.counter(numMessages[level.ordinal()]).increment();
@@ -77,7 +76,8 @@ public final class SpectatorAppender extends AppenderSkeleton {
         registry.counter(stackTraceId).increment();
       }
     } finally {
-      APPENDING.set(false);
+      // Keep the entry to avoid allocating a ThreadLocalMap entry per log event.
+      APPENDING.set(Boolean.FALSE);
     }
   }
 

--- a/spectator-ext-log4j1/src/main/java/com/netflix/spectator/log4j/SpectatorAppender.java
+++ b/spectator-ext-log4j1/src/main/java/com/netflix/spectator/log4j/SpectatorAppender.java
@@ -28,6 +28,11 @@ import org.apache.log4j.spi.ThrowableInformation;
  */
 public final class SpectatorAppender extends AppenderSkeleton {
 
+  // Recording a message can fail inside the registry (see Registry#propagate), which logs a
+  // warning that routes back through the root logger and re-enters this appender on the same
+  // thread. Skip the re-entrant call to avoid an infinite recursion.
+  private static final ThreadLocal<Boolean> APPENDING = ThreadLocal.withInitial(() -> false);
+
   private final Registry registry;
   private final Id[] numMessages;
   private final Id[] numStackTraces;
@@ -54,17 +59,25 @@ public final class SpectatorAppender extends AppenderSkeleton {
   }
 
   @Override protected void append(LoggingEvent event) {
-    final LevelTag level = LevelTag.get(event.getLevel());
-    registry.counter(numMessages[level.ordinal()]).increment();
+    if (APPENDING.get()) {
+      return;
+    }
+    APPENDING.set(true);
+    try {
+      final LevelTag level = LevelTag.get(event.getLevel());
+      registry.counter(numMessages[level.ordinal()]).increment();
 
-    ThrowableInformation info = event.getThrowableInformation();
-    if (info != null) {
-      LocationInfo loc = event.getLocationInformation();
-      final String file = (loc == null) ? "unknown" : loc.getFileName();
-      Id stackTraceId = numStackTraces[level.ordinal()]
-          .withTag("exception", info.getThrowable().getClass().getSimpleName())
-          .withTag("file", file);
-      registry.counter(stackTraceId).increment();
+      ThrowableInformation info = event.getThrowableInformation();
+      if (info != null) {
+        LocationInfo loc = event.getLocationInformation();
+        final String file = (loc == null) ? "unknown" : loc.getFileName();
+        Id stackTraceId = numStackTraces[level.ordinal()]
+            .withTag("exception", info.getThrowable().getClass().getSimpleName())
+            .withTag("file", file);
+        registry.counter(stackTraceId).increment();
+      }
+    } finally {
+      APPENDING.set(false);
     }
   }
 

--- a/spectator-ext-log4j1/src/test/java/com/netflix/spectator/log4j/SpectatorAppenderTest.java
+++ b/spectator-ext-log4j1/src/test/java/com/netflix/spectator/log4j/SpectatorAppenderTest.java
@@ -15,10 +15,17 @@
  */
 package com.netflix.spectator.log4j;
 
+import com.netflix.spectator.api.AbstractRegistry;
+import com.netflix.spectator.api.Clock;
 import com.netflix.spectator.api.Counter;
 import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.DistributionSummary;
+import com.netflix.spectator.api.Gauge;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Meter;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Spectator;
+import com.netflix.spectator.api.Timer;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.apache.log4j.PropertyConfigurator;
@@ -28,6 +35,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 
 public class SpectatorAppenderTest {
 
@@ -73,6 +82,62 @@ public class SpectatorAppenderTest {
     e.fillInStackTrace();
     appender.append(newEvent(Level.DEBUG, e));
     Assertions.assertEquals(1, c.count());
+  }
+
+  @Test
+  public void appendIsNotReentrant() {
+    // The registry can log a warning during a meter lookup (Registry#propagate), which in
+    // production routes back through the root logger and re-enters the appender on the same
+    // thread. Without a re-entrancy guard this recurses until a StackOverflowError.
+    AtomicInteger lookups = new AtomicInteger();
+    SpectatorAppender[] holder = new SpectatorAppender[1];
+    Registry reentrant = new ReentrantRegistry(() -> {
+      lookups.incrementAndGet();
+      holder[0].append(newEvent(Level.ERROR, null));
+    });
+    holder[0] = new SpectatorAppender(reentrant);
+
+    holder[0].append(newEvent(Level.ERROR, null));
+
+    // Only the outer append reaches the registry; the re-entrant append is skipped by the guard.
+    Assertions.assertEquals(1, lookups.get());
+  }
+
+  /** Registry that runs an action on every meter lookup to exercise re-entrant logging. */
+  private static final class ReentrantRegistry extends AbstractRegistry {
+    private final Registry delegate = new DefaultRegistry();
+    private final Runnable onLookup;
+
+    ReentrantRegistry(Runnable onLookup) {
+      super(Clock.SYSTEM);
+      this.onLookup = onLookup;
+    }
+
+    @Override protected <T extends Meter> T getOrCreate(
+        Id id, Class<T> cls, T dflt, Function<Id, T> factory) {
+      onLookup.run();
+      return super.getOrCreate(id, cls, dflt, factory);
+    }
+
+    @Override protected Counter newCounter(Id id) {
+      return delegate.counter(id);
+    }
+
+    @Override protected DistributionSummary newDistributionSummary(Id id) {
+      return delegate.distributionSummary(id);
+    }
+
+    @Override protected Timer newTimer(Id id) {
+      return delegate.timer(id);
+    }
+
+    @Override protected Gauge newGauge(Id id) {
+      return delegate.gauge(id);
+    }
+
+    @Override protected Gauge newMaxGauge(Id id) {
+      return delegate.maxGauge(id);
+    }
   }
 
   @Test

--- a/spectator-ext-log4j1/src/test/java/com/netflix/spectator/log4j/SpectatorAppenderTest.java
+++ b/spectator-ext-log4j1/src/test/java/com/netflix/spectator/log4j/SpectatorAppenderTest.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
 public class SpectatorAppenderTest {
@@ -86,24 +87,22 @@ public class SpectatorAppenderTest {
 
   @Test
   public void appendIsNotReentrant() {
-    // The registry can log a warning during a meter lookup (Registry#propagate), which in
-    // production routes back through the root logger and re-enters the appender on the same
-    // thread. Without a re-entrancy guard this recurses until a StackOverflowError.
     AtomicInteger lookups = new AtomicInteger();
-    SpectatorAppender[] holder = new SpectatorAppender[1];
-    Registry reentrant = new ReentrantRegistry(() -> {
+    AtomicReference<SpectatorAppender> appenderRef = new AtomicReference<>();
+    ReentrantRegistry reentrant = new ReentrantRegistry(() -> {
       lookups.incrementAndGet();
-      holder[0].append(newEvent(Level.ERROR, null));
+      appenderRef.get().append(newEvent(Level.ERROR, null));
     });
-    holder[0] = new SpectatorAppender(reentrant);
+    appenderRef.set(new SpectatorAppender(reentrant));
 
-    holder[0].append(newEvent(Level.ERROR, null));
+    appenderRef.get().append(newEvent(Level.ERROR, null));
+    appenderRef.get().append(newEvent(Level.ERROR, null));
 
-    // Only the outer append reaches the registry; the re-entrant append is skipped by the guard.
-    Assertions.assertEquals(1, lookups.get());
+    Assertions.assertEquals(2, lookups.get(), "each outer append should reach one lookup");
+    Assertions.assertEquals(2, reentrant.count("log4j.numMessages", "loglevel", "2_ERROR"));
   }
 
-  /** Registry that runs an action on every meter lookup to exercise re-entrant logging. */
+  /** Registry that runs an action before each meter lookup. */
   private static final class ReentrantRegistry extends AbstractRegistry {
     private final Registry delegate = new DefaultRegistry();
     private final Runnable onLookup;
@@ -111,6 +110,10 @@ public class SpectatorAppenderTest {
     ReentrantRegistry(Runnable onLookup) {
       super(Clock.SYSTEM);
       this.onLookup = onLookup;
+    }
+
+    double count(String name, String... tags) {
+      return delegate.counter(name, tags).count();
     }
 
     @Override protected <T extends Meter> T getOrCreate(

--- a/spectator-ext-log4j2/src/main/java/com/netflix/spectator/log4j/SpectatorAppender.java
+++ b/spectator-ext-log4j2/src/main/java/com/netflix/spectator/log4j/SpectatorAppender.java
@@ -80,6 +80,12 @@ public final class SpectatorAppender extends AbstractAppender {
 
   private static final long serialVersionUID = 42L;
 
+  // Recording a message can fail inside the registry (see Registry#propagate), which logs a
+  // warning that routes back through the root logger and re-enters this appender on the same
+  // thread. Skip the re-entrant call to avoid log4j2 emitting a "Recursive call to appender"
+  // error to stdout.
+  private static final ThreadLocal<Boolean> APPENDING = ThreadLocal.withInitial(() -> false);
+
   private final transient Registry registry;
   private transient Id[] numMessages;
   private transient Id[] numStackTraces;
@@ -131,14 +137,23 @@ public final class SpectatorAppender extends AbstractAppender {
   }
 
   @Override public void append(LogEvent event) {
-    final LevelTag level = LevelTag.get(event.getLevel());
-    registry.counter(numMessages[level.ordinal()]).increment();
-    if (!ignoreExceptions() && event.getThrown() != null) {
-      final String file = (event.getSource() == null) ? "unknown" : event.getSource().getFileName();
-      Id stackTraceId = numStackTraces[level.ordinal()]
-          .withTag("exception", event.getThrown().getClass().getSimpleName())
-          .withTag("file", file == null ? "unknown" : file);
-      registry.counter(stackTraceId).increment();
+    if (APPENDING.get()) {
+      return;
+    }
+    APPENDING.set(true);
+    try {
+      final LevelTag level = LevelTag.get(event.getLevel());
+      registry.counter(numMessages[level.ordinal()]).increment();
+      if (!ignoreExceptions() && event.getThrown() != null) {
+        final String file =
+            (event.getSource() == null) ? "unknown" : event.getSource().getFileName();
+        Id stackTraceId = numStackTraces[level.ordinal()]
+            .withTag("exception", event.getThrown().getClass().getSimpleName())
+            .withTag("file", file == null ? "unknown" : file);
+        registry.counter(stackTraceId).increment();
+      }
+    } finally {
+      APPENDING.set(false);
     }
   }
 }

--- a/spectator-ext-log4j2/src/main/java/com/netflix/spectator/log4j/SpectatorAppender.java
+++ b/spectator-ext-log4j2/src/main/java/com/netflix/spectator/log4j/SpectatorAppender.java
@@ -80,11 +80,9 @@ public final class SpectatorAppender extends AbstractAppender {
 
   private static final long serialVersionUID = 42L;
 
-  // Recording a message can fail inside the registry (see Registry#propagate), which logs a
-  // warning that routes back through the root logger and re-enters this appender on the same
-  // thread. Skip the re-entrant call to avoid log4j2 emitting a "Recursive call to appender"
-  // error to stdout.
-  private static final ThreadLocal<Boolean> APPENDING = ThreadLocal.withInitial(() -> false);
+  // Registry warnings can route through the root logger while this appender is recording.
+  // Drop nested calls on the same thread to avoid appender recursion.
+  private static final ThreadLocal<Boolean> APPENDING = new ThreadLocal<>();
 
   private final transient Registry registry;
   private transient Id[] numMessages;
@@ -137,10 +135,10 @@ public final class SpectatorAppender extends AbstractAppender {
   }
 
   @Override public void append(LogEvent event) {
-    if (APPENDING.get()) {
+    if (Boolean.TRUE.equals(APPENDING.get())) {
       return;
     }
-    APPENDING.set(true);
+    APPENDING.set(Boolean.TRUE);
     try {
       final LevelTag level = LevelTag.get(event.getLevel());
       registry.counter(numMessages[level.ordinal()]).increment();
@@ -153,7 +151,8 @@ public final class SpectatorAppender extends AbstractAppender {
         registry.counter(stackTraceId).increment();
       }
     } finally {
-      APPENDING.set(false);
+      // Keep the entry to avoid allocating a ThreadLocalMap entry per log event.
+      APPENDING.set(Boolean.FALSE);
     }
   }
 }

--- a/spectator-ext-log4j2/src/test/java/com/netflix/spectator/log4j/SpectatorAppenderTest.java
+++ b/spectator-ext-log4j2/src/test/java/com/netflix/spectator/log4j/SpectatorAppenderTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
 public class SpectatorAppenderTest {
@@ -123,25 +124,25 @@ public class SpectatorAppenderTest {
 
   @Test
   public void appendIsNotReentrant() {
-    // The registry can log a warning during a meter lookup (Registry#propagate), which in
-    // production routes back through the root logger and re-enters the appender on the same
-    // thread. Without a re-entrancy guard this recurses until a StackOverflowError.
     AtomicInteger lookups = new AtomicInteger();
-    SpectatorAppender[] holder = new SpectatorAppender[1];
-    Registry reentrant = new ReentrantRegistry(() -> {
+    AtomicReference<SpectatorAppender> appenderRef = new AtomicReference<>();
+    ReentrantRegistry reentrant = new ReentrantRegistry(() -> {
       lookups.incrementAndGet();
-      holder[0].append(newEvent(Level.ERROR, null));
+      appenderRef.get().append(newEvent(Level.ERROR, null));
     });
-    holder[0] = new SpectatorAppender(reentrant, "foo", null, null, false, Property.EMPTY_ARRAY);
-    holder[0].start();
+    appenderRef.set(new SpectatorAppender(
+        reentrant, "foo", null, null, false, Property.EMPTY_ARRAY));
+    appenderRef.get().start();
 
-    holder[0].append(newEvent(Level.ERROR, null));
+    appenderRef.get().append(newEvent(Level.ERROR, null));
+    appenderRef.get().append(newEvent(Level.ERROR, null));
 
-    // Only the outer append reaches the registry; the re-entrant append is skipped by the guard.
-    Assertions.assertEquals(1, lookups.get());
+    Assertions.assertEquals(2, lookups.get(), "each outer append should reach one lookup");
+    Assertions.assertEquals(2, reentrant.count(
+        "log4j.numMessages", "appender", "foo", "loglevel", "2_ERROR"));
   }
 
-  /** Registry that runs an action on every meter lookup to exercise re-entrant logging. */
+  /** Registry that runs an action before each meter lookup. */
   private static final class ReentrantRegistry extends AbstractRegistry {
     private final Registry delegate = new DefaultRegistry();
     private final Runnable onLookup;
@@ -149,6 +150,10 @@ public class SpectatorAppenderTest {
     ReentrantRegistry(Runnable onLookup) {
       super(Clock.SYSTEM);
       this.onLookup = onLookup;
+    }
+
+    double count(String name, String... tags) {
+      return delegate.counter(name, tags).count();
     }
 
     @Override protected <T extends Meter> T getOrCreate(

--- a/spectator-ext-log4j2/src/test/java/com/netflix/spectator/log4j/SpectatorAppenderTest.java
+++ b/spectator-ext-log4j2/src/test/java/com/netflix/spectator/log4j/SpectatorAppenderTest.java
@@ -15,9 +15,16 @@
  */
 package com.netflix.spectator.log4j;
 
+import com.netflix.spectator.api.AbstractRegistry;
+import com.netflix.spectator.api.Clock;
 import com.netflix.spectator.api.Counter;
 import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.DistributionSummary;
+import com.netflix.spectator.api.Gauge;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Meter;
 import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Timer;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.config.Property;
@@ -25,6 +32,9 @@ import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 
 public class SpectatorAppenderTest {
 
@@ -109,6 +119,63 @@ public class SpectatorAppenderTest {
     Assertions.assertEquals(0, c.count());
     appender.append(newEvent(Level.DEBUG, new IllegalArgumentException("foo")));
     Assertions.assertEquals(0, c.count());
+  }
+
+  @Test
+  public void appendIsNotReentrant() {
+    // The registry can log a warning during a meter lookup (Registry#propagate), which in
+    // production routes back through the root logger and re-enters the appender on the same
+    // thread. Without a re-entrancy guard this recurses until a StackOverflowError.
+    AtomicInteger lookups = new AtomicInteger();
+    SpectatorAppender[] holder = new SpectatorAppender[1];
+    Registry reentrant = new ReentrantRegistry(() -> {
+      lookups.incrementAndGet();
+      holder[0].append(newEvent(Level.ERROR, null));
+    });
+    holder[0] = new SpectatorAppender(reentrant, "foo", null, null, false, Property.EMPTY_ARRAY);
+    holder[0].start();
+
+    holder[0].append(newEvent(Level.ERROR, null));
+
+    // Only the outer append reaches the registry; the re-entrant append is skipped by the guard.
+    Assertions.assertEquals(1, lookups.get());
+  }
+
+  /** Registry that runs an action on every meter lookup to exercise re-entrant logging. */
+  private static final class ReentrantRegistry extends AbstractRegistry {
+    private final Registry delegate = new DefaultRegistry();
+    private final Runnable onLookup;
+
+    ReentrantRegistry(Runnable onLookup) {
+      super(Clock.SYSTEM);
+      this.onLookup = onLookup;
+    }
+
+    @Override protected <T extends Meter> T getOrCreate(
+        Id id, Class<T> cls, T dflt, Function<Id, T> factory) {
+      onLookup.run();
+      return super.getOrCreate(id, cls, dflt, factory);
+    }
+
+    @Override protected Counter newCounter(Id id) {
+      return delegate.counter(id);
+    }
+
+    @Override protected DistributionSummary newDistributionSummary(Id id) {
+      return delegate.distributionSummary(id);
+    }
+
+    @Override protected Timer newTimer(Id id) {
+      return delegate.timer(id);
+    }
+
+    @Override protected Gauge newGauge(Id id) {
+      return delegate.gauge(id);
+    }
+
+    @Override protected Gauge newMaxGauge(Id id) {
+      return delegate.maxGauge(id);
+    }
   }
 
   @Test


### PR DESCRIPTION
## Problem

`SpectatorAppender` (both the log4j1 and log4j2 variants) records a counter
for every log event in `append()`. That recording goes through the registry,
and any failure on the lookup/record path is handled by `Registry#propagate`,
which **logs a warning**:

```java
default void propagate(String msg, Throwable t) {
  LoggerFactory.getLogger(getClass()).warn(msg, t);
  ...
}
```

That warning is dispatched to the root logger, whose appenders include the
`SpectatorAppender` itself, so `append()` is re-entered on the same thread.

- **log4j2:** `AppenderControl` detects the recursion and emits an ERROR-level
  `Recursive call to appender <name>` through the status logger. The status
  logger writes to **stdout** by default, so the message can leak into stdout
  of tools that treat it as a clean data channel (e.g. `spark-sql` results).
- **log4j1:** there is no recursion guard, so the same path can recurse without
  bound.

## Fix

Add a per-thread re-entrancy guard so a nested `append()` on the same thread is
skipped. Applied to both the log4j1 and log4j2 appenders for parity.

## Tests

Each module gets an `appendIsNotReentrant` regression test using a registry that
re-enters the appender during meter lookup (mimicking the `propagate -> warn`
path). The tests fail with `StackOverflowError` without the guard and pass with
it. Verified locally:

```
./gradlew :spectator-ext-log4j2:check :spectator-ext-log4j1:check
```
