### PR TITLE
atlas: fix invalid tag characters at meter creation

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/AbstractRegistry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/AbstractRegistry.java
@@ -187,9 +187,31 @@ public abstract class AbstractRegistry implements Registry, AutoCloseable {
    * then it will not create a new instance.
    */
   private Id normalizeId(Id id) {
+    // For a foreign Id implementation the normalization (sort/dedup plus the subclass tag
+    // constraints) is cached so that ids created in a tight loop do not repeat the work. The
+    // tag fixing is done inside the cache computation so the cached value is the fully
+    // normalized id and does not need to be re-checked on every lookup.
+    //
+    // A DefaultId is already sorted and de-duped, so it short circuits on the type and only the
+    // tag fixing is applied. That check is a cheap scan that returns the same instance when
+    // everything is already valid, which avoids a second concurrent map lookup on the hot path
+    // for the common case.
     return (id instanceof DefaultId)
-        ? id
-        : idNormalizationCache.computeIfAbsent(id, i -> createId(i.name(), i.tags()));
+        ? normalizeTags(id)
+        : idNormalizationCache.computeIfAbsent(id, i -> normalizeTags(createId(i.name(), i.tags())));
+  }
+
+  /**
+   * Hook that allows subclasses to enforce backend specific constraints on the tags of an id,
+   * for example replacing characters that are not permitted by the storage layer. It is called
+   * for every id used to create or look up a meter so that the meter, and the measurements it
+   * produces, use the constrained form consistently. Since this is on the meter lookup path,
+   * implementations must be cheap and should return the same id instance when no changes are
+   * needed to avoid unnecessary allocations. The default implementation returns the id
+   * unchanged.
+   */
+  protected Id normalizeTags(Id id) {
+    return id;
   }
 
   private void logTypeError(Id id, Class<?> desired, Class<?> found) {

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/AsciiSet.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/AsciiSet.java
@@ -188,7 +188,13 @@ public final class AsciiSet implements Serializable {
    * Returns true if all characters in the string are contained within the set.
    */
   public boolean containsAll(CharSequence str) {
-    return indexOfNonMember(str) == str.length();
+    final int n = str.length();
+    for (int i = 0; i < n; ++i) {
+      if (!contains(str.charAt(i))) {
+        return false;
+      }
+    }
+    return true;
   }
 
   private int indexOfNonMember(CharSequence str) {

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasRegistry.java
@@ -33,6 +33,7 @@ import com.netflix.spectator.atlas.impl.EvalPayload;
 import com.netflix.spectator.atlas.impl.Evaluator;
 import com.netflix.spectator.atlas.impl.EvaluatorConfig;
 import com.netflix.spectator.atlas.impl.PublishPayload;
+import com.netflix.spectator.impl.AsciiSet;
 import com.netflix.spectator.impl.Scheduler;
 import com.netflix.spectator.ipc.http.HttpClient;
 
@@ -75,6 +76,10 @@ public final class AtlasRegistry extends AbstractRegistry {
   private final int batchSize;
   private final int numThreads;
   private final Map<String, String> commonTags;
+
+  // Set of characters permitted by the storage layer, used to fix tag keys and values when a
+  // meter is created. Null if no restriction is configured, in which case no fixing is done.
+  private final AsciiSet validTagCharacters;
 
   private final Registry debugRegistry;
 
@@ -127,6 +132,8 @@ public final class AtlasRegistry extends AbstractRegistry {
     this.batchSize = config.batchSize();
     this.numThreads = config.numThreads();
     this.commonTags = new TreeMap<>(config.commonTags());
+    String validChars = config.validTagCharacters();
+    this.validTagCharacters = (validChars == null) ? null : AsciiSet.fromPattern(validChars);
 
     this.debugRegistry = Optional.ofNullable(config.debugRegistry()).orElse(this);
 
@@ -454,5 +461,52 @@ public final class AtlasRegistry extends AbstractRegistry {
 
   @Override protected Gauge newMaxGauge(Id id) {
     return new AtlasMaxGauge(id, clock(), meterTTL, lwcStepMillis);
+  }
+
+  /**
+   * Replace characters in the tag keys and values that are not permitted by the storage layer
+   * so that meters use a valid id. Applying the fix on the meter creation and lookup path keeps
+   * the publish and streaming paths consistent and means the id does not need to be fixed again
+   * each time it is reported.
+   *
+   * <p>This runs on every meter lookup, so it is on a hot path. When there is no restriction
+   * configured it returns immediately without inspecting the id. Otherwise it only allocates a
+   * new id when a character actually needs to be replaced; an id that is already valid is
+   * returned as is.
+   */
+  @Override protected Id normalizeTags(Id id) {
+    final AsciiSet allowed = validTagCharacters;
+    if (allowed == null) {
+      return id;
+    }
+
+    final int size = id.size();
+
+    // Detect whether any characters need to be fixed without allocating. containsAll scans and
+    // short circuits on the first invalid character, so the common case where everything is
+    // already valid returns the original id as is.
+    boolean changed = !allowed.containsAll(id.name());
+    if (!changed) {
+      for (int i = 1; i < size; ++i) {
+        if (!allowed.containsAll(id.getKey(i)) || !allowed.containsAll(id.getValue(i))) {
+          changed = true;
+          break;
+        }
+      }
+    }
+
+    if (!changed) {
+      return id;
+    }
+
+    // Fixing a tag key can change the ordering or introduce duplicate keys, so unsafeCreate is
+    // used as it will re-sort and de-dup the resulting array.
+    final String[] tags = new String[2 * (size - 1)];
+    int pos = 0;
+    for (int i = 1; i < size; ++i) {
+      tags[pos++] = allowed.replaceNonMembers(id.getKey(i), '_');
+      tags[pos++] = allowed.replaceNonMembers(id.getValue(i), '_');
+    }
+    return Id.unsafeCreate(allowed.replaceNonMembers(id.name(), '_'), tags, tags.length);
   }
 }

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/DefaultPublisher.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/DefaultPublisher.java
@@ -40,7 +40,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Function;
 
 public final class DefaultPublisher implements Publisher {
 
@@ -88,10 +87,8 @@ public final class DefaultPublisher implements Publisher {
 
     this.client = client != null ? client : HttpClient.create(debugRegistry);
 
-    Function<String, String> replacementFunc =
-        JsonUtils.createReplacementFunction(config.validTagCharacters());
-    this.jsonMapper = JsonUtils.createMapper(new JsonFactory(), replacementFunc);
-    this.smileMapper = JsonUtils.createMapper(new SmileFactory(), replacementFunc);
+    this.jsonMapper = JsonUtils.createMapper(new JsonFactory());
+    this.smileMapper = JsonUtils.createMapper(new SmileFactory());
 
     this.validationHelper = new ValidationHelper(LOGGER, jsonMapper, debugRegistry);
   }

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/EvaluatorConfig.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/EvaluatorConfig.java
@@ -22,7 +22,6 @@ import com.netflix.spectator.atlas.AtlasConfig;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 
 /**
  * Additional interface that can be implemented by the AtlasConfig instance providing knobs
@@ -46,10 +45,6 @@ public interface EvaluatorConfig {
         @Override public Map<String, String> commonTags() {
           return config.commonTags();
         }
-
-        @Override public BiFunction<Id, Set<String>, Map<String, String>> idMapper() {
-          return new IdMapper(JsonUtils.createReplacementFunction(config.validTagCharacters()));
-        }
       };
     }
   }
@@ -62,7 +57,7 @@ public interface EvaluatorConfig {
 
   /** Function to convert an id to a map of key/value pairs. */
   default BiFunction<Id, Set<String>, Map<String, String>> idMapper() {
-    return new IdMapper(Function.identity());
+    return new IdMapper();
   }
 
   /** Supplier for cache to use within the evaluator query index. */

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/IdMapper.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/IdMapper.java
@@ -21,7 +21,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 
 /**
  * Default mapping function from an Id to a Map.
@@ -31,13 +30,6 @@ import java.util.function.Function;
  */
 public final class IdMapper implements BiFunction<Id, Set<String>, Map<String, String>> {
 
-  private final Function<String, String> fixTagString;
-
-  /** Create a new instance using the provided function to fix invalid characters in the tags. */
-  public IdMapper(Function<String, String> fixTagString) {
-    this.fixTagString = fixTagString;
-  }
-
   @Override
   public Map<String, String> apply(Id id, Set<String> keys) {
     int size = id.size();
@@ -45,18 +37,16 @@ public final class IdMapper implements BiFunction<Id, Set<String>, Map<String, S
 
     // Start at 1 as name will be added last
     for (int i = 1; i < size; ++i) {
-      String k = fixTagString.apply(id.getKey(i));
+      String k = id.getKey(i);
       if (keys.contains(k)) {
-        String v = fixTagString.apply(id.getValue(i));
-        tags.put(k, v);
+        tags.put(k, id.getValue(i));
       }
     }
 
     // Add the name, it is added last so it will have precedence if the user tried to
     // use a tag key of "name".
     if (keys.contains("name")) {
-      String name = fixTagString.apply(id.name());
-      tags.put("name", name);
+      tags.put("name", id.name());
     }
 
     return tags;

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/JsonUtils.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/JsonUtils.java
@@ -19,9 +19,6 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.netflix.spectator.api.Measurement;
-import com.netflix.spectator.impl.AsciiSet;
-
-import java.util.function.Function;
 
 /**
  * Helper functions for creating the mappers used to encode Atlas payloads.
@@ -31,23 +28,10 @@ public final class JsonUtils {
   private JsonUtils() {
   }
 
-  /**
-   * Return a mapping function that will replace characters that are not matched by the
-   * pattern with an underscore.
-   */
-  public static Function<String, String> createReplacementFunction(String pattern) {
-    if (pattern == null) {
-      return Function.identity();
-    } else {
-      AsciiSet set = AsciiSet.fromPattern(pattern);
-      return s -> set.replaceNonMembers(s, '_');
-    }
-  }
-
   /** Create an object mapper with a custom serializer for measurements. */
-  public static ObjectMapper createMapper(JsonFactory factory, Function<String, String> fixTag) {
+  public static ObjectMapper createMapper(JsonFactory factory) {
     SimpleModule module = new SimpleModule()
-        .addSerializer(Measurement.class, new MeasurementSerializer(fixTag));
+        .addSerializer(Measurement.class, new MeasurementSerializer());
     return new ObjectMapper(factory).registerModule(module);
   }
 }

--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/MeasurementSerializer.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/MeasurementSerializer.java
@@ -22,29 +22,21 @@ import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Measurement;
 
 import java.io.IOException;
-import java.util.function.Function;
 
 /**
- * Jackson serializer for measurements. Values will be converted to a
- * valid set as they are written out by replacing invalid characters with
- * an '_'.
+ * Jackson serializer for measurements. Tag keys and values are written out as is; ensuring they
+ * only use characters permitted by the storage layer is the responsibility of the registry when
+ * the meter is created (see {@code AtlasRegistry.normalizeTags}). Keeping the replacement in a
+ * single place avoids inconsistent behavior between the publish and streaming paths.
  *
  * <b>Classes in this package are only intended for use internally within spectator. They may
  * change at any time and without notice.</b>
  */
 public class MeasurementSerializer extends JsonSerializer<Measurement> {
 
-  private final Function<String, String> fixTagString;
-
-  /**
-   * Create a new instance of the serializer.
-   *
-   * @param fixTagString
-   *     Function that fixes characters used for tag keys and values.
-   */
-  public MeasurementSerializer(Function<String, String> fixTagString) {
+  /** Create a new instance of the serializer. */
+  public MeasurementSerializer() {
     super();
-    this.fixTagString = fixTagString;
   }
 
   @Override
@@ -55,12 +47,12 @@ public class MeasurementSerializer extends JsonSerializer<Measurement> {
     Id id = value.id();
     gen.writeStartObject();
     gen.writeObjectFieldStart("tags");
-    gen.writeStringField("name", fixTagString.apply(id.name()));
+    gen.writeStringField("name", id.name());
     boolean explicitDsType = false;
     int n = id.size();
     for (int i = 1; i < n; ++i) {
-      final String k = fixTagString.apply(id.getKey(i));
-      final String v = fixTagString.apply(id.getValue(i));
+      final String k = id.getKey(i);
+      final String v = id.getValue(i);
       if (!"name".equals(k)) {
         if ("atlas.dstype".equals(k)) {
           explicitDsType = true;

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasRegistryTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasRegistryTest.java
@@ -136,6 +136,48 @@ public class AtlasRegistryTest {
     Assertions.assertEquals(0, getMeasurements().size());
   }
 
+  private String tagValue(Id id, String key) {
+    for (int i = 1; i < id.size(); ++i) {
+      if (id.getKey(i).equals(key)) {
+        return id.getValue(i);
+      }
+    }
+    return null;
+  }
+
+  @Test
+  public void invalidCharactersFixedAtCreation() {
+    // A path-like tag value with characters that are not permitted by the storage layer
+    // ('/') should be fixed when the meter is created so that reported measurements use the
+    // sanitized form. This keeps the publish and streaming paths consistent.
+    registry.counter(registry.createId("test", "path", "/api/v1")).increment();
+    List<Measurement> ms = getMeasurements();
+    Assertions.assertEquals(1, ms.size());
+    Assertions.assertEquals("_api_v1", tagValue(ms.get(0).id(), "path"));
+  }
+
+  @Test
+  public void invalidCharactersFixedInNameAndKey() {
+    // Fixing applies to the name and tag keys as well as values, not just values.
+    registry.counter(registry.createId("f@%", "b$$", "baz")).increment();
+    List<Measurement> ms = getMeasurements();
+    Assertions.assertEquals(1, ms.size());
+    Id id = ms.get(0).id();
+    Assertions.assertEquals("f__", id.name());
+    Assertions.assertEquals("baz", tagValue(id, "b__"));
+  }
+
+  @Test
+  public void invalidCharactersShareMeter() {
+    // Two ids that only differ by invalid characters map to the same meter once fixed, so they
+    // produce a single series rather than colliding as two separate series downstream.
+    registry.counter(registry.createId("test", "path", "/api/v1")).increment();
+    registry.counter(registry.createId("test", "path", "_api_v1")).increment();
+    List<Measurement> ms = getMeasurements();
+    Assertions.assertEquals(1, ms.size());
+    Assertions.assertEquals("_api_v1", tagValue(ms.get(0).id(), "path"));
+  }
+
   @Test
   public void measurementsWithMaxGauge() {
     registry.maxGauge(registry.createId("test")).set(4.0);

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/SubscriptionManagerTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/SubscriptionManagerTest.java
@@ -23,7 +23,6 @@ import com.netflix.spectator.api.Measurement;
 import com.netflix.spectator.atlas.impl.MeasurementSerializer;
 import com.netflix.spectator.atlas.impl.Subscription;
 import com.netflix.spectator.atlas.impl.Subscriptions;
-import com.netflix.spectator.impl.AsciiSet;
 import com.netflix.spectator.ipc.http.HttpClient;
 import com.netflix.spectator.ipc.http.HttpRequestBuilder;
 import com.netflix.spectator.ipc.http.HttpResponse;
@@ -47,9 +46,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class SubscriptionManagerTest {
 
   private final SimpleModule module = new SimpleModule()
-      .addSerializer(
-          Measurement.class,
-          new MeasurementSerializer(s -> AsciiSet.fromPattern("a-z").replaceNonMembers(s, '_')));
+      .addSerializer(Measurement.class, new MeasurementSerializer());
 
   private final ObjectMapper mapper = new ObjectMapper(new JsonFactory()).registerModule(module);
 

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/MeasurementSerializerTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/MeasurementSerializerTest.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Measurement;
-import com.netflix.spectator.impl.AsciiSet;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -29,11 +28,9 @@ import java.util.Collections;
 
 public class MeasurementSerializerTest {
 
-  private final AsciiSet set = AsciiSet.fromPattern("-._A-Za-z0-9");
-
   private final DefaultRegistry registry = new DefaultRegistry();
   private final SimpleModule module = new SimpleModule()
-      .addSerializer(Measurement.class, new MeasurementSerializer(s -> set.replaceNonMembers(s, '_')));
+      .addSerializer(Measurement.class, new MeasurementSerializer());
   private final ObjectMapper mapper = new ObjectMapper().registerModule(module);
 
   @Test
@@ -57,11 +54,13 @@ public class MeasurementSerializerTest {
   }
 
   @Test
-  public void invalidName() throws Exception {
+  public void nameWrittenVerbatim() throws Exception {
+    // The serializer no longer fixes invalid characters; that is handled when the meter is
+    // created. Whatever id reaches the serializer is written out as is.
     Id id = registry.createId("f@%", "bar", "baz");
     Measurement m = new Measurement(id, 42L, 3.0);
     String json = mapper.writeValueAsString(m);
-    String tags = "{\"name\":\"f__\",\"bar\":\"baz\",\"atlas.dstype\":\"gauge\"}";
+    String tags = "{\"name\":\"f@%\",\"bar\":\"baz\",\"atlas.dstype\":\"gauge\"}";
     String expected = "{\"tags\":" + tags + ",\"timestamp\":42,\"value\":3.0}";
     Assertions.assertEquals(expected, json);
   }
@@ -77,21 +76,21 @@ public class MeasurementSerializerTest {
   }
 
   @Test
-  public void invalidKey() throws Exception {
+  public void keyWrittenVerbatim() throws Exception {
     Id id = registry.createId("foo", "b$$", "baz");
     Measurement m = new Measurement(id, 42L, 3.0);
     String json = mapper.writeValueAsString(m);
-    String tags = "{\"name\":\"foo\",\"b__\":\"baz\",\"atlas.dstype\":\"gauge\"}";
+    String tags = "{\"name\":\"foo\",\"b$$\":\"baz\",\"atlas.dstype\":\"gauge\"}";
     String expected = "{\"tags\":" + tags + ",\"timestamp\":42,\"value\":3.0}";
     Assertions.assertEquals(expected, json);
   }
 
   @Test
-  public void invalidValue() throws Exception {
+  public void valueWrittenVerbatim() throws Exception {
     Id id = registry.createId("foo", "bar", "b&*");
     Measurement m = new Measurement(id, 42L, 3.0);
     String json = mapper.writeValueAsString(m);
-    String tags = "{\"name\":\"foo\",\"bar\":\"b__\",\"atlas.dstype\":\"gauge\"}";
+    String tags = "{\"name\":\"foo\",\"bar\":\"b&*\",\"atlas.dstype\":\"gauge\"}";
     String expected = "{\"tags\":" + tags + ",\"timestamp\":42,\"value\":3.0}";
     Assertions.assertEquals(expected, json);
   }


### PR DESCRIPTION
Move the replacement of characters not permitted by the storage layer from the report paths to meter creation. Previously the fix was applied independently on the publish path (MeasurementSerializer) and the LWC streaming path (IdMapper), which allowed the two to diverge: subscription matching on the streaming path ran against the raw id, so a query written against the sanitized form (e.g. ipc.endpoint,_api_v,:re) would match the persisted data but silently drop on streaming.

Add a protected AbstractRegistry.normalizeTags hook (default no-op) that runs for every id used to create or look up a meter, and override it in AtlasRegistry to replace invalid characters using the configured validTagCharacters set. Meters are now created with a valid id, so both report paths receive already-fixed ids and no longer need to fix them. This also makes ids that differ only by invalid characters collapse to a single meter/series.

- normalizeTags returns the same id instance when nothing needs fixing (uses AsciiSet.containsAll to detect without allocating) and only rebuilds via Id.unsafeCreate when a replacement is required. A null validTagCharacters short circuits with no work.
- Remove the now-redundant fixing from MeasurementSerializer, JsonUtils, DefaultPublisher, and the EvaluatorConfig idMapper; drop the vestigial fixTagString parameter from IdMapper.
- Cache normalizeTags inside idNormalizationCache for foreign ids so the fully-normalized id is cached; DefaultId keeps the type short circuit.
- AsciiSet.containsAll: scan directly instead of comparing indexOfNonMember to length twice.