### PR TITLE
Clean up PolledMeter and registry resources on close

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/AbstractRegistry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/AbstractRegistry.java
@@ -343,12 +343,46 @@ public abstract class AbstractRegistry implements Registry {
   }
 
   /**
+   * Release resources associated with the registry, stopping any background work and clearing
+   * the meters. This closes any {@link AutoCloseable} values stored in the {@link #state()} map,
+   * for example the background polling tasks created by
+   * {@link com.netflix.spectator.api.patterns.PolledMeter}. The registry does not need to know
+   * about the helpers that registered the state; anything that needs cleanup just implements
+   * {@link AutoCloseable}.
+   *
+   * <p>Safe to call more than once.</p>
+   */
+  @Override public void close() {
+    closeState();
+  }
+
+  /**
    * This can be called be sub-classes to reset all state for the registry. Typically this
    * should only be exposed for test registries as most users should not be able to reset the
    * state and interrupt metrics collection for the overall system.
    */
   protected void reset() {
-    meters.clear();
+    closeState();
+  }
+
+  /**
+   * Close any {@link AutoCloseable} state values, then clear the state and meter maps. Exceptions
+   * thrown while closing an individual entry are caught and logged so the remaining entries are
+   * still processed. Called by both {@link #close()} and {@link #reset()}; kept private so a
+   * {@code reset()} cannot trigger a sub-class override of {@code close()}.
+   */
+  private void closeState() {
+    for (Map.Entry<Id, Object> entry : state.entrySet()) {
+      Object obj = entry.getValue();
+      if (obj instanceof AutoCloseable) {
+        try {
+          ((AutoCloseable) obj).close();
+        } catch (Exception e) {
+          logger.warn("exception thrown while closing registry state for [{}]", entry.getKey(), e);
+        }
+      }
+    }
     state.clear();
+    meters.clear();
   }
 }

--- a/spectator-api/src/main/java/com/netflix/spectator/api/ExtendedRegistry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/ExtendedRegistry.java
@@ -63,6 +63,10 @@ public final class ExtendedRegistry implements Registry {
     return impl.state();
   }
 
+  @Override public void close() {
+    impl.close();
+  }
+
   @Override public Counter counter(Id id) {
     return impl.counter(id);
   }

--- a/spectator-api/src/main/java/com/netflix/spectator/api/Registry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/Registry.java
@@ -31,12 +31,24 @@ import java.util.stream.StreamSupport;
 /**
  * Registry to manage a set of meters.
  */
