### PR TITLE
Short circuit empty other-checks in QueryIndex match path

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/QueryIndex.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/QueryIndex.java
@@ -400,14 +400,17 @@ public final class QueryIndex<T> {
 
   /** Get cached matches for the value or compute a new one. */
   private List<QueryIndex<T>> otherChecksComputeIfAbsent(String value) {
+    // Most nodes only have :eq children and no other checks. Short circuit before touching
+    // the cache so the hot matching path avoids the cache lookup and its associated counter
+    // updates (hit/miss plus per-entry frequency), which otherwise dominate when scanning ids.
+    if (otherChecks.isEmpty()) {
+      return Collections.emptyList();
+    }
     CacheValue<T> cacheValue = otherChecksCache.get(value);
     long version = otherChecksVersion.get();
     if (cacheValue != null && cacheValue.version == version) {
       // Cached value on consistent version of other checks, use the cached value
       return cacheValue.indices;
-    } else if (otherChecks.isEmpty()) {
-      // No other checks, use empty list
-      return Collections.emptyList();
     } else {
       // Compute a new value
       List<QueryIndex<T>> tmp = new ArrayList<>();


### PR DESCRIPTION
QueryIndex.otherChecksComputeIfAbsent did a cache lookup for every tag value at every node visited during matching, before checking whether the node had any non-equality (:re/:in/:gt/...) clauses at all. Most nodes only have :eq children, so this paid a ConcurrentHashMap lookup plus two contended LongAdder increments (cache hit/miss counter and per-entry frequency counter) on the hot path only to fall through to an empty result.

Hoisting the otherChecks.isEmpty() check ahead of the cache lookup short circuits this work for the common case. Behavior is unchanged: when otherChecks is empty the previous code also returned an empty list, since any cached value was computed at an older version and fails the version check. In a CPU profile of the LWC bridge match path this removed most of the ~12% spent in LongAdder weakCompareAndSetRelease and a chunk of the ~25% in ConcurrentHashMap.get.