### PR TITLE
Do not extend AutoCloseable from the Registry interface

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/AbstractRegistry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/AbstractRegistry.java
@@ -34,7 +34,7 @@ import java.util.function.LongSupplier;
  * Base class to make it easier to implement a simple registry that only needs to customise the
  * types returned for Counter, DistributionSummary, and Timer calls.
  */
-public abstract class AbstractRegistry implements Registry {
+public abstract class AbstractRegistry implements Registry, AutoCloseable {
 
   /** Not used for this registry, always return 0. */
   private static final LongSupplier VERSION = () -> 0L;

--- a/spectator-api/src/main/java/com/netflix/spectator/api/Registry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/Registry.java
@@ -31,7 +31,7 @@ import java.util.stream.StreamSupport;
 /**
  * Registry to manage a set of meters.
  */
-public interface Registry extends Iterable<Meter>, AutoCloseable {
+public interface Registry extends Iterable<Meter> {
 
   /**
    * The clock used by the registry for timing events.
@@ -39,15 +39,22 @@ public interface Registry extends Iterable<Meter>, AutoCloseable {
   Clock clock();
 
   /**
-   * Release any resources associated with the registry. This allows a registry to be used with
-   * try-with-resources and is most useful for registries that are created for temporary use.
+   * Release any resources associated with the registry. Most code that uses a registry does not
+   * manage its lifecycle: the registry is typically a long-lived, often injected, dependency and
+   * is only closed by whatever is responsible for creating it, if at all.
    *
    * <p>The default implementation does nothing, so existing registries are unaffected.
    * Implementations that maintain background work, such as the polling tasks created by
    * {@link com.netflix.spectator.api.patterns.PolledMeter}, should override this to stop that
    * work.</p>
+   *
+   * <p>Concrete registry implementations also implement {@link AutoCloseable} so they can be used
+   * with try-with-resources. The {@code Registry} interface itself intentionally does not extend
+   * {@link AutoCloseable}, because the vast majority of call sites that hold a {@code Registry}
+   * reference never manage its lifecycle, and having the interface be {@code AutoCloseable} leads
+   * to spurious "resource leak" warnings from IDEs and static analysis tools at those sites.</p>
    */
-  @Override default void close() {
+  default void close() {
   }
 
   /**

--- a/spectator-api/src/test/java/com/netflix/spectator/api/SpectatorTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/SpectatorTest.java
@@ -55,4 +55,27 @@ public class SpectatorTest {
     }
     Assertions.assertTrue(found, "id for sub-registry could not be found in global iterator");
   }
+
+  // The static type of a reference determines whether IDEs and static analysis tools flag it as
+  // an unclosed AutoCloseable resource. Normal usage holds a Registry (e.g. injected) or the type
+  // returned by Spectator.globalRegistry(), neither of which manages a lifecycle, so neither
+  // should be AutoCloseable. These tests guard against re-introducing AutoCloseable on those types
+  // and reviving the spurious resource-leak warnings.
+
+  @Test
+  public void registryInterfaceIsNotAutoCloseable() {
+    Assertions.assertFalse(AutoCloseable.class.isAssignableFrom(Registry.class));
+  }
+
+  @Test
+  public void globalRegistryReturnTypeIsNotAutoCloseable() throws Exception {
+    Class<?> returnType = Spectator.class.getMethod("globalRegistry").getReturnType();
+    Assertions.assertFalse(AutoCloseable.class.isAssignableFrom(returnType));
+  }
+
+  @Test
+  public void concreteRegistryIsAutoCloseable() {
+    // Registries that own background work still support try-with-resources via the concrete type.
+    Assertions.assertTrue(AutoCloseable.class.isAssignableFrom(DefaultRegistry.class));
+  }
 }

--- a/spectator-api/src/test/java/com/netflix/spectator/api/patterns/PolledMeterTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/patterns/PolledMeterTest.java
@@ -398,7 +398,7 @@ public class PolledMeterTest {
   @Test
   public void registryCloseViaTryWithResources() {
     AtomicLong closed = new AtomicLong();
-    try (Registry r = new DefaultRegistry()) {
+    try (DefaultRegistry r = new DefaultRegistry()) {
       PolledMeter.using(r).withName("gauge")
           .withCleanupAction(closed::incrementAndGet)
           .monitorValue(new AtomicLong(1));

--- a/spectator-reg-micrometer/src/main/java/com/netflix/spectator/micrometer/MicrometerRegistry.java
+++ b/spectator-reg-micrometer/src/main/java/com/netflix/spectator/micrometer/MicrometerRegistry.java
@@ -44,7 +44,7 @@ import java.util.stream.Collectors;
 /**
  * Wraps a Micrometer MeterRegistry to make it conform to the Spectator API.
  */
-public final class MicrometerRegistry implements Registry {
+public final class MicrometerRegistry implements Registry, AutoCloseable {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(MicrometerRegistry.class);
 


### PR DESCRIPTION
Registry extending AutoCloseable (added in v1.10.0) causes IDEs and static analysis tools to flag spurious resource-leak warnings at the many call sites that hold a Registry reference but never manage its lifecycle, such as injected registries and Spectator.globalRegistry().

Keep close() on the Registry interface for polymorphic use, but move AutoCloseable down to the concrete implementations that own background work: AbstractRegistry (and its subclasses), MicrometerRegistry, and SidecarRegistry (already Closeable). CompositeRegistry, NoopRegistry, and ExtendedRegistry are intentionally left as plain registries.

try-with-resources now requires the concrete registry type rather than the Registry interface.