### PR TITLE
Sample frequency updates in LfuCache

### DIFF
--- a/spectator-api/src/jmh/java/com/netflix/spectator/perf/LfuCacheBench.java
+++ b/spectator-api/src/jmh/java/com/netflix/spectator/perf/LfuCacheBench.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2014-2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.perf;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.netflix.spectator.api.NoopRegistry;
+import com.netflix.spectator.impl.Cache;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Concurrency benchmark for the LFU {@link Cache} under an access pattern modeled on a metric
+ * stream processor (e.g. the LWC bridge): every thread processes a "payload" as a run of
+ * {@code BATCH_SIZE} repeated lookups of one value (within-payload tag affinity) before rotating
+ * to another value drawn from {@code keySpace} distinct values. The {@code get}-then-{@code put}
+ * on a miss mirrors how the query index actually uses the cache.
+ *
+ * <p>This is the scenario where the per-read frequency-counter cost shows up: a very high volume
+ * of hits concentrated on a few hot caches. The two cache types are configured with the same
+ * bound ({@link #CACHE_SIZE}) so the comparison is apples-to-apples, and {@code keySpace} relative
+ * to that bound controls churn:
+ * <ul>
+ *   <li>100   - fits the cache, no eviction: isolates the steady-state read path.</li>
+ *   <li>20000 - exceeds it: entries are created and evicted continuously.</li>
+ * </ul>
+ *
+ * <p>The {@code caffeine} method is included for contrast; its per-cache maintenance lock does not
+ * scale to this concurrency under churn. Runs at {@link Threads#MAX} (all available processors),
+ * since the cost being measured is a concurrency effect. To run only this benchmark set
+ * {@code includes = ['.*LfuCacheBench.*']} in the {@code jmh} block of build.gradle.
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Threads(Threads.MAX)
+@State(Scope.Benchmark)
+public class LfuCacheBench {
+
+  private static final String VALUE = "v";
+  private static final int BATCH_SIZE = 1000;
+  private static final int CACHE_SIZE = 1000;
+
+  @Param({"100", "20000"})
+  public int keySpace;
+
+  private Cache<String, String> lfuCache;
+  private com.github.benmanes.caffeine.cache.Cache<String, String> caffeineCache;
+  private String[] keys;
+
+  @Setup(Level.Trial)
+  public void setup() {
+    lfuCache = Cache.lfu(new NoopRegistry(), "jmh", CACHE_SIZE / 10, CACHE_SIZE);
+    caffeineCache = Caffeine.newBuilder().maximumSize(CACHE_SIZE).build();
+    keys = new String[keySpace];
+    for (int i = 0; i < keySpace; ++i) {
+      keys[i] = "app" + i + "-main-v042";
+    }
+  }
+
+  /** Per-thread cursor tracking the current payload's value and the lookups remaining in it. */
+  @State(Scope.Thread)
+  public static class Cursor {
+    int remaining;
+    String key;
+  }
+
+  private String nextKey(Cursor cursor) {
+    if (cursor.remaining <= 0) {
+      cursor.key = keys[ThreadLocalRandom.current().nextInt(keySpace)];
+      cursor.remaining = BATCH_SIZE;
+    }
+    --cursor.remaining;
+    return cursor.key;
+  }
+
+  @Benchmark
+  public String lfu(Cursor cursor) {
+    String key = nextKey(cursor);
+    String v = lfuCache.get(key);
+    if (v == null) {
+      v = VALUE;
+      lfuCache.put(key, v);
+    }
+    return v;
+  }
+
+  @Benchmark
+  public String caffeine(Cursor cursor) {
+    String key = nextKey(cursor);
+    String v = caffeineCache.getIfPresent(key);
+    if (v == null) {
+      v = VALUE;
+      caffeineCache.put(key, v);
+    }
+    return v;
+  }
+}

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/LfuCache.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/LfuCache.java
@@ -24,8 +24,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.LongAdder;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
@@ -35,6 +36,12 @@ import java.util.stream.Collectors;
  * LFU implementation of {@link Cache}.
  */
 class LfuCache<K, V> implements Cache<K, V> {
+
+  // Frequency counts are sampled to reduce the per-read atomic update cost, which otherwise
+  // dominates CPU for hot caches under high-concurrency access. Must be a power of two so the
+  // mask can select ~1-in-SAMPLE reads.
+  private static final int SAMPLE = 16;
+  private static final int SAMPLE_MASK = SAMPLE - 1;
 
   private final Counter hits;
   private final Counter misses;
@@ -164,15 +171,23 @@ class LfuCache<K, V> implements Cache<K, V> {
 
   private static class Pair<V> {
     private final V value;
-    private final LongAdder count;
+    private final AtomicLong count;
 
     Pair(V value) {
       this.value = value;
-      this.count = new LongAdder();
+      this.count = new AtomicLong();
     }
 
     V get() {
-      count.increment();
+      // Sample the frequency update rather than incrementing on every read. Updating ~1-in-SAMPLE
+      // reads and adding SAMPLE keeps the accumulated value an unbiased estimate of the access
+      // count, cutting the per-read atomic traffic that dominates CPU on hot caches by roughly a
+      // factor of SAMPLE. Eviction ordering is preserved for hot entries, where the estimate is
+      // precise; lightly accessed entries may still read as zero, which is acceptable since a
+      // wrong eviction only forces a recompute, never an incorrect result.
+      if ((ThreadLocalRandom.current().nextInt() & SAMPLE_MASK) == 0) {
+        count.addAndGet(SAMPLE);
+      }
       return value;
     }
 
@@ -181,7 +196,7 @@ class LfuCache<K, V> implements Cache<K, V> {
     }
 
     long snapshot() {
-      return count.sum();
+      return count.get();
     }
   }
 

--- a/spectator-api/src/test/java/com/netflix/spectator/impl/LfuCacheTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/LfuCacheTest.java
@@ -108,12 +108,18 @@ public class LfuCacheTest {
   public void computeIfAbsentCompaction() {
     Cache<String, String> cache = create(1, 2);
     Assertions.assertEquals("A", cache.computeIfAbsent("a", String::toUpperCase));
-    Assertions.assertEquals("B", cache.computeIfAbsent("b", String::toUpperCase));
-    Assertions.assertEquals("B", cache.computeIfAbsent("b", String::toUpperCase));
+
+    // Frequency is sampled, so a single extra access is not reliably recorded. Access "b" enough
+    // times that its (approximate) count overwhelmingly exceeds "a" and it survives compaction.
+    // The chance that none of these accesses are sampled is ~(15/16)^n, negligible for large n.
+    int frequentAccesses = 1000;
+    for (int i = 0; i < frequentAccesses; ++i) {
+      Assertions.assertEquals("B", cache.computeIfAbsent("b", String::toUpperCase));
+    }
     Assertions.assertEquals(2, cache.size());
 
     Assertions.assertEquals("C", cache.computeIfAbsent("c", String::toUpperCase));
-    Assertions.assertEquals(1, hits());
+    Assertions.assertEquals(frequentAccesses - 1, hits());
     Assertions.assertEquals(3, misses());
     Assertions.assertEquals(1, compactions());
     Assertions.assertEquals(1, cache.size());


### PR DESCRIPTION
The LFU cache incremented a per-entry counter on every read to drive eviction. On hot caches under high-concurrency access (e.g. the LWC bridge matching every datapoint against the query index), that per-read atomic update is a major CPU cost: profiling attributed ~12% of CPU to it, and it is paid on the ~99.8% of accesses that hit.

Sample the update instead: touch the counter on ~1-in-16 reads, adding 16 each time. The accumulated value stays an unbiased estimate of the access count, so eviction ordering is preserved for hot entries, while the atomic traffic is cut by roughly 16x. Switch the counter from LongAdder to AtomicLong, which is cheaper and smaller now that the contention LongAdder was striping for has been sampled away.

Add a JMH benchmark (LfuCacheBench) covering the concurrent batch-affinity access pattern, comparing against Caffeine.