### PR TITLE
Remove the division from StepLong/StepDouble rollCount

### DIFF
--- a/spectator-api/src/jmh/java/com/netflix/spectator/perf/StepValueUpdate.java
+++ b/spectator-api/src/jmh/java/com/netflix/spectator/perf/StepValueUpdate.java
@@ -31,16 +31,13 @@ import org.openjdk.jmh.annotations.State;
  * measurement is the step bookkeeping plus the atomic update and not a {@code currentTimeMillis}
  * call, which is more expensive than either and would hide them.</p>
  *
- * <p>Read the {@code WithClock} variants as the headline numbers. The others deliberately leave
- * the clock read out to isolate the bookkeeping, and that makes them easy to misread: the division
- * being removed here is long-latency work on a separate execution port, so on {@code main} it
- * masks whatever else the loop is doing. Remove it and that other work stops hiding, which can
- * make a synthetic loop measure slower even though strictly less work is being done. Measured on
- * {@code main} this benchmark is flat at roughly 490-510M ops/s whether the timestamp is a
- * constant, a counter increment or an array load; with the division gone the same three land at
- * 495M, 471M and 453M, tracking the cost of the timestamp source itself. A real caller reads a
- * clock, which is far more expensive than anything the division could mask, so the effect does
- * not survive contact with the production path.</p>
+ * <p>Read the {@code WithClock} variants as the headline numbers. The others leave the clock read
+ * out to isolate the bookkeeping, which makes them easy to misread: a division is long-latency
+ * work on a separate execution port, so on {@code main} it masks whatever else the loop does.
+ * Remove it and that other work stops hiding, which can make a synthetic loop measure slower
+ * while doing strictly less. On {@code main} these are flat near 490-510M ops/s whichever way the
+ * timestamp is produced; without the division they track the cost of the timestamp source itself.
+ * A real caller reads a clock, which dwarfs anything the division could mask.</p>
  *
  * <p>{@code poll} isolates the bookkeeping on its own: it is the step handling followed by a
  * volatile read, with no atomic update. {@code addAndGet} adds the atomic update that a real

