### PR TITLE
remove JDK 8 zero-copy String optimization from AsciiSet

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/impl/AsciiSet.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/AsciiSet.java
@@ -16,9 +16,6 @@
 package com.netflix.spectator.impl;
 
 import java.io.Serializable;
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.reflect.Constructor;
 import java.util.Arrays;
 import java.util.Optional;
 
@@ -31,50 +28,9 @@ import java.util.Optional;
  * <p><b>This class is an internal implementation detail only intended for use within spectator.
  * It is subject to change without notice.</b></p>
  */
-@SuppressWarnings("PMD.AvoidAccessibilityAlteration")
 public final class AsciiSet implements Serializable {
 
   private static final long serialVersionUID = 1L;
-
-  private static boolean isJava8() {
-    String version = System.getProperty("java.version", "1.8");
-    return version.startsWith("1.8");
-  }
-
-  private static final MethodHandle STRING_CONSTRUCTOR;
-  static {
-    if (isJava8()) {
-      MethodHandle handle;
-      try {
-        Constructor<String> ctor = String.class.getDeclaredConstructor(char[].class, boolean.class);
-        ctor.setAccessible(true);
-        handle = MethodHandles.lookup().unreflectConstructor(ctor);
-      } catch (Exception e) {
-        handle = null;
-      }
-      STRING_CONSTRUCTOR = handle;
-    } else {
-      STRING_CONSTRUCTOR = null;
-    }
-  }
-
-  /**
-   * Creates a new string without copying the buffer if possible. The String class has a
-   * package private constructor that allows the buffer to be shared.
-   */
-  private static String newString(char[] buf) {
-    if (STRING_CONSTRUCTOR != null) {
-      try {
-        return (String) STRING_CONSTRUCTOR.invokeExact(buf, true);
-      } catch (Throwable t) {
-        // Note: `invokeExact` explicitly throws Throwable to propagate any exception of the
-        // method unchanged. For our purposes we just fallback to the string constructor.
-        return new String(buf);
-      }
-    } else {
-      return new String(buf);
-    }
-  }
 
   /**
    * Create a set containing ascii characters using a simple pattern. The pattern is similar
@@ -268,7 +224,7 @@ public final class AsciiSet implements Serializable {
       if (!contains(c))
         buf[i] = replacement;
     }
-    return newString(buf);
+    return new String(buf);
   }
 
   /**


### PR DESCRIPTION
The package-private String(char[], boolean) constructor that allowed sharing the buffer without copying was removed in JDK 9, so this code only ever took effect when running on a JDK 8 runtime. On JDK 9+ the reflection was skipped and newString already fell back to new String(buf).

Since we run almost exclusively on newer JDKs, drop the isJava8 check, the reflective STRING_CONSTRUCTOR handle, and the newString helper, and call new String(buf) directly. Also removes the now-unused imports and the class-level PMD AvoidAccessibilityAlteration suppression that only existed for the setAccessible call. Still compiles and runs on JDK 8.