### PR TITLE
Stop scheduler on StatelessRegistry close

### DIFF
--- a/spectator-reg-stateless/src/main/java/com/netflix/spectator/stateless/StatelessRegistry.java
+++ b/spectator-reg-stateless/src/main/java/com/netflix/spectator/stateless/StatelessRegistry.java
@@ -118,6 +118,18 @@ public final class StatelessRegistry extends AbstractRegistry {
     }
   }
 
+  /**
+   * Stops the registry, releasing the resources it owns. Shuts down the publishing scheduler
+   * started by {@link #start()} (flushing a final batch) and then lets the base registry release
+   * any remaining state, such as {@code PolledMeter} background tasks. Without this override the
+   * inherited {@link AbstractRegistry#close()} would clear the meters but leave the scheduler
+   * thread running.
+   */
+  @Override public void close() {
+    stop();
+    super.close();
+  }
+
   private void collectData() {
     try {
       for (List<Measurement> batch : getBatches()) {

--- a/spectator-reg-stateless/src/test/java/com/netflix/spectator/stateless/StatelessRegistryTest.java
+++ b/spectator-reg-stateless/src/test/java/com/netflix/spectator/stateless/StatelessRegistryTest.java
@@ -120,4 +120,38 @@ public class StatelessRegistryTest {
     clock.setWallTime(Duration.ofMinutes(15).toMillis() + 1);
     Assertions.assertEquals(0, registry.getBatches().size());
   }
+
+  private static boolean schedulerThreadActive() {
+    for (Thread t : Thread.getAllStackTraces().keySet()) {
+      if (t.isAlive() && t.getName().contains("spectator-reg-stateless")) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Test
+  public void closeStopsScheduler() throws Exception {
+    StatelessRegistry r = new StatelessRegistry(clock, newConfig());
+    r.start();
+    // close() must shut the scheduler down, not just clear the meters like the inherited
+    // AbstractRegistry.close() would. Run it in a finally so a failed precondition assertion
+    // does not leak the daemon scheduler thread into later tests.
+    try {
+      Assertions.assertTrue(schedulerThreadActive(), "scheduler thread should be running after start");
+    } finally {
+      r.close();
+    }
+    // shutdown() blocks until the threads stop; poll briefly as belt-and-suspenders.
+    for (int i = 0; i < 50 && schedulerThreadActive(); ++i) {
+      Thread.sleep(10);
+    }
+    Assertions.assertFalse(schedulerThreadActive(), "scheduler thread should be stopped after close");
+  }
+
+  @Test
+  public void closeWithoutStart() {
+    // Closing a registry that was never started must not throw.
+    new StatelessRegistry(clock, newConfig()).close();
+  }
 }


### PR DESCRIPTION
StatelessRegistry started a publishing Scheduler in start() and shut it down only in stop(), but did not override close(). The inherited AbstractRegistry.close() cleared the meters but left the scheduler thread running, so closing the registry leaked the spectator-reg-stateless thread (and skipped the final flush), unlike AtlasRegistry whose close() calls stop().

Override close() to stop() the scheduler and then super.close() to release the remaining state, mirroring AtlasRegistry. Adds tests that the scheduler thread is stopped after close() and that closing a never-started registry does not throw.