### PR TITLE
Tie JFR and GC logging to registry lifecycle 

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/patterns/PolledMeter.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/patterns/PolledMeter.java
@@ -209,10 +209,38 @@ public final class PolledMeter {
     // reported as meters.
     Id id = registry.createId("spectator.gauge.pollTask")
         .withTag("seq", Long.toString(POLL_TASK_SEQ.getAndIncrement()));
-    PollState state = new PollState(id);
+    BackgroundState state = new BackgroundState(id);
     state.setFuture(future);
     registry.state().put(id, state);
     return new PollFuture(registry, id, future);
+  }
+
+  /**
+   * Register an {@link AutoCloseable} resource that performs background work for the registry
+   * and updates meters on its own, for example a Java Flight Recorder event stream that runs on
+   * its own thread. This is for background activity that manages its own scheduling rather than
+   * relying on {@link #poll(Registry, Runnable)}.
+   *
+   * <p>The resource is tied to the registry lifecycle: it will be closed when
+   * {@link #removeAll(Registry)} is called or the registry is closed, alongside the polled
+   * meters. Exceptions thrown by {@code close()} are caught and logged.</p>
+   *
+   * @param registry
+   *     Registry that the resource is associated with.
+   * @param resource
+   *     Resource to close when the registry is torn down.
+   * @return
+   *     Handle that can be used to stop earlier: closing it runs the cleanup and removes the
+   *     registry bookkeeping. Closing the handle is idempotent and is also harmless if the
+   *     registry has already been closed.
+   */
+  public static AutoCloseable monitorResource(Registry registry, AutoCloseable resource) {
+    Id id = registry.createId("spectator.gauge.resource")
+        .withTag("seq", Long.toString(POLL_TASK_SEQ.getAndIncrement()));
+    BackgroundState state = new BackgroundState(id);
+    state.addCleanupAction(resource);
+    registry.state().put(id, state);
+    return () -> state.cleanup(registry);
   }
 
   /**
@@ -672,15 +700,17 @@ public final class PolledMeter {
   }
 
   /**
-   * Bookkeeping for a raw task scheduled via {@link #poll(Registry, Runnable)}. The task runs
-   * the user function directly on the executor, so there is nothing to update here; this state
-   * exists only so the future can be cancelled by {@link #removeAll(Registry)}.
+   * Bookkeeping for background work that is associated with a registry but manages its own
+   * execution, such as a task scheduled via {@link #poll(Registry, Runnable)} or a resource
+   * registered via {@link #monitorResource(Registry, AutoCloseable)}. There is no value to
+   * sample here; the entry exists only so the work can be stopped (future cancelled and/or
+   * cleanup actions run) by {@link #removeAll(Registry)} or when the registry is closed.
    */
