### PR TITLE
Add DistinctCountSketch pattern

### DIFF
--- a/spectator-api/src/jmh/java/com/netflix/spectator/perf/DistinctCountSketches.java
+++ b/spectator-api/src/jmh/java/com/netflix/spectator/perf/DistinctCountSketches.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2014-2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.perf;
+
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.patterns.DistinctCountSketch;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Hot path cost of recording into a {@link DistinctCountSketch} relative to a plain counter.
+ * The {@code record} overloads measure the hash plus register update (the per-observation
+ * cost); the {@code get} variant additionally pays the cache lookup that a call site avoids
+ * by holding onto the sketch instance.
+ *
+ * <p>The recorded values are fixed so the benchmark isolates the recording cost rather than
+ * the allocation of the input. The {@code long} and {@code byte[]} overloads are allocation
+ * free; the {@code CharSequence} overload routes through {@link com.netflix.spectator.impl.Hash64}
+ * which is non-allocating for short strings (see {@code IdHash} for the string hashing
+ * numbers).</p>
+ */
+@State(Scope.Thread)
+public class DistinctCountSketches {
+
+  private final Registry registry = new DefaultRegistry();
+
+  private final Counter counterCached = registry.counter("default-cached");
+
+  private final DistinctCountSketch sketchCached =
+      DistinctCountSketch.get(registry, registry.createId("sketch-cached"));
+
+  private final Id sketchId = registry.createId("sketch");
+
+  private final long longValue = 0x0123456789ABCDEFL;
+
+  // Short ASCII id, the common string key case (user id, ip, session id).
+  private final String stringValue = "i-0123456789abcdef";
+
+  private final byte[] bytesValue = "i-0123456789abcdef".getBytes(StandardCharsets.UTF_8);
+
+  @Threads(1)
+  @Benchmark
+  public void counterReuse() {
+    counterCached.increment();
+  }
+
+  @Threads(1)
+  @Benchmark
+  public void sketchRecordLongReuse() {
+    sketchCached.record(longValue);
+  }
+
+  @Threads(1)
+  @Benchmark
+  public void sketchRecordStringReuse() {
+    sketchCached.record(stringValue);
+  }
+
+  @Threads(1)
+  @Benchmark
+  public void sketchRecordBytesReuse() {
+    sketchCached.record(bytesValue);
+  }
+
+  @Threads(1)
+  @Benchmark
+  public void sketchRecordLongGet() {
+    DistinctCountSketch.get(registry, sketchId).record(longValue);
+  }
+}

