### PR TITLE
Bump bundled jackson-databind to 2.22.2 (CVE-2026-68497, GHSA-gx83-3vf8-gh7j)

### DIFF
--- a/dependencies.properties
+++ b/dependencies.properties
@@ -2,9 +2,9 @@
 ch.qos.reload4j:reload4j = 1.2.26
 com.amazonaws:aws-java-sdk-core = 1.12.797
 com.amazonaws:aws-java-sdk-cloudwatch = 1.12.797
-com.fasterxml.jackson.core:jackson-core = 2.22.1
-com.fasterxml.jackson.core:jackson-databind = 2.22.1
-com.fasterxml.jackson.dataformat:jackson-dataformat-smile = 2.22.1
+com.fasterxml.jackson.core:jackson-core = 2.22.2
+com.fasterxml.jackson.core:jackson-databind = 2.22.2
+com.fasterxml.jackson.dataformat:jackson-dataformat-smile = 2.22.2
 com.github.ben-manes.caffeine:caffeine = 2.9.3
 com.google.inject.extensions:guice-servlet = 5.1.0
 com.google.inject:guice = 5.1.0


### PR DESCRIPTION
Bumps the bundled (shaded) Jackson from 2.22.1 to 2.22.2 in `dependencies.properties`, covering `jackson-core`, `jackson-databind`, and `jackson-dataformat-smile`. `spectator-reg-atlas` shades and relocates Jackson, so downstream consumers cannot override the bundled version themselves and the fix has to come from a Spectator release.

2.22.2 addresses two advisories:

- **CVE-2026-68497**, resource exhaustion in the XML `Duration` / `XMLGregorianCalendar` deserializers.
- **GHSA-gx83-3vf8-gh7j**, `java.lang.Comparable` missing from the unsafe polymorphic base type list in `DefaultBaseTypeLimitingValidator`.

Verification against the rebuilt shaded jar (bytecode inspected with `javap`):

- GHSA-gx83-3vf8-gh7j: the shaded `DefaultBaseTypeLimitingValidator` now includes `java.lang.Comparable` in its unsafe base type set, matching 2.22.2. The 2.22.1 based 1.10.5 release did not.
- CVE-2026-68497: `CoreXMLDeserializers` is not bundled, since `shadowJar` `minimize()` strips it because no XML deserialization is reachable, so the artifact is not exposed to this advisory. The 2.22.2 guard method is present in the bundled `StdDeserializer` regardless.

`spectator-web-spring`, which also shades `jackson-databind`, picks up 2.22.2 from the same file.

Fixes #1278
