### PR TITLE
Escape backslash beginning a unicode escape

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Parser.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/Parser.java
@@ -267,6 +267,24 @@ public final class Parser {
     zeroPad(Integer.toHexString(codePoint), builder);
   }
 
+  private static boolean isHexDigit(char c) {
+    return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+  }
+
+  /**
+   * Returns true if the backslash at position {@code i} begins a {@code \\uXXXX} escape
+   * sequence, i.e. it is followed by a {@code u} and four hex digits. Used so that a value
+   * literally containing such a sequence can be escaped and round-trip through {@link #unescape}.
+   */
+  private static boolean beginsUnicodeEscape(String str, int i) {
+    return str.length() - i > 5
+        && str.charAt(i + 1) == 'u'
+        && isHexDigit(str.charAt(i + 2))
+        && isHexDigit(str.charAt(i + 3))
+        && isHexDigit(str.charAt(i + 4))
+        && isHexDigit(str.charAt(i + 5));
+  }
+
   /**
    * Escape special characters in the input string to unicode escape sequences (uXXXX).
    */
@@ -286,7 +304,10 @@ public final class Parser {
     for (int i = 0; i < length;) {
       final int cp = str.codePointAt(i);
       final int len = Character.charCount(cp);
-      if (isSpecial(cp))
+      // Escape special characters, and also a backslash that begins a unicode escape sequence
+      // so that a value literally containing "\\uXXXX" is not decoded back into a different
+      // character by unescape().
+      if (isSpecial(cp) || (cp == '\\' && beginsUnicodeEscape(str, i)))
         escapeCodePoint(cp, builder);
       else
         builder.appendCodePoint(cp);
@@ -311,25 +332,14 @@ public final class Parser {
     StringBuilder builder = new StringBuilder(length);
     for (int i = 0; i < length; ++i) {
       final char c = str.charAt(i);
-      if (c == '\\') {
-        // Ensure there is enough space for an encoded character, there must be at
-        // least 5 characters left in the string (uXXXX).
-        if (length - i <= 5) {
-          builder.append(str.substring(i));
-          i = length;
-        } else if (str.charAt(i + 1) == 'u') {
-          try {
-            int cp = Integer.parseInt(str.substring(i + 2, i + 6), 16);
-            builder.appendCodePoint(cp);
-            i += 5;
-          } catch (NumberFormatException e) {
-            builder.append(c);
-          }
-        } else {
-          // Some other escape, copy into buffer and move on
-          builder.append(c);
-        }
+      if (c == '\\' && beginsUnicodeEscape(str, i)) {
+        // beginsUnicodeEscape has verified there are four hex digits, so the parse cannot fail.
+        int cp = Integer.parseInt(str.substring(i + 2, i + 6), 16);
+        builder.appendCodePoint(cp);
+        i += 5;
       } else {
+        // Not a complete unicode escape (incomplete, non-hex, or some other escape such as
+        // "\\d"); copy the character through unchanged.
         builder.append(c);
       }
     }

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/ParserTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/ParserTest.java
@@ -69,4 +69,76 @@ public class ParserTest {
     String str = "foo\\uzyff";
     Assertions.assertEquals(str, Parser.unescape(str));
   }
+
+  private void assertRoundTrip(String value) {
+    Assertions.assertEquals(value, Parser.unescape(Parser.escape(value)));
+  }
+
+  @Test
+  public void escapeBackslashBeginningUnicodeEscape() {
+    // A value literally containing "\\u002c" must have its backslash escaped so unescape does
+    // not decode it back into a comma. Cover the escape both mid-string and at the end.
+    Assertions.assertEquals("a\\u005cu002cb", Parser.escape("a\\u002cb"));
+    Assertions.assertEquals("x\\u005cu002c", Parser.escape("x\\u002c"));
+    assertRoundTrip("a\\u002cb");
+    assertRoundTrip("\\u002c");
+  }
+
+  @Test
+  public void escapeBackslashNotBeginningUnicodeEscape() {
+    // Backslashes that do not begin a unicode escape are left readable (e.g. regex-style "\\d").
+    Assertions.assertEquals("\\d", Parser.escape("\\d"));
+    assertRoundTrip("\\d");
+    assertRoundTrip("C:\\users\\foo");
+  }
+
+  @Test
+  public void escapeBackslashAdjacentToSpecialChar() {
+    // A literal backslash immediately before a character that escape() renders as a \\uXXXX
+    // sequence (here the comma -> \\u002c) must stay a literal backslash and round-trip; it
+    // must not be merged with the following escape when unescaping.
+    Assertions.assertEquals("\\\\u002c", Parser.escape("\\,"));
+    assertRoundTrip("\\,");
+  }
+
+  @Test
+  public void escapeIncompleteUnicodeEscape() {
+    // Trailing or non-hex sequences are not unicode escapes: escape() leaves them unchanged
+    // (so this also pins the length boundary, e.g. "\\u002" has too few chars) and they
+    // round-trip.
+    for (String v : new String[] {"foo\\u", "foo\\u00", "foo\\u002", "foo\\uzzzz"}) {
+      Assertions.assertEquals(v, Parser.escape(v));
+      assertRoundTrip(v);
+    }
+  }
+
+  @Test
+  public void escapeRoundTripSpecialChars() {
+    assertRoundTrip("a,b");
+    assertRoundTrip("a:b");
+    assertRoundTrip("a b");
+    assertRoundTrip("(");
+    assertRoundTrip(")");
+  }
+
+  @Test
+  public void escapeSupplementaryCodePoint() {
+    // Characters above the BMP are not special, so escape() passes them through unchanged
+    // (they are never routed through escapeCodePoint) and they round-trip via unescape. This
+    // is why the surrogate-pair handling needed in the Atlas Strings escaper is not required
+    // here.
+    String emoji = "a😀b"; // U+1F600
+    Assertions.assertEquals(emoji, Parser.escape(emoji));
+    assertRoundTrip(emoji);
+    // Adjacent to a special character that does get escaped.
+    assertRoundTrip("a😀,b");
+  }
+
+  @Test
+  public void unescapeSupplementaryCodePoint() {
+    // An above-BMP character encoded as a surrogate pair of \\uXXXX escapes (the form produced
+    // by the Atlas Strings escaper) must unescape back to the original code point.
+    Assertions.assertEquals("😀", Parser.unescape("\\ud83d\\ude00")); // U+1F600
+    Assertions.assertEquals("a😀b", Parser.unescape("a\\ud83d\\ude00b"));
+  }
 }


### PR DESCRIPTION
Parser.escape only escaped the structural special characters (comma, colon, whitespace), so a key or value that literally contained the text "\uXXXX" passed through unchanged and was then decoded by unescape into a different character, breaking the escape/unescape round-trip (e.g. "a,b" became "a,b").

Mirror the Atlas server fix (Interpreter): add a beginsUnicodeEscape helper and escape a backslash that begins a "\uXXXX" sequence so it round-trips, while leaving other backslashes (such as "\d") readable. unescape is refactored to use the same predicate, removing the parse try/catch.

Adds round-trip tests for literal unicode escapes, regex-style backslashes, incomplete/non-hex sequences, and special characters. Also covers above-BMP code points: they are passed through by escape (never special) and a surrogate-pair "\uXXXX\uXXXX" escape in the input unescapes back to the original code point.