### PR TITLE
Avoid NPE if logEntry attribute isn't present

### DIFF
--- a/spectator-ext-aws2/src/main/java/com/netflix/spectator/aws2/SpectatorExecutionInterceptor.java
+++ b/spectator-ext-aws2/src/main/java/com/netflix/spectator/aws2/SpectatorExecutionInterceptor.java
@@ -155,13 +155,15 @@ public class SpectatorExecutionInterceptor implements ExecutionInterceptor {
 
   @Override
   public void afterTransmission(Context.AfterTransmission context, ExecutionAttributes attrs) {
-    SdkHttpResponse response = context.httpResponse();
-    IpcLogEntry logEntry = attrs.getAttribute(LOG_ENTRY)
-        .markEnd()
-        .withHttpStatus(response.statusCode());
-    attrs.putAttribute(STATUS_IS_SET, true);
-
-    response.headers().forEach((k, vs) -> vs.forEach(v -> logEntry.addResponseHeader(k, v)));
+    // The log entry is populated by beforeTransmission. Guard against it being absent in case
+    // the SDK invokes this callback without a preceding transmission attempt.
+    IpcLogEntry logEntry = attrs.getAttribute(LOG_ENTRY);
+    if (logEntry != null) {
+      SdkHttpResponse response = context.httpResponse();
+      logEntry.markEnd().withHttpStatus(response.statusCode());
+      attrs.putAttribute(STATUS_IS_SET, true);
+      response.headers().forEach((k, vs) -> vs.forEach(v -> logEntry.addResponseHeader(k, v)));
+    }
   }
 
   private Id createRequestCountId(ExecutionAttributes attrs, String result) {
@@ -184,30 +186,39 @@ public class SpectatorExecutionInterceptor implements ExecutionInterceptor {
 
   @Override
   public void afterExecution(Context.AfterExecution context, ExecutionAttributes attrs) {
-    attrs.getAttribute(LOG_ENTRY).log();
+    // The log entry is populated by beforeTransmission. Guard against it being absent in case
+    // the SDK invokes this callback without a preceding transmission attempt.
+    IpcLogEntry logEntry = attrs.getAttribute(LOG_ENTRY);
+    if (logEntry != null) {
+      logEntry.log();
+    }
     registry.counter(createRequestCountId(attrs, "success")).increment();
   }
 
   @Override
   public void onExecutionFailure(Context.FailedExecution context, ExecutionAttributes attrs) {
-    IpcLogEntry logEntry = attrs.getAttribute(LOG_ENTRY);
     Throwable t = context.exception();
-    String result = "failure";
-    if (t instanceof AwsServiceException) {
-      AwsServiceException exception = ((AwsServiceException) t);
-      if (exception.isThrottlingException()) {
-        if (logEntry != null) {
-          logEntry.withStatus(IpcStatus.throttled);
-        }
-        result = "throttled";
-      }
-      if (logEntry != null) {
-        logEntry.withStatusDetail(exception.awsErrorDetails().errorCode());
-      }
-    }
+    AwsServiceException serviceException = (t instanceof AwsServiceException)
+        ? (AwsServiceException) t
+        : null;
+    boolean throttled = serviceException != null && serviceException.isThrottlingException();
+    String result = throttled ? "throttled" : "failure";
+
+    // The log entry is only populated by beforeTransmission once an attempt is made. Failures
+    // earlier in the request pipeline (marshalling, endpoint or credentials resolution, signing)
+    // never reach that stage, so the attribute may be absent. In that case there was no IPC
+    // attempt to log and we just record the failure in the request counter below.
+    IpcLogEntry logEntry = attrs.getAttribute(LOG_ENTRY);
     if (logEntry != null) {
-      logEntry.withException(context.exception()).log();
+      if (throttled) {
+        logEntry.withStatus(IpcStatus.throttled);
+      }
+      if (serviceException != null && serviceException.awsErrorDetails() != null) {
+        logEntry.withStatusDetail(serviceException.awsErrorDetails().errorCode());
+      }
+      logEntry.withException(t).log();
     }
+
     registry.counter(createRequestCountId(attrs, result)).increment();
   }
 }

--- a/spectator-ext-aws2/src/main/java/com/netflix/spectator/aws2/SpectatorExecutionInterceptor.java
+++ b/spectator-ext-aws2/src/main/java/com/netflix/spectator/aws2/SpectatorExecutionInterceptor.java
@@ -196,12 +196,18 @@ public class SpectatorExecutionInterceptor implements ExecutionInterceptor {
     if (t instanceof AwsServiceException) {
       AwsServiceException exception = ((AwsServiceException) t);
       if (exception.isThrottlingException()) {
-        logEntry.withStatus(IpcStatus.throttled);
+        if (logEntry != null) {
+          logEntry.withStatus(IpcStatus.throttled);
+        }
         result = "throttled";
       }
-      logEntry.withStatusDetail(exception.awsErrorDetails().errorCode());
+      if (logEntry != null) {
+        logEntry.withStatusDetail(exception.awsErrorDetails().errorCode());
+      }
     }
-    logEntry.withException(context.exception()).log();
+    if (logEntry != null) {
+      logEntry.withException(context.exception()).log();
+    }
     registry.counter(createRequestCountId(attrs, result)).increment();
   }
 }

--- a/spectator-ext-aws2/src/test/java/com/netflix/spectator/aws2/SpectatorExecutionInterceptorTest.java
+++ b/spectator-ext-aws2/src/test/java/com/netflix/spectator/aws2/SpectatorExecutionInterceptorTest.java
@@ -393,6 +393,113 @@ public class SpectatorExecutionInterceptorTest {
     Assertions.assertEquals("failure", get(c.id(), "result"));
   }
 
+  @Test
+  public void preTransmissionFailure() {
+    // Failure occurs before beforeTransmission runs (e.g. marshalling, endpoint/credentials
+    // resolution, or signing), so the log entry attribute was never populated. This must not
+    // throw an NPE and mask the underlying exception.
+    SdkHttpRequest request = SdkHttpRequest.builder()
+        .method(SdkHttpMethod.POST)
+        .uri(URI.create("https://ec2.us-east-1.amazonaws.com"))
+        .build();
+    Throwable error = new IllegalStateException("unable to resolve endpoint");
+    TestContext context = new TestContext(request, null, error);
+    ExecutionAttributes attrs = createAttributes("EC2", "DescribeInstances");
+    interceptor.onExecutionFailure(context.failureContext(), attrs);
+
+    // No IPC log entry / timer since no attempt was made, but the failure is still counted.
+    Assertions.assertEquals(0, registry.timers().count());
+    Counter c = findCounter("aws.requests");
+    Assertions.assertNotNull(c);
+    Assertions.assertEquals(1, c.count());
+    Assertions.assertEquals("failure", get(c.id(), "result"));
+  }
+
+  @Test
+  public void preTransmissionServiceException() {
+    // A service exception (here throttling) surfacing before transmission must also avoid the
+    // NPE while still classifying the result correctly.
+    Throwable error = AwsServiceException.builder()
+        .awsErrorDetails(AwsErrorDetails.builder()
+            .errorCode("Throttling")
+            .errorMessage("too many requests")
+            .build())
+        .build();
+    TestContext context = new TestContext(null, null, error);
+    ExecutionAttributes attrs = createAttributes("EC2", "DescribeInstances");
+    interceptor.onExecutionFailure(context.failureContext(), attrs);
+
+    Assertions.assertEquals(0, registry.timers().count());
+    Counter c = findCounter("aws.requests");
+    Assertions.assertNotNull(c);
+    Assertions.assertEquals(1, c.count());
+    Assertions.assertEquals("throttled", get(c.id(), "result"));
+  }
+
+  @Test
+  public void awsFailureWithoutErrorDetails() {
+    // A throttling error can be classified via status code alone, leaving awsErrorDetails null.
+    // The log entry is present (transmission occurred), so withStatusDetail must not NPE on the
+    // missing details.
+    SdkHttpRequest request = SdkHttpRequest.builder()
+        .method(SdkHttpMethod.POST)
+        .uri(URI.create("https://ec2.us-east-1.amazonaws.com"))
+        .build();
+    SdkHttpResponse response = SdkHttpResponse.builder()
+        .statusCode(429)
+        .build();
+    Throwable error = AwsServiceException.builder()
+        .statusCode(429)
+        .build();
+    TestContext context = new TestContext(request, response, error);
+    execute(context, createAttributes("EC2", "DescribeInstances"), millis(30));
+    Assertions.assertEquals(1, registry.timers().count());
+
+    Timer t = registry.timers().findFirst().orElse(null);
+    Assertions.assertNotNull(t);
+    Assertions.assertEquals(1, t.count());
+    Assertions.assertEquals("throttled", get(t.id(), "ipc.status"));
+  }
+
+  @Test
+  public void afterTransmissionWithoutLogEntry() {
+    // afterTransmission invoked without a preceding beforeTransmission must not throw.
+    SdkHttpRequest request = SdkHttpRequest.builder()
+        .method(SdkHttpMethod.POST)
+        .uri(URI.create("https://ec2.us-east-1.amazonaws.com"))
+        .build();
+    SdkHttpResponse response = SdkHttpResponse.builder()
+        .statusCode(200)
+        .build();
+    TestContext context = new TestContext(request, response);
+    ExecutionAttributes attrs = createAttributes("EC2", "DescribeInstances");
+    interceptor.afterTransmission(context, attrs);
+
+    Assertions.assertEquals(0, registry.timers().count());
+  }
+
+  @Test
+  public void afterExecutionWithoutLogEntry() {
+    // afterExecution invoked without a preceding beforeTransmission must not throw, but should
+    // still count the successful request.
+    SdkHttpRequest request = SdkHttpRequest.builder()
+        .method(SdkHttpMethod.POST)
+        .uri(URI.create("https://ec2.us-east-1.amazonaws.com"))
+        .build();
+    SdkHttpResponse response = SdkHttpResponse.builder()
+        .statusCode(200)
+        .build();
+    TestContext context = new TestContext(request, response);
+    ExecutionAttributes attrs = createAttributes("EC2", "DescribeInstances");
+    interceptor.afterExecution(context, attrs);
+
+    Assertions.assertEquals(0, registry.timers().count());
+    Counter c = findCounter("aws.requests");
+    Assertions.assertNotNull(c);
+    Assertions.assertEquals(1, c.count());
+    Assertions.assertEquals("success", get(c.id(), "result"));
+  }
+
   private static class TestContext implements Context.AfterExecution {
 
     private SdkHttpRequest request;


### PR DESCRIPTION
Seeing this with e.g. an S3 client, where the original exception is getting masked because the interceptor then emits an NPE:

```
java.lang.NullPointerException: Cannot invoke "com.netflix.spectator.ipc.IpcLogEntry.withException(java.lang.Throwable)" because "logEntry" is null
  at com.netflix.spectator.aws2.SpectatorExecutionInterceptor.onExecutionFailure(SpectatorExecutionInterceptor.java:204)
  at software.amazon.awssdk.core.interceptor.ExecutionInterceptorChain.lambda$onExecutionFailure$15(ExecutionInterceptorChain.java:194)
  at java.util.ArrayList.forEach(ArrayList.java:1596)
  at software.amazon.awssdk.core.interceptor.ExecutionInterceptorChain.onExecutionFailure(ExecutionInterceptorChain.java:194)
  at software.amazon.awssdk.core.internal.http.pipeline.stages.utils.ExceptionReportingUtils.reportFailureToInterceptors(ExceptionReportingUtils.java:41)
  [...]
```