-public interface Registry extends Iterable<Meter> {
+public interface Registry extends Iterable<Meter>, AutoCloseable {
 
   /**
    * The clock used by the registry for timing events.
    */
   Clock clock();
+
+  /**
+   * Release any resources associated with the registry. This allows a registry to be used with
+   * try-with-resources and is most useful for registries that are created for temporary use.
+   *
+   * <p>The default implementation does nothing, so existing registries are unaffected.
+   * Implementations that maintain background work, such as the polling tasks created by
+   * {@link com.netflix.spectator.api.patterns.PolledMeter}, should override this to stop that
+   * work.</p>
+   */
+  @Override default void close() {
+  }
 
   /**
    * Configuration settings used for this registry.

--- a/spectator-api/src/main/java/com/netflix/spectator/api/patterns/PolledMeter.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/patterns/PolledMeter.java
@@ -34,9 +34,14 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Delayed;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.DoubleSupplier;
 import java.util.function.LongSupplier;
 import java.util.function.ToDoubleFunction;
@@ -84,6 +89,10 @@ import java.util.function.ToLongFunction;
 public final class PolledMeter {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(PolledMeter.class);
+
+  // Used to generate unique ids for tracking raw poll tasks in the registry state so that they
+  // can be cancelled by removeAll(Registry).
+  private static final AtomicLong POLL_TASK_SEQ = new AtomicLong();
 
   private PolledMeter() {
   }
@@ -134,6 +143,38 @@ public final class PolledMeter {
   }
 
   /**
+   * Stop polling and remove all polled meters that have been registered with the registry,
+   * running any cleanup actions configured via {@link Builder#withCleanupAction(AutoCloseable)}.
+   * This also cancels any tasks scheduled via {@link #poll(Registry, Runnable)}.
+   *
+   * <p>This is intended for tearing down a registry that is used temporarily. The background
+   * polling tasks would otherwise keep running, and because each scheduled task holds a
+   * reference to the registry, they can also prevent the registry from being garbage collected.
+   * A typical usage is:</p>
+   *
+   * <pre>
+   *   Registry registry = new DefaultRegistry();
+   *   try {
+   *     // ... register polled meters and do work ...
+   *   } finally {
+   *     PolledMeter.removeAll(registry);
+   *   }
+   * </pre>
+   *
+   * <p>Only polled meters are affected. Other entries stored in the registry state are left
+   * in place.</p>
+   */
+  public static void removeAll(Registry registry) {
+    Iterator<Map.Entry<Id, Object>> iter = registry.state().entrySet().iterator();
+    while (iter.hasNext()) {
+      Map.Entry<Id, Object> entry = iter.next();
+      if (entry.getValue() instanceof AbstractMeterState) {
+        ((AbstractMeterState) entry.getValue()).cleanup(registry);
+      }
+    }
+  }
+
+  /**
    * Poll by executing {@code f.accept(registry)} using the default thread pool for polling
    * gauges at the default frequency configured for the registry. If more customization is
    * needed, then it can be done by using a {@code ScheduledExecutorService} directly and
@@ -143,6 +184,10 @@ public final class PolledMeter {
    * <p>The provided function must be thread safe and cheap to execute. Expensive operations,
    * including any IO or network calls, should not be performed inline. Assume that the function
    * will be called frequently and may be called concurrently.
+   *
+   * <p>The task is tracked with the registry so that it can be cancelled along with the polled
+   * meters by {@link #removeAll(Registry)}. It can also be stopped individually by cancelling
+   * the returned future; doing so removes the associated bookkeeping from the registry.</p>
    *
    * @param registry
    *     Registry that will maintain the state and receive the sampled values for the
@@ -157,7 +202,17 @@ public final class PolledMeter {
     // with the function
     f.run();
     long delay = registry.config().gaugePollingFrequency().toMillis();
-    return GaugePoller.schedule(delay, f);
+    ScheduledFuture<?> future = GaugePoller.schedule(delay, f);
+
+    // Track the task in the registry state so removeAll(registry) can cancel it. A unique
+    // synthetic id is used for each call; these entries are internal bookkeeping and are never
+    // reported as meters.
+    Id id = registry.createId("spectator.gauge.pollTask")
+        .withTag("seq", Long.toString(POLL_TASK_SEQ.getAndIncrement()));
+    PollState state = new PollState(id);
+    state.setFuture(future);
+    registry.state().put(id, state);
+    return new PollFuture(registry, id, future);
   }
 
   /**
@@ -169,6 +224,7 @@ public final class PolledMeter {
     private final Id baseId;
     private ScheduledExecutorService executor;
     private long delay;
+    private AutoCloseable cleanupAction;
 
     /** Create a new instance. */
     Builder(Registry registry, Id baseId) {
@@ -176,6 +232,28 @@ public final class PolledMeter {
       this.registry = registry;
       this.baseId = baseId;
       this.delay = registry.config().gaugePollingFrequency().toMillis();
+    }
+
+    /**
+     * Register an action to run when the meter is removed or otherwise cleaned up. This is
+     * intended for releasing resources whose lifecycle should match the meter, for example a
+     * custom executor created for use with {@link #scheduleOn(ScheduledExecutorService)} or
+     * some other {@link AutoCloseable} associated with the polled value.
+     *
+     * <p>The action runs whenever the meter is cleaned up: explicitly via
+     * {@link PolledMeter#remove(Registry, Id)} or {@link PolledMeter#removeAll(Registry)}, or
+     * automatically when the monitored object has been garbage collected and polling stops.
+     * Exceptions thrown by the action are caught and logged. If multiple values are monitored
+     * with the same id, then each registered action will be run.</p>
+     *
+     * @param action
+     *     Resource to close when the meter is cleaned up.
+     * @return
+     *     This builder instance to allow chaining of operations.
+     */
+    public Builder withCleanupAction(AutoCloseable action) {
+      this.cleanupAction = action;
+      return this;
     }
 
     /**
@@ -271,6 +349,9 @@ public final class PolledMeter {
       } else {
         ValueState<T> t = (ValueState<T>) c;
         t.add(obj, f);
+        if (cleanupAction != null) {
+          t.addCleanupAction(cleanupAction);
+        }
         t.schedule(registry, executor, delay);
       }
 
@@ -415,6 +496,9 @@ public final class PolledMeter {
       } else {
         CounterState<T> t = (CounterState<T>) c;
         t.add(obj, f);
+        if (cleanupAction != null) {
+          t.addCleanupAction(cleanupAction);
+        }
         t.schedule(registry, executor, delay);
       }
 
@@ -506,8 +590,12 @@ public final class PolledMeter {
   }
 
   /** Base class for meter state used for bookkeeping. */
-  abstract static class AbstractMeterState {
-    private Future<?> future = null;
+  abstract static class AbstractMeterState implements AutoCloseable {
+    // Volatile: written by schedule()/setFuture() after the state is published into the
+    // registry map, and read by close()/cleanup() which may run on a different thread.
+    private volatile Future<?> future = null;
+    private final ConcurrentLinkedQueue<AutoCloseable> cleanupActions =
+        new ConcurrentLinkedQueue<>();
 
     /** Return the id for the meter. */
     protected abstract Id id();
@@ -518,12 +606,39 @@ public final class PolledMeter {
     /** Sample the meter and send updates to the registry. */
     protected abstract void update(Registry registry);
 
-    /** Cleanup any state associated with this meter and stop polling. */
-    void cleanup(Registry registry) {
+    /** Register an action to run when this meter is cleaned up. */
+    void addCleanupAction(AutoCloseable action) {
+      cleanupActions.add(action);
+    }
+
+    /** Set the future for a task that was scheduled outside of {@link #schedule}. */
+    void setFuture(Future<?> f) {
+      this.future = f;
+    }
+
+    /**
+     * Stop polling and run any registered cleanup actions. This is the registry-independent
+     * part of teardown so it can be invoked generically when the registry is closed. Safe to
+     * call multiple times; the cleanup actions are drained so each runs at most once.
+     */
+    @Override public void close() {
       if (future != null) {
         future.cancel(true);
       }
+      AutoCloseable action;
+      while ((action = cleanupActions.poll()) != null) {
+        try {
+          action.close();
+        } catch (Exception e) {
+          LOGGER.warn("exception thrown by cleanup action for [{}]", id(), e);
+        }
+      }
+    }
+
+    /** Cleanup any state associated with this meter and stop polling. */
+    void cleanup(Registry registry) {
       registry.state().remove(id());
+      close();
     }
 
     /**
@@ -553,6 +668,33 @@ public final class PolledMeter {
           future = GaugePoller.schedule(executor, tupleRef, delay, t -> t.doUpdate(registry));
         }
       }
+    }
+  }
+
+  /**
+   * Bookkeeping for a raw task scheduled via {@link #poll(Registry, Runnable)}. The task runs
+   * the user function directly on the executor, so there is nothing to update here; this state
+   * exists only so the future can be cancelled by {@link #removeAll(Registry)}.
+   */
+  static final class PollState extends AbstractMeterState {
+    private final Id id;
+
+    /** Create a new instance. */
+    PollState(Id id) {
+      super();
+      this.id = id;
+    }
+
+    @Override protected Id id() {
+      return id;
+    }
+
+    @Override protected boolean hasExpired() {
+      return false;
+    }
+
+    @Override protected void update(Registry registry) {
+      // The scheduled task runs the user function directly; nothing to do here.
     }
   }
 
@@ -749,6 +891,68 @@ public final class PolledMeter {
         }
         previous = current;
       }
+    }
+  }
+
+  /**
+   * Wraps the future returned by {@link #poll(Registry, Runnable)} so that cancelling it also
+   * removes the bookkeeping entry from the registry state, keeping the two cleanup paths
+   * (explicit cancel and {@link #removeAll(Registry)}) consistent.
+   */
+  private static final class PollFuture implements ScheduledFuture<Object> {
+    private final Registry registry;
+    private final Id id;
+    private final ScheduledFuture<?> delegate;
+
+    PollFuture(Registry registry, Id id, ScheduledFuture<?> delegate) {
+      this.registry = registry;
+      this.id = id;
+      this.delegate = delegate;
+    }
+
+    @Override public boolean cancel(boolean mayInterruptIfRunning) {
+      boolean result = delegate.cancel(mayInterruptIfRunning);
+      registry.state().remove(id);
+      return result;
+    }
+
+    @Override public boolean isCancelled() {
+      return delegate.isCancelled();
+    }
+
+    @Override public boolean isDone() {
+      return delegate.isDone();
+    }
+
+    @Override public Object get() throws InterruptedException, ExecutionException {
+      return delegate.get();
+    }
+
+    @Override public Object get(long timeout, TimeUnit unit)
+        throws InterruptedException, ExecutionException, TimeoutException {
+      return delegate.get(timeout, unit);
+    }
+
+    @Override public long getDelay(TimeUnit unit) {
+      return delegate.getDelay(unit);
+    }
+
+    @Override public int compareTo(Delayed o) {
+      return delegate.compareTo(o);
+    }
+
+    @Override public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof PollFuture)) {
+        return false;
+      }
+      return delegate.equals(((PollFuture) o).delegate);
+    }
+
+    @Override public int hashCode() {
+      return delegate.hashCode();
     }
   }
 }