--- a/spectator-api/src/jmh/java/com/netflix/spectator/perf/StepValueUpdate.java
+++ b/spectator-api/src/jmh/java/com/netflix/spectator/perf/StepValueUpdate.java
@@ -151,7 +151,6 @@ public class StepValueUpdate {
   @State(Scope.Thread)
   public static class Varying {
     StepLong stepLong;
-    StepDouble stepDouble;
     long base;
     int i;
 
@@ -160,7 +159,6 @@ public class StepValueUpdate {
       // Align to the start of the current interval so base + 0..255 stays inside it.
       base = Clock.SYSTEM.wallTime() / 5000L * 5000L;
       stepLong = new StepLong(0L, Clock.SYSTEM, 5000L);
-      stepDouble = new StepDouble(0.0, Clock.SYSTEM, 5000L);
     }
 
     long next() {

--- a/spectator-api/src/jmh/java/com/netflix/spectator/perf/StepValueUpdate.java
+++ b/spectator-api/src/jmh/java/com/netflix/spectator/perf/StepValueUpdate.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2014-2025 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.perf;
+
+import com.netflix.spectator.api.Clock;
+import com.netflix.spectator.impl.StepDouble;
+import com.netflix.spectator.impl.StepLong;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+/**
+ * Measures the update path of {@link StepLong} and {@link StepDouble}, which every counter,
+ * timer, gauge and distribution summary in a step based registry goes through.
+ *
+ * <p>The timestamp is supplied by the benchmark rather than read from a clock so that the
+ * measurement is the step bookkeeping plus the atomic update and not a {@code currentTimeMillis}
+ * call, which is more expensive than either and would hide them.</p>
+ *
+ * <p>{@code poll} isolates the bookkeeping on its own: it is the step handling followed by a
+ * volatile read, with no atomic update. {@code addAndGet} adds the atomic update that a real
+ * counter pays. The {@code rolling} variants use a 1ms step with a timestamp that advances on
+ * every call, so every single call rolls over to a new interval; that is the worst case for any
+ * scheme that tries to make the common in-interval update cheaper.</p>
+ */
+public class StepValueUpdate {
+
+  /** Step of 5s, matching the default publish interval, with a fixed timestamp. */
+  @State(Scope.Benchmark)
+  public static class InInterval {
+    StepLong stepLong;
+    StepDouble stepDouble;
+    long now;
+
+    @Setup
+    public void setup() {
+      now = Clock.SYSTEM.wallTime();
+      stepLong = new StepLong(0L, Clock.SYSTEM, 5000L);
+      stepDouble = new StepDouble(0.0, Clock.SYSTEM, 5000L);
+    }
+  }
+
+  /**
+   * Step of 1ms with an advancing timestamp, so every call rolls over. Per thread rather than
+   * shared, because the advancing timestamp is a plain field and threads sharing it would race
+   * on it rather than measuring the rollover.
+   */
+  @State(Scope.Thread)
+  public static class Rolling {
+    StepLong stepLong;
+    StepDouble stepDouble;
+    long now;
+
+    @Setup
+    public void setup() {
+      now = Clock.SYSTEM.wallTime();
+      stepLong = new StepLong(0L, Clock.SYSTEM, 1L);
+      stepDouble = new StepDouble(0.0, Clock.SYSTEM, 1L);
+    }
+  }
+
+  /** Step bookkeeping plus a volatile read, no atomic update. */
+  @Benchmark
+  public long stepLongPoll(InInterval state) {
+    return state.stepLong.poll(state.now);
+  }
+
+  /** Step bookkeeping plus a volatile read, no atomic update. */
+  @Benchmark
+  public double stepDoublePoll(InInterval state) {
+    return state.stepDouble.poll(state.now);
+  }
+
+  /** Step bookkeeping plus the atomic add a counter pays. */
+  @Benchmark
+  public long stepLongAddAndGet(InInterval state) {
+    return state.stepLong.addAndGet(state.now, 1L);
+  }
+
+  /** Step bookkeeping plus the CAS loop a double valued counter pays. */
+  @Benchmark
+  public double stepDoubleAddAndGet(InInterval state) {
+    return state.stepDouble.addAndGet(state.now, 1.0);
+  }
+
+  /** Worst case: a rollover on every call. See {@link Rolling}. */
+  @Benchmark
+  public long rollingStepLong(Rolling state) {
+    return state.stepLong.addAndGet(state.now++, 1L);
+  }
+
+  /** Worst case: a rollover on every call. See {@link Rolling}. */
+  @Benchmark
+  public double rollingStepDouble(Rolling state) {
+    return state.stepDouble.addAndGet(state.now++, 1.0);
+  }
+}

--- a/spectator-api/src/jmh/java/com/netflix/spectator/perf/StepValueUpdate.java
+++ b/spectator-api/src/jmh/java/com/netflix/spectator/perf/StepValueUpdate.java
@@ -108,4 +108,64 @@ public class StepValueUpdate {
   public double rollingStepDouble(Rolling state) {
     return state.stepDouble.addAndGet(state.now++, 1.0);
   }
+
+  /**
+   * The shape a real update has: a wall clock read feeding the timestamp, as
+   * {@code AtlasCounter.add} does. The clock read is the dominant cost here, so this is the
+   * benchmark that says what fraction of a real update the step bookkeeping actually is.
+   */
+  @Benchmark
+  public long stepLongAddAndGetWithClock(InInterval state) {
+    return state.stepLong.addAndGet(Clock.SYSTEM.wallTime(), 1L);
+  }
+
+  /** See {@link #stepLongAddAndGetWithClock}. */
+  @Benchmark
+  public double stepDoubleAddAndGetWithClock(InInterval state) {
+    return state.stepDouble.addAndGet(Clock.SYSTEM.wallTime(), 1.0);
+  }
+
+  /** A wall clock read on its own, for scale against the two benchmarks above. */
+  @Benchmark
+  public long wallTime() {
+    return Clock.SYSTEM.wallTime();
+  }
+
+  /**
+   * A timestamp that changes on every call but stays inside the current interval, so the step
+   * bookkeeping cannot be hoisted out of the measurement loop and no rollover is triggered.
+   * Separates "the division is gone" from "the JIT hoisted the division" without paying for a
+   * clock read.
+   */
+  @State(Scope.Thread)
+  public static class Varying {
+    StepLong stepLong;
+    StepDouble stepDouble;
+    long base;
+    int i;
+
+    @Setup
+    public void setup() {
+      // Align to the start of the current interval so base + 0..255 stays inside it.
+      base = Clock.SYSTEM.wallTime() / 5000L * 5000L;
+      stepLong = new StepLong(0L, Clock.SYSTEM, 5000L);
+      stepDouble = new StepDouble(0.0, Clock.SYSTEM, 5000L);
+    }
+
+    long next() {
+      return base + (i++ & 0xFF);
+    }
+  }
+
+  /** See {@link Varying}. */
+  @Benchmark
+  public long varyingStepLongPoll(Varying state) {
+    return state.stepLong.poll(state.next());
+  }
+
+  /** See {@link Varying}. */
+  @Benchmark
+  public long varyingStepLongAddAndGet(Varying state) {
+    return state.stepLong.addAndGet(state.next(), 1L);
+  }
 }

--- a/spectator-api/src/jmh/java/com/netflix/spectator/perf/StepValueUpdate.java
+++ b/spectator-api/src/jmh/java/com/netflix/spectator/perf/StepValueUpdate.java
@@ -31,6 +31,17 @@ import org.openjdk.jmh.annotations.State;
  * measurement is the step bookkeeping plus the atomic update and not a {@code currentTimeMillis}
  * call, which is more expensive than either and would hide them.</p>
  *
+ * <p>Read the {@code WithClock} variants as the headline numbers. The others deliberately leave
+ * the clock read out to isolate the bookkeeping, and that makes them easy to misread: the division
+ * being removed here is long-latency work on a separate execution port, so on {@code main} it
+ * masks whatever else the loop is doing. Remove it and that other work stops hiding, which can
+ * make a synthetic loop measure slower even though strictly less work is being done. Measured on
+ * {@code main} this benchmark is flat at roughly 490-510M ops/s whether the timestamp is a
+ * constant, a counter increment or an array load; with the division gone the same three land at
+ * 495M, 471M and 453M, tracking the cost of the timestamp source itself. A real caller reads a
+ * clock, which is far more expensive than anything the division could mask, so the effect does
+ * not survive contact with the production path.</p>
+ *
  * <p>{@code poll} isolates the bookkeeping on its own: it is the step handling followed by a
  * volatile read, with no atomic update. {@code addAndGet} adds the atomic update that a real
  * counter pays. The {@code rolling} variants use a 1ms step with a timestamp that advances on

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/StepDouble.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/StepDouble.java
@@ -40,10 +40,15 @@ public class StepDouble implements StepValue {
   private static final AtomicLongFieldUpdater<StepDouble> CURRENT_UPDATER =
       AtomicLongFieldUpdater.newUpdater(StepDouble.class, "current");
 
-  private volatile long lastInitPos;
+  /**
+   * Wall time at which the current step interval ends. Holding this boundary rather than the step
+   * index means an update landing inside the current interval is a comparison instead of a
+   * division.
+   */
+  private volatile long nextStepBoundary;
 
-  private static final AtomicLongFieldUpdater<StepDouble> LAST_INIT_POS_UPDATER =
-      AtomicLongFieldUpdater.newUpdater(StepDouble.class, "lastInitPos");
+  private static final AtomicLongFieldUpdater<StepDouble> NEXT_STEP_BOUNDARY_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(StepDouble.class, "nextStepBoundary");
 
   /** Create a new instance. */
   public StepDouble(double init, Clock clock, long step) {
@@ -52,19 +57,40 @@ public class StepDouble implements StepValue {
     this.step = step;
     previous = init;
     current = Double.doubleToLongBits(init);
-    lastInitPos = clock.wallTime() / step;
+    nextStepBoundary = (clock.wallTime() / step + 1) * step;
   }
 
+  /**
+   * Roll over to a new step interval if {@code now} has moved past the end of the current one.
+   *
+   * <p>Kept small so it inlines into the update methods. {@code step} is a non-trusted final
+   * instance field, so C2 cannot constant fold it and {@code now / step} compiles to a real
+   * {@code idivq} plus the divide-by-zero and {@code MIN_VALUE / -1} guards. Comparing against
+   * the boundary keeps all of that off the update path and pays for the division only on an
+   * actual rollover.</p>
+   */
   private void rollCount(long now) {
-    final long stepTime = now / step;
-    final long lastInit = lastInitPos;
-    if (lastInit < stepTime && LAST_INIT_POS_UPDATER.compareAndSet(this, lastInit, stepTime)) {
+    if (now >= nextStepBoundary) {
+      rollCountSlow(now);
+    }
+  }
+
+  private void rollCountSlow(long now) {
+    // Boundaries are exact multiples of step, so comparing them orders the intervals the same
+    // way comparing the step indices did.
+    final long boundary = (now / step + 1) * step;
+    final long lastBoundary = nextStepBoundary;
+    // The boundary compare is not redundant with the CAS. Without it two threads that both see
+    // the same boundary would both roll: the second would reset `current` again and overwrite
+    // `previous` with init, publishing zero for an interval that had data.
+    if (lastBoundary < boundary
+        && NEXT_STEP_BOUNDARY_UPDATER.compareAndSet(this, lastBoundary, boundary)) {
       final double v = Double.longBitsToDouble(
           CURRENT_UPDATER.getAndSet(this, Double.doubleToLongBits(init)));
       // Need to check if there was any activity during the previous step interval. If there was
       // then the init position will move forward by 1, otherwise it will be older. No activity
       // means the previous interval should be set to the `init` value.
-      previous = (lastInit == stepTime - 1) ? v : init;
+      previous = (lastBoundary == boundary - step) ? v : init;
     }
   }
 
@@ -191,13 +217,15 @@ public class StepDouble implements StepValue {
 
   /** Get the timestamp for the end of the last completed interval. */
   @Override public long timestamp() {
-    return lastInitPos * step;
+    // Start of the current interval, which is the end of the last completed one. Equivalent to
+    // the lastInitPos * step this used to compute.
+    return nextStepBoundary - step;
   }
 
   @Override public String toString() {
     return "StepDouble{init="  + init
         + ", previous=" + previous
         + ", current=" + Double.longBitsToDouble(current)
-        + ", lastInitPos=" + lastInitPos + '}';
+        + ", lastInitPos=" + (nextStepBoundary / step - 1) + '}';
   }
 }

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/StepDouble.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/StepDouble.java
@@ -40,10 +40,8 @@ public class StepDouble implements StepValue {
   private static final AtomicLongFieldUpdater<StepDouble> CURRENT_UPDATER =
       AtomicLongFieldUpdater.newUpdater(StepDouble.class, "current");
 
-  /**
-   * Wall time at which the current step interval ends. Holding the boundary rather than the step
-   * index is what lets an in-interval update be a comparison instead of a division.
-   */
+  // Wall time at which the current step interval ends. Holding the boundary rather than the step
+  // index is what lets an in-interval update be a comparison instead of a division.
   private volatile long nextStepBoundary;
 
   private static final AtomicLongFieldUpdater<StepDouble> NEXT_STEP_BOUNDARY_UPDATER =
@@ -60,11 +58,9 @@ public class StepDouble implements StepValue {
   }
 
   /**
-   * Roll over to a new step interval if {@code now} has moved past the end of the current one.
-   * Split from the rollover itself so the common case, an update inside the current interval,
-   * stays small enough to inline into the callers. {@code step} is an instance field rather than
-   * a constant, so the JIT cannot fold the division away; this pays for it only on an actual
-   * rollover.
+   * Roll over if {@code now} has moved past the end of the current interval. {@code step} is an
+   * instance field rather than a constant, so the JIT cannot fold the division away; keeping the
+   * boundary pays for it only on an actual rollover.
    */
   private void rollCount(long now) {
     if (now >= nextStepBoundary) {
@@ -73,13 +69,12 @@ public class StepDouble implements StepValue {
   }
 
   private void rollCountSlow(long now) {
-    // Boundaries are exact multiples of step, so comparing them orders the intervals the same
-    // way comparing the step indices did.
+    // Boundaries are exact multiples of step, so comparing them orders intervals the same way
+    // comparing the step indices did.
     final long boundary = (now / step + 1) * step;
     final long lastBoundary = nextStepBoundary;
-    // The boundary compare is not redundant with the CAS. Without it two threads that both see
-    // the same boundary would both roll: the second would reset `current` again and overwrite
-    // `previous` with init, publishing zero for an interval that had data.
+    // Not redundant with the CAS: without it, two threads seeing the same boundary would both
+    // roll, and the second would reset `current` and publish zero for an interval that had data.
     if (lastBoundary < boundary
         && NEXT_STEP_BOUNDARY_UPDATER.compareAndSet(this, lastBoundary, boundary)) {
       final double v = Double.longBitsToDouble(

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/StepDouble.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/StepDouble.java
@@ -214,8 +214,7 @@ public class StepDouble implements StepValue {
 
   /** Get the timestamp for the end of the last completed interval. */
   @Override public long timestamp() {
-    // Start of the current interval, which is the end of the last completed one. Equivalent to
-    // the lastInitPos * step this used to compute.
+    // Start of the current interval, which is the end of the last completed one.
     return nextStepBoundary - step;
   }
 
@@ -223,6 +222,6 @@ public class StepDouble implements StepValue {
     return "StepDouble{init="  + init
         + ", previous=" + previous
         + ", current=" + Double.longBitsToDouble(current)
-        + ", lastInitPos=" + (nextStepBoundary / step - 1) + '}';
+        + ", nextStepBoundary=" + nextStepBoundary + '}';
   }
 }

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/StepDouble.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/StepDouble.java
@@ -41,9 +41,8 @@ public class StepDouble implements StepValue {
       AtomicLongFieldUpdater.newUpdater(StepDouble.class, "current");
 
   /**
-   * Wall time at which the current step interval ends. Holding this boundary rather than the step
-   * index means an update landing inside the current interval is a comparison instead of a
-   * division.
+   * Wall time at which the current step interval ends. Holding the boundary rather than the step
+   * index is what lets an in-interval update be a comparison instead of a division.
    */
   private volatile long nextStepBoundary;
 
@@ -62,12 +61,10 @@ public class StepDouble implements StepValue {
 
   /**
    * Roll over to a new step interval if {@code now} has moved past the end of the current one.
-   *
-   * <p>Kept small so it inlines into the update methods. {@code step} is a non-trusted final
-   * instance field, so C2 cannot constant fold it and {@code now / step} compiles to a real
-   * {@code idivq} plus the divide-by-zero and {@code MIN_VALUE / -1} guards. Comparing against
-   * the boundary keeps all of that off the update path and pays for the division only on an
-   * actual rollover.</p>
+   * Split from the rollover itself so the common case, an update inside the current interval,
+   * stays small enough to inline into the callers. {@code step} is an instance field rather than
+   * a constant, so the JIT cannot fold the division away; this pays for it only on an actual
+   * rollover.
    */
   private void rollCount(long now) {
     if (now >= nextStepBoundary) {
@@ -88,8 +85,8 @@ public class StepDouble implements StepValue {
       final double v = Double.longBitsToDouble(
           CURRENT_UPDATER.getAndSet(this, Double.doubleToLongBits(init)));
       // Need to check if there was any activity during the previous step interval. If there was
-      // then the init position will move forward by 1, otherwise it will be older. No activity
-      // means the previous interval should be set to the `init` value.
+      // then the boundary moves forward by exactly one step, otherwise it jumps further. No
+      // activity means the previous interval should be set to the `init` value.
       previous = (lastBoundary == boundary - step) ? v : init;
     }
   }

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/StepLong.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/StepLong.java
@@ -40,10 +40,15 @@ public class StepLong implements StepValue {
   private static final AtomicLongFieldUpdater<StepLong> CURRENT_UPDATER =
       AtomicLongFieldUpdater.newUpdater(StepLong.class, "current");
 
-  private volatile long lastInitPos;
+  /**
+   * Wall time at which the current step interval ends. Holding this boundary rather than the step
+   * index means an update landing inside the current interval is a comparison instead of a
+   * division.
+   */
+  private volatile long nextStepBoundary;
 
-  private static final AtomicLongFieldUpdater<StepLong> LAST_INIT_POS_UPDATER =
-      AtomicLongFieldUpdater.newUpdater(StepLong.class, "lastInitPos");
+  private static final AtomicLongFieldUpdater<StepLong> NEXT_STEP_BOUNDARY_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(StepLong.class, "nextStepBoundary");
 
   /** Create a new instance. */
   public StepLong(long init, Clock clock, long step) {
@@ -52,18 +57,39 @@ public class StepLong implements StepValue {
     this.step = step;
     previous = init;
     current = init;
-    lastInitPos = clock.wallTime() / step;
+    nextStepBoundary = (clock.wallTime() / step + 1) * step;
   }
 
+  /**
+   * Roll over to a new step interval if {@code now} has moved past the end of the current one.
+   *
+   * <p>Kept small so it inlines into the update methods. {@code step} is a non-trusted final
+   * instance field, so C2 cannot constant fold it and {@code now / step} compiles to a real
+   * {@code idivq} plus the divide-by-zero and {@code MIN_VALUE / -1} guards. Comparing against
+   * the boundary keeps all of that off the update path and pays for the division only on an
+   * actual rollover.</p>
+   */
   private void rollCount(long now) {
-    final long stepTime = now / step;
-    final long lastInit = lastInitPos;
-    if (lastInit < stepTime && LAST_INIT_POS_UPDATER.compareAndSet(this, lastInit, stepTime)) {
+    if (now >= nextStepBoundary) {
+      rollCountSlow(now);
+    }
+  }
+
+  private void rollCountSlow(long now) {
+    // Boundaries are exact multiples of step, so comparing them orders the intervals the same
+    // way comparing the step indices did.
+    final long boundary = (now / step + 1) * step;
+    final long lastBoundary = nextStepBoundary;
+    // The boundary compare is not redundant with the CAS. Without it two threads that both see
+    // the same boundary would both roll: the second would reset `current` again and overwrite
+    // `previous` with init, publishing zero for an interval that had data.
+    if (lastBoundary < boundary
+        && NEXT_STEP_BOUNDARY_UPDATER.compareAndSet(this, lastBoundary, boundary)) {
       final long v = CURRENT_UPDATER.getAndSet(this, init);
       // Need to check if there was any activity during the previous step interval. If there was
       // then the init position will move forward by 1, otherwise it will be older. No activity
       // means the previous interval should be set to the `init` value.
-      previous = (lastInit == stepTime - 1) ? v : init;
+      previous = (lastBoundary == boundary - step) ? v : init;
     }
   }
 
@@ -163,13 +189,15 @@ public class StepLong implements StepValue {
 
   /** Get the timestamp for the end of the last completed interval. */
   @Override public long timestamp() {
-    return lastInitPos * step;
+    // Start of the current interval, which is the end of the last completed one. Equivalent to
+    // the lastInitPos * step this used to compute.
+    return nextStepBoundary - step;
   }
 
   @Override public String toString() {
     return "StepLong{init="  + init
         + ", previous=" + previous
         + ", current=" + current
-        + ", lastInitPos=" + lastInitPos + '}';
+        + ", lastInitPos=" + (nextStepBoundary / step - 1) + '}';
   }
 }

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/StepLong.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/StepLong.java
@@ -40,10 +40,8 @@ public class StepLong implements StepValue {
   private static final AtomicLongFieldUpdater<StepLong> CURRENT_UPDATER =
       AtomicLongFieldUpdater.newUpdater(StepLong.class, "current");
 
-  /**
-   * Wall time at which the current step interval ends. Holding the boundary rather than the step
-   * index is what lets an in-interval update be a comparison instead of a division.
-   */
+  // Wall time at which the current step interval ends. Holding the boundary rather than the step
+  // index is what lets an in-interval update be a comparison instead of a division.
   private volatile long nextStepBoundary;
 
   private static final AtomicLongFieldUpdater<StepLong> NEXT_STEP_BOUNDARY_UPDATER =
@@ -60,11 +58,9 @@ public class StepLong implements StepValue {
   }
 
   /**
-   * Roll over to a new step interval if {@code now} has moved past the end of the current one.
-   * Split from the rollover itself so the common case, an update inside the current interval,
-   * stays small enough to inline into the callers. {@code step} is an instance field rather than
-   * a constant, so the JIT cannot fold the division away; this pays for it only on an actual
-   * rollover.
+   * Roll over if {@code now} has moved past the end of the current interval. {@code step} is an
+   * instance field rather than a constant, so the JIT cannot fold the division away; keeping the
+   * boundary pays for it only on an actual rollover.
    */
   private void rollCount(long now) {
     if (now >= nextStepBoundary) {
@@ -73,13 +69,12 @@ public class StepLong implements StepValue {
   }
 
   private void rollCountSlow(long now) {
-    // Boundaries are exact multiples of step, so comparing them orders the intervals the same
-    // way comparing the step indices did.
+    // Boundaries are exact multiples of step, so comparing them orders intervals the same way
+    // comparing the step indices did.
     final long boundary = (now / step + 1) * step;
     final long lastBoundary = nextStepBoundary;
-    // The boundary compare is not redundant with the CAS. Without it two threads that both see
-    // the same boundary would both roll: the second would reset `current` again and overwrite
-    // `previous` with init, publishing zero for an interval that had data.
+    // Not redundant with the CAS: without it, two threads seeing the same boundary would both
+    // roll, and the second would reset `current` and publish zero for an interval that had data.
     if (lastBoundary < boundary
         && NEXT_STEP_BOUNDARY_UPDATER.compareAndSet(this, lastBoundary, boundary)) {
       final long v = CURRENT_UPDATER.getAndSet(this, init);

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/StepLong.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/StepLong.java
@@ -41,9 +41,8 @@ public class StepLong implements StepValue {
       AtomicLongFieldUpdater.newUpdater(StepLong.class, "current");
 
   /**
-   * Wall time at which the current step interval ends. Holding this boundary rather than the step
-   * index means an update landing inside the current interval is a comparison instead of a
-   * division.
+   * Wall time at which the current step interval ends. Holding the boundary rather than the step
+   * index is what lets an in-interval update be a comparison instead of a division.
    */
   private volatile long nextStepBoundary;
 
@@ -62,12 +61,10 @@ public class StepLong implements StepValue {
 
   /**
    * Roll over to a new step interval if {@code now} has moved past the end of the current one.
-   *
-   * <p>Kept small so it inlines into the update methods. {@code step} is a non-trusted final
-   * instance field, so C2 cannot constant fold it and {@code now / step} compiles to a real
-   * {@code idivq} plus the divide-by-zero and {@code MIN_VALUE / -1} guards. Comparing against
-   * the boundary keeps all of that off the update path and pays for the division only on an
-   * actual rollover.</p>
+   * Split from the rollover itself so the common case, an update inside the current interval,
+   * stays small enough to inline into the callers. {@code step} is an instance field rather than
+   * a constant, so the JIT cannot fold the division away; this pays for it only on an actual
+   * rollover.
    */
   private void rollCount(long now) {
     if (now >= nextStepBoundary) {
@@ -87,8 +84,8 @@ public class StepLong implements StepValue {
         && NEXT_STEP_BOUNDARY_UPDATER.compareAndSet(this, lastBoundary, boundary)) {
       final long v = CURRENT_UPDATER.getAndSet(this, init);
       // Need to check if there was any activity during the previous step interval. If there was
-      // then the init position will move forward by 1, otherwise it will be older. No activity
-      // means the previous interval should be set to the `init` value.
+      // then the boundary moves forward by exactly one step, otherwise it jumps further. No
+      // activity means the previous interval should be set to the `init` value.
       previous = (lastBoundary == boundary - step) ? v : init;
     }
   }

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/StepLong.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/StepLong.java
@@ -186,8 +186,7 @@ public class StepLong implements StepValue {
 
   /** Get the timestamp for the end of the last completed interval. */
   @Override public long timestamp() {
-    // Start of the current interval, which is the end of the last completed one. Equivalent to
-    // the lastInitPos * step this used to compute.
+    // Start of the current interval, which is the end of the last completed one.
     return nextStepBoundary - step;
   }
 
@@ -195,6 +194,6 @@ public class StepLong implements StepValue {
     return "StepLong{init="  + init
         + ", previous=" + previous
         + ", current=" + current
-        + ", lastInitPos=" + (nextStepBoundary / step - 1) + '}';
+        + ", nextStepBoundary=" + nextStepBoundary + '}';
   }
 }

--- a/spectator-api/src/test/java/com/netflix/spectator/impl/StepRollCountConcurrencyTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/StepRollCountConcurrencyTest.java
@@ -136,6 +136,16 @@ public class StepRollCountConcurrencyTest {
     StepLong value = new StepLong(0L, clock, STEP);
     final int perThread = 100_000;
     final long now = 5L * STEP;
+
+    // Perform this interval's rollover up front. ManualClock starts at 0, so nextStepBoundary is
+    // STEP and the first update at 5 * STEP would otherwise roll over while all the threads are
+    // already incrementing: a thread that loses the boundary CAS still completes its addAndGet,
+    // and if that lands before the winner's getAndSet the increment is wiped. Rolling over here
+    // makes the body of the test genuinely in-interval, which is what it means to measure.
+    value.getCurrent(now);
+    Assertions.assertEquals(now, value.timestamp(),
+        "precondition: the rollover must already have happened before the threads start");
+
     ExecutorService pool = Executors.newFixedThreadPool(THREADS);
     try {
       CyclicBarrier start = new CyclicBarrier(THREADS);

--- a/spectator-api/src/test/java/com/netflix/spectator/impl/StepRollCountConcurrencyTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/StepRollCountConcurrencyTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2014-2025 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.impl;
+
+import com.netflix.spectator.api.ManualClock;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Only one thread may perform a given rollover. If several threads are allowed through, the
+ * second one resets {@code current} again and overwrites {@code previous} with the init value, so
+ * the completed interval is published as zero and its data is lost.
+ *
+ * <p>The guard that prevents this is a compare of the interval boundaries before the CAS. It
+ * cannot be exercised by a single threaded test, so it is covered here: every thread is released
+ * onto the same rollover at once and the value for the completed interval has to survive.</p>
+ */
+public class StepRollCountConcurrencyTest {
+
+  private static final long STEP = 10_000L;
+  private static final int THREADS = 8;
+  private static final int ROUNDS = 2_000;
+
+  @Test
+  @Timeout(60)
+  public void stepDoubleRollsExactlyOncePerInterval() throws Exception {
+    ManualClock clock = new ManualClock();
+    StepDouble value = new StepDouble(0.0, clock, STEP);
+    CyclicBarrier barrier = new CyclicBarrier(THREADS + 1);
+    ExecutorService pool = Executors.newFixedThreadPool(THREADS);
+    try {
+      // Interval index for the round, starting past zero so the first round has a real previous.
+      final long[] interval = {1L};
+      for (int t = 0; t < THREADS; ++t) {
+        pool.submit(() -> {
+          try {
+            for (int r = 0; r < ROUNDS; ++r) {
+              barrier.await(30, TimeUnit.SECONDS);
+              // All threads attempt the same rollover simultaneously.
+              value.getCurrent(interval[0] * STEP);
+              barrier.await(30, TimeUnit.SECONDS);
+            }
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+        });
+      }
+
+      for (int r = 0; r < ROUNDS; ++r) {
+        // Seed a known value into the current interval, which the rollover must publish.
+        double expected = 3.0;
+        value.setCurrent((interval[0] - 1) * STEP, expected);
+
+        barrier.await(30, TimeUnit.SECONDS);
+        barrier.await(30, TimeUnit.SECONDS);
+
+        Assertions.assertEquals(expected, value.poll(interval[0] * STEP), 1e-12,
+            "round " + r + ": completed interval value was lost to a duplicate rollover");
+        interval[0] += 1;
+      }
+    } finally {
+      pool.shutdownNow();
+      Assertions.assertTrue(pool.awaitTermination(30, TimeUnit.SECONDS));
+    }
+  }
+
+  @Test
+  @Timeout(60)
+  public void stepLongRollsExactlyOncePerInterval() throws Exception {
+    ManualClock clock = new ManualClock();
+    StepLong value = new StepLong(0L, clock, STEP);
+    CyclicBarrier barrier = new CyclicBarrier(THREADS + 1);
+    ExecutorService pool = Executors.newFixedThreadPool(THREADS);
+    try {
+      final long[] interval = {1L};
+      for (int t = 0; t < THREADS; ++t) {
+        pool.submit(() -> {
+          try {
+            for (int r = 0; r < ROUNDS; ++r) {
+              barrier.await(30, TimeUnit.SECONDS);
+              value.getCurrent(interval[0] * STEP);
+              barrier.await(30, TimeUnit.SECONDS);
+            }
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+        });
+      }
+
+      for (int r = 0; r < ROUNDS; ++r) {
+        long expected = 3L;
+        value.setCurrent((interval[0] - 1) * STEP, expected);
+
+        barrier.await(30, TimeUnit.SECONDS);
+        barrier.await(30, TimeUnit.SECONDS);
+
+        Assertions.assertEquals(expected, value.poll(interval[0] * STEP),
+            "round " + r + ": completed interval value was lost to a duplicate rollover");
+        interval[0] += 1;
+      }
+    } finally {
+      pool.shutdownNow();
+      Assertions.assertTrue(pool.awaitTermination(30, TimeUnit.SECONDS));
+    }
+  }
+
+  /**
+   * Concurrent updates inside one interval must all be retained, then published in full by the
+   * rollover. Only the last completed interval is kept, so this deliberately stays within a
+   * single interval: values for intervals that roll by without being polled are dropped by
+   * design and counting them would not be a conservation property of this class.
+   */
+  @Test
+  @Timeout(60)
+  public void concurrentUpdatesWithinAnIntervalAreConserved() throws Exception {
+    ManualClock clock = new ManualClock();
+    StepLong value = new StepLong(0L, clock, STEP);
+    final int perThread = 100_000;
+    final long now = 5L * STEP;
+    ExecutorService pool = Executors.newFixedThreadPool(THREADS);
+    try {
+      CyclicBarrier start = new CyclicBarrier(THREADS);
+      for (int t = 0; t < THREADS; ++t) {
+        pool.submit(() -> {
+          try {
+            start.await(30, TimeUnit.SECONDS);
+            for (int i = 0; i < perThread; ++i) {
+              value.addAndGet(now, 1L);
+            }
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+        });
+      }
+      pool.shutdown();
+      Assertions.assertTrue(pool.awaitTermination(45, TimeUnit.SECONDS));
+
+      Assertions.assertEquals((long) THREADS * perThread, value.getCurrent(now),
+          "updates were lost by the CAS retry loop");
+      // The single rollover must publish the whole amount.
+      Assertions.assertEquals((long) THREADS * perThread, value.poll(now + STEP),
+          "rollover did not publish the full interval");
+      Assertions.assertEquals(0L, value.getCurrent(now + STEP));
+    } finally {
+      pool.shutdownNow();
+    }
+  }
+}

--- a/spectator-api/src/test/java/com/netflix/spectator/impl/StepRollCountConcurrencyTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/StepRollCountConcurrencyTest.java
@@ -79,8 +79,10 @@ public class StepRollCountConcurrencyTest {
       }
     } finally {
       pool.shutdownNow();
-      Assertions.assertTrue(pool.awaitTermination(30, TimeUnit.SECONDS));
     }
+    // Checked outside the finally so that a failure here cannot replace a round assertion.
+    Assertions.assertTrue(pool.awaitTermination(30, TimeUnit.SECONDS),
+        "worker threads did not terminate");
   }
 
   @Test
@@ -119,8 +121,10 @@ public class StepRollCountConcurrencyTest {
       }
     } finally {
       pool.shutdownNow();
-      Assertions.assertTrue(pool.awaitTermination(30, TimeUnit.SECONDS));
     }
+    // Checked outside the finally so that a failure here cannot replace a round assertion.
+    Assertions.assertTrue(pool.awaitTermination(30, TimeUnit.SECONDS),
+        "worker threads did not terminate");
   }
 
   /**

--- a/spectator-api/src/test/java/com/netflix/spectator/impl/StepRollCountDifferentialTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/StepRollCountDifferentialTest.java
@@ -280,9 +280,11 @@ public class StepRollCountDifferentialTest {
           now += r.nextInt(500);
           break;
       }
-      // Wall time is not expected to be negative, but a backwards jump near zero can get there
-      // with a ManualClock, and integer division truncates toward zero rather than flooring, so
-      // the two implementations are compared over that range too rather than assumed equal.
+      // A backwards jump near zero can push the time negative with a ManualClock. Both
+      // implementations only move their bookkeeping forward from a non-negative start, so
+      // neither rolls at a negative time and those timestamps are a no-op on both sides. Wall
+      // time is not expected to be negative and every start below is non-negative, so a clock
+      // that begins below zero is out of scope here.
       if (now < -3 * step) {
         now = 0;
       }
@@ -461,8 +463,8 @@ public class StepRollCountDifferentialTest {
     v.addAndGet(base + 5, 1.0);
     Assertions.assertEquals(9.0, v.getCurrent(base + 5), 1e-12);
 
-    // Backwards into an earlier interval: the existing lastInit < stepTime guard means this
-    // does not roll backwards, and the current value is retained.
+    // Backwards into an earlier interval: now is below nextStepBoundary, so there is no
+    // rollover, and the current value is retained.
     Assertions.assertEquals(9.0, v.getCurrent(base - STEP * 3), 1e-12);
 
     // Forwards again past the boundary: the rollover still happens.

--- a/spectator-api/src/test/java/com/netflix/spectator/impl/StepRollCountDifferentialTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/impl/StepRollCountDifferentialTest.java
@@ -1,0 +1,472 @@
+/*
+ * Copyright 2014-2025 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.impl;
+
+import com.netflix.spectator.api.Clock;
+import com.netflix.spectator.api.ManualClock;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
+/**
+ * {@link StepDouble} and {@link StepLong} cache the end of the current step interval so that the
+ * division in {@code rollCount} is only paid on an actual rollover. The published values have to
+ * be unchanged by that, so this drives the current implementation and a copy of the previous one
+ * over identical timestamp sequences and requires the results to be bit-for-bit equal.
+ *
+ * <p>The sequences deliberately include the cases that distinguish the two: timestamps landing
+ * exactly on a boundary, gaps that skip whole intervals so the previous interval had no activity,
+ * and time moving backwards the way NTP can move it.</p>
+ *
+ * <p>The comparison is run over several step sizes rather than one. The cached boundary is derived
+ * from {@code step}, so a step that does not divide the starting timestamp, and a step small
+ * enough that nearly every update rolls, exercise different alignment than the 5s step used in
+ * practice.</p>
+ *
+ * <p>Every mutating and reading entry point is driven, not just {@code addAndGet}: they all funnel
+ * through {@code rollCount}, but they leave the current bucket in different states, and the value
+ * published on a rollover depends on that state. After each operation both the value for the
+ * current bucket and {@code timestamp()} are compared, so a divergence is caught at the operation
+ * that caused it rather than whenever it happens to surface.</p>
+ */
+public class StepRollCountDifferentialTest {
+
+  private static final long STEP = 5000L;
+
+  /** The implementation of rollCount that shipped before the boundary was cached. */
+  private static class LegacyStepDouble {
+
+    private final double init;
+    private final long step;
+
+    private volatile double previous;
+    private volatile long current;
+    private volatile long lastInitPos;
+
+    private static final AtomicLongFieldUpdater<LegacyStepDouble> CURRENT_UPDATER =
+        AtomicLongFieldUpdater.newUpdater(LegacyStepDouble.class, "current");
+
+    private static final AtomicLongFieldUpdater<LegacyStepDouble> LAST_INIT_POS_UPDATER =
+        AtomicLongFieldUpdater.newUpdater(LegacyStepDouble.class, "lastInitPos");
+
+    LegacyStepDouble(double init, Clock clock, long step) {
+      this.init = init;
+      this.step = step;
+      previous = init;
+      current = Double.doubleToLongBits(init);
+      lastInitPos = clock.wallTime() / step;
+    }
+
+    private void rollCount(long now) {
+      final long stepTime = now / step;
+      final long lastInit = lastInitPos;
+      if (lastInit < stepTime && LAST_INIT_POS_UPDATER.compareAndSet(this, lastInit, stepTime)) {
+        final double v = Double.longBitsToDouble(
+            CURRENT_UPDATER.getAndSet(this, Double.doubleToLongBits(init)));
+        previous = (lastInit == stepTime - 1) ? v : init;
+      }
+    }
+
+    double addAndGet(long now, double amount) {
+      rollCount(now);
+      long v;
+      double d;
+      double n;
+      long next;
+      do {
+        v = current;
+        d = Double.longBitsToDouble(v);
+        n = d + amount;
+        next = Double.doubleToLongBits(n);
+      } while (!CURRENT_UPDATER.compareAndSet(this, v, next));
+      return n;
+    }
+
+    double getCurrent(long now) {
+      rollCount(now);
+      return Double.longBitsToDouble(current);
+    }
+
+    void setCurrent(long now, double value) {
+      rollCount(now);
+      current = Double.doubleToLongBits(value);
+    }
+
+    double getAndSet(long now, double value) {
+      rollCount(now);
+      long v = CURRENT_UPDATER.getAndSet(this, Double.doubleToLongBits(value));
+      return Double.longBitsToDouble(v);
+    }
+
+    private boolean compareAndSet(double expect, double update) {
+      long e = Double.doubleToLongBits(expect);
+      long u = Double.doubleToLongBits(update);
+      return CURRENT_UPDATER.compareAndSet(this, e, u);
+    }
+
+    void min(long now, double value) {
+      if (Double.isFinite(value)) {
+        rollCount(now);
+        double min = Double.longBitsToDouble(current);
+        while ((value < min || Double.isNaN(min)) && !compareAndSet(min, value)) {
+          min = Double.longBitsToDouble(current);
+        }
+      }
+    }
+
+    void max(long now, double value) {
+      if (Double.isFinite(value)) {
+        rollCount(now);
+        double max = Double.longBitsToDouble(current);
+        while ((value > max || Double.isNaN(max)) && !compareAndSet(max, value)) {
+          max = Double.longBitsToDouble(current);
+        }
+      }
+    }
+
+    double poll(long now) {
+      rollCount(now);
+      return previous;
+    }
+
+    double pollAsRate(long now) {
+      final double amount = poll(now);
+      final double period = step / 1000.0;
+      return amount / period;
+    }
+
+    long timestamp() {
+      return lastInitPos * step;
+    }
+  }
+
+  /** The implementation of rollCount that shipped before the boundary was cached. */
+  private static class LegacyStepLong {
+
+    private final long init;
+    private final long step;
+
+    private volatile long previous;
+    private volatile long current;
+    private volatile long lastInitPos;
+
+    private static final AtomicLongFieldUpdater<LegacyStepLong> CURRENT_UPDATER =
+        AtomicLongFieldUpdater.newUpdater(LegacyStepLong.class, "current");
+
+    private static final AtomicLongFieldUpdater<LegacyStepLong> LAST_INIT_POS_UPDATER =
+        AtomicLongFieldUpdater.newUpdater(LegacyStepLong.class, "lastInitPos");
+
+    LegacyStepLong(long init, Clock clock, long step) {
+      this.init = init;
+      this.step = step;
+      previous = init;
+      current = init;
+      lastInitPos = clock.wallTime() / step;
+    }
+
+    private void rollCount(long now) {
+      final long stepTime = now / step;
+      final long lastInit = lastInitPos;
+      if (lastInit < stepTime && LAST_INIT_POS_UPDATER.compareAndSet(this, lastInit, stepTime)) {
+        final long v = CURRENT_UPDATER.getAndSet(this, init);
+        previous = (lastInit == stepTime - 1) ? v : init;
+      }
+    }
+
+    long addAndGet(long now, long amount) {
+      rollCount(now);
+      return CURRENT_UPDATER.addAndGet(this, amount);
+    }
+
+    long getCurrent(long now) {
+      rollCount(now);
+      return current;
+    }
+
+    void setCurrent(long now, long value) {
+      rollCount(now);
+      current = value;
+    }
+
+    long getAndSet(long now, long value) {
+      rollCount(now);
+      return CURRENT_UPDATER.getAndSet(this, value);
+    }
+
+    void min(long now, long value) {
+      rollCount(now);
+      long min = current;
+      while (value < min && !CURRENT_UPDATER.compareAndSet(this, min, value)) {
+        min = current;
+      }
+    }
+
+    void max(long now, long value) {
+      rollCount(now);
+      long max = current;
+      while (value > max && !CURRENT_UPDATER.compareAndSet(this, max, value)) {
+        max = current;
+      }
+    }
+
+    long poll(long now) {
+      rollCount(now);
+      return previous;
+    }
+
+    double pollAsRate(long now) {
+      final long amount = poll(now);
+      final double period = step / 1000.0;
+      return amount / period;
+    }
+
+    long timestamp() {
+      return lastInitPos * step;
+    }
+  }
+
+  /**
+   * Timestamps covering the interesting rollover shapes: repeats within an interval, exact
+   * boundaries, boundary minus and plus one, multi interval gaps, and backwards movement.
+   */
+  private List<Long> timestamps(long start, long step) {
+    List<Long> ts = new ArrayList<>();
+    Random r = new Random(42);
+    long now = start;
+    for (int i = 0; i < 20_000; ++i) {
+      ts.add(now);
+      switch (r.nextInt(10)) {
+        case 0:
+          // Land exactly on the next boundary.
+          now = (now / step + 1) * step;
+          break;
+        case 1:
+          // One millisecond short of the next boundary.
+          now = (now / step + 1) * step - 1;
+          break;
+        case 2:
+          // One millisecond past the next boundary.
+          now = (now / step + 1) * step + 1;
+          break;
+        case 3:
+          // Skip several whole intervals, so the previous interval saw no activity.
+          now += step * (2 + r.nextInt(5));
+          break;
+        case 4:
+          // Time moves backwards, as it can when NTP adjusts the clock.
+          now -= r.nextInt((int) Math.min(Integer.MAX_VALUE, step * 3));
+          break;
+        default:
+          // Stay inside the current interval most of the time.
+          now += r.nextInt(500);
+          break;
+      }
+      // Wall time is not expected to be negative, but a backwards jump near zero can get there
+      // with a ManualClock, and integer division truncates toward zero rather than flooring, so
+      // the two implementations are compared over that range too rather than assumed equal.
+      if (now < -3 * step) {
+        now = 0;
+      }
+    }
+    return ts;
+  }
+
+  /** Starting timestamps covering aligned, off-by-one and realistic epoch alignment. */
+  private long[] starts(long step) {
+    return new long[] {0L, 1L, step, step - 1, 1_700_000_000_000L};
+  }
+
+  @ParameterizedTest
+  @ValueSource(longs = {1L, 7L, 13L, 1000L, 5000L, 60_000L})
+  public void stepDoubleMatchesLegacyBitForBit(long step) {
+    for (long start : starts(step)) {
+      ManualClock clock = new ManualClock(start, start);
+      StepDouble actual = new StepDouble(0.0, clock, step);
+      LegacyStepDouble expected = new LegacyStepDouble(0.0, clock, step);
+
+      int op = 0;
+      for (long now : timestamps(start, step)) {
+        // Exercise every read and write path, since they all funnel through rollCount.
+        switch (op++ % 8) {
+          case 0:
+            Assertions.assertEquals(
+                Double.doubleToRawLongBits(expected.addAndGet(now, 1.0)),
+                Double.doubleToRawLongBits(actual.addAndGet(now, 1.0)),
+                "addAndGet at " + now + " from start " + start);
+            break;
+          case 1:
+            Assertions.assertEquals(
+                Double.doubleToRawLongBits(expected.getCurrent(now)),
+                Double.doubleToRawLongBits(actual.getCurrent(now)),
+                "getCurrent at " + now + " from start " + start);
+            break;
+          case 2:
+            Assertions.assertEquals(
+                Double.doubleToRawLongBits(expected.poll(now)),
+                Double.doubleToRawLongBits(actual.poll(now)),
+                "poll at " + now + " from start " + start);
+            break;
+          case 3:
+            Assertions.assertEquals(
+                Double.doubleToRawLongBits(expected.pollAsRate(now)),
+                Double.doubleToRawLongBits(actual.pollAsRate(now)),
+                "pollAsRate at " + now + " from start " + start);
+            break;
+          case 4:
+            expected.setCurrent(now, op);
+            actual.setCurrent(now, op);
+            break;
+          case 5:
+            Assertions.assertEquals(
+                Double.doubleToRawLongBits(expected.getAndSet(now, op)),
+                Double.doubleToRawLongBits(actual.getAndSet(now, op)),
+                "getAndSet at " + now + " from start " + start);
+            break;
+          case 6:
+            expected.max(now, op % 17);
+            actual.max(now, op % 17);
+            break;
+          default:
+            expected.min(now, op % 17);
+            actual.min(now, op % 17);
+            break;
+        }
+        Assertions.assertEquals(
+            Double.doubleToRawLongBits(expected.getCurrent(now)),
+            Double.doubleToRawLongBits(actual.getCurrent(now)),
+            "current after op at " + now + " from start " + start);
+        Assertions.assertEquals(expected.timestamp(), actual.timestamp(),
+            "timestamp at " + now + " from start " + start);
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(longs = {1L, 7L, 13L, 1000L, 5000L, 60_000L})
+  public void stepLongMatchesLegacyBitForBit(long step) {
+    for (long start : starts(step)) {
+      ManualClock clock = new ManualClock(start, start);
+      StepLong actual = new StepLong(0L, clock, step);
+      LegacyStepLong expected = new LegacyStepLong(0L, clock, step);
+
+      int op = 0;
+      for (long now : timestamps(start, step)) {
+        switch (op++ % 8) {
+          case 0:
+            Assertions.assertEquals(
+                expected.addAndGet(now, 1L),
+                actual.addAndGet(now, 1L),
+                "addAndGet at " + now + " from start " + start);
+            break;
+          case 1:
+            Assertions.assertEquals(
+                expected.getCurrent(now),
+                actual.getCurrent(now),
+                "getCurrent at " + now + " from start " + start);
+            break;
+          case 2:
+            Assertions.assertEquals(
+                expected.poll(now),
+                actual.poll(now),
+                "poll at " + now + " from start " + start);
+            break;
+          case 3:
+            Assertions.assertEquals(
+                Double.doubleToRawLongBits(expected.pollAsRate(now)),
+                Double.doubleToRawLongBits(actual.pollAsRate(now)),
+                "pollAsRate at " + now + " from start " + start);
+            break;
+          case 4:
+            expected.setCurrent(now, op);
+            actual.setCurrent(now, op);
+            break;
+          case 5:
+            Assertions.assertEquals(
+                expected.getAndSet(now, op),
+                actual.getAndSet(now, op),
+                "getAndSet at " + now + " from start " + start);
+            break;
+          case 6:
+            expected.max(now, op % 17);
+            actual.max(now, op % 17);
+            break;
+          default:
+            expected.min(now, op % 17);
+            actual.min(now, op % 17);
+            break;
+        }
+        Assertions.assertEquals(expected.getCurrent(now), actual.getCurrent(now),
+            "current after op at " + now + " from start " + start);
+        Assertions.assertEquals(expected.timestamp(), actual.timestamp(),
+            "timestamp at " + now + " from start " + start);
+      }
+    }
+  }
+
+  /**
+   * An interval with no activity has to publish the init value rather than carrying the previous
+   * interval forward. This is the case the cached boundary could plausibly break, so it is
+   * asserted directly as well as through the differential comparison.
+   */
+  @Test
+  public void noActivityInPreviousIntervalPublishesInit() {
+    ManualClock clock = new ManualClock();
+    StepDouble v = new StepDouble(0.0, clock, STEP);
+
+    v.addAndGet(0L, 42.0);
+
+    // Next interval: the 42.0 recorded above becomes the value for the completed interval.
+    Assertions.assertEquals(42.0, v.poll(STEP), 1e-12);
+
+    // Skip an entire interval with no updates at all. The completed interval had no activity,
+    // so it must report init and not the stale 42.0.
+    Assertions.assertEquals(0.0, v.poll(STEP * 4), 1e-12);
+    Assertions.assertEquals(0.0, v.getCurrent(STEP * 4), 1e-12);
+  }
+
+  /**
+   * The cached boundary must not let a rollover be skipped when the clock jumps backwards and
+   * then forwards again, and a backwards jump inside the current interval must not roll.
+   */
+  @Test
+  public void clockMovingBackwardsDoesNotRollOrSkip() {
+    ManualClock clock = new ManualClock();
+    StepDouble v = new StepDouble(0.0, clock, STEP);
+
+    long base = STEP * 100;
+    v.addAndGet(base, 7.0);
+    Assertions.assertEquals(7.0, v.getCurrent(base), 1e-12);
+
+    // Backwards within the same interval: no rollover, the value is still accumulating.
+    v.addAndGet(base + 10, 1.0);
+    v.addAndGet(base + 5, 1.0);
+    Assertions.assertEquals(9.0, v.getCurrent(base + 5), 1e-12);
+
+    // Backwards into an earlier interval: the existing lastInit < stepTime guard means this
+    // does not roll backwards, and the current value is retained.
+    Assertions.assertEquals(9.0, v.getCurrent(base - STEP * 3), 1e-12);
+
+    // Forwards again past the boundary: the rollover still happens.
+    Assertions.assertEquals(9.0, v.poll(base + STEP), 1e-12);
+    Assertions.assertEquals(0.0, v.getCurrent(base + STEP), 1e-12);
+  }
+}


### PR DESCRIPTION
## Summary

Every update to a step value calls `rollCount`, which divided the current wall time by the step size to get the interval index. `step` is a non-trusted final instance field, so C2 cannot constant fold it, and this compiles to a real `idivq` on the update path of every counter, timer, gauge and distribution summary.

Cache the end of the current interval instead of its index. An in-interval update then becomes a comparison against a volatile long, and the division is paid only on an actual rollover. Boundaries are exact multiples of `step`, so comparing them orders the intervals exactly the way comparing the indices did.

No public API or behavior change. The only externally visible difference is `toString`, which used to print `lastInitPos`; it now prints the field that actually exists. Both classes are documented as internal implementation details subject to change.

## Correctness

`StepRollCountDifferentialTest` drives the new implementation and a copy of the previous one over identical timestamp sequences and requires bit-for-bit equal results. It covers every entry point (`addAndGet`, `getCurrent`, `setCurrent`, `getAndSet`, `min`, `max`, `poll`, `pollAsRate`), asserting both the current value and `timestamp()` after each operation, over step sizes of 1ms, 7ms, 13ms, 1s, 5s and 60s and five starting alignments. The sequences deliberately include exact boundaries, boundary +/- 1, multi-interval gaps and backwards clock movement.

`StepRollCountConcurrencyTest` covers the boundary compare that precedes the CAS. Without it, two threads that both observe the same boundary would both roll, and the second would reset `current` and publish the completed interval as zero. That cannot be exercised single threaded.

I checked the tests are not vacuous by injecting four bugs; all were caught:

| Injected bug | Caught by |
|---|---|
| `>=` weakened to `>` in the boundary check | differential (all step sizes) |
| `timestamp()` off by one step | differential |
| always carry `previous` forward | differential |
| drop the boundary compare before the CAS | concurrency test only |

`./gradlew :spectator-api:build` passes, including checkstyle, spotbugs and the JDK 17/25/26 test tasks.

## Benchmark

New `StepValueUpdate` JMH benchmark in `spectator-api` (the change is here, and it needs no registry). JDK 25, 5 forks x (5 x 1s warmup + 10 x 2s measurement) = 50 measurement iterations, single threaded. Errors are 99.9% confidence intervals including fork-to-fork variance. "Before" is this repo's `main` with only the benchmark file itself added, so both runs measure identical call sequences.

| Benchmark | Before (ops/s) | After (ops/s) | Change | What it isolates |
|---|---:|---:|---:|---|
| `stepLongAddAndGetWithClock` | 30,501,630 ± 2,954 | 33,893,242 ± 2,623 | **+11.1%** | Production shape: clock read then update, as `AtlasCounter.add` does |
| `stepDoubleAddAndGetWithClock` | 30,235,242 ± 20,295 | 33,314,284 ± 17,130 | **+10.2%** | Same, for the double valued path |
| `stepDoublePoll` | 523,071,218 ± 23,004 | 1,421,236,753 ± 4,409,376 | **+171.7%** | Step bookkeeping alone, no atomic update |
| `stepLongPoll` | 523,059,413 ± 27,033 | 1,413,357,287 ± 3,879,963 | **+170.2%** | Step bookkeeping alone, no atomic update |
| `varyingStepLongPoll` | 523,041,511 ± 42,926 | 1,107,528,228 ± 848,189 | **+111.7%** | Bookkeeping alone, timestamp the JIT cannot hoist |
| `stepLongAddAndGet` | 492,950,974 ± 316,047 | 501,408,748 ± 848,167 | +1.7% | Bookkeeping plus the atomic add |
| `stepDoubleAddAndGet` | 228,828,698 ± 15,665 | 228,837,004 ± 15,354 | +0.0% | Bookkeeping plus the CAS loop |
| `varyingStepLongAddAndGet` | 496,459,787 ± 162,386 | 471,198,933 ± 271,861 | **-5.1%** | As above, timestamp from a counter increment |
| `rollingStepLong` | 108,540,850 ± 70,225 | 101,583,257 ± 143,372 | **-6.4%** | Worst case: 1ms step, a rollover on every call |
| `rollingStepDouble` | 108,370,102 ± 330,907 | 101,761,468 ± 133,115 | **-6.1%** | Worst case: 1ms step, a rollover on every call |
| `wallTime` | 41,131,379 ± 2,581 | 41,132,156 ± 2,244 | +0.0% | Control: one wall clock read, for scale |

`*WithClock` is the shape a real update has, matching `AtlasCounter.add`: read the clock, then update. That is the number worth quoting. The `wallTime` control matching to 0.02% across the two runs indicates the machine was not drifting between them.

The disassembly confirms the mechanism directly: `idivq` appears throughout the `before` compilation of the hot loop and is entirely absent after.

### On the two apparent regressions

`rollingStepLong` and `rollingStepDouble` use a 1ms step with a timestamp advancing every call, so every single update rolls over. That is the adversarial case: the division is still paid and the boundary load is added on top. It costs ~6%, and it only applies to a meter rolling over on essentially every update. With the 5s step used in practice a rollover is one update in millions.

`varyingStepLongAddAndGet` at -5.0% is reproducible rather than noise, and it is worth being precise about because it is not a cost of this change. The division is long-latency work on a separate execution port, so on `main` it masks whatever else the loop is doing. Measured on `main`, that benchmark is flat at 492-510M ops/s whether the timestamp comes from a constant, a counter increment, or an array load (a throwaway variant used to diagnose this, not included here). With the division gone the same three land at 501M, 471M and 453M, tracking the cost of the timestamp source itself. In other words the loop with a trivial timestamp is *faster* after this change (`stepLongAddAndGet`, 501.4M vs 493.0M); what the slower variants measure is the benchmark's own timestamp generation emerging from behind the divide.

I ruled out the alternatives before settling on that: splitting `rollCount` into a fast path plus a cold `rollCountSlow` is not responsible (an unsplit build measures the same, 470.7M vs 471.6M); nor is field layout (padding `nextStepBoundary` onto its own cache line, verified in the disassembly to move it from offset `0x30` to `0x70`, changes nothing); nor loop alignment or unrolling (`-XX:OptoLoopAlignment=32` and `-XX:LoopUnrollLimit=1` leave both builds unmoved).

A real caller reads a clock, which costs far more than anything the division could mask, which is why the production-shaped benchmark gains 11%.

