### PR TITLE
Speed up the Counter.increment() hot path

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/AbstractRegistry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/AbstractRegistry.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Spliterator;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import java.util.function.LongSupplier;
 
@@ -36,8 +37,27 @@ import java.util.function.LongSupplier;
  */
 public abstract class AbstractRegistry implements Registry, AutoCloseable {
 
-  /** Not used for this registry, always return 0. */
+  /**
+   * This registry has no notion of a registry level version, so the signal used by
+   * {@link SwapMeter#hasExpired()} is constant, as it has always been. Meter removal is tracked
+   * separately by {@link #removals}.
+   */
   private static final LongSupplier VERSION = () -> 0L;
+
+  /**
+   * Incremented whenever a meter is removed from {@link #meters}. The {@link SwapMeter} types
+   * handed out by this registry use it to notice that their underlying meter is gone and needs to
+   * be resolved again, which keeps a wall clock read off the update path.
+   *
+   * <p>Deliberately not the same signal as {@code VERSION}. That one feeds {@code hasExpired()},
+   * which callers act on destructively, and removal happens on every cleanup pass. Bumping one
+   * counter does invalidate every outstanding wrapper rather than only the affected ones, but
+   * removal only happens during the periodic cleanup, so the cost is one map lookup per held
+   * reference per pass.
+   */
+  private final AtomicLong removals = new AtomicLong();
+
+  private final LongSupplier removalSupplier = removals::get;
 
   /** Logger instance for the class. */
   protected final Logger logger;
@@ -236,32 +256,38 @@ public abstract class AbstractRegistry implements Registry, AutoCloseable {
   }
 
   @Override public final Counter counter(Id id) {
+    // Sample the removal counter before resolving so a removal racing with the lookup is seen.
+    final long v = removals.get();
     Counter c = getOrCreate(id, Counter.class, NoopCounter.INSTANCE, counterFactory);
-    return new SwapCounter(this, VERSION, c.id(), c);
+    return new SwapCounter(this, VERSION, removalSupplier, v, c.id(), c);
   }
 
   @Override public final DistributionSummary distributionSummary(Id id) {
+    final long v = removals.get();
     DistributionSummary ds = getOrCreate(
         id,
         DistributionSummary.class,
         NoopDistributionSummary.INSTANCE,
         distSummaryFactory);
-    return new SwapDistributionSummary(this, VERSION, ds.id(), ds);
+    return new SwapDistributionSummary(this, VERSION, removalSupplier, v, ds.id(), ds);
   }
 
   @Override public final Timer timer(Id id) {
+    final long v = removals.get();
     Timer t = getOrCreate(id, Timer.class, NoopTimer.INSTANCE, timerFactory);
-    return new SwapTimer(this, VERSION, t.id(), t);
+    return new SwapTimer(this, VERSION, removalSupplier, v, t.id(), t);
   }
 
   @Override public final Gauge gauge(Id id) {
+    final long v = removals.get();
     Gauge g = getOrCreate(id, Gauge.class, NoopGauge.INSTANCE, gaugeFactory);
-    return new SwapGauge(this, VERSION, g.id(), g);
+    return new SwapGauge(this, VERSION, removalSupplier, v, g.id(), g);
   }
 
   @Override public final Gauge maxGauge(Id id) {
+    final long v = removals.get();
     Gauge g = getOrCreate(id, Gauge.class, NoopGauge.INSTANCE, maxGaugeFactory);
-    return new SwapMaxGauge(this, VERSION, g.id(), g);
+    return new SwapMaxGauge(this, VERSION, removalSupplier, v, g.id(), g);
   }
 
   /**
@@ -316,7 +342,38 @@ public abstract class AbstractRegistry implements Registry, AutoCloseable {
   }
 
   @Override public final Iterator<Meter> iterator() {
-    return meters.values().iterator();
+    return new VersionedIterator(meters.values().iterator());
+  }
+
+  /**
+   * Wraps the iterator over the meter map so that a removal bumps {@link #version} no matter who
+   * performs it. Sub-classes such as {@code AtlasRegistry} implement their own cleanup pass on
+   * top of {@link #iterator()}, and third parties are able to call it as well, so the bump is
+   * done here rather than relying on every caller to remember it. Without it a
+   * {@link SwapMeter} would never notice that its underlying meter had been removed.
+   */
+  private final class VersionedIterator implements Iterator<Meter> {
+
+    private final Iterator<Meter> delegate;
+
+    VersionedIterator(Iterator<Meter> delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override public boolean hasNext() {
+      return delegate.hasNext();
+    }
+
+    @Override public Meter next() {
+      return delegate.next();
+    }
+
+    @Override public void remove() {
+      delegate.remove();
+      // Bump after the entry is actually gone. A reader that sees the new version is guaranteed
+      // to miss the removed entry and will resolve a fresh meter.
+      removals.incrementAndGet();
+    }
   }
 
   @Override
@@ -331,7 +388,7 @@ public abstract class AbstractRegistry implements Registry, AutoCloseable {
   protected void removeExpiredMeters() {
     int total = 0;
     int expired = 0;
-    Iterator<Meter> it = meters.values().iterator();
+    Iterator<Meter> it = iterator();
     while (it.hasNext()) {
       ++total;
       Meter m = it.next();
@@ -406,5 +463,7 @@ public abstract class AbstractRegistry implements Registry, AutoCloseable {
     }
     state.clear();
     meters.clear();
+    // Clearing the map removes every meter, so any outstanding SwapMeter has to resolve again.
+    removals.incrementAndGet();
   }
 }

--- a/spectator-api/src/main/java/com/netflix/spectator/api/AbstractRegistry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/AbstractRegistry.java
@@ -49,11 +49,10 @@ public abstract class AbstractRegistry implements Registry, AutoCloseable {
    * handed out by this registry use it to notice that their underlying meter is gone and needs to
    * be resolved again, which keeps a wall clock read off the update path.
    *
-   * <p>Deliberately not the same signal as {@code VERSION}. That one feeds {@code hasExpired()},
-   * which callers act on destructively, and removal happens on every cleanup pass. Bumping one
-   * counter does invalidate every outstanding wrapper rather than only the affected ones, but
-   * removal only happens during the periodic cleanup, so the cost is one map lookup per held
-   * reference per pass.
+   * <p>Deliberately not the same signal as {@code VERSION}: that one feeds {@code hasExpired()},
+   * which callers act on destructively, and removal happens on every cleanup pass rather than
+   * rarely. Bumping one counter invalidates every outstanding wrapper, not just the affected one,
+   * but that only costs an extra map lookup per held reference per cleanup pass.
    */
   private final AtomicLong removals = new AtomicLong();
 
@@ -346,11 +345,10 @@ public abstract class AbstractRegistry implements Registry, AutoCloseable {
   }
 
   /**
-   * Wraps the iterator over the meter map so that a removal bumps {@link #version} no matter who
-   * performs it. Sub-classes such as {@code AtlasRegistry} implement their own cleanup pass on
-   * top of {@link #iterator()}, and third parties are able to call it as well, so the bump is
-   * done here rather than relying on every caller to remember it. Without it a
-   * {@link SwapMeter} would never notice that its underlying meter had been removed.
+   * Wraps the iterator over the meter map so that a removal bumps {@link #removals} no matter who
+   * performs it. Sub-classes such as {@code AtlasRegistry} implement their own cleanup pass on top
+   * of {@link #iterator()}, so the bump happens here rather than relying on every caller to
+   * remember it.
    */
   private final class VersionedIterator implements Iterator<Meter> {
 

--- a/spectator-api/src/main/java/com/netflix/spectator/api/SwapCounter.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/SwapCounter.java
@@ -29,6 +29,16 @@ final class SwapCounter extends SwapMeter<Counter> implements Counter {
     super(registry, versionSupplier, id, underlying);
   }
 
+  SwapCounter(
+      Registry registry,
+      LongSupplier versionSupplier,
+      LongSupplier resolveSupplier,
+      long resolveVersion,
+      Id id,
+      Counter underlying) {
+    super(registry, versionSupplier, resolveSupplier, resolveVersion, id, underlying);
+  }
+
   @Override public Counter lookup() {
     return registry.counter(id);
   }

--- a/spectator-api/src/main/java/com/netflix/spectator/api/SwapDistributionSummary.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/SwapDistributionSummary.java
@@ -33,6 +33,16 @@ final class SwapDistributionSummary extends SwapMeter<DistributionSummary> imple
     super(registry, versionSupplier, id, underlying);
   }
 
+  SwapDistributionSummary(
+      Registry registry,
+      LongSupplier versionSupplier,
+      LongSupplier resolveSupplier,
+      long resolveVersion,
+      Id id,
+      DistributionSummary underlying) {
+    super(registry, versionSupplier, resolveSupplier, resolveVersion, id, underlying);
+  }
+
   @Override public DistributionSummary lookup() {
     return registry.distributionSummary(id);
   }

--- a/spectator-api/src/main/java/com/netflix/spectator/api/SwapGauge.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/SwapGauge.java
@@ -27,6 +27,16 @@ final class SwapGauge extends SwapMeter<Gauge> implements Gauge {
     super(registry, versionSupplier, id, underlying);
   }
 
+  SwapGauge(
+      Registry registry,
+      LongSupplier versionSupplier,
+      LongSupplier resolveSupplier,
+      long resolveVersion,
+      Id id,
+      Gauge underlying) {
+    super(registry, versionSupplier, resolveSupplier, resolveVersion, id, underlying);
+  }
+
   @Override public Gauge lookup() {
     return registry.gauge(id);
   }

--- a/spectator-api/src/main/java/com/netflix/spectator/api/SwapMaxGauge.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/SwapMaxGauge.java
@@ -27,6 +27,16 @@ final class SwapMaxGauge extends SwapMeter<Gauge> implements Gauge {
     super(registry, versionSupplier, id, underlying);
   }
 
+  SwapMaxGauge(
+      Registry registry,
+      LongSupplier versionSupplier,
+      LongSupplier resolveSupplier,
+      long resolveVersion,
+      Id id,
+      Gauge underlying) {
+    super(registry, versionSupplier, resolveSupplier, resolveVersion, id, underlying);
+  }
+
   @Override public Gauge lookup() {
     return registry.maxGauge(id);
   }

--- a/spectator-api/src/main/java/com/netflix/spectator/api/SwapTimer.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/SwapTimer.java
@@ -30,6 +30,16 @@ final class SwapTimer extends SwapMeter<Timer> implements Timer {
     super(registry, versionSupplier, id, underlying);
   }
 
+  SwapTimer(
+      Registry registry,
+      LongSupplier versionSupplier,
+      LongSupplier resolveSupplier,
+      long resolveVersion,
+      Id id,
+      Timer underlying) {
+    super(registry, versionSupplier, resolveSupplier, resolveVersion, id, underlying);
+  }
+
   @Override public Timer lookup() {
     return registry.timer(id);
   }

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/StepDouble.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/StepDouble.java
@@ -40,10 +40,18 @@ public class StepDouble implements StepValue {
   private static final AtomicLongFieldUpdater<StepDouble> CURRENT_UPDATER =
       AtomicLongFieldUpdater.newUpdater(StepDouble.class, "current");
 
-  private volatile long lastInitPos;
+  /**
+   * Wall time at which the current step interval ends, i.e. {@code (lastInitPos + 1) * step} in
+   * terms of the step index this used to track. Holding the boundary rather than the index means
+   * an update landing inside the current interval is a comparison instead of a division, and
+   * since the two are related by a fixed factor there is no second piece of state that has to be
+   * kept in agreement. The index is recovered where it is needed as {@code boundary / step - 1},
+   * or equivalently the start of the current interval is {@code boundary - step}.
+   */
+  private volatile long nextStepBoundary;
 
-  private static final AtomicLongFieldUpdater<StepDouble> LAST_INIT_POS_UPDATER =
-      AtomicLongFieldUpdater.newUpdater(StepDouble.class, "lastInitPos");
+  private static final AtomicLongFieldUpdater<StepDouble> NEXT_STEP_BOUNDARY_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(StepDouble.class, "nextStepBoundary");
 
   /** Create a new instance. */
   public StepDouble(double init, Clock clock, long step) {
@@ -52,19 +60,40 @@ public class StepDouble implements StepValue {
     this.step = step;
     previous = init;
     current = Double.doubleToLongBits(init);
-    lastInitPos = clock.wallTime() / step;
+    nextStepBoundary = (clock.wallTime() / step + 1) * step;
   }
 
+  /**
+   * Roll over to a new step interval if {@code now} has moved past the end of the current one.
+   *
+   * <p>Kept small so it inlines into the update methods. {@code step} is a non-trusted final
+   * instance field, so C2 cannot constant fold it and {@code now / step} compiles to a real
+   * {@code idivq} plus the divide-by-zero and {@code MIN_VALUE / -1} guards. Comparing against
+   * the boundary keeps all of that off the update path and pays for the division only on an
+   * actual rollover.</p>
+   */
   private void rollCount(long now) {
-    final long stepTime = now / step;
-    final long lastInit = lastInitPos;
-    if (lastInit < stepTime && LAST_INIT_POS_UPDATER.compareAndSet(this, lastInit, stepTime)) {
+    if (now >= nextStepBoundary) {
+      rollCountSlow(now);
+    }
+  }
+
+  private void rollCountSlow(long now) {
+    // Boundaries are exact multiples of step, so comparing them orders the intervals the same
+    // way comparing the step indices did.
+    final long boundary = (now / step + 1) * step;
+    final long lastBoundary = nextStepBoundary;
+    // The boundary compare is not redundant with the CAS. Without it two threads that both see
+    // the same boundary would both roll: the second would reset `current` again and overwrite
+    // `previous` with init, publishing zero for an interval that had data.
+    if (lastBoundary < boundary
+        && NEXT_STEP_BOUNDARY_UPDATER.compareAndSet(this, lastBoundary, boundary)) {
       final double v = Double.longBitsToDouble(
           CURRENT_UPDATER.getAndSet(this, Double.doubleToLongBits(init)));
       // Need to check if there was any activity during the previous step interval. If there was
       // then the init position will move forward by 1, otherwise it will be older. No activity
       // means the previous interval should be set to the `init` value.
-      previous = (lastInit == stepTime - 1) ? v : init;
+      previous = (lastBoundary == boundary - step) ? v : init;
     }
   }
 
@@ -191,13 +220,15 @@ public class StepDouble implements StepValue {
 
   /** Get the timestamp for the end of the last completed interval. */
   @Override public long timestamp() {
-    return lastInitPos * step;
+    // Start of the current interval, which is the end of the last completed one. Equivalent to
+    // the lastInitPos * step this used to compute.
+    return nextStepBoundary - step;
   }
 
   @Override public String toString() {
     return "StepDouble{init="  + init
         + ", previous=" + previous
         + ", current=" + Double.longBitsToDouble(current)
-        + ", lastInitPos=" + lastInitPos + '}';
+        + ", lastInitPos=" + (nextStepBoundary / step - 1) + '}';
   }
 }

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/StepDouble.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/StepDouble.java
@@ -41,12 +41,9 @@ public class StepDouble implements StepValue {
       AtomicLongFieldUpdater.newUpdater(StepDouble.class, "current");
 
   /**
-   * Wall time at which the current step interval ends, i.e. {@code (lastInitPos + 1) * step} in
-   * terms of the step index this used to track. Holding the boundary rather than the index means
-   * an update landing inside the current interval is a comparison instead of a division, and
-   * since the two are related by a fixed factor there is no second piece of state that has to be
-   * kept in agreement. The index is recovered where it is needed as {@code boundary / step - 1},
-   * or equivalently the start of the current interval is {@code boundary - step}.
+   * Wall time at which the current step interval ends. Holding this boundary rather than the step
+   * index means an update landing inside the current interval is a comparison instead of a
+   * division.
    */
   private volatile long nextStepBoundary;
 

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/StepLong.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/StepLong.java
@@ -41,12 +41,9 @@ public class StepLong implements StepValue {
       AtomicLongFieldUpdater.newUpdater(StepLong.class, "current");
 
   /**
-   * Wall time at which the current step interval ends, i.e. {@code (lastInitPos + 1) * step} in
-   * terms of the step index this used to track. Holding the boundary rather than the index means
-   * an update landing inside the current interval is a comparison instead of a division, and
-   * since the two are related by a fixed factor there is no second piece of state that has to be
-   * kept in agreement. The index is recovered where it is needed as {@code boundary / step - 1},
-   * or equivalently the start of the current interval is {@code boundary - step}.
+   * Wall time at which the current step interval ends. Holding this boundary rather than the step
+   * index means an update landing inside the current interval is a comparison instead of a
+   * division.
    */
   private volatile long nextStepBoundary;
 

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/StepLong.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/StepLong.java
@@ -40,10 +40,18 @@ public class StepLong implements StepValue {
   private static final AtomicLongFieldUpdater<StepLong> CURRENT_UPDATER =
       AtomicLongFieldUpdater.newUpdater(StepLong.class, "current");
 
-  private volatile long lastInitPos;
+  /**
+   * Wall time at which the current step interval ends, i.e. {@code (lastInitPos + 1) * step} in
+   * terms of the step index this used to track. Holding the boundary rather than the index means
+   * an update landing inside the current interval is a comparison instead of a division, and
+   * since the two are related by a fixed factor there is no second piece of state that has to be
+   * kept in agreement. The index is recovered where it is needed as {@code boundary / step - 1},
+   * or equivalently the start of the current interval is {@code boundary - step}.
+   */
+  private volatile long nextStepBoundary;
 
-  private static final AtomicLongFieldUpdater<StepLong> LAST_INIT_POS_UPDATER =
-      AtomicLongFieldUpdater.newUpdater(StepLong.class, "lastInitPos");
+  private static final AtomicLongFieldUpdater<StepLong> NEXT_STEP_BOUNDARY_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(StepLong.class, "nextStepBoundary");
 
   /** Create a new instance. */
   public StepLong(long init, Clock clock, long step) {
@@ -52,18 +60,39 @@ public class StepLong implements StepValue {
     this.step = step;
     previous = init;
     current = init;
-    lastInitPos = clock.wallTime() / step;
+    nextStepBoundary = (clock.wallTime() / step + 1) * step;
   }
 
+  /**
+   * Roll over to a new step interval if {@code now} has moved past the end of the current one.
+   *
+   * <p>Kept small so it inlines into the update methods. {@code step} is a non-trusted final
+   * instance field, so C2 cannot constant fold it and {@code now / step} compiles to a real
+   * {@code idivq} plus the divide-by-zero and {@code MIN_VALUE / -1} guards. Comparing against
+   * the boundary keeps all of that off the update path and pays for the division only on an
+   * actual rollover.</p>
+   */
   private void rollCount(long now) {
-    final long stepTime = now / step;
-    final long lastInit = lastInitPos;
-    if (lastInit < stepTime && LAST_INIT_POS_UPDATER.compareAndSet(this, lastInit, stepTime)) {
+    if (now >= nextStepBoundary) {
+      rollCountSlow(now);
+    }
+  }
+
+  private void rollCountSlow(long now) {
+    // Boundaries are exact multiples of step, so comparing them orders the intervals the same
+    // way comparing the step indices did.
+    final long boundary = (now / step + 1) * step;
+    final long lastBoundary = nextStepBoundary;
+    // The boundary compare is not redundant with the CAS. Without it two threads that both see
+    // the same boundary would both roll: the second would reset `current` again and overwrite
+    // `previous` with init, publishing zero for an interval that had data.
+    if (lastBoundary < boundary
+        && NEXT_STEP_BOUNDARY_UPDATER.compareAndSet(this, lastBoundary, boundary)) {
       final long v = CURRENT_UPDATER.getAndSet(this, init);
       // Need to check if there was any activity during the previous step interval. If there was
       // then the init position will move forward by 1, otherwise it will be older. No activity
       // means the previous interval should be set to the `init` value.
-      previous = (lastInit == stepTime - 1) ? v : init;
+      previous = (lastBoundary == boundary - step) ? v : init;
     }
   }
 
@@ -163,13 +192,15 @@ public class StepLong implements StepValue {
 
   /** Get the timestamp for the end of the last completed interval. */
   @Override public long timestamp() {
-    return lastInitPos * step;
+    // Start of the current interval, which is the end of the last completed one. Equivalent to
+    // the lastInitPos * step this used to compute.
+    return nextStepBoundary - step;
   }
 
   @Override public String toString() {
     return "StepLong{init="  + init
         + ", previous=" + previous
         + ", current=" + current
-        + ", lastInitPos=" + lastInitPos + '}';
+        + ", lastInitPos=" + (nextStepBoundary / step - 1) + '}';
   }
 }

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/SwapMeter.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/SwapMeter.java
@@ -35,8 +35,25 @@ public abstract class SwapMeter<T extends Meter> implements Meter {
   /** Registry used to lookup values after expiration. */
   protected final Registry registry;
 
+  /**
+   * Signals that the shape of the registry changed, for example a registry being added to a
+   * composite. Participates in {@link #hasExpired()}: a change means callers should stop using
+   * this wrapper and obtain a fresh one.
+   */
   private final LongSupplier versionSupplier;
   private volatile long currentVersion;
+
+  /**
+   * Signals that a meter was removed from the registry, so this wrapper may be holding one that
+   * is no longer registered. Kept separate from {@code versionSupplier} on purpose. Meter removal
+   * happens on every cleanup pass, whereas a registry level change is rare, and
+   * {@link #hasExpired()} is acted on destructively by callers such as {@code PolledMeter}, which
+   * drops the meter from the set it aggregates. Folding routine removals into that signal would
+   * report healthy meters as expired once per cleanup pass. This one therefore feeds
+   * {@link #get()} only.
+   */
+  private final LongSupplier resolveSupplier;
+  private volatile long currentResolveVersion;
 
   /** Id to use when performing a lookup after expiration. */
   protected final Id id;
@@ -46,9 +63,43 @@ public abstract class SwapMeter<T extends Meter> implements Meter {
 
   /** Create a new instance. */
   public SwapMeter(Registry registry, LongSupplier versionSupplier, Id id, T underlying) {
+    this(registry, versionSupplier, versionSupplier, versionSupplier.getAsLong(), id, underlying);
+  }
+
+  /**
+   * Create a new instance with a dedicated signal for meter removal, and the value of that signal
+   * as observed <i>before</i> {@code underlying} was resolved.
+   *
+   * <p>Ordering matters here. The signal has to be sampled first so that a removal racing with
+   * the resolution is noticed: sampled afterwards it would already account for that removal and
+   * this wrapper would stay bound to a meter that is no longer registered, silently dropping
+   * every later update. Sampling early can only cause one redundant re-resolution.
+   *
+   * @param registry
+   *     Registry used to lookup the meter after expiration.
+   * @param versionSupplier
+   *     Supplies the registry level version, used by {@link #hasExpired()}.
+   * @param resolveSupplier
+   *     Supplies a counter that changes whenever a meter is removed, used by {@link #get()}.
+   * @param resolveVersion
+   *     Value of {@code resolveSupplier} sampled before {@code underlying} was looked up.
+   * @param id
+   *     Id to use when performing a lookup after expiration.
+   * @param underlying
+   *     Meter to delegate operations to.
+   */
+  public SwapMeter(
+      Registry registry,
+      LongSupplier versionSupplier,
+      LongSupplier resolveSupplier,
+      long resolveVersion,
+      Id id,
+      T underlying) {
     this.registry = registry;
     this.versionSupplier = versionSupplier;
     this.currentVersion = versionSupplier.getAsLong();
+    this.resolveSupplier = resolveSupplier;
+    this.currentResolveVersion = resolveVersion;
     this.id = id;
     this.underlying = unwrap(underlying);
   }
@@ -66,6 +117,12 @@ public abstract class SwapMeter<T extends Meter> implements Meter {
     return get().measure();
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Routine meter removal is deliberately not part of this signal; see {@link #resolveSupplier}
+   * for why.
+   */
   @Override public boolean hasExpired() {
     return currentVersion < versionSupplier.getAsLong() || underlying.hasExpired();
   }
@@ -78,9 +135,30 @@ public abstract class SwapMeter<T extends Meter> implements Meter {
     underlying = unwrap(meter);
   }
 
-  /** Return the underlying instance of the meter. */
+  /**
+   * Return the underlying instance of the meter, resolving a new one if the registry may have
+   * removed the current instance.
+   *
+   * <p>This runs on the update path of every meter operation, so it checks a counter rather than
+   * {@code underlying.hasExpired()}. The counter is a plain volatile read, whereas the expiry
+   * check costs a wall clock read: for {@code AtlasMeter} that is a {@code clock_gettime} to
+   * evaluate a TTL measured in minutes, paid on every single update.
+   *
+   * <p>Not consulting the expiry check does not change which meter updates land on. A meter that
+   * is past its TTL but still registered is returned by {@code lookup()} anyway, since the lookup
+   * resolves through the same registry map that still holds it, so the old code did a map lookup
+   * only to arrive back at the same instance. Once cleanup actually removes the meter the counter
+   * moves and the next call here resolves a fresh instance, which is if anything more timely than
+   * waiting for the TTL to be observed.
+   */
   public T get() {
-    if (hasExpired()) {
+    // Sampled once: re-reading for the assignment could store a value newer than what lookup()
+    // actually observed, which would then swallow a subsequent removal.
+    final long resolveVersion = resolveSupplier.getAsLong();
+    if (currentResolveVersion < resolveVersion) {
+      currentResolveVersion = resolveVersion;
+      // Resolving also clears the registry level staleness reported by hasExpired(), since the
+      // meter being delegated to has just been looked up afresh.
       currentVersion = versionSupplier.getAsLong();
       underlying = unwrap(lookup());
     }

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/SwapMeter.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/SwapMeter.java
@@ -70,10 +70,10 @@ public abstract class SwapMeter<T extends Meter> implements Meter {
    * Create a new instance with a dedicated signal for meter removal, and the value of that signal
    * as observed <i>before</i> {@code underlying} was resolved.
    *
-   * <p>Ordering matters here. The signal has to be sampled first so that a removal racing with
-   * the resolution is noticed: sampled afterwards it would already account for that removal and
-   * this wrapper would stay bound to a meter that is no longer registered, silently dropping
-   * every later update. Sampling early can only cause one redundant re-resolution.
+   * <p>{@code resolveVersion} must be sampled before resolving {@code underlying}: sampled
+   * afterwards it would already account for a removal racing with the resolution, and this
+   * wrapper would stay bound to a meter that is no longer registered, silently dropping every
+   * later update. Sampling early can only cause one redundant re-resolution.
    *
    * @param registry
    *     Registry used to lookup the meter after expiration.
@@ -140,16 +140,12 @@ public abstract class SwapMeter<T extends Meter> implements Meter {
    * removed the current instance.
    *
    * <p>This runs on the update path of every meter operation, so it checks a counter rather than
-   * {@code underlying.hasExpired()}. The counter is a plain volatile read, whereas the expiry
-   * check costs a wall clock read: for {@code AtlasMeter} that is a {@code clock_gettime} to
-   * evaluate a TTL measured in minutes, paid on every single update.
-   *
-   * <p>Not consulting the expiry check does not change which meter updates land on. A meter that
-   * is past its TTL but still registered is returned by {@code lookup()} anyway, since the lookup
-   * resolves through the same registry map that still holds it, so the old code did a map lookup
-   * only to arrive back at the same instance. Once cleanup actually removes the meter the counter
-   * moves and the next call here resolves a fresh instance, which is if anything more timely than
-   * waiting for the TTL to be observed.
+   * {@code underlying.hasExpired()}: the counter is a plain volatile read, whereas the expiry
+   * check costs a wall clock read on every update (for {@code AtlasMeter}, a {@code clock_gettime}
+   * to evaluate a TTL measured in minutes). This does not change which meter updates land on — a
+   * meter that is past its TTL but still registered resolves back to the same instance either
+   * way — and once cleanup actually removes the meter the counter moves, so the next call here
+   * resolves a fresh one.
    */
   public T get() {
     // Sampled once: re-reading for the assignment could store a value newer than what lookup()

--- a/spectator-api/src/test/java/com/netflix/spectator/api/SwapMeterExpiryReportingTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/SwapMeterExpiryReportingTest.java
@@ -121,4 +121,37 @@ public class SwapMeterExpiryReportingTest {
     Assertions.assertTrue(visible > 0,
         "cleanup must not filter every meter out of the composite's published stream");
   }
+
+  /**
+   * A composite hands out wrappers keyed on its own version, which only changes when a registry is
+   * added or removed, so a sweep inside a sub registry does not invalidate them. Recovery has to
+   * come from the sub registry's own wrapper nested inside the composite meter, which is why
+   * {@code SwapMeter.unwrap} only flattens wrappers belonging to the same registry.
+   */
+  @Test
+  public void updatesThroughACompositeSurviveASubRegistrySweep() {
+    ManualClock clock = new ManualClock();
+    ExpiringRegistry underlying = new ExpiringRegistry(clock);
+    CompositeRegistry composite = new CompositeRegistry(clock);
+    composite.add(underlying);
+
+    Counter held = composite.counter("test");
+    held.increment();
+    Assertions.assertEquals(1, underlying.counters().count());
+
+    // Make the meter eligible for removal and sweep it. The composite's version is untouched.
+    clock.setWallTime(1);
+    underlying.removeExpiredMeters();
+    Assertions.assertEquals(0, underlying.counters().count(), "the sweep should have removed it");
+
+    // The update has to land on a re-registered meter rather than on the orphaned instance.
+    held.increment();
+    Assertions.assertEquals(1, underlying.counters().count(),
+        "an update through the composite reference must re-register the swept meter");
+    Assertions.assertEquals(
+        1.0,
+        underlying.counters().findFirst().orElseThrow(AssertionError::new).actualCount(),
+        1e-12,
+        "the update must be recorded on the live meter, not lost on the swept one");
+  }
 }

--- a/spectator-api/src/test/java/com/netflix/spectator/api/SwapMeterExpiryReportingTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/SwapMeterExpiryReportingTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2014-2025 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.api;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The registry bumps a version when it removes a meter so that held references know to resolve
+ * again. That signal must not leak into {@code hasExpired()}.
+ *
+ * <p>Callers treat a true result as licence to discard the meter: {@code PolledMeter} drops it
+ * from the set it aggregates, {@code Registry.measurements()} filters its data out, and
+ * {@code cleanupCachedState()} evicts it. A {@link CompositeMeter} reports expired only when all
+ * of its delegates do, and its delegates are the per registry swap wrappers, so a version based
+ * answer there would blank out every meter in a composite after the first cleanup pass. That
+ * matters because {@code Spectator.globalRegistry()} is a composite.</p>
+ */
+public class SwapMeterExpiryReportingTest {
+
+  @Test
+  public void cleanupDoesNotExpireHealthyMeters() {
+    ManualClock clock = new ManualClock();
+    ExpiringRegistry registry = new ExpiringRegistry(clock);
+
+    // Counters in this registry expire as soon as the clock moves past their creation time.
+    registry.counter("idle").increment();
+    clock.setWallTime(1);
+
+    Counter active = registry.counter("active");
+    active.increment();
+    Assertions.assertFalse(active.hasExpired(), "precondition: freshly created meter is healthy");
+
+    registry.removeExpiredMeters();
+    Assertions.assertEquals(1, registry.counters().count(), "the idle meter should be gone");
+
+    Assertions.assertFalse(active.hasExpired(),
+        "cleanup of an unrelated meter must not report a healthy meter as expired");
+  }
+
+  /**
+   * The registry version has to be sampled before the meter is looked up, not after.
+   *
+   * <p>If it were sampled afterwards, a cleanup pass landing between the lookup and the sampling
+   * would already be accounted for, so the returned wrapper would never notice that the meter it
+   * captured is no longer registered. Every later update through it would be silently dropped.
+   * The registry is subclassed here to run a removal in exactly that window.</p>
+   */
+  @Test
+  public void versionIsSampledBeforeTheMeterIsResolved() {
+    ManualClock clock = new ManualClock();
+
+    class RacingRegistry extends ExpiringRegistry {
+      private boolean sweepDuringLookup;
+
+      RacingRegistry() {
+        super(clock);
+      }
+
+      void armSweep() {
+        sweepDuringLookup = true;
+      }
+
+      @Override protected <T extends Meter> T getOrCreate(
+          Id id, Class<T> cls, T dflt, java.util.function.Function<Id, T> factory) {
+        T m = super.getOrCreate(id, cls, dflt, factory);
+        if (sweepDuringLookup) {
+          sweepDuringLookup = false;
+          // Simulates the cleanup pass removing this meter right after it was resolved but
+          // before the caller has finished building the wrapper around it.
+          removeExpiredMeters();
+        }
+        return m;
+      }
+    }
+
+    RacingRegistry registry = new RacingRegistry();
+    registry.counter("test").increment();
+
+    // Move past the creation time so the meter is now eligible for removal, then arrange for the
+    // sweep to happen inside the next lookup.
+    clock.setWallTime(1);
+    registry.armSweep();
+
+    Counter held = registry.counter("test");
+    Assertions.assertEquals(0, registry.counters().count(), "the sweep should have removed it");
+
+    held.increment();
+    Assertions.assertEquals(1, registry.counters().count(),
+        "the returned reference must notice the removal and re-register the meter");
+  }
+
+  @Test
+  public void cleanupDoesNotBlankOutACompositeRegistry() {
+    ManualClock clock = new ManualClock();
+    ExpiringRegistry underlying = new ExpiringRegistry(clock);
+    CompositeRegistry composite = new CompositeRegistry(clock);
+    composite.add(underlying);
+
+    composite.counter("idle").increment();
+    clock.setWallTime(1);
+
+    Counter active = composite.counter("active");
+    active.increment();
+
+    underlying.removeExpiredMeters();
+
+    Assertions.assertFalse(active.hasExpired(),
+        "a composite meter must not report expired because the sub registry ran cleanup");
+
+    // The whole point: the meter's data still has to reach the published stream, which filters
+    // on hasExpired().
+    long visible = composite.stream().filter(m -> !m.hasExpired()).count();
+    Assertions.assertTrue(visible > 0,
+        "cleanup must not filter every meter out of the composite's published stream");
+  }
+}

--- a/spectator-api/src/test/java/com/netflix/spectator/api/SwapMeterExpiryReportingTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/SwapMeterExpiryReportingTest.java
@@ -20,14 +20,11 @@ import org.junit.jupiter.api.Test;
 
 /**
  * The registry bumps a version when it removes a meter so that held references know to resolve
- * again. That signal must not leak into {@code hasExpired()}.
- *
- * <p>Callers treat a true result as licence to discard the meter: {@code PolledMeter} drops it
- * from the set it aggregates, {@code Registry.measurements()} filters its data out, and
- * {@code cleanupCachedState()} evicts it. A {@link CompositeMeter} reports expired only when all
- * of its delegates do, and its delegates are the per registry swap wrappers, so a version based
- * answer there would blank out every meter in a composite after the first cleanup pass. That
- * matters because {@code Spectator.globalRegistry()} is a composite.</p>
+ * again. That signal must not leak into {@code hasExpired()}: callers treat a true result as
+ * licence to discard the meter ({@code PolledMeter} drops it, {@code measurements()} filters it
+ * out, {@code cleanupCachedState()} evicts it), and a {@link CompositeMeter} — which is what
+ * {@code Spectator.globalRegistry()} is — reports expired only when all of its delegates do, so a
+ * version based answer would blank out every meter in it after the first cleanup pass.
  */
 public class SwapMeterExpiryReportingTest {
 
@@ -52,12 +49,9 @@ public class SwapMeterExpiryReportingTest {
   }
 
   /**
-   * The registry version has to be sampled before the meter is looked up, not after.
-   *
-   * <p>If it were sampled afterwards, a cleanup pass landing between the lookup and the sampling
-   * would already be accounted for, so the returned wrapper would never notice that the meter it
-   * captured is no longer registered. Every later update through it would be silently dropped.
-   * The registry is subclassed here to run a removal in exactly that window.</p>
+   * The registry version has to be sampled before the meter is looked up, not after; see
+   * {@link com.netflix.spectator.impl.SwapMeter} for why. The registry is subclassed here to run
+   * a removal in exactly that window.
    */
   @Test
   public void versionIsSampledBeforeTheMeterIsResolved() {

--- a/spectator-api/src/test/java/com/netflix/spectator/impl/StepRollCountConcurrencyTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/StepRollCountConcurrencyTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2014-2025 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.impl;
+
+import com.netflix.spectator.api.ManualClock;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Only one thread may perform a given rollover. If several threads are allowed through, the
+ * second one resets {@code current} again and overwrites {@code previous} with the init value, so
+ * the completed interval is published as zero and its data is lost.
+ *
+ * <p>The guard that prevents this is a compare of the interval boundaries before the CAS. It
+ * cannot be exercised by a single threaded test, so it is covered here: every thread is released
+ * onto the same rollover at once and the value for the completed interval has to survive.</p>
+ */
+public class StepRollCountConcurrencyTest {
+
+  private static final long STEP = 10_000L;
+  private static final int THREADS = 8;
+  private static final int ROUNDS = 2_000;
+
+  @Test
+  @Timeout(60)
+  public void stepDoubleRollsExactlyOncePerInterval() throws Exception {
+    ManualClock clock = new ManualClock();
+    StepDouble value = new StepDouble(0.0, clock, STEP);
+    CyclicBarrier barrier = new CyclicBarrier(THREADS + 1);
+    ExecutorService pool = Executors.newFixedThreadPool(THREADS);
+    try {
+      // Interval index for the round, starting past zero so the first round has a real previous.
+      final long[] interval = {1L};
+      for (int t = 0; t < THREADS; ++t) {
+        pool.submit(() -> {
+          try {
+            for (int r = 0; r < ROUNDS; ++r) {
+              barrier.await(30, TimeUnit.SECONDS);
+              // All threads attempt the same rollover simultaneously.
+              value.getCurrent(interval[0] * STEP);
+              barrier.await(30, TimeUnit.SECONDS);
+            }
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+        });
+      }
+
+      for (int r = 0; r < ROUNDS; ++r) {
+        // Seed a known value into the current interval, which the rollover must publish.
+        double expected = 3.0;
+        value.setCurrent((interval[0] - 1) * STEP, expected);
+
+        barrier.await(30, TimeUnit.SECONDS);
+        barrier.await(30, TimeUnit.SECONDS);
+
+        Assertions.assertEquals(expected, value.poll(interval[0] * STEP), 1e-12,
+            "round " + r + ": completed interval value was lost to a duplicate rollover");
+        interval[0] += 1;
+      }
+    } finally {
+      pool.shutdownNow();
+      Assertions.assertTrue(pool.awaitTermination(30, TimeUnit.SECONDS));
+    }
+  }
+
+  @Test
+  @Timeout(60)
+  public void stepLongRollsExactlyOncePerInterval() throws Exception {
+    ManualClock clock = new ManualClock();
+    StepLong value = new StepLong(0L, clock, STEP);
+    CyclicBarrier barrier = new CyclicBarrier(THREADS + 1);
+    ExecutorService pool = Executors.newFixedThreadPool(THREADS);
+    try {
+      final long[] interval = {1L};
+      for (int t = 0; t < THREADS; ++t) {
+        pool.submit(() -> {
+          try {
+            for (int r = 0; r < ROUNDS; ++r) {
+              barrier.await(30, TimeUnit.SECONDS);
+              value.getCurrent(interval[0] * STEP);
+              barrier.await(30, TimeUnit.SECONDS);
+            }
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+        });
+      }
+
+      for (int r = 0; r < ROUNDS; ++r) {
+        long expected = 3L;
+        value.setCurrent((interval[0] - 1) * STEP, expected);
+
+        barrier.await(30, TimeUnit.SECONDS);
+        barrier.await(30, TimeUnit.SECONDS);
+
+        Assertions.assertEquals(expected, value.poll(interval[0] * STEP),
+            "round " + r + ": completed interval value was lost to a duplicate rollover");
+        interval[0] += 1;
+      }
+    } finally {
+      pool.shutdownNow();
+      Assertions.assertTrue(pool.awaitTermination(30, TimeUnit.SECONDS));
+    }
+  }
+
+  /**
+   * Concurrent updates inside one interval must all be retained, then published in full by the
+   * rollover. Only the last completed interval is kept, so this deliberately stays within a
+   * single interval: values for intervals that roll by without being polled are dropped by
+   * design and counting them would not be a conservation property of this class.
+   */
+  @Test
+  @Timeout(60)
+  public void concurrentUpdatesWithinAnIntervalAreConserved() throws Exception {
+    ManualClock clock = new ManualClock();
+    StepLong value = new StepLong(0L, clock, STEP);
+    final int perThread = 100_000;
+    final long now = 5L * STEP;
+    ExecutorService pool = Executors.newFixedThreadPool(THREADS);
+    try {
+      CyclicBarrier start = new CyclicBarrier(THREADS);
+      for (int t = 0; t < THREADS; ++t) {
+        pool.submit(() -> {
+          try {
+            start.await(30, TimeUnit.SECONDS);
+            for (int i = 0; i < perThread; ++i) {
+              value.addAndGet(now, 1L);
+            }
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+        });
+      }
+      pool.shutdown();
+      Assertions.assertTrue(pool.awaitTermination(45, TimeUnit.SECONDS));
+
+      Assertions.assertEquals((long) THREADS * perThread, value.getCurrent(now),
+          "updates were lost by the CAS retry loop");
+      // The single rollover must publish the whole amount.
+      Assertions.assertEquals((long) THREADS * perThread, value.poll(now + STEP),
+          "rollover did not publish the full interval");
+      Assertions.assertEquals(0L, value.getCurrent(now + STEP));
+    } finally {
+      pool.shutdownNow();
+    }
+  }
+}

--- a/spectator-api/src/test/java/com/netflix/spectator/impl/StepRollCountDifferentialTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/StepRollCountDifferentialTest.java
@@ -19,6 +19,8 @@ import com.netflix.spectator.api.Clock;
 import com.netflix.spectator.api.ManualClock;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -34,6 +36,11 @@ import java.util.concurrent.atomic.AtomicLongFieldUpdater;
  * <p>The sequences deliberately include the cases that distinguish the two: timestamps landing
  * exactly on a boundary, gaps that skip whole intervals so the previous interval had no activity,
  * and time moving backwards the way NTP can move it.</p>
+ *
+ * <p>The comparison is run over several step sizes rather than one. The cached boundary is derived
+ * from {@code step}, so a step that does not divide the starting timestamp, and a step small
+ * enough that nearly every update rolls, exercise different alignment than the 5s step used in
+ * practice.</p>
  */
 public class StepRollCountDifferentialTest {
 
@@ -172,7 +179,7 @@ public class StepRollCountDifferentialTest {
    * Timestamps covering the interesting rollover shapes: repeats within an interval, exact
    * boundaries, boundary minus and plus one, multi interval gaps, and backwards movement.
    */
-  private List<Long> timestamps(long start) {
+  private List<Long> timestamps(long start, long step) {
     List<Long> ts = new ArrayList<>();
     Random r = new Random(42);
     long now = start;
@@ -181,23 +188,23 @@ public class StepRollCountDifferentialTest {
       switch (r.nextInt(10)) {
         case 0:
           // Land exactly on the next boundary.
-          now = (now / STEP + 1) * STEP;
+          now = (now / step + 1) * step;
           break;
         case 1:
           // One millisecond short of the next boundary.
-          now = (now / STEP + 1) * STEP - 1;
+          now = (now / step + 1) * step - 1;
           break;
         case 2:
           // One millisecond past the next boundary.
-          now = (now / STEP + 1) * STEP + 1;
+          now = (now / step + 1) * step + 1;
           break;
         case 3:
           // Skip several whole intervals, so the previous interval saw no activity.
-          now += STEP * (2 + r.nextInt(5));
+          now += step * (2 + r.nextInt(5));
           break;
         case 4:
           // Time moves backwards, as it can when NTP adjusts the clock.
-          now -= r.nextInt((int) STEP * 3);
+          now -= r.nextInt((int) Math.min(Integer.MAX_VALUE, step * 3));
           break;
         default:
           // Stay inside the current interval most of the time.
@@ -207,22 +214,28 @@ public class StepRollCountDifferentialTest {
       // Wall time is not expected to be negative, but a backwards jump near zero can get there
       // with a ManualClock, and integer division truncates toward zero rather than flooring, so
       // the two implementations are compared over that range too rather than assumed equal.
-      if (now < -3 * STEP) {
+      if (now < -3 * step) {
         now = 0;
       }
     }
     return ts;
   }
 
-  @Test
-  public void stepDoubleMatchesLegacyBitForBit() {
-    for (long start : new long[] {0L, 1L, STEP, STEP - 1, 1_700_000_000_000L}) {
+  /** Starting timestamps covering aligned, off-by-one and realistic epoch alignment. */
+  private long[] starts(long step) {
+    return new long[] {0L, 1L, step, step - 1, 1_700_000_000_000L};
+  }
+
+  @ParameterizedTest
+  @ValueSource(longs = {1L, 7L, 13L, 1000L, 5000L, 60_000L})
+  public void stepDoubleMatchesLegacyBitForBit(long step) {
+    for (long start : starts(step)) {
       ManualClock clock = new ManualClock(start, start);
-      StepDouble actual = new StepDouble(0.0, clock, STEP);
-      LegacyStepDouble expected = new LegacyStepDouble(0.0, clock, STEP);
+      StepDouble actual = new StepDouble(0.0, clock, step);
+      LegacyStepDouble expected = new LegacyStepDouble(0.0, clock, step);
 
       int op = 0;
-      for (long now : timestamps(start)) {
+      for (long now : timestamps(start, step)) {
         // Exercise every read and write path, since they all funnel through rollCount.
         switch (op++ % 4) {
           case 0:
@@ -256,15 +269,16 @@ public class StepRollCountDifferentialTest {
     }
   }
 
-  @Test
-  public void stepLongMatchesLegacyBitForBit() {
-    for (long start : new long[] {0L, 1L, STEP, STEP - 1, 1_700_000_000_000L}) {
+  @ParameterizedTest
+  @ValueSource(longs = {1L, 7L, 13L, 1000L, 5000L, 60_000L})
+  public void stepLongMatchesLegacyBitForBit(long step) {
+    for (long start : starts(step)) {
       ManualClock clock = new ManualClock(start, start);
-      StepLong actual = new StepLong(0L, clock, STEP);
-      LegacyStepLong expected = new LegacyStepLong(0L, clock, STEP);
+      StepLong actual = new StepLong(0L, clock, step);
+      LegacyStepLong expected = new LegacyStepLong(0L, clock, step);
 
       int op = 0;
-      for (long now : timestamps(start)) {
+      for (long now : timestamps(start, step)) {
         switch (op++ % 4) {
           case 0:
             Assertions.assertEquals(

--- a/spectator-api/src/test/java/com/netflix/spectator/impl/StepRollCountDifferentialTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/StepRollCountDifferentialTest.java
@@ -1,0 +1,347 @@
+/*
+ * Copyright 2014-2025 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.impl;
+
+import com.netflix.spectator.api.Clock;
+import com.netflix.spectator.api.ManualClock;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
+/**
+ * {@link StepDouble} and {@link StepLong} cache the end of the current step interval so that the
+ * division in {@code rollCount} is only paid on an actual rollover. The published values have to
+ * be unchanged by that, so this drives the current implementation and a copy of the previous one
+ * over identical timestamp sequences and requires the results to be bit-for-bit equal.
+ *
+ * <p>The sequences deliberately include the cases that distinguish the two: timestamps landing
+ * exactly on a boundary, gaps that skip whole intervals so the previous interval had no activity,
+ * and time moving backwards the way NTP can move it.</p>
+ */
+public class StepRollCountDifferentialTest {
+
+  private static final long STEP = 5000L;
+
+  /** The implementation of rollCount that shipped before the boundary was cached. */
+  private static class LegacyStepDouble {
+
+    private final double init;
+    private final long step;
+
+    private volatile double previous;
+    private volatile long current;
+    private volatile long lastInitPos;
+
+    private static final AtomicLongFieldUpdater<LegacyStepDouble> CURRENT_UPDATER =
+        AtomicLongFieldUpdater.newUpdater(LegacyStepDouble.class, "current");
+
+    private static final AtomicLongFieldUpdater<LegacyStepDouble> LAST_INIT_POS_UPDATER =
+        AtomicLongFieldUpdater.newUpdater(LegacyStepDouble.class, "lastInitPos");
+
+    LegacyStepDouble(double init, Clock clock, long step) {
+      this.init = init;
+      this.step = step;
+      previous = init;
+      current = Double.doubleToLongBits(init);
+      lastInitPos = clock.wallTime() / step;
+    }
+
+    private void rollCount(long now) {
+      final long stepTime = now / step;
+      final long lastInit = lastInitPos;
+      if (lastInit < stepTime && LAST_INIT_POS_UPDATER.compareAndSet(this, lastInit, stepTime)) {
+        final double v = Double.longBitsToDouble(
+            CURRENT_UPDATER.getAndSet(this, Double.doubleToLongBits(init)));
+        previous = (lastInit == stepTime - 1) ? v : init;
+      }
+    }
+
+    double addAndGet(long now, double amount) {
+      rollCount(now);
+      long v;
+      double d;
+      double n;
+      long next;
+      do {
+        v = current;
+        d = Double.longBitsToDouble(v);
+        n = d + amount;
+        next = Double.doubleToLongBits(n);
+      } while (!CURRENT_UPDATER.compareAndSet(this, v, next));
+      return n;
+    }
+
+    double getCurrent(long now) {
+      rollCount(now);
+      return Double.longBitsToDouble(current);
+    }
+
+    double poll(long now) {
+      rollCount(now);
+      return previous;
+    }
+
+    double pollAsRate(long now) {
+      final double amount = poll(now);
+      final double period = step / 1000.0;
+      return amount / period;
+    }
+
+    long timestamp() {
+      return lastInitPos * step;
+    }
+  }
+
+  /** The implementation of rollCount that shipped before the boundary was cached. */
+  private static class LegacyStepLong {
+
+    private final long init;
+    private final long step;
+
+    private volatile long previous;
+    private volatile long current;
+    private volatile long lastInitPos;
+
+    private static final AtomicLongFieldUpdater<LegacyStepLong> CURRENT_UPDATER =
+        AtomicLongFieldUpdater.newUpdater(LegacyStepLong.class, "current");
+
+    private static final AtomicLongFieldUpdater<LegacyStepLong> LAST_INIT_POS_UPDATER =
+        AtomicLongFieldUpdater.newUpdater(LegacyStepLong.class, "lastInitPos");
+
+    LegacyStepLong(long init, Clock clock, long step) {
+      this.init = init;
+      this.step = step;
+      previous = init;
+      current = init;
+      lastInitPos = clock.wallTime() / step;
+    }
+
+    private void rollCount(long now) {
+      final long stepTime = now / step;
+      final long lastInit = lastInitPos;
+      if (lastInit < stepTime && LAST_INIT_POS_UPDATER.compareAndSet(this, lastInit, stepTime)) {
+        final long v = CURRENT_UPDATER.getAndSet(this, init);
+        previous = (lastInit == stepTime - 1) ? v : init;
+      }
+    }
+
+    long addAndGet(long now, long amount) {
+      rollCount(now);
+      return CURRENT_UPDATER.addAndGet(this, amount);
+    }
+
+    long getCurrent(long now) {
+      rollCount(now);
+      return current;
+    }
+
+    long poll(long now) {
+      rollCount(now);
+      return previous;
+    }
+
+    double pollAsRate(long now) {
+      final long amount = poll(now);
+      final double period = step / 1000.0;
+      return amount / period;
+    }
+
+    long timestamp() {
+      return lastInitPos * step;
+    }
+  }
+
+  /**
+   * Timestamps covering the interesting rollover shapes: repeats within an interval, exact
+   * boundaries, boundary minus and plus one, multi interval gaps, and backwards movement.
+   */
+  private List<Long> timestamps(long start) {
+    List<Long> ts = new ArrayList<>();
+    Random r = new Random(42);
+    long now = start;
+    for (int i = 0; i < 20_000; ++i) {
+      ts.add(now);
+      switch (r.nextInt(10)) {
+        case 0:
+          // Land exactly on the next boundary.
+          now = (now / STEP + 1) * STEP;
+          break;
+        case 1:
+          // One millisecond short of the next boundary.
+          now = (now / STEP + 1) * STEP - 1;
+          break;
+        case 2:
+          // One millisecond past the next boundary.
+          now = (now / STEP + 1) * STEP + 1;
+          break;
+        case 3:
+          // Skip several whole intervals, so the previous interval saw no activity.
+          now += STEP * (2 + r.nextInt(5));
+          break;
+        case 4:
+          // Time moves backwards, as it can when NTP adjusts the clock.
+          now -= r.nextInt((int) STEP * 3);
+          break;
+        default:
+          // Stay inside the current interval most of the time.
+          now += r.nextInt(500);
+          break;
+      }
+      // Wall time is not expected to be negative, but a backwards jump near zero can get there
+      // with a ManualClock, and integer division truncates toward zero rather than flooring, so
+      // the two implementations are compared over that range too rather than assumed equal.
+      if (now < -3 * STEP) {
+        now = 0;
+      }
+    }
+    return ts;
+  }
+
+  @Test
+  public void stepDoubleMatchesLegacyBitForBit() {
+    for (long start : new long[] {0L, 1L, STEP, STEP - 1, 1_700_000_000_000L}) {
+      ManualClock clock = new ManualClock(start, start);
+      StepDouble actual = new StepDouble(0.0, clock, STEP);
+      LegacyStepDouble expected = new LegacyStepDouble(0.0, clock, STEP);
+
+      int op = 0;
+      for (long now : timestamps(start)) {
+        // Exercise every read and write path, since they all funnel through rollCount.
+        switch (op++ % 4) {
+          case 0:
+            Assertions.assertEquals(
+                Double.doubleToRawLongBits(expected.addAndGet(now, 1.0)),
+                Double.doubleToRawLongBits(actual.addAndGet(now, 1.0)),
+                "addAndGet at " + now + " from start " + start);
+            break;
+          case 1:
+            Assertions.assertEquals(
+                Double.doubleToRawLongBits(expected.getCurrent(now)),
+                Double.doubleToRawLongBits(actual.getCurrent(now)),
+                "getCurrent at " + now + " from start " + start);
+            break;
+          case 2:
+            Assertions.assertEquals(
+                Double.doubleToRawLongBits(expected.poll(now)),
+                Double.doubleToRawLongBits(actual.poll(now)),
+                "poll at " + now + " from start " + start);
+            break;
+          default:
+            Assertions.assertEquals(
+                Double.doubleToRawLongBits(expected.pollAsRate(now)),
+                Double.doubleToRawLongBits(actual.pollAsRate(now)),
+                "pollAsRate at " + now + " from start " + start);
+            break;
+        }
+        Assertions.assertEquals(expected.timestamp(), actual.timestamp(),
+            "timestamp at " + now + " from start " + start);
+      }
+    }
+  }
+
+  @Test
+  public void stepLongMatchesLegacyBitForBit() {
+    for (long start : new long[] {0L, 1L, STEP, STEP - 1, 1_700_000_000_000L}) {
+      ManualClock clock = new ManualClock(start, start);
+      StepLong actual = new StepLong(0L, clock, STEP);
+      LegacyStepLong expected = new LegacyStepLong(0L, clock, STEP);
+
+      int op = 0;
+      for (long now : timestamps(start)) {
+        switch (op++ % 4) {
+          case 0:
+            Assertions.assertEquals(
+                expected.addAndGet(now, 1L),
+                actual.addAndGet(now, 1L),
+                "addAndGet at " + now + " from start " + start);
+            break;
+          case 1:
+            Assertions.assertEquals(
+                expected.getCurrent(now),
+                actual.getCurrent(now),
+                "getCurrent at " + now + " from start " + start);
+            break;
+          case 2:
+            Assertions.assertEquals(
+                expected.poll(now),
+                actual.poll(now),
+                "poll at " + now + " from start " + start);
+            break;
+          default:
+            Assertions.assertEquals(
+                Double.doubleToRawLongBits(expected.pollAsRate(now)),
+                Double.doubleToRawLongBits(actual.pollAsRate(now)),
+                "pollAsRate at " + now + " from start " + start);
+            break;
+        }
+        Assertions.assertEquals(expected.timestamp(), actual.timestamp(),
+            "timestamp at " + now + " from start " + start);
+      }
+    }
+  }
+
+  /**
+   * An interval with no activity has to publish the init value rather than carrying the previous
+   * interval forward. This is the case the cached boundary could plausibly break, so it is
+   * asserted directly as well as through the differential comparison.
+   */
+  @Test
+  public void noActivityInPreviousIntervalPublishesInit() {
+    ManualClock clock = new ManualClock();
+    StepDouble v = new StepDouble(0.0, clock, STEP);
+
+    v.addAndGet(0L, 42.0);
+
+    // Next interval: the 42.0 recorded above becomes the value for the completed interval.
+    Assertions.assertEquals(42.0, v.poll(STEP), 1e-12);
+
+    // Skip an entire interval with no updates at all. The completed interval had no activity,
+    // so it must report init and not the stale 42.0.
+    Assertions.assertEquals(0.0, v.poll(STEP * 4), 1e-12);
+    Assertions.assertEquals(0.0, v.getCurrent(STEP * 4), 1e-12);
+  }
+
+  /**
+   * The cached boundary must not let a rollover be skipped when the clock jumps backwards and
+   * then forwards again, and a backwards jump inside the current interval must not roll.
+   */
+  @Test
+  public void clockMovingBackwardsDoesNotRollOrSkip() {
+    ManualClock clock = new ManualClock();
+    StepDouble v = new StepDouble(0.0, clock, STEP);
+
+    long base = STEP * 100;
+    v.addAndGet(base, 7.0);
+    Assertions.assertEquals(7.0, v.getCurrent(base), 1e-12);
+
+    // Backwards within the same interval: no rollover, the value is still accumulating.
+    v.addAndGet(base + 10, 1.0);
+    v.addAndGet(base + 5, 1.0);
+    Assertions.assertEquals(9.0, v.getCurrent(base + 5), 1e-12);
+
+    // Backwards into an earlier interval: the existing lastInit < stepTime guard means this
+    // does not roll backwards, and the current value is retained.
+    Assertions.assertEquals(9.0, v.getCurrent(base - STEP * 3), 1e-12);
+
+    // Forwards again past the boundary: the rollover still happens.
+    Assertions.assertEquals(9.0, v.poll(base + STEP), 1e-12);
+    Assertions.assertEquals(0.0, v.getCurrent(base + STEP), 1e-12);
+  }
+}

--- a/spectator-reg-atlas/src/jmh/java/com/netflix/spectator/atlas/CounterIncrement.java
+++ b/spectator-reg-atlas/src/jmh/java/com/netflix/spectator/atlas/CounterIncrement.java
@@ -56,11 +56,7 @@ public class CounterIncrement {
     /** The step value underneath the meter. */
     StepDouble stepDouble;
 
-    /**
-     * A timer drives four step values per record (count, total, totalOfSquares, max), so it pays
-     * the rollCount cost four times where a counter pays it once. Measured separately because the
-     * counter path alone understates the change for timers.
-     */
+    /** A timer drives four step values per record, so it pays the rollCount cost four times. */
     Timer timer;
 
     /** Id used to measure the cost of resolving a meter from the registry. */
@@ -70,10 +66,8 @@ public class CounterIncrement {
     long now;
 
     /**
-     * Step of 1ms driven by a timestamp that advances every call, so essentially every update
-     * crosses a boundary. This is the adversarial case for caching the boundary: the fast path
-     * never hits, and the slow path pays for the cached read on top of the division it still has
-     * to do. Included to bound the downside rather than only measuring the favourable case.
+     * Step of 1ms with a timestamp that advances every call, so every update rolls over: the
+     * adversarial case where the cached boundary read is pure overhead on top of the division.
      */
     StepDouble rolling;
     long rollingNow;
@@ -126,29 +120,19 @@ public class CounterIncrement {
     return shared.stepDouble.addAndGet(shared.now, 1.0);
   }
 
-  /**
-   * Worst case for the boundary cache: a rollover on essentially every update, so the division
-   * is still paid and the cached read is pure overhead. Single threaded only; this is about the
-   * instruction cost of the slow path, not contention.
-   */
+  /** Worst case for the boundary cache; see {@link Shared#rolling}. */
   @Benchmark
   public double rollingStepDouble(Shared shared) {
     return shared.rolling.addAndGet(shared.rollingNow++, 1.0);
   }
 
-  /**
-   * Timer record through a held reference. Four step values per call, so four rollCounts.
-   */
+  /** Timer record through a held reference. */
   @Benchmark
   public void timerRecord(Shared shared) {
     shared.timer.record(42L, TimeUnit.NANOSECONDS);
   }
 
-  /**
-   * Cost of resolving a meter from the registry. This is what a held reference pays once per
-   * cleanup pass when the removal counter moves, so it sizes the re-resolution cost that the
-   * version based approach trades the per update clock read for.
-   */
+  /** Cost of resolving a meter from the registry, i.e. what a held reference pays on re-resolve. */
   @Benchmark
   public Counter lookupCost(Shared shared) {
     return shared.registry.counter(shared.lookupId);
@@ -166,11 +150,7 @@ public class CounterIncrement {
     state.counter.increment();
   }
 
-  /**
-   * Per-thread batch updater feeding the shared counter. This is the mitigation the library
-   * already provides for a single very hot counter: it amortises the CAS over the batch instead
-   * of striping every meter in the registry.
-   */
+  /** Per-thread batch updater feeding the shared counter, amortising the CAS over the batch. */
   @State(Scope.Thread)
   public static class Batched {
     Counter.BatchUpdater updater;

--- a/spectator-reg-atlas/src/jmh/java/com/netflix/spectator/atlas/CounterIncrement.java
+++ b/spectator-reg-atlas/src/jmh/java/com/netflix/spectator/atlas/CounterIncrement.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2014-2025 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import com.netflix.spectator.api.Clock;
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Timer;
+import com.netflix.spectator.impl.StepDouble;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Measures the {@code Counter.increment()} hot path for the Atlas registry. The layers are
+ * benchmarked separately so that the cost of the clock reads, the {@code rollCount} division
+ * and the CAS can be attributed rather than inferred from a single aggregate number.
+ *
+ * <p>Run the shared-counter benchmarks at {@code -t 1} and again at {@code -t N} to see whether
+ * the single-field CAS in {@link StepDouble} is actually contended. {@code perThread} keeps the
+ * code path identical but gives every thread its own counter, so it isolates path cost from
+ * cache-line contention.</p>
+ */
+public class CounterIncrement {
+
+  /** Shared state: one counter that every benchmark thread increments. */
+  @State(Scope.Benchmark)
+  public static class Shared {
+    AtlasRegistry registry;
+    Clock clock;
+
+    /** The counter a user would hold: a SwapCounter wrapping an AtlasCounter. */
+    Counter swapCounter;
+
+    /** The same meter with the SwapMeter layer stripped off. */
+    Counter atlasCounter;
+
+    /** The step value underneath the meter. */
+    StepDouble stepDouble;
+
+    /**
+     * A timer drives four step values per record (count, total, totalOfSquares, max), so it pays
+     * the rollCount cost four times where a counter pays it once. Measured separately because the
+     * counter path alone understates the change for timers.
+     */
+    Timer timer;
+
+    /** Id used to measure the cost of resolving a meter from the registry. */
+    Id lookupId;
+
+    /** Fixed timestamp so stepDouble benchmarks measure rollCount + CAS with no clock read. */
+    long now;
+
+    /**
+     * Step of 1ms driven by a timestamp that advances every call, so essentially every update
+     * crosses a boundary. This is the adversarial case for caching the boundary: the fast path
+     * never hits, and the slow path pays for the cached read on top of the division it still has
+     * to do. Included to bound the downside rather than only measuring the favourable case.
+     */
+    StepDouble rolling;
+    long rollingNow;
+
+    @Setup
+    public void setup() {
+      // Not started: the publishing scheduler is irrelevant to the write path and would
+      // otherwise add background work that shows up as benchmark noise.
+      registry = new AtlasRegistry(Clock.SYSTEM, System::getProperty);
+      clock = registry.clock();
+      swapCounter = registry.counter("test.counter");
+      atlasCounter = (Counter) registry.get(registry.createId("test.counter"));
+      stepDouble = new StepDouble(0.0, Clock.SYSTEM, 5000L);
+      now = Clock.SYSTEM.wallTime();
+      rolling = new StepDouble(0.0, Clock.SYSTEM, 1L);
+      rollingNow = Clock.SYSTEM.wallTime();
+      timer = registry.timer("test.timer");
+      lookupId = registry.createId("test.counter");
+    }
+  }
+
+  /** Per-thread state: each thread gets its own counter, so the CAS is uncontended. */
+  @State(Scope.Thread)
+  public static class PerThread {
+    private static final AtomicInteger NEXT = new AtomicInteger();
+
+    Counter counter;
+
+    @Setup
+    public void setup(Shared shared) {
+      counter = shared.registry.counter("test.perThread." + NEXT.getAndIncrement());
+    }
+  }
+
+  /** The production path: increment through a held reference. */
+  @Benchmark
+  public void swapCounter(Shared shared) {
+    shared.swapCounter.increment();
+  }
+
+  /** Same path without the SwapMeter indirection and its expiry check. */
+  @Benchmark
+  public void atlasCounter(Shared shared) {
+    shared.atlasCounter.increment();
+  }
+
+  /** rollCount + CAS only, with the clock read hoisted out. */
+  @Benchmark
+  public double stepDouble(Shared shared) {
+    return shared.stepDouble.addAndGet(shared.now, 1.0);
+  }
+
+  /**
+   * Worst case for the boundary cache: a rollover on essentially every update, so the division
+   * is still paid and the cached read is pure overhead. Single threaded only; this is about the
+   * instruction cost of the slow path, not contention.
+   */
+  @Benchmark
+  public double rollingStepDouble(Shared shared) {
+    return shared.rolling.addAndGet(shared.rollingNow++, 1.0);
+  }
+
+  /**
+   * Timer record through a held reference. Four step values per call, so four rollCounts.
+   */
+  @Benchmark
+  public void timerRecord(Shared shared) {
+    shared.timer.record(42L, TimeUnit.NANOSECONDS);
+  }
+
+  /**
+   * Cost of resolving a meter from the registry. This is what a held reference pays once per
+   * cleanup pass when the removal counter moves, so it sizes the re-resolution cost that the
+   * version based approach trades the per update clock read for.
+   */
+  @Benchmark
+  public Counter lookupCost(Shared shared) {
+    return shared.registry.counter(shared.lookupId);
+  }
+
+  /** Cost of a single wall clock read, for scale. */
+  @Benchmark
+  public long wallTime(Shared shared) {
+    return shared.clock.wallTime();
+  }
+
+  /** Production path, but with no cache line sharing between threads. */
+  @Benchmark
+  public void perThread(PerThread state) {
+    state.counter.increment();
+  }
+
+  /**
+   * Per-thread batch updater feeding the shared counter. This is the mitigation the library
+   * already provides for a single very hot counter: it amortises the CAS over the batch instead
+   * of striping every meter in the registry.
+   */
+  @State(Scope.Thread)
+  public static class Batched {
+    Counter.BatchUpdater updater;
+
+    @Setup
+    public void setup(Shared shared) {
+      updater = shared.swapCounter.batchUpdater(1000);
+    }
+
+    @TearDown
+    public void tearDown() throws Exception {
+      updater.close();
+    }
+  }
+
+  /** Shared counter, but updates are batched per thread. */
+  @Benchmark
+  public void batched(Batched state) {
+    state.updater.increment();
+  }
+}

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasCounterTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasCounterTest.java
@@ -118,6 +118,37 @@ public class AtlasCounterTest {
     Assertions.assertFalse(counter.hasExpired());
   }
 
+  /**
+   * Amounts that are ignored must not refresh the last modified time. That is what allows a
+   * counter that is only ever handed junk to expire and be dropped from the registry rather
+   * than being kept alive forever by calls that record nothing.
+   */
+  @Test
+  public void ignoredAmountsDoNotRefreshExpiry() {
+    long start = clock.wallTime();
+    clock.setWallTime(start + step * 2);
+    Assertions.assertTrue(counter.hasExpired());
+
+    counter.add(0.0);
+    Assertions.assertTrue(counter.hasExpired(), "add(0.0) must not refresh lastUpdated");
+
+    counter.add(-42.0);
+    Assertions.assertTrue(counter.hasExpired(), "add(negative) must not refresh lastUpdated");
+
+    counter.add(Double.NaN);
+    Assertions.assertTrue(counter.hasExpired(), "add(NaN) must not refresh lastUpdated");
+
+    counter.add(Double.POSITIVE_INFINITY);
+    Assertions.assertTrue(counter.hasExpired(), "add(+Inf) must not refresh lastUpdated");
+
+    counter.add(Double.NEGATIVE_INFINITY);
+    Assertions.assertTrue(counter.hasExpired(), "add(-Inf) must not refresh lastUpdated");
+
+    // A real amount does refresh it.
+    counter.add(1.0);
+    Assertions.assertFalse(counter.hasExpired());
+  }
+
   @Test
   public void preferStatisticFromTags() {
     Id id = Id.create("test").withTag(Statistic.percentile);

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasHeldReferenceExpiryTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasHeldReferenceExpiryTest.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2014-2025 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.ManualClock;
+import com.netflix.spectator.api.Meter;
+import com.netflix.spectator.api.Timer;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A user is expected to hold a {@code Counter} reference for the life of the process. If the
+ * meter behind it goes idle long enough to be removed by the cleanup pass, later updates through
+ * that stale reference still have to reach the registry.
+ *
+ * <p>{@code SwapMeter.get()} detects this from the registry version rather than from the TTL of
+ * the underlying meter, so that the update path does not have to read the wall clock. These tests
+ * pin that recovery down through the real Atlas registry.</p>
+ */
+public class AtlasHeldReferenceExpiryTest {
+
+  private static final long STEP = 10_000L;
+  private static final long TTL = 60_000L;
+
+  private AtlasRegistry newRegistry(ManualClock clock) {
+    // The core meter types are created with lwcStep as their step size, not step, so both are
+    // pinned to STEP here to keep the roll forward in these tests exactly one interval.
+    return new AtlasRegistry(clock, k -> {
+      switch (k) {
+        case "atlas.step":      return "PT10S";
+        case "atlas.lwc.step":  return "PT10S";
+        case "atlas.meterTTL":  return "PT1M";
+        case "atlas.enabled":   return "false";
+        default: return null;
+      }
+    });
+  }
+
+  @Test
+  public void heldCounterRecoversAfterMeterIsRemoved() {
+    ManualClock clock = new ManualClock();
+    AtlasRegistry registry = newRegistry(clock);
+
+    Counter held = registry.counter("test.counter");
+    held.increment();
+
+    Id id = registry.createId("test.counter");
+    Meter original = registry.get(id);
+    Assertions.assertNotNull(original);
+
+    // Go idle past the TTL and run the cleanup pass, which drops the meter.
+    clock.setWallTime(TTL * 2);
+    registry.removeExpiredMeters();
+    Assertions.assertNull(registry.get(id), "meter should have been removed");
+
+    // The stale reference must resolve a fresh meter and the update must land on it.
+    held.increment();
+
+    Meter resurrected = registry.get(id);
+    Assertions.assertNotNull(resurrected, "held reference must re-register the meter");
+    Assertions.assertNotSame(original, resurrected);
+    // actualCount reports the last completed interval, so roll forward to publish the update.
+    clock.setWallTime(TTL * 2 + STEP);
+    Assertions.assertEquals(1.0, ((Counter) resurrected).actualCount(), 1e-12);
+
+    // And it must keep working, rather than recovering exactly once.
+    clock.setWallTime(TTL * 4);
+    registry.removeExpiredMeters();
+    Assertions.assertNull(registry.get(id));
+    held.increment();
+    Meter second = registry.get(id);
+    Assertions.assertNotNull(second);
+    clock.setWallTime(TTL * 4 + STEP);
+    Assertions.assertEquals(1.0, ((Counter) second).actualCount(), 1e-12);
+  }
+
+  @Test
+  public void heldTimerRecoversAfterMeterIsRemoved() {
+    ManualClock clock = new ManualClock();
+    AtlasRegistry registry = newRegistry(clock);
+
+    Timer held = registry.timer("test.timer");
+    held.record(5, TimeUnit.MILLISECONDS);
+
+    Id id = registry.createId("test.timer");
+    clock.setWallTime(TTL * 2);
+    registry.removeExpiredMeters();
+    Assertions.assertNull(registry.get(id));
+
+    held.record(5, TimeUnit.MILLISECONDS);
+    Meter resurrected = registry.get(id);
+    Assertions.assertNotNull(resurrected, "held reference must re-register the meter");
+    // count reports the last completed interval, so roll forward to publish the update.
+    clock.setWallTime(TTL * 2 + STEP);
+    Assertions.assertEquals(1L, ((Timer) resurrected).count());
+  }
+
+  /**
+   * Updates through a held reference must not be silently dropped on the floor. Before the
+   * registry tracked a version, removal was noticed via the underlying TTL check; if that check
+   * is removed without a version bump the first update after removal refreshes the orphaned
+   * meter's timestamp, the reference never re-resolves, and every later update is lost.
+   */
+  @Test
+  public void updatesAfterRemovalAreNotLost() {
+    ManualClock clock = new ManualClock();
+    AtlasRegistry registry = newRegistry(clock);
+
+    Counter held = registry.counter("test.counter");
+    Id id = registry.createId("test.counter");
+
+    clock.setWallTime(TTL * 2);
+    registry.removeExpiredMeters();
+
+    // Several updates through the stale reference, all inside one step interval so they
+    // accumulate into the same bucket.
+    for (int i = 0; i < 5; ++i) {
+      held.increment();
+    }
+
+    Meter m = registry.get(id);
+    Assertions.assertNotNull(m, "held reference must re-register the meter");
+    clock.setWallTime(TTL * 2 + STEP);
+    Assertions.assertEquals(5.0, ((Counter) m).actualCount(), 1e-12,
+        "every update through the held reference must reach the registered meter");
+
+    // Repeat across another expiry cycle to confirm recovery is not a one shot.
+    clock.setWallTime(TTL * 4);
+    registry.removeExpiredMeters();
+    Assertions.assertNull(registry.get(id));
+    for (int i = 0; i < 3; ++i) {
+      held.increment();
+    }
+    Meter m2 = registry.get(id);
+    Assertions.assertNotNull(m2);
+    clock.setWallTime(TTL * 4 + STEP);
+    Assertions.assertEquals(3.0, ((Counter) m2).actualCount(), 1e-12);
+  }
+
+  /**
+   * Sweeping one meter must not make unrelated healthy meters report themselves as expired; see
+   * the class javadoc for why that signal is kept out of {@code hasExpired()}.
+   */
+  @Test
+  public void sweepingOneMeterDoesNotExpireOthers() {
+    ManualClock clock = new ManualClock();
+    AtlasRegistry registry = newRegistry(clock);
+
+    Counter idle = registry.counter("test.idle");
+    idle.increment();
+
+    // Let the idle meter age out, then keep the other one active right up to now.
+    clock.setWallTime(TTL * 2);
+    Counter active = registry.counter("test.active");
+    active.increment();
+
+    registry.removeExpiredMeters();
+    Assertions.assertNull(registry.get(registry.createId("test.idle")),
+        "the idle meter should have been swept");
+
+    Assertions.assertFalse(active.hasExpired(),
+        "an active meter must not report expired just because another meter was swept");
+
+    // And its data must still be published rather than filtered out as expired.
+    clock.setWallTime(TTL * 2 + STEP);
+    Assertions.assertTrue(
+        registry.measurements().anyMatch(m -> "test.active".equals(m.id().name())),
+        "an active meter's measurements must not be filtered out of the published stream");
+  }
+
+  /**
+   * A meter that is past its TTL but has not been swept yet must keep accumulating into the same
+   * instance, so that an actively used meter is not reset by the expiry check itself.
+   */
+  @Test
+  public void expiredButNotYetRemovedMeterKeepsSameInstance() {
+    ManualClock clock = new ManualClock();
+    AtlasRegistry registry = newRegistry(clock);
+
+    Counter held = registry.counter("test.counter");
+    held.increment();
+
+    Id id = registry.createId("test.counter");
+    Meter original = registry.get(id);
+
+    // Past the TTL, but no cleanup pass has run.
+    clock.setWallTime(TTL * 2);
+    held.increment();
+
+    Assertions.assertSame(original, registry.get(id));
+    // The update refreshed the meter, so it is no longer a candidate for removal.
+    registry.removeExpiredMeters();
+    Assertions.assertSame(original, registry.get(id));
+  }
+}


### PR DESCRIPTION
## Summary
- Removes a division from `StepDouble`/`StepLong.rollCount` on every update by caching the end of the current step interval and only computing a new boundary on an actual rollover. Adds a guard so concurrent rollovers cannot double-reset the interval and lose data.
- Collapses `SwapMeter`'s use of `underlying.hasExpired()` (a wall clock read on every update) into a plain volatile counter that `AbstractRegistry` bumps whenever it removes a meter, keeping `hasExpired()` itself unchanged so destructive callers like `PolledMeter` still only see real expiry.

## Test plan
- [x] `StepRollCountDifferentialTest` drives the new `rollCount` against a copy of the previous implementation over identical timestamp sequences (including exact boundaries, multi-interval gaps, and backwards clock movement) and requires bit-for-bit equal results. Run over step sizes of 1ms, 7ms, 13ms, 1s, 5s and 60s, so a step that rolls on nearly every update and steps that do not divide any round timestamp are covered as well as the aligned 5s case.
- [x] `StepRollCountConcurrencyTest` exercises concurrent rollovers to confirm the CAS guard prevents double-reset data loss.
- [x] `SwapMeterExpiryReportingTest` and `AtlasHeldReferenceExpiryTest` pin down that routine meter removal is not conflated with `hasExpired()`, that held references still recover after a meter is swept, that updates through a stale reference are not lost, and that an update through a `CompositeRegistry` reference still lands after a sub registry sweeps the meter.
- [x] New JMH benchmark `CounterIncrement` isolates the cost of each layer of the update path (clock read, rollCount, CAS, registry lookup).
- [x] `./gradlew :spectator-api:test :spectator-reg-atlas:test` passes.

## Note on the `SwapMeter` semantics

The re-resolve trigger changes from `underlying.hasExpired()` to a removal counter, so it is worth
being precise about what that does and does not change.

For a meter that is **past its TTL but not yet swept**, the two are equivalent rather than merely
close: `lookup()` goes through `getOrCreate`, which is a `computeIfAbsent` on the meter map and does
not replace expired entries, so the old code's re-resolve returned the *same instance* it already
held. The update lands on the same object either way. For `AbstractRegistry` the old `hasExpired()`
check also reduced to exactly `underlying.hasExpired()`, since its registry level `VERSION` is a
constant `() -> 0L` both before and after this change.

Once the meter is **actually swept**, the removal counter moves and the next call re-resolves, which
is if anything more timely than waiting for the TTL to be observed. `AtlasHeldReferenceExpiryTest`
covers that path.

The one case that genuinely differs is `CompositeRegistry`, which still uses the old constructor and
a version that only changes when a registry is added or removed — so a sweep inside a sub registry
no longer invalidates the composite's wrapper. Recovery there comes from the sub registry's own
wrapper nested inside the composite meter, which survives because `unwrap()` only flattens wrappers
belonging to the same registry. `updatesThroughACompositeSurviveASubRegistrySweep` pins that down.

`lookupCost` above is the measurable cost of this trade.

## Benchmark results

`./gradlew :spectator-reg-atlas:jmh` (`CounterIncrement`, JDK 25, 5 forks x (5 x 2s warmup + 10 x 3s measurement) = 50 measurement iterations per benchmark, single thread unless noted, no profilers attached). "Before" is this repo's `main` with only the `CounterIncrement` benchmark file itself kept at this PR's version, so both runs measure the exact same call sequences; "after" is this branch. Errors are JMH's 99.9% confidence intervals and include fork-to-fork variance.

| Benchmark | Before (ops/s) | After (ops/s) | Change | What it isolates |
|---|---:|---:|---:|---|
| `swapCounter` | 16,927,174 ± 24,465 | 33,246,268 ± 22,866 | **+96%** | Production path: `SwapCounter.increment()` through a held reference |
| `perThread` | 16,940,904 ± 2,612 | 33,234,296 ± 28,377 | **+96%** | Same path with no cache-line sharing between threads |
| `timerRecord` | 15,929,431 ± 99,575 | 29,838,483 ± 63,708 | **+87%** | `Timer.record()`, which pays the `rollCount` cost across four step values |
| `atlasCounter` | 29,727,295 ± 6,455 | 33,242,211 ± 17,675 | +11.8% | Same path with the `SwapMeter` indirection/expiry check stripped off |
| `batched` | 291,635,390 ± 4,448,067 | 298,290,827 ± 14,027 | +2.3% | Per-thread `BatchUpdater` amortizing the CAS over a batch of 1000 |
| `rollingStepDouble` | 110,969,861 ± 33,206 | 112,700,011 ± 34,016 | +1.6% | Worst case: 1ms step, every call rolls the boundary over |
| `stepDouble` | 226,028,968 ± 392,638 | 226,497,284 ± 71,016 | +0.2% | `rollCount` + CAS only, clock read hoisted out |
| `wallTime` | 38,979,556 ± 5,407 | 38,978,659 ± 6,409 | 0.0% | Control: a single wall clock read, for scale |
| `lookupCost` | 39,803,685 ± 102,233 | 38,580,497 ± 298,467 | **-3.1%** | Cost of re-resolving a meter from the registry |

The two changes contribute very unevenly, and it seems worth being explicit about that rather than crediting the whole gain to both:

- The **`SwapMeter` change is the dominant win**: `swapCounter`, `perThread`, and `timerRecord` all go through `SwapMeter.get()` on every call, and all roughly double. That is consistent with removing a wall clock read (`AtlasMeter.hasExpired()`'s TTL check) from every update. `perThread` matching `swapCounter` confirms it is a per-call path cost and not cache-line contention on the shared counter.
- The **`rollCount` division removal is real but much smaller**. `atlasCounter` bypasses `SwapMeter` and so isolates this half of the PR: +11.8%. On `stepDouble` the effect is inside the noise (+0.2%), which is expected — with the clock read hoisted out, the CAS dominates and the division was never the bottleneck at that granularity.
- `rollingStepDouble` is the adversarial case for the change (1ms step, a rollover on essentially every call, so the division is still paid *and* the cached boundary read is added on top). It comes out +1.6%, i.e. slightly ahead rather than behind, so the cached read does not cost anything measurable even when the fast path never hits.
- **`lookupCost` regresses ~3.1%**, and at these error bars that is a real effect rather than noise. This is the expected trade: constructing a wrapper now samples the removal counter as well and carries one more volatile field. It is paid once per held reference per cleanup pass, against a ~2x saving on every single update, but it is a regression and not worth hiding.
- `wallTime` is unchanged to within 0.002%, which is a useful check that the two runs saw the same machine conditions.