--- a/spectator-api/src/test/java/com/netflix/spectator/api/patterns/PolledMeterTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/patterns/PolledMeterTest.java
@@ -270,4 +270,216 @@ public class PolledMeterTest {
     PolledMeter.update(r);
     Assertions.assertEquals(0.0, r.gauge(id).value());
   }
+
+  @Test
+  public void removeAllClearsPolledState() {
+    Registry r = new DefaultRegistry();
+
+    PolledMeter.using(r).withName("gauge").monitorValue(new AtomicLong(1));
+    PolledMeter.using(r).withName("counter").monitorMonotonicCounter(new AtomicLong(1));
+    Assertions.assertFalse(r.state().isEmpty());
+
+    PolledMeter.removeAll(r);
+    Assertions.assertTrue(r.state().isEmpty());
+  }
+
+  @Test
+  public void removeAllLeavesNonPolledStateUntouched() {
+    Registry r = new DefaultRegistry();
+
+    // State entries that are not polled meters must be left alone.
+    Id marker = r.createId("marker");
+    r.state().put(marker, new Object());
+
+    Id gauge = r.createId("gauge");
+    PolledMeter.using(r).withId(gauge).monitorValue(new AtomicLong(1));
+
+    PolledMeter.removeAll(r);
+    Assertions.assertFalse(r.state().containsKey(gauge));
+    Assertions.assertTrue(r.state().containsKey(marker));
+  }
+
+  @Test
+  public void cleanupActionRunsOnRemove() {
+    Registry r = new DefaultRegistry();
+    Id id = r.createId("test");
+    AtomicLong closed = new AtomicLong();
+
+    PolledMeter.using(r).withId(id)
+        .withCleanupAction(closed::incrementAndGet)
+        .monitorValue(new AtomicLong(1));
+
+    Assertions.assertEquals(0, closed.get());
+    PolledMeter.remove(r, id);
+    Assertions.assertEquals(1, closed.get());
+  }
+
+  @Test
+  public void cleanupActionRunsOnRemoveAll() {
+    Registry r = new DefaultRegistry();
+    AtomicLong closed = new AtomicLong();
+
+    // Exercise the monotonic-counter path so the action is threaded through CounterState too.
+    PolledMeter.using(r).withName("test")
+        .withCleanupAction(closed::incrementAndGet)
+        .monitorMonotonicCounter(new AtomicLong(1));
+
+    PolledMeter.removeAll(r);
+    Assertions.assertEquals(1, closed.get());
+  }
+
+  @Test
+  public void cleanupActionExceptionDoesNotPropagate() {
+    Registry r = new DefaultRegistry();
+    Id id = r.createId("test");
+
+    PolledMeter.using(r).withId(id)
+        .withCleanupAction(() -> {
+          throw new IllegalStateException("boom");
+        })
+        .monitorValue(new AtomicLong(1));
+
+    // Must not throw, and the meter state should still be cleared.
+    PolledMeter.remove(r, id);
+    Assertions.assertTrue(r.state().isEmpty());
+  }
+
+  @Test
+  public void multipleCleanupActionsForSameId() {
+    Registry r = new DefaultRegistry();
+    Id id = r.createId("test");
+    AtomicLong closed = new AtomicLong();
+
+    PolledMeter.using(r).withId(id)
+        .withCleanupAction(closed::incrementAndGet)
+        .monitorValue(new AtomicLong(1));
+    PolledMeter.using(r).withId(id)
+        .withCleanupAction(closed::incrementAndGet)
+        .monitorValue(new AtomicLong(2));
+
+    PolledMeter.remove(r, id);
+    Assertions.assertEquals(2, closed.get());
+  }
+
+  @Test
+  public void registryCloseCancelsPolledMetersAndPollTasks() {
+    Registry r = new DefaultRegistry();
+    AtomicLong closed = new AtomicLong();
+
+    PolledMeter.using(r).withName("gauge")
+        .withCleanupAction(closed::incrementAndGet)
+        .monitorValue(new AtomicLong(1));
+    ScheduledFuture<?> poll = PolledMeter.poll(r, () -> { });
+    Assertions.assertFalse(r.state().isEmpty());
+
+    r.close();
+
+    Assertions.assertTrue(r.state().isEmpty());
+    Assertions.assertTrue(poll.isCancelled());
+    Assertions.assertEquals(1, closed.get());
+  }
+
+  @Test
+  public void registryCloseViaTryWithResources() {
+    AtomicLong closed = new AtomicLong();
+    try (Registry r = new DefaultRegistry()) {
+      PolledMeter.using(r).withName("gauge")
+          .withCleanupAction(closed::incrementAndGet)
+          .monitorValue(new AtomicLong(1));
+    }
+    Assertions.assertEquals(1, closed.get());
+  }
+
+  @Test
+  public void registryCloseIsIdempotent() {
+    Registry r = new DefaultRegistry();
+    AtomicLong closed = new AtomicLong();
+
+    PolledMeter.using(r).withName("gauge")
+        .withCleanupAction(closed::incrementAndGet)
+        .monitorValue(new AtomicLong(1));
+
+    r.close();
+    r.close();
+    Assertions.assertEquals(1, closed.get());
+  }
+
+  @Test
+  public void registryCloseClearsMeters() {
+    Registry r = new DefaultRegistry();
+    PolledMeter.using(r).withName("gauge").monitorValue(new AtomicLong(1));
+    Assertions.assertTrue(r.iterator().hasNext());
+
+    r.close();
+    Assertions.assertFalse(r.iterator().hasNext());
+    Assertions.assertTrue(r.state().isEmpty());
+  }
+
+  @Test
+  public void cleanupActionExceptionDoesNotPropagateOnClose() {
+    Registry r = new DefaultRegistry();
+    PolledMeter.using(r).withName("gauge")
+        .withCleanupAction(() -> {
+          throw new IllegalStateException("boom");
+        })
+        .monitorValue(new AtomicLong(1));
+
+    // close() must not propagate the exception and must still clear state.
+    r.close();
+    Assertions.assertTrue(r.state().isEmpty());
+  }
+
+  @Test
+  public void resetCancelsPolledMeters() {
+    DefaultRegistry r = new DefaultRegistry();
+    AtomicLong closed = new AtomicLong();
+
+    PolledMeter.using(r).withName("gauge")
+        .withCleanupAction(closed::incrementAndGet)
+        .monitorValue(new AtomicLong(1));
+
+    r.reset();
+    Assertions.assertEquals(1, closed.get());
+    Assertions.assertTrue(r.state().isEmpty());
+  }
+
+  @Test
+  public void removeAllCancelsPollTask() {
+    Registry r = new DefaultRegistry();
+
+    ScheduledFuture<?> future = PolledMeter.poll(r, () -> { });
+    Assertions.assertFalse(future.isCancelled());
+    Assertions.assertFalse(r.state().isEmpty());
+
+    PolledMeter.removeAll(r);
+    Assertions.assertTrue(future.isCancelled());
+    Assertions.assertTrue(r.state().isEmpty());
+  }
+
+  @Test
+  public void pollFutureCancelRemovesState() {
+    Registry r = new DefaultRegistry();
+
+    ScheduledFuture<?> future = PolledMeter.poll(r, () -> { });
+    Assertions.assertFalse(r.state().isEmpty());
+
+    future.cancel(true);
+    Assertions.assertTrue(future.isCancelled());
+    Assertions.assertTrue(r.state().isEmpty());
+  }
+
+  @Test
+  public void cleanupActionRunsAtMostOnce() {
+    Registry r = new DefaultRegistry();
+    Id id = r.createId("test");
+    AtomicLong closed = new AtomicLong();
+
+    PolledMeter.using(r).withId(id)
+        .withCleanupAction(closed::incrementAndGet)
+        .monitorValue(new AtomicLong(1));
+
+    PolledMeter.remove(r, id);
+    PolledMeter.removeAll(r);
+    Assertions.assertEquals(1, closed.get());
+  }
 }

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
@@ -54,7 +54,7 @@ import java.util.stream.StreamSupport;
 /**
  * Registry for reporting metrics to Atlas.
  */
