### PR TITLE
Release agent and spark resources on close

### DIFF
--- a/spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java
+++ b/spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java
@@ -17,6 +17,7 @@ package com.netflix.spectator.agent;
 
 import com.netflix.spectator.api.Clock;
 import com.netflix.spectator.api.Spectator;
+import com.netflix.spectator.api.patterns.PolledMeter;
 import com.netflix.spectator.atlas.AtlasConfig;
 import com.netflix.spectator.atlas.AtlasRegistry;
 import com.netflix.spectator.gc.GcLogger;
@@ -120,13 +121,13 @@ public final class Agent {
     // Setup Registry
     AtlasRegistry registry = new AtlasRegistry(Clock.SYSTEM, new AgentAtlasConfig(config));
 
-    // Add to global registry for http stats and GC logger
+    // Add to global registry for http stats
     Spectator.globalRegistry().add(registry);
 
-    // Enable GC logger
-    GcLogger gcLogger = new GcLogger();
+    // Enable GC logger, tied to the registry lifecycle so it is stopped when the registry
+    // is closed.
     if (config.getBoolean("collection.gc")) {
-      gcLogger.start(null);
+      GcLogger.monitor(registry);
     }
 
     // Enable JVM data collection
@@ -166,13 +167,19 @@ public final class Agent {
         }
         poller.poll();
       }, delay, delay, TimeUnit.MILLISECONDS);
+
+      // Tie the JMX polling executor to the registry lifecycle so it is shut down when the
+      // registry is closed.
+      PolledMeter.monitorResource(registry, exec::shutdownNow);
     }
 
     // Start collection for the registry
     registry.start();
 
-    // Shutdown registry
-    Runtime.getRuntime().addShutdownHook(new Thread(registry::stop, "spectator-agent-shutdown"));
+    // Shutdown registry. close() flushes and stops the publishing scheduler (like stop()) and
+    // also releases the resources tied to the registry above: the GC logger, the JFR recording
+    // stream, and the JMX polling executor.
+    Runtime.getRuntime().addShutdownHook(new Thread(registry::close, "spectator-agent-shutdown"));
   }
 
   private static class AgentAtlasConfig implements AtlasConfig {

--- a/spectator-ext-spark/src/main/java/com/netflix/spectator/spark/SparkSink.java
+++ b/spectator-ext-spark/src/main/java/com/netflix/spectator/spark/SparkSink.java
@@ -45,8 +45,6 @@ public final class SparkSink implements Sink {
   private final long pollPeriod;
   private final TimeUnit pollUnit;
 
-  private GcLogger gcLogger;
-
   /**
    * Create a new instance. Spark looks for a constructor with all three parameters, so the
    * {@code SecurityManager} needs to be in the signature even though it isn't used.
@@ -92,8 +90,7 @@ public final class SparkSink implements Sink {
   private void startJvmCollection() {
     try {
       Jmx.registerStandardMXBeans(sidecarRegistry);
-      gcLogger = new GcLogger();
-      gcLogger.start(null);
+      GcLogger.monitor(sidecarRegistry);
     } catch (Exception e) {
       LOGGER.error("failed to start collection of jvm stats", e);
       throw e;
@@ -124,7 +121,11 @@ public final class SparkSink implements Sink {
   @Override public void stop() {
     LOGGER.info("stopping poller");
     reporter.stop();
-    gcLogger.stop();
+    // Detach from the global registry (if it was added) and close the sidecar registry to
+    // release the resources started in start(): the JFR recording stream and its executor, the
+    // GC logger (both tied to the registry lifecycle), and the sidecar writer.
+    Spectator.globalRegistry().remove(sidecarRegistry);
+    sidecarRegistry.close();
   }
 
   @Override public void report() {


### PR DESCRIPTION
Both the agent and the Spark sink started JVM collection (GC logger, JFR recording stream, JMX polling executor) but did not release it on shutdown, leaking threads and notification listeners. The Spark sink also never closed its sidecar registry, leaking the recording stream and writer across sink start/stop cycles.

Tie those resources to the registry lifecycle and close the registry on shutdown, using the machinery from #1255:

- Agent: report GC via GcLogger.monitor(registry), register the JMX polling executor with PolledMeter.monitorResource(registry, exec::shutdownNow), and change the shutdown hook from registry::stop to registry::close so the final flush plus all tied resources are released. GcLogger is now only created when collection.gc is enabled (previously it was always constructed, registering jvm.gc.* meters even when disabled).
- SparkSink: report GC via GcLogger.monitor(sidecarRegistry) and, on stop(), detach the registry from the global registry and close it, releasing the GC logger, JFR stream/executor, and sidecar writer. Removing the gcLogger field also fixes an NPE/IllegalStateException if stop() ran without start(). GC metrics now flow to the sidecar registry rather than only the global one.