### PR TITLE
Bound {n} repeat to avoid CPU hang

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/RepeatMatcher.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/matcher/RepeatMatcher.java
@@ -37,8 +37,10 @@ final class RepeatMatcher implements Matcher, Serializable {
     this.min = min;
     this.max = max;
     // minLength is fixed for an immutable matcher; precompute it to avoid walking the
-    // repeated sub-matcher on every matches() call.
-    this.minLength = min * repeated.minLength();
+    // repeated sub-matcher on every matches() call. Use a long product and saturate so a
+    // large repetition count cannot overflow to a negative value that would corrupt the
+    // fast-reject/bounds arithmetic in the greedy matchers.
+    this.minLength = (int) Math.min((long) min * repeated.minLength(), Integer.MAX_VALUE);
   }
 
   Matcher repeated() {
@@ -70,9 +72,16 @@ final class RepeatMatcher implements Matcher, Serializable {
     int numMatches = 0;
     while (pos >= 0 && numMatches < max) {
       int p = repeated.matches(str, pos, end - pos);
-      if (p >= 0) {
+      if (p > pos) {
+        // Made forward progress, try to match additional repetitions.
         ++numMatches;
         pos = p;
+      } else if (p == pos) {
+        // The repeated portion matched the empty string. Any remaining repetitions would
+        // also match empty without advancing, so the minimum count is satisfiable and there
+        // is nothing more to consume. Return here rather than looping up to max, which may be
+        // a very large count, with no forward progress. Mirrors the guard in ZeroOrMoreMatcher.
+        return pos;
       } else {
         return (numMatches >= min) ? pos : Constants.NO_MATCH;
       }

--- a/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/AbstractPatternMatcherTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/AbstractPatternMatcherTest.java
@@ -540,6 +540,19 @@ public abstract class AbstractPatternMatcherTest {
   }
 
   @Test
+  public void repeatEmptyClause() {
+    // Repetition whose body can match the empty string, via the {n,m} RepeatMatcher path
+    // (the +/* paths go through ZeroOrMoreMatcher which is covered separately). Compared
+    // against the reference engine to confirm the empty-match handling is correct.
+    testRE("foo-h2(prod|){2,5}-bar-*", "foo-h2prod-abc-v123");
+    testRE("foo-h2(prod|){2,5}-bar-*", "foo-h2prod-bar-v123");
+    testRE("(a|){3}", "aa");
+    testRE("(a|){3}", "");
+    testRE("(abc|){0,3}def", "def");
+    testRE("(abc|){2,4}def", "abcdef");
+  }
+
+  @Test
   public void repeatWithOr() {
     testRE("(a|b|c){1,3}d", "aaad");
     testRE("(a|b|c){1,3}d", "aaa");

--- a/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/PatternMatcherTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/matcher/PatternMatcherTest.java
@@ -17,7 +17,10 @@ package com.netflix.spectator.impl.matcher;
 
 import com.netflix.spectator.impl.PatternMatcher;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 public class PatternMatcherTest extends AbstractPatternMatcherTest {
@@ -38,5 +41,22 @@ public class PatternMatcherTest extends AbstractPatternMatcherTest {
 
     // Check we can serialize and deserialize the matchers
     MatcherSerializationTest.checkSerde(matcher);
+  }
+
+  @Test
+  @Timeout(value = 10, unit = TimeUnit.SECONDS)
+  public void repeatLargeBoundTerminates() {
+    // A repetition with a huge count whose body can match the empty string must not loop up
+    // to that count with no forward progress (previously a CPU-exhaustion vector). It must
+    // still return the correct result quickly, hence the timeout to fail fast on a regression.
+    PatternMatcher empty = PatternMatcher.compile("foo-(bar|){2000000000}-baz");
+    Assertions.assertTrue(empty.matches("foo-barbar-baz"));
+    Assertions.assertTrue(empty.matches("foo--baz"));
+    Assertions.assertFalse(empty.matches("foo-bar-qux"));
+
+    // A huge count on a non-empty body would overflow min * minLength; the saturating
+    // computation keeps minLength non-negative and matching bounded by the input length.
+    PatternMatcher nonEmpty = PatternMatcher.compile("(ab){2000000000}");
+    Assertions.assertFalse(nonEmpty.matches("abab"));
   }
 }


### PR DESCRIPTION
RepeatMatcher.matches() looped up to the (attacker-chosen) repetition count with no forward progress when the repeated body matched the empty string, so a subscription pattern like (x?){2000000000} could pin a CPU per id on the streaming eval path. Add an empty-match guard mirroring ZeroOrMoreMatcher: on a non-advancing match the minimum is satisfiable via further empty matches, so return immediately. Iterations are now bounded by the input length rather than the count.

Also compute minLength as a saturating long product so a large count cannot overflow to a negative value that would corrupt the fast-reject bounds arithmetic in the greedy matchers.