### PR TITLE
Dedup repeated PolledMeter cleanup actions

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/patterns/PolledMeter.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/patterns/PolledMeter.java
@@ -272,7 +272,8 @@ public final class PolledMeter {
      * {@link PolledMeter#remove(Registry, Id)} or {@link PolledMeter#removeAll(Registry)}, or
      * automatically when the monitored object has been garbage collected and polling stops.
      * Exceptions thrown by the action are caught and logged. If multiple values are monitored
-     * with the same id, then each registered action will be run.</p>
+     * with the same id, then each registered action will be run. Registering the same action
+     * instance more than once for an id has no additional effect; it runs once.</p>
      *
      * @param action
      *     Resource to close when the meter is cleaned up.
@@ -636,6 +637,16 @@ public final class PolledMeter {
 
     /** Register an action to run when this meter is cleaned up. */
     void addCleanupAction(AutoCloseable action) {
+      // Avoid accumulating duplicates when the same action is registered repeatedly for an id
+      // (for example a reused builder or repeated idempotent registration). Dedup is by identity
+      // so distinct actions for an aggregated id are all retained even if they happen to compare
+      // equal. The queue holds at most a handful of entries, so the linear scan is cheap, and on
+      // close() each action is drained (run once).
+      for (AutoCloseable existing : cleanupActions) {
+        if (existing == action) {
+          return;
+        }
+      }
       cleanupActions.add(action);
     }
 

--- a/spectator-api/src/test/java/com/netflix/spectator/api/patterns/PolledMeterTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/patterns/PolledMeterTest.java
@@ -362,6 +362,22 @@ public class PolledMeterTest {
   }
 
   @Test
+  public void duplicateCleanupActionRegisteredOnce() {
+    Registry r = new DefaultRegistry();
+    Id id = r.createId("test");
+    AtomicLong closed = new AtomicLong();
+    AutoCloseable action = closed::incrementAndGet;
+
+    // Re-registering the same action instance for the same id must not accumulate duplicates,
+    // so it runs exactly once on cleanup (unlike two distinct actions, which both run).
+    PolledMeter.using(r).withId(id).withCleanupAction(action).monitorValue(new AtomicLong(1));
+    PolledMeter.using(r).withId(id).withCleanupAction(action).monitorValue(new AtomicLong(2));
+
+    PolledMeter.remove(r, id);
+    Assertions.assertEquals(1, closed.get());
+  }
+
+  @Test
   public void registryCloseCancelsPolledMetersAndPollTasks() {
     Registry r = new DefaultRegistry();
     AtomicLong closed = new AtomicLong();


### PR DESCRIPTION
PolledMeter.Builder.withCleanupAction appends the action to the meter state on every registration, so re-registering the same action instance for an id (a reused builder or repeated idempotent registration) accumulated duplicate entries that each ran on cleanup.

Dedup by identity in AbstractMeterState.addCleanupAction: skip the add if the same instance is already registered. Distinct actions for an aggregated id are still all retained and run (matching the documented behavior); only repeats of the same instance collapse to one. The close() drain via poll() is unchanged.