### PR TITLE
Add direct-mapped cache and use for QueryIndex

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/impl/Cache.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/Cache.java
@@ -47,6 +47,32 @@ public interface Cache<K, V> {
   }
 
   /**
+   * Create a new direct-mapped cache: an open-addressed table that evicts on hash collision, so
+   * eviction is O(1) with no compaction sweep and reads and writes are lock-free. The table is
+   * allocated lazily on the first write and grows from {@code initialSize} to {@code maxSize} as its
+   * working set fills it, so memory tracks live entries rather than the configured maximum. Writes
+   * are best-effort (a collision or a race may drop an entry, causing a later miss but never an
+   * incorrect result), which makes this a good fit for memoizing a pure function.
+   *
+   * @param registry
+   *     Registry to use for tracking stats about the cache.
+   * @param id
+   *     Used with metrics to identify a particular instance of the cache.
+   * @param initialSize
+   *     Initial number of slots allocated on the first write. Use a small value so lightly used
+   *     instances stay cheap.
+   * @param maxSize
+   *     Maximum number of slots the table can grow to. Use {@code initialSize == maxSize} for a
+   *     fixed-capacity, non-growing cache.
+   * @return
+   *     Instance of a direct-mapped cache.
+   */
+  static <K1, V1> Cache<K1, V1> directMapped(
+      Registry registry, String id, int initialSize, int maxSize) {
+    return new DirectMappedCache<>(registry, id, initialSize, maxSize);
+  }
+
+  /**
    * Returns the cached value associated with the key or null if none is found.
    */
   V get(K key);

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/DirectMappedCache.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/DirectMappedCache.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2014-2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.impl;
+
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.Registry;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Function;
+
+/**
+ * Direct-mapped implementation of {@link Cache}. An open-addressed table where a hash collision
+ * evicts the current occupant rather than probing, so eviction is O(1) and amortized into each put
+ * with no periodic compaction sweep. Each slot holds an immutable key/value entry published through
+ * an {@link AtomicReferenceArray}, making a read a single volatile array load plus a key compare and
+ * a write a single {@code getAndSet} — no locks and no per-read frequency bookkeeping on the hot
+ * path.
+ *
+ * <p>The table is allocated lazily on the first write and grows on demand: it starts at
+ * {@code initialSize} and doubles up to {@code maxSize} as the working set fills it (when occupancy
+ * crosses 3/4 of the current length). This lets a cache that is never written cost nothing and one
+ * with a small working set stay small, so memory tracks live entries rather than the configured
+ * maximum. Use {@code initialSize == maxSize} for a fixed-capacity, non-growing cache.
+ *
+ * <p>Writes are best-effort: a collision evicts whatever occupied the slot, concurrent writes to the
+ * same slot or a value racing a resize may be dropped, and a resize itself may drop entries that
+ * collide when rehashed into the larger table (self-healing, since they are recomputed on the next
+ * miss). A dropped entry only causes a later miss (and recompute), never an incorrect result, so
+ * this is well suited to memoizing a pure function. It is a poor fit where a value must remain
+ * resident once written.
+ *
+ * <p><b>This class is an internal implementation detail only intended for use within spectator.
+ * It is subject to change without notice.</b></p>
+ */
+class DirectMappedCache<K, V> implements Cache<K, V> {
+
+  private final Counter hits;
+  private final Counter misses;
+  private final Counter resizes;
+
+  private final int initialLen;
+  private final int maxLen;
+
+  // null until the first put; holds the slot array directly so a read is a single load with no
+  // wrapper indirection. Volatile so a resize (which swaps in a larger array) is safely published.
+  private volatile AtomicReferenceArray<Entry<K, V>> table;
+
+  // Filled-slot count for the current table, reset on resize. Approximate under races (only used as
+  // a grow-trigger hint) and updated only while the table can still grow.
+  private final AtomicInteger occupied;
+
+  // Guards lazy allocation and resize, which are rare; the get/put steady path stays lock-free.
+  private final Lock lock;
+
+  DirectMappedCache(Registry registry, String id, int initialSize, int maxSize) {
+    this.hits = registry.counter("spectator.cache.requests", "id", id, "result", "hit");
+    this.misses = registry.counter("spectator.cache.requests", "id", id, "result", "miss");
+    this.resizes = registry.counter("spectator.cache.resizes", "id", id);
+    this.maxLen = tableSize(Math.max(1, maxSize));
+    this.initialLen = Math.min(tableSize(Math.max(1, initialSize)), maxLen);
+    this.occupied = new AtomicInteger();
+    this.lock = new ReentrantLock();
+    this.table = null;
+  }
+
+  private AtomicReferenceArray<Entry<K, V>> allocate() {
+    lock.lock();
+    try {
+      if (table == null) {
+        table = new AtomicReferenceArray<>(initialLen);
+      }
+      return table;
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  private void grow(AtomicReferenceArray<Entry<K, V>> old) {
+    lock.lock();
+    try {
+      // Recheck under lock: another thread may have already grown past this generation.
+      if (table == old && old.length() < maxLen) {
+        int newLen = old.length() << 1;
+        AtomicReferenceArray<Entry<K, V>> next = new AtomicReferenceArray<>(newLen);
+        int mask = newLen - 1;
+        int occ = 0;
+        for (int i = 0; i < old.length(); ++i) {
+          Entry<K, V> e = old.get(i);
+          if (e != null) {
+            int j = mix(e.key.hashCode()) & mask;
+            if (next.get(j) == null) {
+              ++occ;
+            }
+            next.set(j, e); // collisions within the 2x array are rare; evict as usual
+          }
+        }
+        occupied.set(occ);
+        resizes.increment();
+        table = next;
+      }
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  private void putEntry(K key, V value) {
+    // Read the volatile field once: a concurrent clear() could null it between a check and a reuse,
+    // and operating on a stale-but-non-null array only drops a best-effort write (never an NPE).
+    AtomicReferenceArray<Entry<K, V>> t = table;
+    if (t == null) {
+      t = allocate();
+    }
+    int len = t.length();
+    Entry<K, V> prev = t.getAndSet(mix(key.hashCode()) & (len - 1), new Entry<>(key, value));
+    // Filling a free slot is the only event that raises occupancy; skip the check once at max size.
+    if (prev == null && len < maxLen && occupied.incrementAndGet() >= len - (len >>> 2)) {
+      grow(t);
+    }
+  }
+
+  @Override public V get(K key) {
+    AtomicReferenceArray<Entry<K, V>> t = table;
+    if (t != null) {
+      Entry<K, V> e = t.get(mix(key.hashCode()) & (t.length() - 1));
+      if (e != null && e.key.equals(key)) {
+        hits.increment();
+        return e.value;
+      }
+    }
+    misses.increment();
+    return null;
+  }
+
+  @Override public V peek(K key) {
+    AtomicReferenceArray<Entry<K, V>> t = table;
+    if (t == null) {
+      return null;
+    }
+    Entry<K, V> e = t.get(mix(key.hashCode()) & (t.length() - 1));
+    return (e != null && e.key.equals(key)) ? e.value : null;
+  }
+
+  @Override public void put(K key, V value) {
+    putEntry(key, value);
+  }
+
+  @Override public V computeIfAbsent(K key, Function<K, V> f) {
+    AtomicReferenceArray<Entry<K, V>> t = table;
+    if (t != null) {
+      Entry<K, V> e = t.get(mix(key.hashCode()) & (t.length() - 1));
+      if (e != null && e.key.equals(key)) {
+        hits.increment();
+        return e.value;
+      }
+    }
+    misses.increment();
+    V value = f.apply(key);
+    putEntry(key, value);
+    return value;
+  }
+
+  @Override public void clear() {
+    lock.lock();
+    try {
+      table = null;
+      occupied.set(0);
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  @Override public int size() {
+    AtomicReferenceArray<Entry<K, V>> t = table;
+    if (t == null) {
+      return 0;
+    }
+    int n = 0;
+    for (int i = 0; i < t.length(); ++i) {
+      if (t.get(i) != null) {
+        ++n;
+      }
+    }
+    return n;
+  }
+
+  @Override public Map<K, V> asMap() {
+    Map<K, V> m = new HashMap<>();
+    AtomicReferenceArray<Entry<K, V>> t = table;
+    if (t != null) {
+      for (int i = 0; i < t.length(); ++i) {
+        Entry<K, V> e = t.get(i);
+        if (e != null) {
+          m.put(e.key, e.value);
+        }
+      }
+    }
+    return m;
+  }
+
+  /** Smallest power of two &gt;= max(1, n), capped at 2^30 so the doubling cannot overflow int. */
+  private static int tableSize(int n) {
+    if (n >= (1 << 30)) {
+      return 1 << 30;
+    }
+    int c = 1;
+    while (c < n) {
+      c <<= 1;
+    }
+    return c;
+  }
+
+  /**
+   * murmur3 fmix32 avalanche. {@code hashCode} values commonly cluster in the low bits that a raw
+   * mask keys on, which would manufacture conflict misses; mixing spreads them across the range.
+   */
+  private static int mix(int h0) {
+    int h = h0;
+    h ^= (h >>> 16);
+    h *= 0x85ebca6b;
+    h ^= (h >>> 13);
+    h *= 0xc2b2ae35;
+    h ^= (h >>> 16);
+    return h;
+  }
+
+  private static final class Entry<K, V> {
+    private final K key;
+    private final V value;
+
+    Entry(K key, V value) {
+      this.key = key;
+      this.value = value;
+    }
+  }
+}

--- a/spectator-api/src/test/java/com/netflix/spectator/impl/DirectMappedCacheTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/DirectMappedCacheTest.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2014-2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.impl;
+
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.Registry;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class DirectMappedCacheTest {
+
+  private Registry registry;
+
+  @BeforeEach
+  public void before() {
+    registry = new DefaultRegistry();
+  }
+
+  private long hits() {
+    return registry
+        .counter("spectator.cache.requests", "id", "test", "result", "hit")
+        .count();
+  }
+
+  private long misses() {
+    return registry
+        .counter("spectator.cache.requests", "id", "test", "result", "miss")
+        .count();
+  }
+
+  private long resizes() {
+    return registry
+        .counter("spectator.cache.resizes", "id", "test")
+        .count();
+  }
+
+  private Cache<String, String> create(int initialSize, int maxSize) {
+    return Cache.directMapped(registry, "test", initialSize, maxSize);
+  }
+
+  @Test
+  public void emptyBeforeFirstPut() {
+    // Lazy: no allocation, no entries, and a lookup is a miss.
+    Cache<String, String> cache = create(64, 1024);
+    Assertions.assertEquals(0, cache.size());
+    Assertions.assertNull(cache.get("a"));
+    Assertions.assertEquals(0, hits());
+    Assertions.assertEquals(1, misses());
+  }
+
+  @Test
+  public void putGet() {
+    Cache<String, String> cache = create(64, 1024);
+    cache.put("a", "A");
+    Assertions.assertEquals("A", cache.get("a"));
+    Assertions.assertEquals(1, hits());
+    Assertions.assertEquals(0, misses());
+  }
+
+  @Test
+  public void peekDoesNotCount() {
+    Cache<String, String> cache = create(64, 1024);
+    cache.put("a", "A");
+    Assertions.assertEquals("A", cache.peek("a"));
+    Assertions.assertNull(cache.peek("b"));
+    Assertions.assertEquals(0, hits());
+    Assertions.assertEquals(0, misses());
+  }
+
+  @Test
+  public void computeIfAbsent() {
+    Cache<String, String> cache = create(64, 1024);
+    Assertions.assertEquals("A", cache.computeIfAbsent("a", String::toUpperCase));
+    Assertions.assertEquals(0, hits());
+    Assertions.assertEquals(1, misses());
+  }
+
+  @Test
+  public void computeIfAbsentRepeat() {
+    Cache<String, String> cache = create(64, 1024);
+    Assertions.assertEquals("A", cache.computeIfAbsent("a", String::toUpperCase));
+    // Same key, same slot untouched by any other write -> deterministic hit, function not called.
+    Assertions.assertEquals("A", cache.computeIfAbsent("a", s -> {
+      throw new RuntimeException("fail");
+    }));
+    Assertions.assertEquals(1, hits());
+    Assertions.assertEquals(1, misses());
+  }
+
+  @Test
+  public void clear() {
+    Cache<String, String> cache = create(64, 1024);
+    cache.put("a", "A");
+    Assertions.assertEquals(1, cache.size());
+    cache.clear();
+    Assertions.assertEquals(0, cache.size());
+    Assertions.assertNull(cache.get("a"));
+  }
+
+  @Test
+  public void growsUpToMax() {
+    Cache<String, String> cache = create(2, 64);
+    for (int i = 0; i < 10_000; ++i) {
+      String v = UUID.randomUUID().toString();
+      cache.put(v, v);
+    }
+    // Grew from the initial size and stays bounded by the max regardless of churn.
+    Assertions.assertTrue(resizes() > 0, "expected at least one resize");
+    Assertions.assertTrue(cache.size() <= 64, "size must stay within max capacity");
+    // Still functional: a fresh entry is readable immediately after it is written.
+    cache.put("fresh", "FRESH");
+    Assertions.assertEquals("FRESH", cache.get("fresh"));
+  }
+
+  @Test
+  public void nonGrowingWhenInitialEqualsMax() {
+    Cache<String, String> cache = create(16, 16);
+    for (int i = 0; i < 10_000; ++i) {
+      String v = UUID.randomUUID().toString();
+      cache.put(v, v);
+    }
+    Assertions.assertEquals(0, resizes());
+    Assertions.assertTrue(cache.size() <= 16, "size must stay within fixed capacity");
+  }
+
+  @Test
+  public void highHitRateWhenWorkingSetFits() {
+    // A fixed table far larger than the working set keeps the load factor low, so conflict misses
+    // are rare and nearly every distinct key stays resident. (A growing table would instead settle
+    // near a 0.5 load factor, where direct-mapping's conflict misses drop ~20% of a uniform scan.)
+    int n = 100;
+    Cache<String, String> cache = create(8192, 8192);
+    String[] keys = new String[n];
+    for (int i = 0; i < n; ++i) {
+      keys[i] = UUID.randomUUID().toString();
+      cache.put(keys[i], keys[i]);
+    }
+    int found = 0;
+    for (String k : keys) {
+      if (k.equals(cache.get(k))) {
+        ++found;
+      }
+    }
+    Assertions.assertTrue(found >= 95, "expected nearly all keys resident, found " + found);
+  }
+
+  @Test
+  public void largeMaxSizeDoesNotHang() {
+    // Regression: tableSize() must cap the power-of-two search so a large cap does not overflow into
+    // an infinite loop in the constructor. Would hang before the cap was added.
+    Assertions.assertTimeoutPreemptively(Duration.ofSeconds(5), () -> {
+      Cache<String, String> cache = Cache.directMapped(registry, "test", 1, Integer.MAX_VALUE);
+      cache.put("a", "A");
+      Assertions.assertEquals("A", cache.get("a"));
+    });
+  }
+
+  @Test
+  public void resizeKeepsTableConsistent() {
+    // Insert enough distinct keys to force several doublings, then assert the rehash left the table
+    // internally consistent: every entry asMap() reports must be retrievable via get() at its
+    // masked slot. A wrong-mask or dropping rehash would leave entries asMap sees but get cannot
+    // find. (A growing direct-mapped table does lose some entries to collisions on each rehash,
+    // self-healing under repeated access, so this checks consistency rather than a survival count.)
+    Cache<String, String> cache = create(2, 4096);
+    for (int i = 0; i < 200; ++i) {
+      String v = UUID.randomUUID().toString();
+      cache.put(v, v);
+    }
+    Assertions.assertTrue(resizes() > 0, "expected resizes growing from 2 toward 4096");
+    Map<String, String> snapshot = cache.asMap();
+    Assertions.assertFalse(snapshot.isEmpty(), "expected resident entries after growth");
+    for (Map.Entry<String, String> e : snapshot.entrySet()) {
+      Assertions.assertEquals(e.getValue(), cache.get(e.getKey()),
+          "asMap reported an entry that get() cannot find at its slot: " + e.getKey());
+    }
+  }
+
+  @Test
+  public void concurrentPutAndClearDoNotThrow() throws Exception {
+    // Regression: put()/computeIfAbsent() must read the volatile table once so a concurrent clear()
+    // cannot null it between a check and a use. Before the fix this raced to a NullPointerException.
+    Cache<String, String> cache = create(64, 1024);
+    int workers = 8;
+    int iterations = 20_000;
+    ExecutorService pool = Executors.newFixedThreadPool(workers + 1);
+    AtomicReference<Throwable> error = new AtomicReference<>();
+    CountDownLatch start = new CountDownLatch(1);
+    List<Future<?>> futures = new ArrayList<>();
+    for (int w = 0; w < workers; ++w) {
+      final int id = w;
+      futures.add(pool.submit(() -> {
+        try {
+          start.await();
+          for (int i = 0; i < iterations; ++i) {
+            String k = "k" + id + "-" + (i & 1023);
+            cache.put(k, k);
+            cache.get(k);
+            cache.computeIfAbsent(k, x -> x);
+          }
+        } catch (Throwable e) {
+          error.compareAndSet(null, e);
+        }
+      }));
+    }
+    futures.add(pool.submit(() -> {
+      try {
+        start.await();
+        for (int i = 0; i < iterations; ++i) {
+          cache.clear();
+        }
+      } catch (Throwable e) {
+        error.compareAndSet(null, e);
+      }
+    }));
+    start.countDown();
+    for (Future<?> f : futures) {
+      f.get();
+    }
+    pool.shutdown();
+    Assertions.assertNull(error.get(), () -> "unexpected exception: " + error.get());
+  }
+}

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/QueryIndex.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/QueryIndex.java
@@ -73,7 +73,7 @@ public final class QueryIndex<T> {
   public interface CacheSupplier<V> extends Supplier<Cache<String, CacheValue<V>>> {
   }
 
-  /** Default supplier based on a simple LFU cache. */
+  /** Default supplier based on a lazy, growable direct-mapped cache. */
   public static class DefaultCacheSupplier<V> implements CacheSupplier<V> {
 
     private final Registry registry;
@@ -84,7 +84,9 @@ public final class QueryIndex<T> {
 
     @Override
     public Cache<String, CacheValue<V>> get() {
-      return Cache.lfu(registry, "QueryIndex", 100, 1000);
+      // Allocated lazily and grows from 64 to 16384 per node, so eq-only nodes (which never write
+      // their cache) cost nothing and only the few hot nodes approach the max.
+      return Cache.directMapped(registry, "QueryIndex", 64, 16384);
     }
   }
 


### PR DESCRIPTION
Add DirectMappedCache: a lock-free, open-addressed Cache that evicts on hash collision (O(1) eviction, no compaction sweep). It allocates lazily on first write and grows from initialSize to maxSize as its working set fills, so memory tracks live entries rather than the configured maximum. Reads/writes are best-effort - a dropped entry only forces a recompute, never a wrong result - making it well suited to memoizing a pure function. Exposed via Cache.directMapped(registry, id, initialSize, maxSize).

Switch QueryIndex's default cache from LFU(100, 1000) to directMapped(64, 16384). The per-node cache is consulted only for nodes with non-equality checks; the many equality-only nodes now allocate nothing, and only hot nodes grow toward the max. Correctness is unaffected: an evicted value simply recomputes, and cached values are already version-checked against otherChecksVersion.