-public final class AtlasRegistry extends AbstractRegistry implements AutoCloseable {
+public final class AtlasRegistry extends AbstractRegistry {
 
   private static final String PUBLISH_TASK_TIMER = "spectator.atlas.publishTaskTime";
 

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
@@ -226,12 +226,17 @@ public final class AtlasRegistry extends AbstractRegistry implements AutoCloseab
   }
 
   /**
-   * Stop the scheduler reporting Atlas data. This is the same as calling {@link #stop()} and
-   * is included to allow the registry to be stopped correctly when used with DI frameworks that
-   * support lifecycle management.
+   * Stop the scheduler reporting Atlas data and release the registry resources. This calls
+   * {@link #stop()} to flush and shut down the publishing scheduler and is included to allow
+   * the registry to be stopped correctly when used with DI frameworks that support lifecycle
+   * management. In addition to {@link #stop()}, it releases any remaining registry state such
+   * as {@code PolledMeter} background tasks.
    */
   @Override public void close() {
+    // Flush and shutdown the publishing scheduler first, then let the base registry release
+    // any remaining state such as PolledMeter background tasks.
     stop();
+    super.close();
   }
 
   /** Returns the timestamp of the last completed interval for the specified step size. */

--- a/spectator-reg-micrometer/src/main/java/com/netflix/spectator/micrometer/MicrometerRegistry.java
+++ b/spectator-reg-micrometer/src/main/java/com/netflix/spectator/micrometer/MicrometerRegistry.java
@@ -29,10 +29,13 @@ import com.netflix.spectator.impl.AtomicDouble;
 import com.netflix.spectator.impl.StepDouble;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.search.MeterNotFoundException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -42,6 +45,8 @@ import java.util.stream.Collectors;
  * Wraps a Micrometer MeterRegistry to make it conform to the Spectator API.
  */
 public final class MicrometerRegistry implements Registry {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(MicrometerRegistry.class);
 
   private final MeterRegistry impl;
   private final Clock clock;
@@ -107,6 +112,23 @@ public final class MicrometerRegistry implements Registry {
 
   @Override public ConcurrentMap<Id, Object> state() {
     return state;
+  }
+
+  @Override public void close() {
+    // Release any AutoCloseable state (e.g. PolledMeter background tasks), then close the
+    // wrapped Micrometer registry.
+    for (Map.Entry<Id, Object> entry : state.entrySet()) {
+      Object obj = entry.getValue();
+      if (obj instanceof AutoCloseable) {
+        try {
+          ((AutoCloseable) obj).close();
+        } catch (Exception e) {
+          LOGGER.warn("exception thrown while closing registry state for [{}]", entry.getKey(), e);
+        }
+      }
+    }
+    state.clear();
+    impl.close();
   }
 
   @Override public Counter counter(Id id) {

--- a/spectator-reg-sidecar/src/main/java/com/netflix/spectator/sidecar/SidecarRegistry.java
+++ b/spectator-reg-sidecar/src/main/java/com/netflix/spectator/sidecar/SidecarRegistry.java
@@ -26,11 +26,14 @@ import com.netflix.spectator.api.Tag;
 import com.netflix.spectator.api.TagList;
 import com.netflix.spectator.api.Timer;
 import com.netflix.spectator.api.patterns.PolledMeter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -39,6 +42,8 @@ import java.util.concurrent.ConcurrentMap;
  * SpectatorD</a>.
  */
 public final class SidecarRegistry implements Registry, Closeable {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SidecarRegistry.class);
 
   private final Clock clock;
   private final TagList commonTags;
@@ -60,11 +65,27 @@ public final class SidecarRegistry implements Registry, Closeable {
   }
 
   /**
-   * Stop the scheduler reporting data.
+   * Stop the scheduler reporting data and release associated resources. Closes any
+   * {@link AutoCloseable} state values, such as {@link PolledMeter} background tasks, before
+   * clearing the state and closing the writer.
    */
-  @Override public void close() throws IOException {
-    writer.close();
+  @Override public void close() {
+    for (Map.Entry<Id, Object> entry : state.entrySet()) {
+      Object obj = entry.getValue();
+      if (obj instanceof AutoCloseable) {
+        try {
+          ((AutoCloseable) obj).close();
+        } catch (Exception e) {
+          LOGGER.warn("exception thrown while closing registry state for [{}]", entry.getKey(), e);
+        }
+      }
+    }
     state.clear();
+    try {
+      writer.close();
+    } catch (IOException e) {
+      LOGGER.warn("failed to close sidecar writer", e);
+    }
   }
 
   @Override


### PR DESCRIPTION
Make it possible to release the background work associated with a registry, which is important for registries created for temporary use.

PolledMeter:
- Add PolledMeter.removeAll(registry) to stop and remove all polled meters registered with a registry.
- Add Builder.withCleanupAction(AutoCloseable) so resources whose lifecycle should match a meter (e.g. a custom executor) are released when the meter is cleaned up.
- Track tasks scheduled via poll(Registry, Runnable) in the registry state so they are cancelled by removeAll/close; the returned future is wrapped so cancelling it directly also drops the bookkeeping. The return type stays ScheduledFuture for backwards compatibility.
- AbstractMeterState now implements AutoCloseable; close() cancels polling and runs cleanup actions, cleanup() also removes the state entry. The future field is volatile for safe cross-thread cancellation.

Registry:
- Registry now extends AutoCloseable with a no-op default close(), so it can be used with try-with-resources without casting and without affecting existing implementations.
- AbstractRegistry.close()/reset() release resources by closing any AutoCloseable values in the state map (e.g. PolledMeter tasks) and clearing the state and meter maps, without needing to know about the helpers built on top of the registry.
- ExtendedRegistry and MicrometerRegistry delegate close() to the wrapped registry; AtlasRegistry and SidecarRegistry release polled-meter state in addition to their existing shutdown. SidecarRegistry.close() no longer declares throws IOException.