### PR TITLE
Add addLogTag for log-only IPC tags

### DIFF
--- a/spectator-ext-ipc/build.gradle
+++ b/spectator-ext-ipc/build.gradle
@@ -4,6 +4,10 @@ dependencies {
   testImplementation 'com.fasterxml.jackson.core:jackson-core'
   testImplementation 'com.fasterxml.jackson.core:jackson-databind'
   testImplementation 'com.netflix.frigga:frigga'
+  // The MDC assertions in IpcLogEntryTest require a logging implementation that supports the
+  // MDC functionality, which the slf4j-nop (default) and slf4j-simple implementations do not.
+  testImplementation 'org.apache.logging.log4j:log4j-core'
+  testImplementation 'org.apache.logging.log4j:log4j-slf4j-impl'
 }
 
 jar {

--- a/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcLogEntry.java
+++ b/spectator-ext-ipc/src/main/java/com/netflix/spectator/ipc/IpcLogEntry.java
@@ -100,6 +100,7 @@ public final class IpcLogEntry {
   private boolean disableMetrics;
 
   private final Map<String, String> additionalTags = new HashMap<>();
+  private final Map<String, String> additionalLogTags = new HashMap<>();
 
   private final StringBuilder builder = new StringBuilder();
 
@@ -642,6 +643,30 @@ public final class IpcLogEntry {
   }
 
   /**
+   * Add a custom tag that is only included on the log entry, both the structured output and
+   * the SLF4J {@link MDC}, and not on the request metrics. This is useful for adding higher
+   * cardinality context that is helpful for the access log, but would be problematic if added
+   * as a dimension on the metrics. As these tags do not impact the metrics, the cardinality
+   * limiter is not applied to the values.
+   */
+  public IpcLogEntry addLogTag(Tag tag) {
+    this.additionalLogTags.put(tag.key(), tag.value());
+    return this;
+  }
+
+  /**
+   * Add a custom tag that is only included on the log entry, both the structured output and
+   * the SLF4J {@link MDC}, and not on the request metrics. This is useful for adding higher
+   * cardinality context that is helpful for the access log, but would be problematic if added
+   * as a dimension on the metrics. As these tags do not impact the metrics, the cardinality
+   * limiter is not applied to the values.
+   */
+  public IpcLogEntry addLogTag(String k, String v) {
+    this.additionalLogTags.put(k, v);
+    return this;
+  }
+
+  /**
    * Disable the metrics. The log will still get written, but none of the metrics will get
    * updated.
    */
@@ -931,6 +956,12 @@ public final class IpcLogEntry {
     putInMDC(IpcTagKey.statusDetail.key(), statusDetail);
 
     putInMDC(IpcTagKey.httpStatus.key(), Integer.toString(httpStatus));
+
+    // User specified log tags are added last so that an explicit value takes precedence
+    // over the standard fields if the same key is used.
+    for (Map.Entry<String, String> entry : additionalLogTags.entrySet()) {
+      putInMDC(entry.getKey(), entry.getValue());
+    }
   }
 
   @Override
@@ -975,6 +1006,7 @@ public final class IpcLogEntry {
         .addField("requestHeaders", requestHeaders)
         .addField("responseHeaders", responseHeaders)
         .addField("additionalTags", additionalTags)
+        .addField("additionalLogTags", additionalLogTags)
         .endObject()
         .toString();
   }
@@ -1024,6 +1056,7 @@ public final class IpcLogEntry {
     remotePort = -1;
     disableMetrics = false;
     additionalTags.clear();
+    additionalLogTags.clear();
     builder.delete(0, builder.length());
     inflightId = null;
   }

--- a/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/IpcLogEntryTest.java
+++ b/spectator-ext-ipc/src/test/java/com/netflix/spectator/ipc/IpcLogEntryTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 import java.io.IOException;
 import java.net.URI;
@@ -645,6 +646,77 @@ public class IpcLogEntryTest {
     Assertions.assertEquals(2, actual.size());
     Assertions.assertEquals("v1", actual.get("k1"));
     Assertions.assertEquals("v2", actual.get("k2"));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void addLogTags() {
+    Map<String, Object> map = entry
+        .addLogTag(new BasicTag("k1", "v1"))
+        .addLogTag("k2", "v2")
+        .convert(this::toMap);
+    Map<String, String> actual = (Map<String, String>) map.get("additionalLogTags");
+    Assertions.assertEquals(2, actual.size());
+    Assertions.assertEquals("v1", actual.get("k1"));
+    Assertions.assertEquals("v2", actual.get("k2"));
+    // Log tags must not leak into the metric tags map (empty maps are omitted from the JSON)
+    Assertions.assertNull(map.get("additionalTags"));
+  }
+
+  @Test
+  public void logTagsNotOnMetrics() {
+    Registry registry = new DefaultRegistry(clock);
+    IpcLogger logger = new IpcLogger(registry, LoggerFactory.getLogger(getClass()));
+    logger.createClientEntry()
+        .markStart()
+        .addTag("metricTag", "a")
+        .addLogTag("logTag", "b")
+        .markEnd()
+        .log();
+    AtomicInteger count = new AtomicInteger();
+    registry
+        .counters()
+        .filter(c -> "ipc.client.call".equals(c.id().name()))
+        .forEach(c -> {
+          count.incrementAndGet();
+          Assertions.assertEquals("a", Utils.getTagValue(c.id(), "metricTag"));
+          Assertions.assertNull(Utils.getTagValue(c.id(), "logTag"));
+        });
+    Assertions.assertTrue(count.get() > 0, "no ipc.client.call counters were checked");
+  }
+
+  @Test
+  public void logTagsInMDC() {
+    Registry registry = new DefaultRegistry(clock);
+    IpcLogger logger = new IpcLogger(registry, LoggerFactory.getLogger(getClass()));
+    IpcLogEntry logEntry = logger.createClientEntry()
+        .addTag("metricTag", "a")
+        .addLogTag("logTag", "b");
+    try {
+      logEntry.populateMDC();
+      // Log tag is exposed via the MDC
+      Assertions.assertEquals("b", MDC.get("logTag"));
+      // Metric-only tags are not automatically placed in the MDC
+      Assertions.assertNull(MDC.get("metricTag"));
+    } finally {
+      MDC.clear();
+    }
+  }
+
+  @Test
+  public void logTagOverridesStandardMDCKey() {
+    Registry registry = new DefaultRegistry(clock);
+    IpcLogger logger = new IpcLogger(registry, LoggerFactory.getLogger(getClass()));
+    IpcLogEntry logEntry = logger.createClientEntry()
+        .withEndpoint("standard")
+        .addLogTag(IpcTagKey.endpoint.key(), "override");
+    try {
+      logEntry.populateMDC();
+      // Explicit log tags are applied last so they take precedence over standard fields
+      Assertions.assertEquals("override", MDC.get(IpcTagKey.endpoint.key()));
+    } finally {
+      MDC.clear();
+    }
   }
 
   @Test


### PR DESCRIPTION
Adds addLogTag(Tag) and addLogTag(String, String) to IpcLogEntry for context that should appear only on the access log entry (JSON output and SLF4J MDC), not on the request metrics. Log tags skip the cardinality limiter since they never become metric dimensions.

Tests use log4j-core/log4j-slf4j-impl to exercise the MDC, matching the spectator-ext-placeholders convention.