### PR TITLE
Flatten multi-segment IndexOf regex chains

### DIFF
--- a/spectator-api/src/jmh/java/com/netflix/spectator/perf/MultiSegmentMatching.java
+++ b/spectator-api/src/jmh/java/com/netflix/spectator/perf/MultiSegmentMatching.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2014-2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.perf;
+
+import com.netflix.spectator.impl.PatternMatcher;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * Benchmark for multi-segment "contains" regex patterns of the form {@code .*A.*B.*C...}, which
+ * compile to a chain of nested {@link com.netflix.spectator.impl.matcher.IndexOfMatcher} instances
+ * (optionally fronted by a start anchor or terminated by an end anchor). These show up in
+ * production LWC subscription expressions, frequently wrapped in {@code :not}, on high-cardinality
+ * keys such as {@code nf.cluster} and {@code ipc.endpoint}:
+ *
+ * <pre>
+ *   nf.cluster,.*-.*-md-preview-.*,:re,:not
+ *   nf.cluster,.*-.*-chap-canary,:re,:not
+ *   ipc.endpoint,.*Available.*SnapshotVersions.*,:re,:not
+ * </pre>
+ *
+ * <p>The matchers are compiled the same way {@code Query.Regex} does ({@code "^" + value}) and
+ * invoked via {@link PatternMatcher#matches(String)}, which is what the inverted-query path in
+ * {@code QueryIndex} ultimately calls per distinct value.</p>
+ *
+ * <p>The {@code depth} parameter is the number of {@code .*}-separated single-dash gap segments
+ * before a fixed terminal segment. The leading gaps have low selectivity (a single {@code "-"}):
+ * the recursive matcher finds a dash at nearly every position and, on each one, recurses into the
+ * next segment and backtracks on failure, so cost grows with both the number of dashes in the
+ * value and the pattern depth. {@code shape} covers the three foldable forms (plain contains,
+ * end-anchored {@code $}, start-anchored {@code ^}). The non-matching value is the dominant
+ * production case (most values do not contain the terminal) and the worst case for backtracking.</p>
+ */
+@State(Scope.Thread)
+public class MultiSegmentMatching {
+
+  /** Number of {@code .*}-separated single-dash gap segments before the terminal segment. */
+  @Param({"1", "2", "3", "4", "5"})
+  public int depth;
+
+  /** Foldable pattern shape: plain contains, end-anchored, or start-anchored. */
+  @Param({"contains", "end", "start"})
+  public String shape;
+
+  /** Whether the value matches the pattern. The non-matching case is the backtracking worst case. */
+  @Param({"noMatch", "match"})
+  public String value;
+
+  private PatternMatcher matcher;
+  private String input;
+
+  @Setup
+  public void setup() {
+    StringBuilder gaps = new StringBuilder();
+    for (int i = 0; i < depth; i++) {
+      gaps.append(".*-");
+    }
+    // Build the user pattern; Query.Regex anchors it with a leading "^".
+    final String regex;
+    switch (shape) {
+      case "end":
+        regex = gaps + ".*mdpreview$";
+        break;
+      case "start":
+        regex = "pre" + gaps + ".*mdpreview.*";
+        break;
+      case "contains":
+      default:
+        regex = gaps + ".*mdpreview.*";
+        break;
+    }
+    this.matcher = PatternMatcher.compile("^" + regex);
+
+    // Both values start with "pre" and have many dashes; the matching value also contains the
+    // terminal segment at the end so it is valid for all three shapes.
+    this.input = "match".equals(value)
+        ? "pre-a-b-c-d-e-f-mdpreview"
+        : "pre-prod-useast1-main-canary-v123-shadow-42";
+  }
+
+  @Benchmark
+  public void match(Blackhole bh) {
+    bh.consume(matcher.matches(input));
+  }
+}

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/CharSeqMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/CharSeqMatcher.java
@@ -48,6 +48,11 @@ final class CharSeqMatcher implements Matcher, Serializable {
     return pattern;
   }
 
+  /** Returns true if the comparison should ignore case. */
+  boolean isIgnoreCase() {
+    return ignoreCase;
+  }
+
   @Override
   public String containedString() {
     return pattern;

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/IndexOfMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/IndexOfMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2023 Netflix, Inc.
+ * Copyright 2014-2026 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ final class IndexOfMatcher implements GreedyMatcher, Serializable {
   private final String pattern;
   private final Matcher next;
   private final boolean ignoreCase;
+  private final int minLength;
 
   /** Create a new instance. */
   IndexOfMatcher(String pattern, Matcher next) {
@@ -42,6 +43,9 @@ final class IndexOfMatcher implements GreedyMatcher, Serializable {
     this.pattern = pattern;
     this.next = next;
     this.ignoreCase = ignoreCase;
+    // minLength is fixed for an immutable matcher; precompute it to avoid walking the
+    // next chain on every matches() call (the hot path uses next.minLength()).
+    this.minLength = pattern.length() + next.minLength();
   }
 
   /** Sub-string to look for within the string being checked. */
@@ -52,6 +56,11 @@ final class IndexOfMatcher implements GreedyMatcher, Serializable {
   /** Return the matcher for the portion that follows the sub-string. */
   Matcher next() {
     return next;
+  }
+
+  /** Returns true if the substring search should ignore case. */
+  boolean isIgnoreCase() {
+    return ignoreCase;
   }
 
   @Override
@@ -130,7 +139,7 @@ final class IndexOfMatcher implements GreedyMatcher, Serializable {
 
   @Override
   public int minLength() {
-    return pattern.length() + next.minLength();
+    return minLength;
   }
 
   @Override
@@ -172,6 +181,7 @@ final class IndexOfMatcher implements GreedyMatcher, Serializable {
     }
     IndexOfMatcher that = (IndexOfMatcher) o;
     return ignoreCase == that.ignoreCase
+        && minLength == that.minLength
         && Objects.equals(pattern, that.pattern)
         && Objects.equals(next, that.next);
   }
@@ -182,6 +192,7 @@ final class IndexOfMatcher implements GreedyMatcher, Serializable {
     result = 31 * result + pattern.hashCode();
     result = 31 * result + next.hashCode();
     result = 31 * result + Boolean.hashCode(ignoreCase);
+    result = 31 * result + minLength;
     return result;
   }
 }

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/IndexOfSeqMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/IndexOfSeqMatcher.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright 2014-2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.impl.matcher;
+
+import com.netflix.spectator.impl.PatternExpr;
+import com.netflix.spectator.impl.PatternMatcher;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.function.Function;
+
+/**
+ * Matches a sequence of literal segments separated by {@code .*}, with anchors permitted only at
+ * the extremes, e.g. {@code .*A.*B.*}, {@code .*A.*B$}, or {@code ^A.*B.*C$}. The equivalent nested
+ * {@link IndexOfMatcher} chain (optionally fronted by a {@link StartsWithMatcher} and/or terminated
+ * by an {@link EndMatcher}) matches the same strings, but does so with a recursive, backtracking
+ * scan that is quadratic when an early segment has low selectivity. This matcher collapses the
+ * chain into a single greedy left-to-right pass with no backtracking.
+ *
+ * <p>The greedy pass is correct because each non-anchored segment is an unanchored substring
+ * search: taking the earliest match of a segment maximizes the remaining window for the segments
+ * that follow, so a failure can never be salvaged by retrying an earlier segment at a later
+ * position. A leading {@code ^} pins the first segment with a {@code startsWith} check; a trailing
+ * {@code $} pins the last segment with an {@code endsWith} check.</p>
+ *
+ * <p>Only {@link #matches(String, int, int)} and {@link #minLength()} use the flattened form. All
+ * other operations (translation, rewriting, trigrams, etc.) are forwarded to the original nested
+ * {@code delegate} so behavior is identical to the unoptimized matcher.</p>
+ */
+final class IndexOfSeqMatcher implements Matcher, Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  private final String[] segments;
+  private final boolean startAnchored;
+  private final boolean endAnchored;
+  private final boolean ignoreCase;
+  private final Matcher delegate;
+  private final int minLength;
+
+  /**
+   * Create a new instance.
+   *
+   * @param segments
+   *     Ordered literal segments. When {@code startAnchored}, the first segment must appear at the
+   *     start of the value; when {@code endAnchored}, the last segment must appear at the end.
+   *     Every other segment is found by an ordered substring search.
+   * @param startAnchored
+   *     True if the first segment is anchored to the start of the value.
+   * @param endAnchored
+   *     True if the last segment is anchored to the end of the value.
+   * @param ignoreCase
+   *     True if the segments should be matched ignoring case.
+   * @param delegate
+   *     Equivalent nested matcher used for all non-matching operations.
+   */
+  IndexOfSeqMatcher(
+      String[] segments,
+      boolean startAnchored,
+      boolean endAnchored,
+      boolean ignoreCase,
+      Matcher delegate) {
+    this.segments = segments;
+    this.startAnchored = startAnchored;
+    this.endAnchored = endAnchored;
+    this.ignoreCase = ignoreCase;
+    this.delegate = delegate;
+    int sum = 0;
+    for (String s : segments) {
+      sum += s.length();
+    }
+    this.minLength = sum;
+  }
+
+  /** Ordered literal segments. */
+  String[] segments() {
+    return segments;
+  }
+
+  /** True if the first segment is anchored to the start of the value. */
+  boolean startAnchored() {
+    return startAnchored;
+  }
+
+  /** True if the last segment is anchored to the end of the value. */
+  boolean endAnchored() {
+    return endAnchored;
+  }
+
+  /** True if the segments are matched ignoring case. */
+  boolean isIgnoreCase() {
+    return ignoreCase;
+  }
+
+  private boolean regionMatches(String str, int offset, String seg) {
+    return str.regionMatches(ignoreCase, offset, seg, 0, seg.length());
+  }
+
+  private int indexOf(String str, String seg, int offset) {
+    if (!ignoreCase) {
+      return str.indexOf(seg, offset);
+    }
+    final int segLength = seg.length();
+    final int end = (str.length() - segLength) + 1;
+    for (int i = offset; i < end; ++i) {
+      if (str.regionMatches(true, i, seg, 0, segLength)) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  @Override
+  public int matches(String str, int start, int length) {
+    // The start-anchored prefix is anchored to absolute position 0 (like StartsWithMatcher), not
+    // to `start`. When this matcher is embedded as a sub-matcher invoked at a non-zero offset
+    // (e.g. a branch of an OrMatcher reached after an earlier match), defer to the delegate to
+    // preserve exact semantics. The flat path below handles the common root case (start == 0).
+    if (startAnchored && start != 0) {
+      return delegate.matches(str, start, length);
+    }
+    if (length < minLength) {
+      return Constants.NO_MATCH;
+    }
+    final int end = start + length;
+    final int n = segments.length;
+    int pos = start;
+    for (int i = 0; i < n; ++i) {
+      final String seg = segments[i];
+      if (i == 0 && startAnchored) {
+        if (!regionMatches(str, start, seg)) {
+          return Constants.NO_MATCH;
+        }
+        pos = start + seg.length();
+      } else if (i == n - 1 && endAnchored) {
+        final int endPos = end - seg.length();
+        if (endPos < pos || !regionMatches(str, endPos, seg)) {
+          return Constants.NO_MATCH;
+        }
+        pos = end;
+      } else {
+        final int p = indexOf(str, seg, pos);
+        if (p < 0) {
+          return Constants.NO_MATCH;
+        }
+        pos = p + seg.length();
+      }
+    }
+    return pos;
+  }
+
+  @Override
+  public int minLength() {
+    return minLength;
+  }
+
+  @Override
+  public boolean matchesAfterPrefix(String str) {
+    // For a start-anchored fold, prefix() returns segments[0], so a caller (e.g. the QueryIndex
+    // prefix tree) may have already verified it; mirror the delegate, which skips re-checking the
+    // prefix rather than failing the value. For the unanchored case there is no fixed prefix, so
+    // matchesAfterPrefix is just matches() and the flat path is both correct and the fast path --
+    // it must NOT defer to the delegate, which would fall back to the slow backtracking chain.
+    return startAnchored ? delegate.matchesAfterPrefix(str) : matches(str);
+  }
+
+  // All remaining behavior is identical to the unoptimized matcher; forward to the delegate.
+
+  @Override
+  public boolean isStartAnchored() {
+    return delegate.isStartAnchored();
+  }
+
+  @Override
+  public boolean isEndAnchored() {
+    return delegate.isEndAnchored();
+  }
+
+  @Override
+  public boolean isPrefixMatcher() {
+    return delegate.isPrefixMatcher();
+  }
+
+  @Override
+  public boolean isContainsMatcher() {
+    return delegate.isContainsMatcher();
+  }
+
+  @Override
+  public boolean alwaysMatches() {
+    return delegate.alwaysMatches();
+  }
+
+  @Override
+  public boolean neverMatches() {
+    return delegate.neverMatches();
+  }
+
+  @Override
+  public String prefix() {
+    return delegate.prefix();
+  }
+
+  @Override
+  public String containedString() {
+    return delegate.containedString();
+  }
+
+  @Override
+  public SortedSet<String> trigrams() {
+    return delegate.trigrams();
+  }
+
+  @Override
+  public Matcher rewrite(Function<Matcher, Matcher> f) {
+    return delegate.rewrite(f);
+  }
+
+  @Override
+  public Matcher rewriteEnd(Function<Matcher, Matcher> f) {
+    return delegate.rewriteEnd(f);
+  }
+
+  @Override
+  public List<PatternMatcher> expandOrClauses(int max) {
+    return delegate.expandOrClauses(max);
+  }
+
+  @Override
+  public PatternExpr toPatternExpr(int max) {
+    return delegate.toPatternExpr(max);
+  }
+
+  @Override
+  public String toSqlPattern() {
+    return delegate.toSqlPattern();
+  }
+
+  @Override
+  public String toString() {
+    return delegate.toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    IndexOfSeqMatcher that = (IndexOfSeqMatcher) o;
+    return startAnchored == that.startAnchored
+        && endAnchored == that.endAnchored
+        && ignoreCase == that.ignoreCase
+        && minLength == that.minLength
+        && Arrays.equals(segments, that.segments);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = Arrays.hashCode(segments);
+    result = 31 * result + Boolean.hashCode(startAnchored);
+    result = 31 * result + Boolean.hashCode(endAnchored);
+    result = 31 * result + Boolean.hashCode(ignoreCase);
+    result = 31 * result + minLength;
+    return result;
+  }
+}

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/Optimizer.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/Optimizer.java
@@ -43,10 +43,51 @@ final class Optimizer {
       m = opt;
       opt = optimizeSinglePass(m);
     }
-    // Flatten contains/anchored IndexOf chains into a single IndexOfSeqMatcher. Done as a
-    // terminal pass after the fixpoint so the new matcher type does not need to participate
-    // in the iterative rewrite rules above.
-    return opt.rewrite(Optimizer::foldIndexOfSeq);
+    // Flatten contains/anchored IndexOf chains and start-anchored literal alternations into single
+    // matchers. Done as one terminal pass after the fixpoint so the new matcher types do not need
+    // to participate in the iterative rewrite rules above. A single pass (rather than chained
+    // rewrites) is required: the folded matchers delegate rewrite() to their original nested form,
+    // so a second rewrite pass traversing into them would undo the fold.
+    return opt.rewrite(Optimizer::fold);
+  }
+
+  /** Apply the available flattening folds; the recognized shapes are disjoint. */
+  private static Matcher fold(Matcher matcher) {
+    Matcher folded = foldIndexOfSeq(matcher);
+    return (folded != matcher) ? folded : foldOrStartsWith(matcher);
+  }
+
+  /**
+   * Fold a start-anchored alternation of literal prefixes ({@code ^(abc|def|ghi)}) into a single
+   * {@link OrStartsWithMatcher} that checks each prefix in one monomorphic loop instead of
+   * dispatching an interface call per branch. The original matcher is retained as the delegate.
+   */
+  static Matcher foldOrStartsWith(Matcher matcher) {
+    if (matcher instanceof SeqMatcher) {
+      List<Matcher> ms = matcher.<SeqMatcher>as().matchers();
+      if (ms.size() == 2 && ms.get(0) instanceof StartMatcher && ms.get(1) instanceof OrMatcher) {
+        List<Matcher> branches = ms.get(1).<OrMatcher>as().matchers();
+        if (branches.size() < 2) {
+          return matcher;
+        }
+        String[] prefixes = new String[branches.size()];
+        boolean ignoreCase = false;
+        for (int i = 0; i < branches.size(); ++i) {
+          if (!(branches.get(i) instanceof CharSeqMatcher)) {
+            return matcher;
+          }
+          CharSeqMatcher cs = branches.get(i).as();
+          if (i == 0) {
+            ignoreCase = cs.isIgnoreCase();
+          } else if (cs.isIgnoreCase() != ignoreCase) {
+            return matcher;
+          }
+          prefixes[i] = cs.pattern();
+        }
+        return new OrStartsWithMatcher(prefixes, ignoreCase, matcher);
+      }
+    }
+    return matcher;
   }
 
   /**

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/Optimizer.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/Optimizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2022 Netflix, Inc.
+ * Copyright 2014-2026 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package com.netflix.spectator.impl.matcher;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
@@ -42,7 +43,75 @@ final class Optimizer {
       m = opt;
       opt = optimizeSinglePass(m);
     }
-    return opt;
+    // Flatten contains/anchored IndexOf chains into a single IndexOfSeqMatcher. Done as a
+    // terminal pass after the fixpoint so the new matcher type does not need to participate
+    // in the iterative rewrite rules above.
+    return opt.rewrite(Optimizer::foldIndexOfSeq);
+  }
+
+  /**
+   * Collect the segments of a contains chain into {@code segs}. The chain is a sequence of
+   * {@link IndexOfMatcher} nodes, optionally terminated by an already-folded contains
+   * {@link IndexOfSeqMatcher} (so the fold composes under the bottom-up rewrite). Returns 0 for a
+   * plain contains terminal ({@code .*}), 1 for an end-anchored terminal ({@code $}), or -1 if the
+   * tail is not a foldable contains chain or the {@code ignoreCase} flag is inconsistent.
+   */
+  private static int collectContainsChain(Matcher matcher, boolean ignoreCase, List<String> segs) {
+    Matcher cur = matcher;
+    while (cur instanceof IndexOfMatcher) {
+      IndexOfMatcher io = cur.as();
+      if (io.isIgnoreCase() != ignoreCase) {
+        return -1;
+      }
+      segs.add(io.pattern());
+      cur = io.next();
+    }
+    if (cur == TrueMatcher.INSTANCE) {
+      return 0;
+    } else if (cur == EndMatcher.INSTANCE) {
+      return 1;
+    } else if (cur instanceof IndexOfSeqMatcher) {
+      IndexOfSeqMatcher seq = cur.as();
+      if (seq.startAnchored() || seq.isIgnoreCase() != ignoreCase) {
+        return -1;
+      }
+      segs.addAll(Arrays.asList(seq.segments()));
+      return seq.endAnchored() ? 1 : 0;
+    }
+    return -1;
+  }
+
+  /**
+   * Fold a contains chain ({@code .*A.*B.*}), an end-anchored chain ({@code .*A.*B$}), or a
+   * start-anchored chain ({@code ^A.*B.*C$}) into a single {@link IndexOfSeqMatcher} that matches
+   * greedily without backtracking. The original matcher is retained as the delegate so all
+   * non-matching operations behave identically.
+   */
+  static Matcher foldIndexOfSeq(Matcher matcher) {
+    if (matcher instanceof IndexOfMatcher) {
+      IndexOfMatcher head = matcher.as();
+      boolean ignoreCase = head.isIgnoreCase();
+      List<String> segs = new ArrayList<>();
+      int anchor = collectContainsChain(head, ignoreCase, segs);
+      if (anchor >= 0 && segs.size() >= 2) {
+        return new IndexOfSeqMatcher(
+            segs.toArray(new String[0]), false, anchor == 1, ignoreCase, matcher);
+      }
+    } else if (matcher instanceof SeqMatcher) {
+      List<Matcher> ms = matcher.<SeqMatcher>as().matchers();
+      if (ms.size() == 2 && ms.get(0) instanceof StartsWithMatcher) {
+        StartsWithMatcher prefix = ms.get(0).as();
+        boolean ignoreCase = prefix.isIgnoreCase();
+        List<String> segs = new ArrayList<>();
+        segs.add(prefix.pattern());
+        int anchor = collectContainsChain(ms.get(1), ignoreCase, segs);
+        if (anchor >= 0 && segs.size() >= 2) {
+          return new IndexOfSeqMatcher(
+              segs.toArray(new String[0]), true, anchor == 1, ignoreCase, matcher);
+        }
+      }
+    }
+    return matcher;
   }
 
   private static Matcher optimizeSinglePass(Matcher matcher) {

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/OrStartsWithMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/OrStartsWithMatcher.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2014-2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.impl.matcher;
+
+import com.netflix.spectator.impl.PatternExpr;
+import com.netflix.spectator.impl.PatternMatcher;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.function.Function;
+
+/**
+ * Matches a start-anchored alternation of literal prefixes, e.g. {@code ^(abc|def|ghi)}. The
+ * equivalent {@code SeqMatcher(StartMatcher, OrMatcher(CharSeq, ...))} matches the same strings by
+ * dispatching an interface call per branch; this matcher collapses it to a single monomorphic loop
+ * of {@code regionMatches} checks, equivalent to "does the value start with any of these prefixes".
+ *
+ * <p>Only {@link #matches(String, int, int)} and {@link #minLength()} use the flattened form; all
+ * other operations forward to the original nested {@code delegate} so behavior is identical.</p>
+ */
+final class OrStartsWithMatcher implements Matcher, Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  private final String[] prefixes;
+  private final boolean ignoreCase;
+  private final Matcher delegate;
+  private final int minLength;
+
+  /**
+   * Create a new instance.
+   *
+   * @param prefixes
+   *     Literal prefixes; the value matches if it starts with any one of them.
+   * @param ignoreCase
+   *     True if the prefixes should be matched ignoring case.
+   * @param delegate
+   *     Equivalent nested matcher used for all non-matching operations.
+   */
+  OrStartsWithMatcher(String[] prefixes, boolean ignoreCase, Matcher delegate) {
+    this.prefixes = prefixes;
+    this.ignoreCase = ignoreCase;
+    this.delegate = delegate;
+    int min = Integer.MAX_VALUE;
+    for (String p : prefixes) {
+      min = Math.min(min, p.length());
+    }
+    this.minLength = min;
+  }
+
+  @Override
+  public int matches(String str, int start, int length) {
+    // The alternation is start-anchored to absolute position 0 (via StartMatcher). When invoked as
+    // an embedded sub-matcher at a non-zero offset, defer to the delegate to preserve semantics
+    // (StartMatcher fails for start != 0). The flat path handles the common root case.
+    if (start != 0) {
+      return delegate.matches(str, start, length);
+    }
+    for (String p : prefixes) {
+      if (str.regionMatches(ignoreCase, 0, p, 0, p.length())) {
+        return p.length();
+      }
+    }
+    return Constants.NO_MATCH;
+  }
+
+  @Override
+  public int minLength() {
+    return minLength;
+  }
+
+  // All remaining behavior is identical to the unoptimized matcher; forward to the delegate.
+
+  @Override
+  public boolean matchesAfterPrefix(String str) {
+    // prefix() forwards to the delegate, whose first element is StartMatcher (no literal prefix),
+    // so prefix() is null and a caller has nothing to have pre-verified -- matchesAfterPrefix is
+    // just matches(). Use the fast flat loop here; deferring to the delegate would fall back to the
+    // slow nested Seq[Start, Or] matching that this matcher exists to avoid.
+    return matches(str);
+  }
+
+  @Override
+  public boolean isStartAnchored() {
+    return delegate.isStartAnchored();
+  }
+
+  @Override
+  public boolean isEndAnchored() {
+    return delegate.isEndAnchored();
+  }
+
+  @Override
+  public boolean isPrefixMatcher() {
+    return delegate.isPrefixMatcher();
+  }
+
+  @Override
+  public boolean isContainsMatcher() {
+    return delegate.isContainsMatcher();
+  }
+
+  @Override
+  public boolean alwaysMatches() {
+    return delegate.alwaysMatches();
+  }
+
+  @Override
+  public boolean neverMatches() {
+    return delegate.neverMatches();
+  }
+
+  @Override
+  public String prefix() {
+    return delegate.prefix();
+  }
+
+  @Override
+  public String containedString() {
+    return delegate.containedString();
+  }
+
+  @Override
+  public SortedSet<String> trigrams() {
+    return delegate.trigrams();
+  }
+
+  @Override
+  public Matcher rewrite(Function<Matcher, Matcher> f) {
+    return delegate.rewrite(f);
+  }
+
+  @Override
+  public Matcher rewriteEnd(Function<Matcher, Matcher> f) {
+    return delegate.rewriteEnd(f);
+  }
+
+  @Override
+  public List<PatternMatcher> expandOrClauses(int max) {
+    return delegate.expandOrClauses(max);
+  }
+
+  @Override
+  public PatternExpr toPatternExpr(int max) {
+    return delegate.toPatternExpr(max);
+  }
+
+  @Override
+  public String toSqlPattern() {
+    return delegate.toSqlPattern();
+  }
+
+  @Override
+  public String toString() {
+    return delegate.toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    OrStartsWithMatcher that = (OrStartsWithMatcher) o;
+    return ignoreCase == that.ignoreCase
+        && minLength == that.minLength
+        && Arrays.equals(prefixes, that.prefixes);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = Arrays.hashCode(prefixes);
+    result = 31 * result + Boolean.hashCode(ignoreCase);
+    result = 31 * result + minLength;
+    return result;
+  }
+}

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/RepeatMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/RepeatMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2023 Netflix, Inc.
+ * Copyright 2014-2026 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,12 +29,16 @@ final class RepeatMatcher implements Matcher, Serializable {
   private final Matcher repeated;
   private final int min;
   private final int max;
+  private final int minLength;
 
   /** Create a new instance. */
   RepeatMatcher(Matcher repeated, int min, int max) {
     this.repeated = repeated;
     this.min = min;
     this.max = max;
+    // minLength is fixed for an immutable matcher; precompute it to avoid walking the
+    // repeated sub-matcher on every matches() call.
+    this.minLength = min * repeated.minLength();
   }
 
   Matcher repeated() {
@@ -78,7 +82,7 @@ final class RepeatMatcher implements Matcher, Serializable {
 
   @Override
   public int minLength() {
-    return min * repeated.minLength();
+    return minLength;
   }
 
   @Override
@@ -109,6 +113,7 @@ final class RepeatMatcher implements Matcher, Serializable {
     RepeatMatcher that = (RepeatMatcher) o;
     return min == that.min
         && max == that.max
+        && minLength == that.minLength
         && Objects.equals(repeated, that.repeated);
   }
 
@@ -118,6 +123,7 @@ final class RepeatMatcher implements Matcher, Serializable {
     result = 31 * result + repeated.hashCode();
     result = 31 * result + min;
     result = 31 * result + max;
+    result = 31 * result + minLength;
     return result;
   }
 }

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/StartsWithMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/StartsWithMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2023 Netflix, Inc.
+ * Copyright 2014-2026 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,11 @@ final class StartsWithMatcher implements Matcher, Serializable {
   /** Pattern to check for at the start of the string. */
   String pattern() {
     return pattern;
+  }
+
+  /** Returns true if the prefix check should ignore case. */
+  boolean isIgnoreCase() {
+    return ignoreCase;
   }
 
   @Override

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/ZeroOrMoreMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/ZeroOrMoreMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2023 Netflix, Inc.
+ * Copyright 2014-2026 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,11 +31,15 @@ final class ZeroOrMoreMatcher implements GreedyMatcher, Serializable {
 
   private final Matcher repeated;
   private final Matcher next;
+  private final int minLength;
 
   /** Create a new instance. */
   ZeroOrMoreMatcher(Matcher repeated, Matcher next) {
     this.repeated = repeated;
     this.next = Preconditions.checkNotNull(next, "next");
+    // minLength is fixed for an immutable matcher; precompute it to avoid walking the
+    // next chain on every matches() call.
+    this.minLength = next.minLength();
   }
 
   /** Return the matcher for the repeated portion. */
@@ -100,7 +104,7 @@ final class ZeroOrMoreMatcher implements GreedyMatcher, Serializable {
 
   @Override
   public int minLength() {
-    return next.minLength();
+    return minLength;
   }
 
   @Override
@@ -147,7 +151,9 @@ final class ZeroOrMoreMatcher implements GreedyMatcher, Serializable {
       return false;
     }
     ZeroOrMoreMatcher that = (ZeroOrMoreMatcher) o;
-    return Objects.equals(repeated, that.repeated) && Objects.equals(next, that.next);
+    return minLength == that.minLength
+        && Objects.equals(repeated, that.repeated)
+        && Objects.equals(next, that.next);
   }
 
   @Override
@@ -155,6 +161,7 @@ final class ZeroOrMoreMatcher implements GreedyMatcher, Serializable {
     int result = 1;
     result = 31 * result + repeated.hashCode();
     result = 31 * result + next.hashCode();
+    result = 31 * result + minLength;
     return result;
   }
 }

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/ZeroOrOneMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/ZeroOrOneMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2023 Netflix, Inc.
+ * Copyright 2014-2026 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,11 +31,15 @@ final class ZeroOrOneMatcher implements GreedyMatcher, Serializable {
 
   private final Matcher repeated;
   private final Matcher next;
+  private final int minLength;
 
   /** Create a new instance. */
   ZeroOrOneMatcher(Matcher repeated, Matcher next) {
     this.repeated = Preconditions.checkNotNull(repeated, "repeated");
     this.next = Preconditions.checkNotNull(next, "next");
+    // minLength is fixed for an immutable matcher; precompute it to avoid walking the
+    // next chain on every matches() call.
+    this.minLength = next.minLength();
   }
 
   /** Return the matcher for the repeated portion. */
@@ -72,7 +76,7 @@ final class ZeroOrOneMatcher implements GreedyMatcher, Serializable {
 
   @Override
   public int minLength() {
-    return next.minLength();
+    return minLength;
   }
 
   @Override
@@ -118,7 +122,9 @@ final class ZeroOrOneMatcher implements GreedyMatcher, Serializable {
       return false;
     }
     ZeroOrOneMatcher that = (ZeroOrOneMatcher) o;
-    return Objects.equals(repeated, that.repeated) && Objects.equals(next, that.next);
+    return minLength == that.minLength
+        && Objects.equals(repeated, that.repeated)
+        && Objects.equals(next, that.next);
   }
 
   @Override
@@ -126,6 +132,7 @@ final class ZeroOrOneMatcher implements GreedyMatcher, Serializable {
     int result = 1;
     result = 31 * result + repeated.hashCode();
     result = 31 * result + next.hashCode();
+    result = 31 * result + minLength;
     return result;
   }
 }

--- a/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/AbstractPatternMatcherTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/AbstractPatternMatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2022 Netflix, Inc.
+ * Copyright 2014-2026 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,6 +78,12 @@ public abstract class AbstractPatternMatcherTest {
     // SeqMatcher
     Assertions.assertTrue(PatternMatcher.compile("^abc").matchesAfterPrefix("abc[d-f]"));
     Assertions.assertTrue(PatternMatcher.compile("^abc").matchesAfterPrefix("bar[d-f]"));
+
+    // Start-anchored IndexOfSeqMatcher: the prefix (abc) is trusted as already verified, so the
+    // remainder is matched without re-checking it.
+    Assertions.assertTrue(PatternMatcher.compile("^abc.*def").matchesAfterPrefix("abcxxdef"));
+    Assertions.assertTrue(PatternMatcher.compile("^abc.*def").matchesAfterPrefix("barxxdef"));
+    Assertions.assertFalse(PatternMatcher.compile("^abc.*def").matchesAfterPrefix("barxxxyz"));
   }
 
   @Test
@@ -149,6 +155,69 @@ public abstract class AbstractPatternMatcherTest {
   public void glob() {
     testRE("^*.abc", "12345 abc 67890");
     testRE("^*abc", "12345 abc 67890");
+  }
+
+  @Test
+  public void indexOfSeqContains() {
+    testRE(".*abc.*def", "abcdef");
+    testRE(".*abc.*def", "xxabcyydefzz");
+    testRE(".*abc.*def", "abc");
+    testRE(".*abc.*def", "defabc");
+    testRE(".*abc.*def.*", "xabcxdefx");
+    testRE(".*abc.*def.*", "xdefxabcx");
+    // Overlap and repeated-segment cases that stress greedy vs backtracking
+    testRE(".*ab.*ab", "abab");
+    testRE(".*ab.*ab", "ab");
+    testRE(".*ab.*ab", "abxab");
+    testRE(".*a.*a.*a", "aa");
+    testRE(".*a.*a.*a", "aaa");
+    // Low-selectivity leading segment (the production pathology)
+    testRE(".*-.*-md-preview-", "a-b-md-preview-c");
+    testRE(".*-.*-md-preview-", "a-b-c-d-e-f");
+  }
+
+  @Test
+  public void indexOfSeqEndAnchored() {
+    testRE(".*abc.*def$", "abcdef");
+    testRE(".*abc.*def$", "abcdefx");
+    testRE(".*abc.*def$", "xabcyydef");
+    testRE(".*ab.*cd$", "abcd");
+    testRE(".*ab.*cd$", "abcdx");
+    testRE(".*ab.*ab$", "abab");
+    testRE(".*ab.*ab$", "abab__");
+  }
+
+  @Test
+  public void indexOfSeqStartAnchored() {
+    testRE("^abc.*def", "abcdef");
+    testRE("^abc.*def", "xabcdef");
+    testRE("^abc.*def", "abcxxdef");
+    testRE("^abc.*def.*ghi", "abcXdefYghi");
+    testRE("^abc.*def.*ghi", "abcXghiYdef");
+    testRE("^abc.*def$", "abcXdef");
+    testRE("^abc.*def$", "abcXdefY");
+    testRE("^a.*a.*a", "aaa");
+    testRE("^a.*a.*a", "baaa");
+  }
+
+  @Test
+  public void indexOfSeqIgnoreCase() {
+    testRE("(?i).*abc.*def", "XYabcZZdef");
+    testRE("(?i).*abc.*def", "XYABCzzDEF");
+    testRE("(?i).*abc.*def", "XYABCzz");
+    testRE("(?i)^abc.*def$", "ABCxxDEF");
+    testRE("(?i)^abc.*def$", "xABCxxDEF");
+  }
+
+  @Test
+  public void indexOfSeqEmbeddedStartAnchor() {
+    // A start anchor in a non-leading position can place a start-anchored fold as a sub-matcher
+    // invoked at a non-zero offset. The anchor must still bind to absolute position 0.
+    testRE("^a(^b.*c|d.*e)", "abc");
+    testRE("^a(^b.*c|d.*e)", "ade");
+    testRE("^a(^b.*c|d.*e)", "abxc");
+    testRE("x(^b.*c|q)", "xbzc");
+    testRE("x(^b.*c|q)", "xq");
   }
 
   @Test

--- a/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/AbstractPatternMatcherTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/AbstractPatternMatcherTest.java
@@ -84,6 +84,12 @@ public abstract class AbstractPatternMatcherTest {
     Assertions.assertTrue(PatternMatcher.compile("^abc.*def").matchesAfterPrefix("abcxxdef"));
     Assertions.assertTrue(PatternMatcher.compile("^abc.*def").matchesAfterPrefix("barxxdef"));
     Assertions.assertFalse(PatternMatcher.compile("^abc.*def").matchesAfterPrefix("barxxxyz"));
+
+    // Start-anchored alternation (OrStartsWithMatcher) has no literal prefix(), so
+    // matchesAfterPrefix is a full match against the prefixes.
+    Assertions.assertTrue(PatternMatcher.compile("^(abc|def)").matchesAfterPrefix("abcxx"));
+    Assertions.assertTrue(PatternMatcher.compile("^(abc|def)").matchesAfterPrefix("defxx"));
+    Assertions.assertFalse(PatternMatcher.compile("^(abc|def)").matchesAfterPrefix("xyz"));
   }
 
   @Test
@@ -207,6 +213,26 @@ public abstract class AbstractPatternMatcherTest {
     testRE("(?i).*abc.*def", "XYABCzz");
     testRE("(?i)^abc.*def$", "ABCxxDEF");
     testRE("(?i)^abc.*def$", "xABCxxDEF");
+  }
+
+  @Test
+  public void orStartsWith() {
+    testRE("^(abc|def|ghi)", "abcxxx");
+    testRE("^(abc|def|ghi)", "defxxx");
+    testRE("^(abc|def|ghi)", "ghi");
+    testRE("^(abc|def|ghi)", "xabc");
+    testRE("^(abc|def|ghi)", "ab");
+    testRE("^(a|bb|ccc)", "ccczz");
+    testRE("^(a|bb|ccc)", "b");
+    testRE("^(a|bb|ccc)", "a");
+    // ignore case
+    testRE("(?i)^(abc|def)", "ABCxx");
+    testRE("(?i)^(abc|def)", "xABC");
+    // start anchor in a non-leading position: the alternation fold is reached at offset>0 and must
+    // still bind to absolute position 0.
+    testRE("^z(^(a|bb)|cd)", "zab");
+    testRE("^z(^(a|bb)|cd)", "zcd");
+    testRE("^z(^(a|bb)|cd)", "zbb");
   }
 
   @Test

--- a/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/OptimizerTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/OptimizerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2022 Netflix, Inc.
+ * Copyright 2014-2026 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -399,9 +399,9 @@ public class OptimizerTest {
   @Test
   public void optimizeIndexOfSeq() {
     PatternMatcher actual = PatternMatcher.compile("^.*abc.*def");
-    PatternMatcher expected = new IndexOfMatcher(
-        "abc",
-        new IndexOfMatcher("def", TrueMatcher.INSTANCE)
+    PatternMatcher expected = new IndexOfSeqMatcher(
+        new String[] {"abc", "def"}, false, false, false,
+        new IndexOfMatcher("abc", new IndexOfMatcher("def", TrueMatcher.INSTANCE))
     );
     Assertions.assertEquals(expected, actual);
   }
@@ -409,9 +409,9 @@ public class OptimizerTest {
   @Test
   public void optimizeIndexOfSeqAny() {
     PatternMatcher actual = PatternMatcher.compile("^.*abc.*def.*");
-    PatternMatcher expected = new IndexOfMatcher(
-        "abc",
-        new IndexOfMatcher("def", TrueMatcher.INSTANCE)
+    PatternMatcher expected = new IndexOfSeqMatcher(
+        new String[] {"abc", "def"}, false, false, false,
+        new IndexOfMatcher("abc", new IndexOfMatcher("def", TrueMatcher.INSTANCE))
     );
     Assertions.assertEquals(expected, actual);
   }


### PR DESCRIPTION
Patterns of the form `.*A.*B.*` (and end- or start-anchored variants) compile to a chain of nested IndexOfMatchers whose matches() recurses and backtracks. When an early segment has low selectivity (e.g. a single "-" in `.*-.*-md-preview-.*`) the cost is quadratic in the number of candidate positions, which shows up as a hot spot when matching high-cardinality tag values against many LWC subscription expressions.

Add IndexOfSeqMatcher, produced by a terminal Optimizer pass, that flattens such a chain into a single greedy left-to-right scan with no backtracking. Greedy first-match per segment is correct because each non-anchored segment is an unanchored substring search, so the earliest match maximizes the remaining window. A leading ^ pins the first segment to position 0; a trailing $ pins the last with endsWith. All non-matching operations forward to the original nested matcher so behavior is otherwise identical.

Also cache minLength in IndexOfMatcher/ZeroOrMoreMatcher/ ZeroOrOneMatcher/RepeatMatcher (it is fixed for an immutable matcher) to avoid walking the next chain on every matches() call.

On a dash-heavy non-matching value the depth-5 case drops from ~398ns to ~28ns; the generic multiIndexOf benchmark improves to ~57M ops/s (~10x JDK, ~2x re2j) with no regression on the other shapes.