### PR TITLE
Throw IllegalArgumentException for unsupported regex features

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/Parser.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/Parser.java
@@ -40,7 +40,7 @@ class Parser {
     return PatternUtils.error(message, tokens, current);
   }
 
-  private UnsupportedOperationException unsupported(String message) {
+  private IllegalArgumentException unsupported(String message) {
     return PatternUtils.unsupported(message, tokens, current);
   }
 

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/PatternUtils.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/PatternUtils.java
@@ -75,11 +75,14 @@ public final class PatternUtils {
   }
 
   /**
-   * Create an UnsupportedOperationException with a message including context based
-   * on the position.
+   * Create an IllegalArgumentException for a regex feature that is not supported by this
+   * matcher, with a message including context based on the position. This is an illegal
+   * argument rather than an unsupported operation: the pattern is the problem, not the
+   * compile operation. The message is prefixed with {@code unsupported:} to distinguish it
+   * from a malformed pattern.
    */
-  static UnsupportedOperationException unsupported(String message, String str, int pos) {
-    return new UnsupportedOperationException(message + "\n" + context(str, pos));
+  static IllegalArgumentException unsupported(String message, String str, int pos) {
+    return new IllegalArgumentException("unsupported: " + message + "\n" + context(str, pos));
   }
 
   @SuppressWarnings("PMD.PreserveStackTrace")

--- a/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/AbstractPatternMatcherTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/AbstractPatternMatcherTest.java
@@ -52,7 +52,10 @@ public abstract class AbstractPatternMatcherTest {
   }
 
   private void testUnsupported(String regex, String message) {
-    intercept(UnsupportedOperationException.class, message, () -> PatternMatcher.compile(regex));
+    // Unsupported regex features are reported as IllegalArgumentException (the pattern is the
+    // problem) with the message prefixed by "unsupported:".
+    intercept(IllegalArgumentException.class, "unsupported: " + message,
+        () -> PatternMatcher.compile(regex));
   }
 
   @Test
@@ -348,13 +351,13 @@ public abstract class AbstractPatternMatcherTest {
 
   @Test
   public void controlEscape() {
-    Assertions.assertThrows(UnsupportedOperationException.class,
+    Assertions.assertThrows(IllegalArgumentException.class,
         () -> PatternMatcher.compile("\\cM"));
   }
 
   @Test
   public void inlineFlags() {
-    Assertions.assertThrows(UnsupportedOperationException.class,
+    Assertions.assertThrows(IllegalArgumentException.class,
         () -> PatternMatcher.compile("(?u)abc"));
   }
 


### PR DESCRIPTION
PatternMatcher.compile threw UnsupportedOperationException when a pattern used a regex feature the matcher does not implement (control characters, back references, inline flags, horizontal/vertical whitespace classes). That is really an invalid argument for this matcher, not an unsupported operation on the object, and it is inconsistent with the malformed-pattern cases which already throw IllegalArgumentException. Callers handling a bad user-supplied pattern then had to catch two different exception types.

Report these as IllegalArgumentException, prefixing the message with "unsupported:" so the distinction from a malformed pattern is preserved in the message.