-  static final class PollState extends AbstractMeterState {
+  static final class BackgroundState extends AbstractMeterState {
     private final Id id;
 
     /** Create a new instance. */
-    PollState(Id id) {
+    BackgroundState(Id id) {
       super();
       this.id = id;
     }
@@ -694,7 +724,7 @@ public final class PolledMeter {
     }
 
     @Override protected void update(Registry registry) {
-      // The scheduled task runs the user function directly; nothing to do here.
+      // The background work runs on its own; nothing to sample here.
     }
   }
 

--- a/spectator-api/src/test/java/com/netflix/spectator/api/patterns/PolledMeterTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/patterns/PolledMeterTest.java
@@ -444,6 +444,51 @@ public class PolledMeterTest {
   }
 
   @Test
+  public void monitorResourceClosedByRemoveAll() {
+    Registry r = new DefaultRegistry();
+    AtomicLong closed = new AtomicLong();
+
+    PolledMeter.monitorResource(r, closed::incrementAndGet);
+    Assertions.assertFalse(r.state().isEmpty());
+
+    PolledMeter.removeAll(r);
+    Assertions.assertEquals(1, closed.get());
+    Assertions.assertTrue(r.state().isEmpty());
+  }
+
+  @Test
+  public void monitorResourceClosedByRegistryClose() {
+    Registry r = new DefaultRegistry();
+    AtomicLong closed = new AtomicLong();
+
+    PolledMeter.monitorResource(r, closed::incrementAndGet);
+    r.close();
+    Assertions.assertEquals(1, closed.get());
+  }
+
+  @Test
+  public void monitorResourceHandleClosesResource() throws Exception {
+    Registry r = new DefaultRegistry();
+    AtomicLong closed = new AtomicLong();
+
+    AutoCloseable handle = PolledMeter.monitorResource(r, closed::incrementAndGet);
+    handle.close();
+    Assertions.assertEquals(1, closed.get());
+    Assertions.assertTrue(r.state().isEmpty());
+  }
+
+  @Test
+  public void monitorResourceHandleCloseIsIdempotent() throws Exception {
+    Registry r = new DefaultRegistry();
+    AtomicLong closed = new AtomicLong();
+
+    AutoCloseable handle = PolledMeter.monitorResource(r, closed::incrementAndGet);
+    handle.close();
+    handle.close();
+    Assertions.assertEquals(1, closed.get());
+  }
+
+  @Test
   public void removeAllCancelsPollTask() {
     Registry r = new DefaultRegistry();
 

--- a/spectator-ext-gc/src/main/java/com/netflix/spectator/gc/GcLogger.java
+++ b/spectator-ext-gc/src/main/java/com/netflix/spectator/gc/GcLogger.java
@@ -20,6 +20,7 @@ import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Spectator;
 import com.netflix.spectator.api.Timer;
+import com.netflix.spectator.api.patterns.PolledMeter;
 import com.netflix.spectator.impl.Preconditions;
 import com.sun.management.GarbageCollectionNotificationInfo;
 import com.sun.management.GcInfo;
@@ -153,6 +154,24 @@ public final class GcLogger {
         oldGenPoolName = poolName;
       }
     }
+  }
+
+  /**
+   * Start collecting GC events for the provided registry and tie the collection to the registry
+   * lifecycle: closing the registry (or calling {@link PolledMeter#removeAll(Registry)}) will
+   * stop the logger. This is a convenience for the common case of monitoring GC for a registry
+   * without managing the {@link #start(GcEventListener)} / {@link #stop()} lifecycle by hand.
+   *
+   * @param registry
+   *     Registry used to report the GC metrics and whose lifecycle controls the logger.
+   * @return
+   *     Handle that can be used to stop the logger earlier; closing it stops collection. Closing
+   *     the handle is idempotent and is harmless if the registry has already been closed.
+   */
+  public static AutoCloseable monitor(Registry registry) {
+    GcLogger logger = new GcLogger(registry);
+    logger.start(null);
+    return PolledMeter.monitorResource(registry, logger::stop);
   }
 
   /**

--- a/spectator-ext-gc/src/test/java/com/netflix/spectator/gc/GcLoggerTest.java
+++ b/spectator-ext-gc/src/test/java/com/netflix/spectator/gc/GcLoggerTest.java
@@ -138,4 +138,33 @@ public class GcLoggerTest {
       logger.stop();
     }
   }
+
+  @Test
+  public void monitorTiesLifecycleToRegistry() {
+    Registry r = new DefaultRegistry();
+    AutoCloseable handle = GcLogger.monitor(r);
+    Assertions.assertNotNull(handle);
+    // monitor() starts the logger and registers a cleanup resource with the registry.
+    Assertions.assertFalse(r.state().isEmpty());
+
+    // Closing the registry stops the logger and clears the registry state.
+    r.close();
+    Assertions.assertTrue(r.state().isEmpty());
+  }
+
+  @Test
+  public void monitorHandleStopsLogger() throws Exception {
+    Registry r = new DefaultRegistry();
+    AutoCloseable handle = GcLogger.monitor(r);
+    int before = r.state().size();
+
+    // Closing the handle stops collection and removes the logger's cleanup resource. The gauge
+    // bookkeeping for the metrics remains until the registry itself is closed.
+    handle.close();
+    Assertions.assertEquals(before - 1, r.state().size());
+
+    // Closing again is a no-op and must not throw.
+    handle.close();
+    Assertions.assertEquals(before - 1, r.state().size());
+  }
 }

--- a/spectator-ext-jvm/src/main/java/com/netflix/spectator/jvm/Jmx.java
+++ b/spectator-ext-jvm/src/main/java/com/netflix/spectator/jvm/Jmx.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
 import java.lang.management.*;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -50,12 +50,21 @@ public final class Jmx {
    */
   public static void registerStandardMXBeans(Registry registry) {
     if (JavaFlightRecorder.isSupported()) {
-      Executor executor = Executors.newSingleThreadExecutor(r -> {
+      ExecutorService executor = Executors.newSingleThreadExecutor(r -> {
         Thread t = new Thread(r, "spectator-jfr");
         t.setDaemon(true);
         return t;
       });
-      JavaFlightRecorder.monitorDefaultEvents(registry, executor);
+      AutoCloseable recordingStream = JavaFlightRecorder.monitorDefaultEvents(registry, executor);
+      // Tie the recording stream and its executor to the registry lifecycle so they are
+      // released when the registry is closed.
+      PolledMeter.monitorResource(registry, () -> {
+        try {
+          recordingStream.close();
+        } finally {
+          executor.shutdownNow();
+        }
+      });
     } else {
       monitorClassLoadingMXBean(registry);
       monitorThreadMXBean(registry);

--- a/spectator-ext-jvm/src/test/java17/com/netflix/spectator/jvm/JavaFlightRecorderTest.java
+++ b/spectator-ext-jvm/src/test/java17/com/netflix/spectator/jvm/JavaFlightRecorderTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.function.BooleanSupplier;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -77,6 +78,36 @@ public class JavaFlightRecorderTest {
     assertEquals(7, daemonThreadCount.value());
     assertNotEquals(null, threadsStarted);
     assertEquals(12, threadsStarted.value());
+  }
+
+  @Test
+  public void registryCloseStopsJfrRecording() throws Exception {
+    Registry registry = new DefaultRegistry();
+    Jmx.registerStandardMXBeans(registry);
+
+    // The flight recorder stream runs on a dedicated "spectator-jfr" executor thread.
+    assertTrue(waitFor(JavaFlightRecorderTest::jfrThreadRunning),
+        "spectator-jfr thread should be running after registration");
+
+    // Closing the registry should close the recording stream and shut down the executor,
+    // releasing the resources that were previously leaked.
+    registry.close();
+
+    assertTrue(waitFor(() -> !jfrThreadRunning()),
+        "spectator-jfr thread should stop after registry.close()");
+    assertTrue(registry.state().isEmpty(), "registry state should be cleared after close");
+  }
+
+  private static boolean jfrThreadRunning() {
+    return Thread.getAllStackTraces().keySet().stream()
+        .anyMatch(t -> "spectator-jfr".equals(t.getName()) && t.isAlive());
+  }
+
+  private static boolean waitFor(BooleanSupplier condition) throws InterruptedException {
+    for (int i = 0; i < 50 && !condition.getAsBoolean(); ++i) {
+      Thread.sleep(100);
+    }
+    return condition.getAsBoolean();
   }
 
 }


### PR DESCRIPTION
Jmx.registerStandardMXBeans discarded the AutoCloseable returned by
JavaFlightRecorder.monitorDefaultEvents and never shut down the spectator-jfr
executor, so the recording stream and its thread leaked for the life of the
JVM.

Add PolledMeter.monitorResource(registry, AutoCloseable) for background work
that manages its own scheduling (like a flight recorder stream) rather than
using PolledMeter.poll. The resource is tracked in the registry the same way
as polled meters, so it is closed by removeAll or when the registry is closed.
It returns an AutoCloseable handle (mirroring how poll() returns a future) so
callers can stop earlier; closing the handle is idempotent and is harmless if
the registry was already closed. The internal PollState bookkeeping is
generalized to BackgroundState since it now backs both poll tasks and
registered resources. Jmx uses this to tie the recording stream and its
executor to the registry lifecycle instead of manipulating the state directly.

Add GcLogger.monitor(registry) as a convenience that creates a logger for the
registry, starts it, and registers stop() as a cleanup resource, so closing
the registry (or PolledMeter.removeAll) stops collection. start()/stop() are
unchanged; because the cleanup is drained, stop() runs exactly once.

Adds tests covering monitorResource cleanup, the GcLogger handle, and a JDK17
test asserting registry.close() stops the spectator-jfr thread and clears the
registry state.