--- a/spectator-api/src/main/java/com/netflix/spectator/api/Statistic.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/Statistic.java
@@ -44,7 +44,10 @@ public enum Statistic implements Tag {
   duration,
 
   /** Value used to compute a distributed percentile estimate. */
-  percentile;
+  percentile,
+
+  /** Register value used to compute a distributed distinct count estimate. */
+  distinct;
 
   @Override public String key() {
     return "statistic";

--- a/spectator-api/src/main/java/com/netflix/spectator/api/patterns/DistinctCountSketch.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/patterns/DistinctCountSketch.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright 2014-2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.api.patterns;
+
+import com.netflix.spectator.api.BasicTag;
+import com.netflix.spectator.api.Gauge;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.Meter;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Statistic;
+import com.netflix.spectator.impl.Hash64;
+
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+
+/**
+ * Estimates the number of distinct values seen during a step interval, for example the
+ * number of unique users, device ids, or source ips. It is backed by a
+ * <a href="https://en.wikipedia.org/wiki/HyperLogLog">HyperLogLog</a> sketch that is
+ * decomposed into a fixed set of per-register max-gauges so that:
+ *
+ * <ul>
+ *   <li>recording a value is a constant time, allocation-free operation,</li>
+ *   <li>sketches from many instances/nodes/regions merge correctly via the normal
+ *   aggregation path (the per-register union is a max),</li>
+ *   <li>the cardinality estimate is computed at query time on the backend, and</li>
+ *   <li>results can still be sliced and diced by any other dimension on the {@link Id}.</li>
+ * </ul>
+ *
+ * <p>The result is an <b>estimate</b>, not an exact count. With the fixed register count
+ * used here the relative standard error is approximately 13%. This is generally good
+ * enough for "how many distinct things this interval" style questions at a fixed and
+ * predictable publishing cost, independent of the true cardinality (whether it is 10 or
+ * 10 million).</p>
+ *
+ * <p><b>Distinct count sketches are more expensive than a plain counter.</b> Each instance
+ * publishes a fixed number of gauges (64). Be diligent about any additional dimensions
+ * added to a sketch and ensure they have a small bounded cardinality, the same way you
+ * would for a percentile timer.</p>
+ */
+public final class DistinctCountSketch implements Meter {
+
+  /**
+   * Number of HLL registers. This is a fixed global constant: a {@code distinct=R##} tag
+   * must mean the same partition of the hash space everywhere or sketches from different
+   * sources cannot be merged from the tag alone. There is deliberately no precision knob.
+   * Exposed so that consumers reconstructing the sketch (such as the backend estimator) can
+   * size the register array consistently.
+   */
+  public static final int REGISTERS = 64;
+
+  /** Number of low bits of the hash used to select the register ({@code log2(REGISTERS)}). */
+  private static final int INDEX_BITS = 6;
+
+  /** Mask to extract the register index from the low bits of the hash. */
+  private static final int INDEX_MASK = REGISTERS - 1;
+
+  // Precomputed register tag values (R00..R3F). This avoids repeated String.format calls,
+  // which use regex internally to parse the format string, when creating the gauges.
+  private static final String[] TAG_VALUES;
+
+  static {
+    TAG_VALUES = new String[REGISTERS];
+    for (int i = 0; i < REGISTERS; ++i) {
+      TAG_VALUES[i] = String.format("R%02X", i);
+    }
+  }
+
+  /**
+   * Only create a new instance of the sketch if there is not a cached copy. The array for
+   * keeping track of the gauge per register is large enough to lead to a high allocation
+   * rate if the sketch is not reused at a high volume call site.
+   */
+  private static DistinctCountSketch computeIfAbsent(Registry registry, Id id) {
+    Object sketch = registry.state().get(id);
+    if (sketch == null) {
+      DistinctCountSketch newSketch = new DistinctCountSketch(registry, id);
+      sketch = registry.state().putIfAbsent(id, newSketch);
+      if (sketch == null) {
+        return newSketch;
+      }
+    }
+    return (sketch instanceof DistinctCountSketch)
+        ? (DistinctCountSketch) sketch
+        : new DistinctCountSketch(registry, id);
+  }
+
+  /**
+   * Creates a sketch that can be used for estimating the number of distinct values.
+   * <b>Distinct count sketches are more expensive than a plain counter.</b> Be diligent
+   * about ensuring that any additional dimensions have a small bounded cardinality.
+   *
+   * @param registry
+   *     Registry to use.
+   * @param id
+   *     Identifier for the metric being registered.
+   * @return
+   *     Sketch that keeps track of the registers used to estimate the distinct count.
+   */
+  public static DistinctCountSketch get(Registry registry, Id id) {
+    return computeIfAbsent(registry, id);
+  }
+
+  /**
+   * Return a builder for configuring and retrieving an instance of a distinct count sketch.
+   * If the sketch has dynamic dimensions, then the builder can be used with the new
+   * dimensions. If the id is the same as an existing sketch, then it will update the same
+   * underlying registers in the registry.
+   */
+  public static IdBuilder<Builder> builder(Registry registry) {
+    return new IdBuilder<Builder>(registry) {
+      @Override protected Builder createTypeBuilder(Id id) {
+        return new Builder(registry, id);
+      }
+    };
+  }
+
+  /**
+   * Helper for getting instances of a DistinctCountSketch.
+   */
+  public static final class Builder extends TagsBuilder<Builder> {
+
+    private final Registry registry;
+    private final Id baseId;
+
+    /** Create a new instance. */
+    Builder(Registry registry, Id baseId) {
+      super();
+      this.registry = registry;
+      this.baseId = baseId;
+    }
+
+    /**
+     * Create or get an instance of the distinct count sketch with the specified settings.
+     */
+    public DistinctCountSketch build() {
+      final Id id = baseId.withTags(extraTags);
+      return computeIfAbsent(registry, id);
+    }
+  }
+
+  private final Registry registry;
+  private final Id id;
+  private final AtomicReferenceArray<Gauge> registers;
+
+  /** Create a new instance. */
+  private DistinctCountSketch(Registry registry, Id id) {
+    this.registry = registry;
+    this.id = id;
+    this.registers = new AtomicReferenceArray<>(REGISTERS);
+  }
+
+  /** Identifier for the sketch. */
+  @Override public Id id() {
+    return id;
+  }
+
+  /**
+   * The sketch publishes its data as the per-register max-gauges, so it has no measurements
+   * of its own. This is only implemented so the registry can reclaim the cached sketch from
+   * its state once the backing registers have expired (see {@link #hasExpired()}).
+   */
+  @Override public Iterable<Measurement> measure() {
+    return Collections.emptyList();
+  }
+
+  /**
+   * Returns true once every register that has been created has expired (and so the cached
+   * sketch can be dropped from the registry state). A register is created lazily on first
+   * use, so a sketch is considered expired until something is recorded into it.
+   *
+   * <p>This is only called by the registry's periodic state cleanup, not on the recording
+   * hot path, so the scan over the registers is inexpensive. It cannot delegate to a single
+   * representative register because registers expire independently: a register that receives
+   * no value for a while can expire while the sketch is still actively recording into others,
+   * so all created registers must be expired before the sketch is reclaimed.</p>
+   */
+  @Override public boolean hasExpired() {
+    for (int i = 0; i < REGISTERS; ++i) {
+      Gauge g = registers.get(i);
+      if (g != null && !g.hasExpired()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  // Lazily load the gauge for a given register. This avoids the allocation for creating the
+  // id and the map lookup after the first time a given register is accessed for a sketch.
+  private Gauge registerFor(int i) {
+    Gauge g = registers.get(i);
+    if (g == null) {
+      Id registerId = id.withTags(Statistic.distinct, new BasicTag("distinct", TAG_VALUES[i]));
+      g = registry.maxGauge(registerId);
+      registers.set(i, g);
+    }
+    return g;
+  }
+
+  // Split the hash into a register index (low INDEX_BITS bits) and rho, the position of the
+  // leftmost one bit in the remaining bits (1 + the leading-zero run). The register keeps
+  // the max rho seen this step, which is exactly the HLL register value and merges across
+  // sources by taking the max.
+  private void update(long hash) {
+    final int idx = (int) (hash & INDEX_MASK);
+    // numberOfLeadingZeros counts the INDEX_BITS bits shifted off the top as zeros, so
+    // subtract them back out; the all-zero remainder yields the maximum rho.
+    final int rho = Long.numberOfLeadingZeros(hash >>> INDEX_BITS) - INDEX_BITS + 1;
+    registerFor(idx).set(rho);
+  }
+
+  /** Record a distinct {@code long} value, such as a numeric id. */
+  public void record(long value) {
+    update(Hash64.hashLong(value));
+  }
+
+  /** Record a distinct string value, such as a string id or ip address. */
+  public void record(CharSequence value) {
+    update(Hash64.hashString(value));
+  }
+
+  /** Record a distinct value from its raw bytes. */
+  public void record(byte[] value) {
+    update(Hash64.hashBytes(value));
+  }
+
+  /**
+   * Estimate the number of distinct values recorded into this sketch on the local node.
+   *
+   * <p>This only reflects what was recorded into this instance. The fleet-wide distinct
+   * count is computed on the backend, which merges the registers across all sources (by
+   * taking the per-register max) before applying the same estimator. The result is an
+   * approximation with a relative standard error of roughly {@code 1.04/sqrt(REGISTERS)}.</p>
+   */
+  public double cardinality() {
+    double[] rho = new double[REGISTERS];
+    for (int i = 0; i < REGISTERS; ++i) {
+      Gauge g = registers.get(i);
+      double v = (g == null) ? 0.0 : g.value();
+      rho[i] = Double.isNaN(v) ? 0.0 : v;
+    }
+    return cardinality(rho);
+  }
+
+  /**
+   * Estimate the number of distinct values from the per-register values of a merged sketch.
+   * The input holds the register value (the max rho, or {@code 0} for an unset register) for
+   * each of the {@code m} registers; it may be any length, with a relative standard error of
+   * roughly {@code 1.04/sqrt(m)}.
+   *
+   * <p>This is the estimator applied at query time on the backend, after the registers have
+   * been merged across the requested space and time aggregation. It is exposed here so that
+   * the client and the backend share a single implementation. It uses the standard
+   * HyperLogLog estimator with linear counting for the small cardinality range.</p>
+   *
+   * @param registers
+   *     Per-register max rho values for the merged sketch.
+   * @return
+   *     Estimated number of distinct values.
+   */
+  public static double cardinality(double[] registers) {
+    final int m = registers.length;
+    if (m == 0) {
+      return 0.0;
+    }
+    // Bias correction constant; for m >= 128 this is the standard 0.7213 / (1 + 1.079/m),
+    // which also gives the commonly cited ~0.709 for the 64 register case used here.
+    final double alpha = 0.7213 / (1.0 + 1.079 / m);
+    double sum = 0.0;
+    int zeros = 0;
+    for (int i = 0; i < m; ++i) {
+      sum += Math.pow(2.0, -registers[i]);
+      if (registers[i] == 0.0) {
+        ++zeros;
+      }
+    }
+    double estimate = alpha * m * m / sum;
+    if (estimate <= 2.5 * m && zeros != 0) {
+      // Small range: linear counting gives a better estimate when registers are still empty.
+      return m * Math.log((double) m / zeros);
+    }
+    return estimate;
+  }
+}

--- a/spectator-api/src/test/java/com/netflix/spectator/api/patterns/DistinctCountSketchTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/patterns/DistinctCountSketchTest.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright 2014-2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.api.patterns;
+
+import com.netflix.spectator.api.BasicTag;
+import com.netflix.spectator.api.Clock;
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.ExpiringRegistry;
+import com.netflix.spectator.api.Gauge;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.ManualClock;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Statistic;
+import com.netflix.spectator.api.Utils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+public class DistinctCountSketchTest {
+
+  private static final int REGISTERS = DistinctCountSketch.REGISTERS;
+
+  private Registry newRegistry() {
+    return new DefaultRegistry(Clock.SYSTEM, k -> null);
+  }
+
+  // Read the current value (max rho) for each register, mapping the unset NaN to 0.
+  private double[] readRegisters(Registry r, Id baseId) {
+    double[] regs = new double[REGISTERS];
+    for (int i = 0; i < REGISTERS; ++i) {
+      Id rid = baseId.withTags(Statistic.distinct, new BasicTag("distinct", String.format("R%02X", i)));
+      Gauge g = r.maxGauge(rid);
+      double v = g.value();
+      regs[i] = Double.isNaN(v) ? 0.0 : v;
+    }
+    return regs;
+  }
+
+  @Test
+  public void id() {
+    Registry r = newRegistry();
+    Id id = r.createId("test");
+    DistinctCountSketch sketch = DistinctCountSketch.get(r, id);
+    Assertions.assertEquals(id, sketch.id());
+  }
+
+  @Test
+  public void expiration() {
+    ManualClock clock = new ManualClock();
+    ExpiringRegistry r = new ExpiringRegistry(clock);
+    DistinctCountSketch sketch = DistinctCountSketch.get(r, r.createId("test"));
+
+    // A sketch with no registers yet has nothing to keep it alive, so it is reclaimable.
+    Assertions.assertTrue(sketch.hasExpired());
+
+    sketch.record(42L);
+    Assertions.assertFalse(sketch.hasExpired());
+
+    // Once the backing register gauge expires, the sketch expires and is dropped from the
+    // registry state by the cleanup sweep.
+    clock.setWallTime(1);
+    Assertions.assertTrue(sketch.hasExpired());
+    r.removeExpiredMeters();
+    Assertions.assertNull(r.state().get(sketch.id()));
+
+    // Recording again revives the self-healing register gauge and the sketch.
+    sketch.record(42L);
+    Assertions.assertFalse(sketch.hasExpired());
+  }
+
+  @Test
+  public void getCachesInstance() {
+    Registry r = newRegistry();
+    Id id = r.createId("test");
+    DistinctCountSketch s1 = DistinctCountSketch.get(r, id);
+    DistinctCountSketch s2 = DistinctCountSketch.get(r, id);
+    Assertions.assertSame(s1, s2);
+  }
+
+  @Test
+  public void builderAppliesTags() {
+    Registry r = newRegistry();
+    DistinctCountSketch sketch = DistinctCountSketch.builder(r)
+        .withName("test")
+        .withTag("region", "us-east-1")
+        .build();
+    Id expected = r.createId("test").withTag("region", "us-east-1");
+    Assertions.assertEquals(expected, sketch.id());
+  }
+
+  @Test
+  public void recordUsesDistinctStatisticAndRegisterTag() {
+    Registry r = newRegistry();
+    Id id = r.createId("test");
+    DistinctCountSketch sketch = DistinctCountSketch.get(r, id);
+    sketch.record(42L);
+
+    // Exactly one register should be populated by a single observation, and it must carry
+    // both the distinct statistic and a R## register tag.
+    int populated = 0;
+    for (Gauge g : r.gauges().toArray(Gauge[]::new)) {
+      if ("test".equals(g.id().name())) {
+        Assertions.assertEquals("distinct", Utils.getTagValue(g.id(), "statistic"));
+        String register = Utils.getTagValue(g.id(), "distinct");
+        Assertions.assertNotNull(register);
+        Assertions.assertTrue(register.matches("R[0-9A-F]{2}"), register);
+        Assertions.assertTrue(g.value() >= 1.0 && g.value() <= 59.0, "rho=" + g.value());
+        ++populated;
+      }
+    }
+    Assertions.assertEquals(1, populated);
+  }
+
+  @Test
+  public void recordingSameValueIsIdempotent() {
+    Registry r = newRegistry();
+    Id id = r.createId("test");
+    DistinctCountSketch sketch = DistinctCountSketch.get(r, id);
+    sketch.record(42L);
+    double[] first = readRegisters(r, id);
+    for (int i = 0; i < 100; ++i) {
+      sketch.record(42L);
+    }
+    double[] second = readRegisters(r, id);
+    Assertions.assertArrayEquals(first, second);
+  }
+
+  @Test
+  public void registersAreUniformlyOccupied() {
+    // Recording many distinct values should populate every register, which catches an
+    // off-by-one in the index bit-split that would leave some registers unreachable.
+    Registry r = newRegistry();
+    Id id = r.createId("test");
+    DistinctCountSketch sketch = DistinctCountSketch.get(r, id);
+    for (long i = 0; i < 100_000; ++i) {
+      sketch.record(i);
+    }
+    double[] regs = readRegisters(r, id);
+    for (int i = 0; i < REGISTERS; ++i) {
+      Assertions.assertTrue(regs[i] >= 1.0, "register " + i + " was not populated");
+    }
+  }
+
+  @Test
+  public void accuracyLong() {
+    for (int n : new int[] {100, 1_000, 10_000, 100_000}) {
+      Registry r = newRegistry();
+      Id id = r.createId("test");
+      DistinctCountSketch sketch = DistinctCountSketch.get(r, id);
+      for (long i = 0; i < n; ++i) {
+        sketch.record(i);
+      }
+      double est = sketch.cardinality();
+      double error = Math.abs(est - n) / n;
+      // 13% standard error; allow a generous multiple to stay non-flaky while still
+      // catching gross encoding errors. Inputs are deterministic so the result is stable.
+      Assertions.assertTrue(error < 0.30, "n=" + n + " est=" + est + " error=" + error);
+    }
+  }
+
+  @Test
+  public void accuracySmall() {
+    // Small cardinalities exercise the linear-counting branch of the estimator. Inputs are
+    // deterministic so the realized error is stable across runs.
+    for (int n : new int[] {1, 2, 5, 10, 25, 50}) {
+      Registry r = newRegistry();
+      Id id = r.createId("test");
+      DistinctCountSketch sketch = DistinctCountSketch.get(r, id);
+      for (long i = 0; i < n; ++i) {
+        sketch.record(i);
+      }
+      double est = sketch.cardinality();
+      // Guard against a no-op record(): the absolute tolerance below would otherwise let an
+      // all-zero (estimate 0) sketch pass for n=1 and n=2.
+      Assertions.assertTrue(est > 0, "n=" + n + " est=" + est);
+      // Absolute tolerance dominates for tiny n (a single register collision is a large
+      // relative error when n is 1 or 2), relative tolerance dominates as n grows.
+      double tolerance = Math.max(2.0, 0.30 * n);
+      Assertions.assertEquals(n, est, tolerance, "n=" + n + " est=" + est);
+    }
+  }
+
+  @Test
+  public void accuracyString() {
+    Registry r = newRegistry();
+    Id id = r.createId("test");
+    DistinctCountSketch sketch = DistinctCountSketch.get(r, id);
+    int n = 50_000;
+    for (int i = 0; i < n; ++i) {
+      sketch.record("user-" + i);
+    }
+    double est = sketch.cardinality();
+    double error = Math.abs(est - n) / n;
+    Assertions.assertTrue(error < 0.30, "est=" + est + " error=" + error);
+  }
+
+  @Test
+  public void accuracyBytes() {
+    Registry r = newRegistry();
+    Id id = r.createId("test");
+    DistinctCountSketch sketch = DistinctCountSketch.get(r, id);
+    int n = 50_000;
+    for (int i = 0; i < n; ++i) {
+      sketch.record(("ip-" + i).getBytes(StandardCharsets.UTF_8));
+    }
+    double est = sketch.cardinality();
+    double error = Math.abs(est - n) / n;
+    Assertions.assertTrue(error < 0.30, "est=" + est + " error=" + error);
+  }
+
+  @Test
+  public void cardinalityOfEmptySketchIsZero() {
+    // All registers unset: linear counting yields m * ln(m/m) = 0.
+    Assertions.assertEquals(0.0, DistinctCountSketch.cardinality(new double[REGISTERS]), 1e-12);
+  }
+
+  @Test
+  public void cardinalityStaticMatchesInstance() {
+    Registry r = newRegistry();
+    Id id = r.createId("test");
+    DistinctCountSketch sketch = DistinctCountSketch.get(r, id);
+    for (long i = 0; i < 10_000; ++i) {
+      sketch.record(i);
+    }
+    Assertions.assertEquals(
+        DistinctCountSketch.cardinality(readRegisters(r, id)),
+        sketch.cardinality(),
+        1e-12);
+  }
+
+  @Test
+  public void supplementaryCodePointAboveBmp() {
+    // A string containing a character above the BMP should hash without error and populate
+    // a register, exercising the surrogate-pair path in the hash.
+    Registry r = newRegistry();
+    Id id = r.createId("test");
+    DistinctCountSketch sketch = DistinctCountSketch.get(r, id);
+    sketch.record("😀"); // U+1F600
+    double[] regs = readRegisters(r, id);
+    int populated = 0;
+    for (double rho : regs) {
+      if (rho >= 1.0) {
+        ++populated;
+      }
+    }
+    Assertions.assertEquals(1, populated);
+  }
+}

--- a/spectator-api/src/test/java/com/netflix/spectator/api/patterns/DistinctCountSketchVectorTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/patterns/DistinctCountSketchVectorTest.java
@@ -1,0 +1,472 @@
+/*
+ * Copyright 2014-2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.api.patterns;
+
+import com.netflix.spectator.api.BasicTag;
+import com.netflix.spectator.api.Clock;
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.Gauge;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Statistic;
+import com.netflix.spectator.api.Utils;
+import com.netflix.spectator.impl.Hash64;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Verifies the {@link DistinctCountSketch} hashing and register encoding against a committed
+ * set of cross-language test vectors. The same vector file is meant to be copied to the
+ * spectatord implementation so that both produce identical registers for the same inputs,
+ * which is what allows their sketches to merge (see the design doc, hash contract section).
+ *
+ * <p>The vectors are generated from this reference implementation. To regenerate after an
+ * intentional change, set the {@code GENERATE_VECTORS=true} environment variable and review
+ * the diff:</p>
+ *
+ * <pre>
+ *   GENERATE_VECTORS=true ./gradlew :spectator-api:test \
+ *       --tests "*DistinctCountSketchVectorTest.generate"
+ * </pre>
+ *
+ * <p>Any unintentional change to the hash or register encoding is a compatibility break and
+ * will fail {@link #encodingVectors()} / {@link #sketchVectors()}.</p>
+ */
+public class DistinctCountSketchVectorTest {
+
+  private static final String RESOURCE = "distinct_count_sketch_test_vectors.txt";
+
+  // Working directory for the test task is the module directory, so the source resource can
+  // be regenerated in place and read back without rebuilding.
+  private static final String SOURCE_PATH = "src/test/resources/" + RESOURCE;
+
+  private static final int REGISTERS = DistinctCountSketch.REGISTERS;
+
+  private Registry newRegistry() {
+    return new DefaultRegistry(Clock.SYSTEM, k -> null);
+  }
+
+  // --- Inputs -------------------------------------------------------------
+
+  private enum Type { LONG, STR, BYTES }
+
+  private static final class Input {
+    private final Type type;
+    private final long longValue;
+    private final String stringValue;
+    private final byte[] bytesValue;
+
+    private Input(Type type, long l, String s, byte[] b) {
+      this.type = type;
+      this.longValue = l;
+      this.stringValue = s;
+      this.bytesValue = b;
+    }
+
+    static Input ofLong(long v) {
+      return new Input(Type.LONG, v, null, null);
+    }
+
+    static Input ofString(String v) {
+      return new Input(Type.STR, 0L, v, null);
+    }
+
+    static Input ofBytes(byte[] v) {
+      return new Input(Type.BYTES, 0L, null, v);
+    }
+  }
+
+  // Curated inputs covering the three overloads and the interesting edges: signed/extreme
+  // longs, empty/ascii/multi-byte UTF-8/supplementary strings, a string past the long-string
+  // hashing threshold, and byte sequences including invalid UTF-8.
+  private static List<Input> encodingInputs() {
+    List<Input> inputs = new ArrayList<>();
+
+    long[] longs = {
+        0L, 1L, -1L, 2L, 7L, 42L, 100L, 1000L, 1_000_000L,
+        123456789L, -123456789L, 0xCAFEBABEL, Long.MAX_VALUE, Long.MIN_VALUE
+    };
+    for (long v : longs) {
+      inputs.add(Input.ofLong(v));
+    }
+
+    String[] strings = {
+        "", "a", "ab", "abc", "user-12345", "192.168.0.1", "2001:db8::1",
+        "key=value,other:thing", "héllo", "naïve", "世界", "日本語",
+        "😀",            // U+1F600 grinning face (supplementary)
+        "👍🏽" // thumbs up + skin tone modifier
+    };
+    for (String v : strings) {
+      inputs.add(Input.ofString(v));
+    }
+    // String longer than Hash64's long-string threshold to exercise that path.
+    StringBuilder longStr = new StringBuilder();
+    for (int i = 0; i < 10; ++i) {
+      longStr.append("/api/v1/users/abcd1234/");
+    }
+    inputs.add(Input.ofString(longStr.toString()));
+
+    inputs.add(Input.ofBytes(new byte[0]));
+    inputs.add(Input.ofBytes(new byte[] {0x00}));
+    inputs.add(Input.ofBytes(new byte[] {(byte) 0xff}));
+    inputs.add(Input.ofBytes(new byte[] {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07}));
+    inputs.add(Input.ofBytes(new byte[] {(byte) 0xde, (byte) 0xad, (byte) 0xbe, (byte) 0xef}));
+    inputs.add(Input.ofBytes(new byte[] {(byte) 0xff, (byte) 0xfe, (byte) 0xfd})); // invalid UTF-8
+
+    return inputs;
+  }
+
+  // Specs for the full-sketch-state vectors. Each is recorded into one sketch and the
+  // resulting 64 registers are captured, exercising the max-register accumulation including
+  // collisions where the larger rho wins.
+  private static final String[] SKETCH_SPECS = {
+      "encoding-inputs",
+      "longs:0:100000"
+  };
+
+  private static List<Input> inputsForSpec(String spec) {
+    if ("encoding-inputs".equals(spec)) {
+      return encodingInputs();
+    }
+    if (spec.startsWith("longs:")) {
+      String[] parts = spec.split(":");
+      long start = Long.parseLong(parts[1]);
+      long end = Long.parseLong(parts[2]);
+      List<Input> inputs = new ArrayList<>();
+      for (long i = start; i < end; ++i) {
+        inputs.add(Input.ofLong(i));
+      }
+      return inputs;
+    }
+    throw new IllegalArgumentException("unknown sketch spec: " + spec);
+  }
+
+  // --- Recording helpers --------------------------------------------------
+
+  private static void recordInto(DistinctCountSketch sketch, Input in) {
+    switch (in.type) {
+      case LONG:  sketch.record(in.longValue); break;
+      case STR:   sketch.record(in.stringValue); break;
+      case BYTES: sketch.record(in.bytesValue); break;
+      default: throw new IllegalStateException();
+    }
+  }
+
+  private static long hashOf(Input in) {
+    switch (in.type) {
+      case LONG:  return Hash64.hashLong(in.longValue);
+      case STR:   return Hash64.hashString(in.stringValue);
+      case BYTES: return Hash64.hashBytes(in.bytesValue);
+      default: throw new IllegalStateException();
+    }
+  }
+
+  // Record a single input and return the populated register as {index, rho}.
+  private int[] recordOne(Input in) {
+    Registry r = newRegistry();
+    DistinctCountSketch sketch = DistinctCountSketch.get(r, r.createId("test"));
+    recordInto(sketch, in);
+    int[] result = null;
+    for (Gauge g : r.gauges().toArray(Gauge[]::new)) {
+      if ("test".equals(g.id().name())) {
+        Assertions.assertNull(result, "more than one register populated");
+        int index = Integer.parseInt(Utils.getTagValue(g.id(), "distinct").substring(1), 16);
+        result = new int[] {index, (int) g.value()};
+      }
+    }
+    Assertions.assertNotNull(result, "no register populated");
+    return result;
+  }
+
+  // Record all inputs for a spec into one sketch and return the 64 register rho values.
+  private int[] recordSketch(String spec) {
+    Registry r = newRegistry();
+    Id id = r.createId("test");
+    DistinctCountSketch sketch = DistinctCountSketch.get(r, id);
+    for (Input in : inputsForSpec(spec)) {
+      recordInto(sketch, in);
+    }
+    int[] regs = new int[REGISTERS];
+    for (int i = 0; i < REGISTERS; ++i) {
+      Id rid = id.withTags(Statistic.distinct, new BasicTag("distinct", String.format("R%02X", i)));
+      double v = r.maxGauge(rid).value();
+      regs[i] = Double.isNaN(v) ? 0 : (int) v;
+    }
+    return regs;
+  }
+
+  // --- Encoding for the vector file --------------------------------------
+
+  private static String typeToken(Type type) {
+    switch (type) {
+      case LONG:  return "long";
+      case STR:   return "str";
+      case BYTES: return "bytes";
+      default: throw new IllegalStateException();
+    }
+  }
+
+  private static String encodeInput(Input in) {
+    switch (in.type) {
+      case LONG:  return Long.toString(in.longValue);
+      case STR:   return escape(in.stringValue);
+      case BYTES: return toHex(in.bytesValue);
+      default: throw new IllegalStateException();
+    }
+  }
+
+  private static Input decodeInput(String type, String value) {
+    switch (type) {
+      case "long":  return Input.ofLong(Long.parseLong(value));
+      case "str":   return Input.ofString(unescape(value));
+      case "bytes": return Input.ofBytes(fromHex(value));
+      default: throw new IllegalArgumentException("unknown type: " + type);
+    }
+  }
+
+  // Backslash escaping so a string value can never contain the tab separator or a newline.
+  private static String escape(String s) {
+    StringBuilder b = new StringBuilder(s.length());
+    for (int i = 0; i < s.length(); ++i) {
+      char c = s.charAt(i);
+      switch (c) {
+        case '\\': b.append("\\\\"); break;
+        case '\t': b.append("\\t"); break;
+        case '\n': b.append("\\n"); break;
+        case '\r': b.append("\\r"); break;
+        default: b.append(c); break;
+      }
+    }
+    return b.toString();
+  }
+
+  private static String unescape(String s) {
+    StringBuilder b = new StringBuilder(s.length());
+    for (int i = 0; i < s.length(); ++i) {
+      char c = s.charAt(i);
+      if (c == '\\' && i + 1 < s.length()) {
+        char n = s.charAt(++i);
+        switch (n) {
+          case '\\': b.append('\\'); break;
+          case 't':  b.append('\t'); break;
+          case 'n':  b.append('\n'); break;
+          case 'r':  b.append('\r'); break;
+          default:   b.append(n); break;
+        }
+      } else {
+        b.append(c);
+      }
+    }
+    return b.toString();
+  }
+
+  private static String toHex(byte[] bytes) {
+    StringBuilder b = new StringBuilder(bytes.length * 2);
+    for (byte value : bytes) {
+      b.append(Character.forDigit((value >> 4) & 0xf, 16));
+      b.append(Character.forDigit(value & 0xf, 16));
+    }
+    return b.toString();
+  }
+
+  private static byte[] fromHex(String hex) {
+    byte[] bytes = new byte[hex.length() / 2];
+    for (int i = 0; i < bytes.length; ++i) {
+      int hi = Character.digit(hex.charAt(2 * i), 16);
+      int lo = Character.digit(hex.charAt(2 * i + 1), 16);
+      bytes[i] = (byte) ((hi << 4) | lo);
+    }
+    return bytes;
+  }
+
+  // --- Vector file IO -----------------------------------------------------
+
+  private static List<String> readVectorLines() throws IOException {
+    // Prefer the source file (so generation + verification stay consistent without a
+    // rebuild); fall back to the classpath copy.
+    if (Files.exists(Paths.get(SOURCE_PATH))) {
+      return Files.readAllLines(Paths.get(SOURCE_PATH), StandardCharsets.UTF_8);
+    }
+    try (InputStream in = DistinctCountSketchVectorTest.class.getResourceAsStream("/" + RESOURCE)) {
+      Assertions.assertNotNull(in, "missing vector resource: " + RESOURCE);
+      List<String> lines = new ArrayList<>();
+      try (BufferedReader reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8))) {
+        String line;
+        while ((line = reader.readLine()) != null) {
+          lines.add(line);
+        }
+      }
+      return lines;
+    }
+  }
+
+  // --- Tests --------------------------------------------------------------
+
+  @Test
+  public void encodingVectors() throws IOException {
+    List<String> lines = readVectorLines();
+    boolean inSection = false;
+    int checked = 0;
+    for (String line : lines) {
+      if (line.isEmpty() || line.startsWith("#")) {
+        continue;
+      }
+      if (line.startsWith("[")) {
+        inSection = "[encoding]".equals(line);
+        continue;
+      }
+      if (!inSection) {
+        continue;
+      }
+      String[] f = line.split("\t", -1);
+      Assertions.assertEquals(5, f.length, "malformed encoding line: " + line);
+      Input in = decodeInput(f[0], f[1]);
+      long expectedHash = Long.parseUnsignedLong(f[2], 16);
+      int expectedIndex = Integer.parseInt(f[3]);
+      int expectedRho = Integer.parseInt(f[4]);
+
+      Assertions.assertEquals(expectedHash, hashOf(in), "hash mismatch: " + line);
+      int[] actual = recordOne(in);
+      Assertions.assertEquals(expectedIndex, actual[0], "index mismatch: " + line);
+      Assertions.assertEquals(expectedRho, actual[1], "rho mismatch: " + line);
+      ++checked;
+    }
+    Assertions.assertTrue(checked > 0, "no encoding vectors were checked");
+  }
+
+  @Test
+  public void sketchVectors() throws IOException {
+    List<String> lines = readVectorLines();
+    boolean inSection = false;
+    int checked = 0;
+    for (String line : lines) {
+      if (line.isEmpty() || line.startsWith("#")) {
+        continue;
+      }
+      if (line.startsWith("[")) {
+        inSection = "[sketch]".equals(line);
+        continue;
+      }
+      if (!inSection) {
+        continue;
+      }
+      String[] f = line.split("\t", -1);
+      Assertions.assertEquals(2, f.length, "malformed sketch line: " + line);
+      String spec = f[0];
+      String[] values = f[1].split(",", -1);
+      Assertions.assertEquals(REGISTERS, values.length, "expected " + REGISTERS + " registers");
+      int[] expected = new int[REGISTERS];
+      for (int i = 0; i < REGISTERS; ++i) {
+        expected[i] = Integer.parseInt(values[i]);
+      }
+      Assertions.assertArrayEquals(expected, recordSketch(spec), "sketch mismatch: " + spec);
+      ++checked;
+    }
+    Assertions.assertTrue(checked > 0, "no sketch vectors were checked");
+  }
+
+  // Documents the byte serialization other implementations must match: a long is hashed as
+  // its 8-byte little-endian representation, a string as its UTF-8 bytes. Both reduce to
+  // xxHash64(bytes, seed=0).
+  @Test
+  public void serializationContract() {
+    long[] longs = {0L, 1L, -1L, 42L, Long.MAX_VALUE, Long.MIN_VALUE};
+    for (long v : longs) {
+      byte[] le = new byte[8];
+      for (int i = 0; i < 8; ++i) {
+        le[i] = (byte) (v >>> (8 * i));
+      }
+      Assertions.assertEquals(Hash64.hashBytes(le), Hash64.hashLong(v), "long " + v);
+    }
+    String[] strings = {"", "a", "héllo", "世界", "😀"};
+    for (String s : strings) {
+      Assertions.assertEquals(
+          Hash64.hashBytes(s.getBytes(StandardCharsets.UTF_8)),
+          Hash64.hashString(s),
+          "str " + s);
+    }
+  }
+
+  @Test
+  @EnabledIfEnvironmentVariable(named = "GENERATE_VECTORS", matches = "true")
+  public void generate() throws IOException {
+    List<String> lines = new ArrayList<>();
+    lines.add("# Distinct count sketch cross-language test vectors.");
+    lines.add("#");
+    lines.add("# Generated from the spectator-java reference implementation");
+    lines.add("# (DistinctCountSketch). Copy this file to other implementations (e.g.");
+    lines.add("# spectatord) and verify they produce the same registers, so that sketches");
+    lines.add("# from different clients merge correctly.");
+    lines.add("#");
+    lines.add("# Hash: xxHash64, seed 0. A long is hashed as its 8-byte little-endian");
+    lines.add("# representation; a string as its UTF-8 bytes. Register index = low 6 bits of");
+    lines.add("# the hash; rho = 1 + the number of leading zeros in the remaining 58 bits.");
+    lines.add("#");
+    lines.add("# [encoding]: <type>\\t<input>\\t<hash>\\t<index>\\t<rho>");
+    lines.add("#   type  = long | str | bytes");
+    lines.add("#   input = long: signed decimal; str: UTF-8 literal with \\\\, \\t, \\n, \\r");
+    lines.add("#           escaped; bytes: lowercase hex");
+    lines.add("#   hash  = unsigned 64-bit hash as 16 hex digits");
+    lines.add("#   index = register index 0..63");
+    lines.add("#   rho   = register value 1..59");
+    lines.add("#");
+    lines.add("# [sketch]: <spec>\\t<r0>,<r1>,...,<r63>");
+    lines.add("#   spec = encoding-inputs (all inputs above) | longs:<start>:<end>");
+    lines.add("#   followed by the 64 register rho values (0 = unused) after recording the");
+    lines.add("#   spec's inputs into a single sketch.");
+    lines.add("[encoding]");
+    for (Input in : encodingInputs()) {
+      int[] ir = recordOne(in);
+      lines.add(String.join("\t",
+          typeToken(in.type),
+          encodeInput(in),
+          String.format("%016x", hashOf(in)),
+          Integer.toString(ir[0]),
+          Integer.toString(ir[1])));
+    }
+    lines.add("[sketch]");
+    for (String spec : SKETCH_SPECS) {
+      int[] regs = recordSketch(spec);
+      StringBuilder csv = new StringBuilder();
+      for (int i = 0; i < regs.length; ++i) {
+        if (i > 0) {
+          csv.append(',');
+        }
+        csv.append(regs[i]);
+      }
+      lines.add(spec + "\t" + csv);
+    }
+    // Write canonical '\n' line endings (not the platform separator) so the committed file
+    // is identical regardless of the platform it is regenerated on, and matches what the
+    // BufferedReader/readAllLines parsers expect.
+    StringBuilder content = new StringBuilder();
+    for (String line : lines) {
+      content.append(line).append('\n');
+    }
+    Files.write(Paths.get(SOURCE_PATH), content.toString().getBytes(StandardCharsets.UTF_8));
+  }
+}

--- a/spectator-api/src/test/resources/distinct_count_sketch_test_vectors.txt
+++ b/spectator-api/src/test/resources/distinct_count_sketch_test_vectors.txt
@@ -1,0 +1,62 @@
+# Distinct count sketch cross-language test vectors.
+#
+# Generated from the spectator-java reference implementation
+# (DistinctCountSketch). Copy this file to other implementations (e.g.
+# spectatord) and verify they produce the same registers, so that sketches
+# from different clients merge correctly.
+#
+# Hash: xxHash64, seed 0. A long is hashed as its 8-byte little-endian
+# representation; a string as its UTF-8 bytes. Register index = low 6 bits of
+# the hash; rho = 1 + the number of leading zeros in the remaining 58 bits.
+#
+# [encoding]: <type>\t<input>\t<hash>\t<index>\t<rho>
+#   type  = long | str | bytes
+#   input = long: signed decimal; str: UTF-8 literal with \\, \t, \n, \r
+#           escaped; bytes: lowercase hex
+#   hash  = unsigned 64-bit hash as 16 hex digits
+#   index = register index 0..63
+#   rho   = register value 1..59
+#
+# [sketch]: <spec>\t<r0>,<r1>,...,<r63>
+#   spec = encoding-inputs (all inputs above) | longs:<start>:<end>
+#   followed by the 64 register rho values (0 = unused) after recording the
+#   spec's inputs into a single sketch.
+[encoding]
+long	0	34c96acdcadb1bbb	59	3
+long	1	9f29cb17a2a49995	21	1
+long	-1	85d136adb773c6c9	9	1
+long	2	eac73e4044e82db0	48	1
+long	7	0876cd406afde455	21	5
+long	42	b556806fb6d14353	19	1
+long	100	a1df9c5cd454307a	58	1
+long	1000	e53f2d22876c9a49	9	1
+long	1000000	f126194744ecba1e	30	1
+long	123456789	cb7c2941b198004d	13	1
+long	-123456789	6652a701f322f9c0	0	2
+long	3405691582	6b4aca62b5efd3db	27	2
+long	9223372036854775807	ff70cc60366e770c	12	1
+long	-9223372036854775808	3f425eacf01544e0	32	3
+str		ef46db3751d8e999	25	1
+str	a	d24ec4f1a98c6e5b	27	1
+str	ab	65f708ca92d04a61	33	2
+str	abc	44bc2cf5ad770999	25	2
+str	user-12345	64797fca50bfc10c	12	2
+str	192.168.0.1	87f49df2f9f76384	4	1
+str	2001:db8::1	26c33ef1c67e1031	49	3
+str	key=value,other:thing	d799484be9292024	36	1
+str	héllo	3bd06310388ebbe4	36	3
+str	naïve	c07351dc8a26afe6	38	1
+str	世界	6af6be193ab0db0f	15	2
+str	日本語	7179a19f3719f5e1	33	2
+str	😀	9025b8abaae87b80	0	1
+str	👍🏽	637d0995477b428c	12	2
+str	/api/v1/users/abcd1234//api/v1/users/abcd1234//api/v1/users/abcd1234//api/v1/users/abcd1234//api/v1/users/abcd1234//api/v1/users/abcd1234//api/v1/users/abcd1234//api/v1/users/abcd1234//api/v1/users/abcd1234//api/v1/users/abcd1234/	92c0d26c7c73d1a6	38	1
+bytes		ef46db3751d8e999	25	1
+bytes	00	e934a84adb052768	40	1
+bytes	ff	95634172a60b7544	4	1
+bytes	0001020304050607	884a173614b81b8d	13	1
+bytes	deadbeef	2ff5cfb6af9aaf68	40	3
+bytes	fffefd	622529177845a110	16	2
+[sketch]
+encoding-inputs	2,0,0,0,1,0,0,0,0,1,0,0,2,1,0,2,2,0,0,1,0,5,0,0,0,2,0,2,0,0,1,0,3,2,0,0,3,0,1,0,3,0,0,0,0,0,0,0,1,3,0,0,0,0,0,0,0,0,1,3,0,0,0,0
+longs:0:100000	15,12,13,11,10,10,13,11,11,11,12,10,9,10,13,12,12,10,9,12,11,10,12,9,12,12,11,14,9,16,17,14,11,12,9,12,11,12,13,15,12,20,12,13,10,11,11,11,11,12,11,9,15,14,10,12,14,11,13,10,13,10,9,14


### PR DESCRIPTION
Implements the spectator-java client portion of the distinct count sketch design: a HyperLogLog sketch decomposed into 64 per-register max-gauges tagged statistic=distinct, distinct=R##. Registers merge across sources via the existing aggregation path (per-register max), and the cardinality estimate is computed at query time on the backend.

- Adds a Statistic.distinct enum value.
- DistinctCountSketch mirrors PercentileTimer (get/builder construction, registry.state() caching) and implements Meter so the cached entry is reclaimed once its registers expire. Recording hashes the value with xxHash64, uses the low 6 bits for the register index and 1 + the leading-zero run of the remaining bits for rho. Provides allocation free long, CharSequence, and byte[] overloads, plus a shared cardinality() estimator the backend can reuse.
- Adds a cross-language test vector file and a test that verifies the hashing and max-register behavior against it, to keep the spectatord implementation consistent.