### PR TITLE
Replace the per-update expiry check in SwapMeter with a removal counter

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/AbstractRegistry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/AbstractRegistry.java
@@ -37,22 +37,15 @@ import java.util.function.LongSupplier;
  */
 public abstract class AbstractRegistry implements Registry, AutoCloseable {
 
-  /**
-   * This registry has no notion of a registry level version, so the signal used by
-   * {@link SwapMeter#hasExpired()} is constant, as it has always been. Meter removal is tracked
-   * separately by {@link #removals}.
-   */
+  /** Not used for this registry, always return 0. Removal is tracked by {@link #removals}. */
   private static final LongSupplier VERSION = () -> 0L;
 
   /**
-   * Incremented whenever a meter is removed from {@link #meters}. The {@link SwapMeter} types
-   * handed out by this registry use it to notice that their underlying meter is gone and needs to
-   * be resolved again, which keeps a wall clock read off the update path.
-   *
-   * <p>Deliberately not the same signal as {@code VERSION}: that one feeds {@code hasExpired()},
-   * which callers act on destructively, and removal happens on every cleanup pass rather than
-   * rarely. Bumping one counter invalidates every outstanding wrapper, not just the affected one,
-   * but that only costs an extra map lookup per held reference per cleanup pass.
+   * Incremented whenever a meter is removed from {@link #meters}, so the {@link SwapMeter} types
+   * handed out here notice their underlying meter is gone without reading the wall clock. Kept
+   * out of {@code VERSION} because that feeds {@code hasExpired()}, which callers act on
+   * destructively. One counter invalidates every outstanding wrapper rather than just the
+   * affected one, costing an extra lookup per held reference per cleanup pass.
    */
   private final AtomicLong removals = new AtomicLong();
 
@@ -255,7 +248,7 @@ public abstract class AbstractRegistry implements Registry, AutoCloseable {
   }
 
   @Override public final Counter counter(Id id) {
-    // Sample the removal counter before resolving so a removal racing with the lookup is seen.
+    // Sampled before resolving so a removal racing the lookup is seen; see SwapMeter.
     final long v = removals.get();
     Counter c = getOrCreate(id, Counter.class, NoopCounter.INSTANCE, counterFactory);
     return new SwapCounter(this, VERSION, removalSupplier, v, c.id(), c);
@@ -345,10 +338,9 @@ public abstract class AbstractRegistry implements Registry, AutoCloseable {
   }
 
   /**
-   * Wraps the iterator over the meter map so that a removal bumps {@link #removals} no matter who
-   * performs it. Sub-classes such as {@code AtlasRegistry} implement their own cleanup pass on top
-   * of {@link #iterator()}, so the bump happens here rather than relying on every caller to
-   * remember it.
+   * Bumps {@link #removals} on removal no matter who performs it. Sub-classes such as
+   * {@code AtlasRegistry} run their own cleanup pass on top of {@link #iterator()}, so the bump
+   * belongs here rather than in every caller.
    */
   private final class VersionedIterator implements Iterator<Meter> {
 
@@ -368,8 +360,7 @@ public abstract class AbstractRegistry implements Registry, AutoCloseable {
 
     @Override public void remove() {
       delegate.remove();
-      // Bump after the entry is actually gone. A reader that sees the new version is guaranteed
-      // to miss the removed entry and will resolve a fresh meter.
+      // Bump after the entry is gone, so a reader seeing the new value cannot still find it.
       removals.incrementAndGet();
     }
   }

--- a/spectator-api/src/main/java/com/netflix/spectator/api/AbstractRegistry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/AbstractRegistry.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Spliterator;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import java.util.function.LongSupplier;
 
@@ -36,8 +37,26 @@ import java.util.function.LongSupplier;
  */
 public abstract class AbstractRegistry implements Registry, AutoCloseable {
 
-  /** Not used for this registry, always return 0. */
+  /**
+   * This registry has no notion of a registry level version, so the signal used by
+   * {@link SwapMeter#hasExpired()} is constant, as it has always been. Meter removal is tracked
+   * separately by {@link #removals}.
+   */
   private static final LongSupplier VERSION = () -> 0L;
+
+  /**
+   * Incremented whenever a meter is removed from {@link #meters}. The {@link SwapMeter} types
+   * handed out by this registry use it to notice that their underlying meter is gone and needs to
+   * be resolved again, which keeps a wall clock read off the update path.
+   *
+   * <p>Deliberately not the same signal as {@code VERSION}: that one feeds {@code hasExpired()},
+   * which callers act on destructively, and removal happens on every cleanup pass rather than
+   * rarely. Bumping one counter invalidates every outstanding wrapper, not just the affected one,
+   * but that only costs an extra map lookup per held reference per cleanup pass.
+   */
+  private final AtomicLong removals = new AtomicLong();
+
+  private final LongSupplier removalSupplier = removals::get;
 
   /** Logger instance for the class. */
   protected final Logger logger;
@@ -236,32 +255,38 @@ public abstract class AbstractRegistry implements Registry, AutoCloseable {
   }
 
   @Override public final Counter counter(Id id) {
+    // Sample the removal counter before resolving so a removal racing with the lookup is seen.
+    final long v = removals.get();
     Counter c = getOrCreate(id, Counter.class, NoopCounter.INSTANCE, counterFactory);
-    return new SwapCounter(this, VERSION, c.id(), c);
+    return new SwapCounter(this, VERSION, removalSupplier, v, c.id(), c);
   }
 
   @Override public final DistributionSummary distributionSummary(Id id) {
+    final long v = removals.get();
     DistributionSummary ds = getOrCreate(
         id,
         DistributionSummary.class,
         NoopDistributionSummary.INSTANCE,
         distSummaryFactory);
-    return new SwapDistributionSummary(this, VERSION, ds.id(), ds);
+    return new SwapDistributionSummary(this, VERSION, removalSupplier, v, ds.id(), ds);
   }
 
   @Override public final Timer timer(Id id) {
+    final long v = removals.get();
     Timer t = getOrCreate(id, Timer.class, NoopTimer.INSTANCE, timerFactory);
-    return new SwapTimer(this, VERSION, t.id(), t);
+    return new SwapTimer(this, VERSION, removalSupplier, v, t.id(), t);
   }
 
   @Override public final Gauge gauge(Id id) {
+    final long v = removals.get();
     Gauge g = getOrCreate(id, Gauge.class, NoopGauge.INSTANCE, gaugeFactory);
-    return new SwapGauge(this, VERSION, g.id(), g);
+    return new SwapGauge(this, VERSION, removalSupplier, v, g.id(), g);
   }
 
   @Override public final Gauge maxGauge(Id id) {
+    final long v = removals.get();
     Gauge g = getOrCreate(id, Gauge.class, NoopGauge.INSTANCE, maxGaugeFactory);
-    return new SwapMaxGauge(this, VERSION, g.id(), g);
+    return new SwapMaxGauge(this, VERSION, removalSupplier, v, g.id(), g);
   }
 
   /**
@@ -316,7 +341,37 @@ public abstract class AbstractRegistry implements Registry, AutoCloseable {
   }
 
   @Override public final Iterator<Meter> iterator() {
-    return meters.values().iterator();
+    return new VersionedIterator(meters.values().iterator());
+  }
+
+  /**
+   * Wraps the iterator over the meter map so that a removal bumps {@link #removals} no matter who
+   * performs it. Sub-classes such as {@code AtlasRegistry} implement their own cleanup pass on top
+   * of {@link #iterator()}, so the bump happens here rather than relying on every caller to
+   * remember it.
+   */
+  private final class VersionedIterator implements Iterator<Meter> {
+
+    private final Iterator<Meter> delegate;
+
+    VersionedIterator(Iterator<Meter> delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override public boolean hasNext() {
+      return delegate.hasNext();
+    }
+
+    @Override public Meter next() {
+      return delegate.next();
+    }
+
+    @Override public void remove() {
+      delegate.remove();
+      // Bump after the entry is actually gone. A reader that sees the new version is guaranteed
+      // to miss the removed entry and will resolve a fresh meter.
+      removals.incrementAndGet();
+    }
   }
 
   @Override
@@ -331,7 +386,7 @@ public abstract class AbstractRegistry implements Registry, AutoCloseable {
   protected void removeExpiredMeters() {
     int total = 0;
     int expired = 0;
-    Iterator<Meter> it = meters.values().iterator();
+    Iterator<Meter> it = iterator();
     while (it.hasNext()) {
       ++total;
       Meter m = it.next();
@@ -406,5 +461,7 @@ public abstract class AbstractRegistry implements Registry, AutoCloseable {
     }
     state.clear();
     meters.clear();
+    // Clearing the map removes every meter, so any outstanding SwapMeter has to resolve again.
+    removals.incrementAndGet();
   }
 }

--- a/spectator-api/src/main/java/com/netflix/spectator/api/SwapCounter.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/SwapCounter.java
@@ -29,6 +29,16 @@ final class SwapCounter extends SwapMeter<Counter> implements Counter {
     super(registry, versionSupplier, id, underlying);
   }
 
+  SwapCounter(
+      Registry registry,
+      LongSupplier versionSupplier,
+      LongSupplier resolveSupplier,
+      long resolveVersion,
+      Id id,
+      Counter underlying) {
+    super(registry, versionSupplier, resolveSupplier, resolveVersion, id, underlying);
+  }
+
   @Override public Counter lookup() {
     return registry.counter(id);
   }

--- a/spectator-api/src/main/java/com/netflix/spectator/api/SwapDistributionSummary.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/SwapDistributionSummary.java
@@ -33,6 +33,16 @@ final class SwapDistributionSummary extends SwapMeter<DistributionSummary> imple
     super(registry, versionSupplier, id, underlying);
   }
 
+  SwapDistributionSummary(
+      Registry registry,
+      LongSupplier versionSupplier,
+      LongSupplier resolveSupplier,
+      long resolveVersion,
+      Id id,
+      DistributionSummary underlying) {
+    super(registry, versionSupplier, resolveSupplier, resolveVersion, id, underlying);
+  }
+
   @Override public DistributionSummary lookup() {
     return registry.distributionSummary(id);
   }

--- a/spectator-api/src/main/java/com/netflix/spectator/api/SwapGauge.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/SwapGauge.java
@@ -27,6 +27,16 @@ final class SwapGauge extends SwapMeter<Gauge> implements Gauge {
     super(registry, versionSupplier, id, underlying);
   }
 
+  SwapGauge(
+      Registry registry,
+      LongSupplier versionSupplier,
+      LongSupplier resolveSupplier,
+      long resolveVersion,
+      Id id,
+      Gauge underlying) {
+    super(registry, versionSupplier, resolveSupplier, resolveVersion, id, underlying);
+  }
+
   @Override public Gauge lookup() {
     return registry.gauge(id);
   }

--- a/spectator-api/src/main/java/com/netflix/spectator/api/SwapMaxGauge.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/SwapMaxGauge.java
@@ -27,6 +27,16 @@ final class SwapMaxGauge extends SwapMeter<Gauge> implements Gauge {
     super(registry, versionSupplier, id, underlying);
   }
 
+  SwapMaxGauge(
+      Registry registry,
+      LongSupplier versionSupplier,
+      LongSupplier resolveSupplier,
+      long resolveVersion,
+      Id id,
+      Gauge underlying) {
+    super(registry, versionSupplier, resolveSupplier, resolveVersion, id, underlying);
+  }
+
   @Override public Gauge lookup() {
     return registry.maxGauge(id);
   }

--- a/spectator-api/src/main/java/com/netflix/spectator/api/SwapTimer.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/SwapTimer.java
@@ -30,6 +30,16 @@ final class SwapTimer extends SwapMeter<Timer> implements Timer {
     super(registry, versionSupplier, id, underlying);
   }
 
+  SwapTimer(
+      Registry registry,
+      LongSupplier versionSupplier,
+      LongSupplier resolveSupplier,
+      long resolveVersion,
+      Id id,
+      Timer underlying) {
+    super(registry, versionSupplier, resolveSupplier, resolveVersion, id, underlying);
+  }
+
   @Override public Timer lookup() {
     return registry.timer(id);
   }

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/SwapMeter.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/SwapMeter.java
@@ -136,11 +136,14 @@ public abstract class SwapMeter<T extends Meter> implements Meter {
     // observed, which would swallow a subsequent removal.
     final long resolveVersion = resolveSupplier.getAsLong();
     if (currentResolveVersion < resolveVersion) {
-      currentResolveVersion = resolveVersion;
       // Resolving also clears the staleness hasExpired() reports, since the meter just came from
       // a fresh lookup.
       currentVersion = versionSupplier.getAsLong();
       underlying = unwrap(lookup());
+      // Published last, so a concurrent caller that sees the new version also sees the meter it
+      // describes. Publishing it first lets that caller skip the resolve and keep updating the
+      // instance this lookup just replaced, silently dropping the update.
+      currentResolveVersion = resolveVersion;
     } else if (resolveOnUnderlyingExpiry && underlying.hasExpired()) {
       currentVersion = versionSupplier.getAsLong();
       underlying = unwrap(lookup());

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/SwapMeter.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/SwapMeter.java
@@ -35,8 +35,25 @@ public abstract class SwapMeter<T extends Meter> implements Meter {
   /** Registry used to lookup values after expiration. */
   protected final Registry registry;
 
+  /**
+   * Signals that the shape of the registry changed, for example a registry being added to a
+   * composite. Participates in {@link #hasExpired()}: a change means callers should stop using
+   * this wrapper and obtain a fresh one.
+   */
   private final LongSupplier versionSupplier;
   private volatile long currentVersion;
+
+  /**
+   * Signals that a meter was removed from the registry, so this wrapper may be holding one that
+   * is no longer registered. Kept separate from {@code versionSupplier} on purpose. Meter removal
+   * happens on every cleanup pass, whereas a registry level change is rare, and
+   * {@link #hasExpired()} is acted on destructively by callers such as {@code PolledMeter}, which
+   * drops the meter from the set it aggregates. Folding routine removals into that signal would
+   * report healthy meters as expired once per cleanup pass. This one therefore feeds
+   * {@link #get()} only.
+   */
+  private final LongSupplier resolveSupplier;
+  private volatile long currentResolveVersion;
 
   /** Id to use when performing a lookup after expiration. */
   protected final Id id;
@@ -46,9 +63,43 @@ public abstract class SwapMeter<T extends Meter> implements Meter {
 
   /** Create a new instance. */
   public SwapMeter(Registry registry, LongSupplier versionSupplier, Id id, T underlying) {
+    this(registry, versionSupplier, versionSupplier, versionSupplier.getAsLong(), id, underlying);
+  }
+
+  /**
+   * Create a new instance with a dedicated signal for meter removal, and the value of that signal
+   * as observed <i>before</i> {@code underlying} was resolved.
+   *
+   * <p>{@code resolveVersion} must be sampled before resolving {@code underlying}: sampled
+   * afterwards it would already account for a removal racing with the resolution, and this
+   * wrapper would stay bound to a meter that is no longer registered, silently dropping every
+   * later update. Sampling early can only cause one redundant re-resolution.
+   *
+   * @param registry
+   *     Registry used to lookup the meter after expiration.
+   * @param versionSupplier
+   *     Supplies the registry level version, used by {@link #hasExpired()}.
+   * @param resolveSupplier
+   *     Supplies a counter that changes whenever a meter is removed, used by {@link #get()}.
+   * @param resolveVersion
+   *     Value of {@code resolveSupplier} sampled before {@code underlying} was looked up.
+   * @param id
+   *     Id to use when performing a lookup after expiration.
+   * @param underlying
+   *     Meter to delegate operations to.
+   */
+  public SwapMeter(
+      Registry registry,
+      LongSupplier versionSupplier,
+      LongSupplier resolveSupplier,
+      long resolveVersion,
+      Id id,
+      T underlying) {
     this.registry = registry;
     this.versionSupplier = versionSupplier;
     this.currentVersion = versionSupplier.getAsLong();
+    this.resolveSupplier = resolveSupplier;
+    this.currentResolveVersion = resolveVersion;
     this.id = id;
     this.underlying = unwrap(underlying);
   }
@@ -66,6 +117,12 @@ public abstract class SwapMeter<T extends Meter> implements Meter {
     return get().measure();
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Routine meter removal is deliberately not part of this signal; see {@link #resolveSupplier}
+   * for why.
+   */
   @Override public boolean hasExpired() {
     return currentVersion < versionSupplier.getAsLong() || underlying.hasExpired();
   }
@@ -78,9 +135,26 @@ public abstract class SwapMeter<T extends Meter> implements Meter {
     underlying = unwrap(meter);
   }
 
-  /** Return the underlying instance of the meter. */
+  /**
+   * Return the underlying instance of the meter, resolving a new one if the registry may have
+   * removed the current instance.
+   *
+   * <p>This runs on the update path of every meter operation, so it checks a counter rather than
+   * {@code underlying.hasExpired()}: the counter is a plain volatile read, whereas the expiry
+   * check costs a wall clock read on every update (for {@code AtlasMeter}, a {@code clock_gettime}
+   * to evaluate a TTL measured in minutes). This does not change which meter updates land on — a
+   * meter that is past its TTL but still registered resolves back to the same instance either
+   * way — and once cleanup actually removes the meter the counter moves, so the next call here
+   * resolves a fresh one.
+   */
   public T get() {
-    if (hasExpired()) {
+    // Sampled once: re-reading for the assignment could store a value newer than what lookup()
+    // actually observed, which would then swallow a subsequent removal.
+    final long resolveVersion = resolveSupplier.getAsLong();
+    if (currentResolveVersion < resolveVersion) {
+      currentResolveVersion = resolveVersion;
+      // Resolving also clears the registry level staleness reported by hasExpired(), since the
+      // meter being delegated to has just been looked up afresh.
       currentVersion = versionSupplier.getAsLong();
       underlying = unwrap(lookup());
     }

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/SwapMeter.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/SwapMeter.java
@@ -35,32 +35,19 @@ public abstract class SwapMeter<T extends Meter> implements Meter {
   /** Registry used to lookup values after expiration. */
   protected final Registry registry;
 
-  /**
-   * Signals that the shape of the registry changed, for example a registry being added to a
-   * composite. Participates in {@link #hasExpired()}: a change means callers should stop using
-   * this wrapper and obtain a fresh one.
-   */
+  // Changes when the shape of the registry changes, for example a registry being added to a
+  // composite. Feeds hasExpired().
   private final LongSupplier versionSupplier;
   private volatile long currentVersion;
 
-  /**
-   * Signals that a meter was removed from the registry, so this wrapper may be holding one that
-   * is no longer registered. Kept separate from {@code versionSupplier} on purpose. Meter removal
-   * happens on every cleanup pass, whereas a registry level change is rare, and
-   * {@link #hasExpired()} is acted on destructively by callers such as {@code PolledMeter}, which
-   * drops the meter from the set it aggregates. Folding routine removals into that signal would
-   * report healthy meters as expired once per cleanup pass. This one therefore feeds
-   * {@link #get()} only.
-   */
+  // Changes when a meter is removed, so this wrapper may be holding one that is no longer
+  // registered. Feeds get() only, never hasExpired(): callers such as PolledMeter treat expiry as
+  // licence to discard the meter, and removal happens on every cleanup pass.
   private final LongSupplier resolveSupplier;
   private volatile long currentResolveVersion;
 
-  /**
-   * Whether {@link #get()} should also re-resolve when the underlying meter reports that it has
-   * expired. Only set for the constructor that has no dedicated removal signal, so that callers
-   * such as {@code CompositeRegistry}, which has no notion of meter removal, keep exactly the
-   * behavior they had before that signal existed.
-   */
+  // Set only by the constructor with no removal signal, so registries without one, such as
+  // CompositeRegistry, keep the original trigger.
   private final boolean resolveOnUnderlyingExpiry;
 
   /** Id to use when performing a lookup after expiration. */
@@ -76,26 +63,11 @@ public abstract class SwapMeter<T extends Meter> implements Meter {
   }
 
   /**
-   * Create a new instance with a dedicated signal for meter removal, and the value of that signal
-   * as observed <i>before</i> {@code underlying} was resolved.
-   *
-   * <p>{@code resolveVersion} must be sampled before resolving {@code underlying}: sampled
-   * afterwards it would already account for a removal racing with the resolution, and this
-   * wrapper would stay bound to a meter that is no longer registered, silently dropping every
-   * later update. Sampling early can only cause one redundant re-resolution.
-   *
-   * @param registry
-   *     Registry used to lookup the meter after expiration.
-   * @param versionSupplier
-   *     Supplies the registry level version, used by {@link #hasExpired()}.
-   * @param resolveSupplier
-   *     Supplies a counter that changes whenever a meter is removed, used by {@link #get()}.
-   * @param resolveVersion
-   *     Value of {@code resolveSupplier} sampled before {@code underlying} was looked up.
-   * @param id
-   *     Id to use when performing a lookup after expiration.
-   * @param underlying
-   *     Meter to delegate operations to.
+   * Create a new instance with a dedicated signal for meter removal. {@code resolveVersion} must
+   * be sampled from {@code resolveSupplier} <i>before</i> {@code underlying} is resolved: sampled
+   * afterwards it would already account for a removal racing the resolution, leaving this wrapper
+   * bound to a meter that is no longer registered and silently dropping every later update.
+   * Sampling early can only cost one redundant re-resolution.
    */
   public SwapMeter(
       Registry registry,
@@ -138,12 +110,7 @@ public abstract class SwapMeter<T extends Meter> implements Meter {
     return get().measure();
   }
 
-  /**
-   * {@inheritDoc}
-   *
-   * <p>Routine meter removal is deliberately not part of this signal; see {@link #resolveSupplier}
-   * for why.
-   */
+  /** {@inheritDoc} Routine meter removal is deliberately not part of this signal. */
   @Override public boolean hasExpired() {
     return currentVersion < versionSupplier.getAsLong() || underlying.hasExpired();
   }
@@ -157,30 +124,24 @@ public abstract class SwapMeter<T extends Meter> implements Meter {
   }
 
   /**
-   * Return the underlying instance of the meter, resolving a new one if the registry may have
-   * removed the current instance.
+   * Return the underlying meter, resolving a new one if the registry may have removed it.
    *
-   * <p>This runs on the update path of every meter operation, so it checks a counter rather than
-   * {@code underlying.hasExpired()}: the counter is a plain volatile read, whereas the expiry
-   * check costs a wall clock read on every update (for {@code AtlasMeter}, a {@code clock_gettime}
-   * to evaluate a TTL measured in minutes). This does not change which meter updates land on — a
-   * meter that is past its TTL but still registered resolves back to the same instance either
-   * way — and once cleanup actually removes the meter the counter moves, so the next call here
-   * resolves a fresh one.
+   * <p>This runs on every meter update, so it checks a counter rather than
+   * {@code underlying.hasExpired()}, which for {@code AtlasMeter} costs a wall clock read. Which
+   * meter an update lands on is unchanged: one past its TTL but still registered resolves back to
+   * the same instance either way, and once cleanup removes it the counter moves.</p>
    */
   public T get() {
     // Sampled once: re-reading for the assignment could store a value newer than what lookup()
-    // actually observed, which would then swallow a subsequent removal.
+    // observed, which would swallow a subsequent removal.
     final long resolveVersion = resolveSupplier.getAsLong();
     if (currentResolveVersion < resolveVersion) {
       currentResolveVersion = resolveVersion;
-      // Resolving also clears the registry level staleness reported by hasExpired(), since the
-      // meter being delegated to has just been looked up afresh.
+      // Resolving also clears the staleness hasExpired() reports, since the meter just came from
+      // a fresh lookup.
       currentVersion = versionSupplier.getAsLong();
       underlying = unwrap(lookup());
     } else if (resolveOnUnderlyingExpiry && underlying.hasExpired()) {
-      // Registries without a removal signal keep the original trigger, so this change is a no-op
-      // for them.
       currentVersion = versionSupplier.getAsLong();
       underlying = unwrap(lookup());
     }

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/SwapMeter.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/SwapMeter.java
@@ -55,6 +55,14 @@ public abstract class SwapMeter<T extends Meter> implements Meter {
   private final LongSupplier resolveSupplier;
   private volatile long currentResolveVersion;
 
+  /**
+   * Whether {@link #get()} should also re-resolve when the underlying meter reports that it has
+   * expired. Only set for the constructor that has no dedicated removal signal, so that callers
+   * such as {@code CompositeRegistry}, which has no notion of meter removal, keep exactly the
+   * behavior they had before that signal existed.
+   */
+  private final boolean resolveOnUnderlyingExpiry;
+
   /** Id to use when performing a lookup after expiration. */
   protected final Id id;
 
@@ -63,7 +71,8 @@ public abstract class SwapMeter<T extends Meter> implements Meter {
 
   /** Create a new instance. */
   public SwapMeter(Registry registry, LongSupplier versionSupplier, Id id, T underlying) {
-    this(registry, versionSupplier, versionSupplier, versionSupplier.getAsLong(), id, underlying);
+    this(registry, versionSupplier, versionSupplier, versionSupplier.getAsLong(), id, underlying,
+        true);
   }
 
   /**
@@ -95,11 +104,23 @@ public abstract class SwapMeter<T extends Meter> implements Meter {
       long resolveVersion,
       Id id,
       T underlying) {
+    this(registry, versionSupplier, resolveSupplier, resolveVersion, id, underlying, false);
+  }
+
+  private SwapMeter(
+      Registry registry,
+      LongSupplier versionSupplier,
+      LongSupplier resolveSupplier,
+      long resolveVersion,
+      Id id,
+      T underlying,
+      boolean resolveOnUnderlyingExpiry) {
     this.registry = registry;
     this.versionSupplier = versionSupplier;
     this.currentVersion = versionSupplier.getAsLong();
     this.resolveSupplier = resolveSupplier;
     this.currentResolveVersion = resolveVersion;
+    this.resolveOnUnderlyingExpiry = resolveOnUnderlyingExpiry;
     this.id = id;
     this.underlying = unwrap(underlying);
   }
@@ -155,6 +176,11 @@ public abstract class SwapMeter<T extends Meter> implements Meter {
       currentResolveVersion = resolveVersion;
       // Resolving also clears the registry level staleness reported by hasExpired(), since the
       // meter being delegated to has just been looked up afresh.
+      currentVersion = versionSupplier.getAsLong();
+      underlying = unwrap(lookup());
+    } else if (resolveOnUnderlyingExpiry && underlying.hasExpired()) {
+      // Registries without a removal signal keep the original trigger, so this change is a no-op
+      // for them.
       currentVersion = versionSupplier.getAsLong();
       underlying = unwrap(lookup());
     }

--- a/spectator-api/src/test/java/com/netflix/spectator/api/SwapMeterConcurrentResolveTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/SwapMeterConcurrentResolveTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.api;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Updates through a held reference must not be lost while another thread is resolving the same
+ * wrapper. The resolve version is published after the meter it describes, so a caller that sees
+ * the new version also sees the new meter; publishing it first would let that caller skip the
+ * resolve and keep writing to the instance the lookup just replaced.
+ */
+public class SwapMeterConcurrentResolveTest {
+
+  /** Counter that reports itself expired once removed, like AtlasCounter past its TTL. */
+  private static final class ExpirableCounter implements Counter {
+    private final Id id;
+    private final AtomicLong count = new AtomicLong();
+    volatile boolean expired = false;
+
+    ExpirableCounter(Id id) {
+      this.id = id;
+    }
+
+    @Override public Id id() {
+      return id;
+    }
+
+    @Override public boolean hasExpired() {
+      return expired;
+    }
+
+    @Override public Iterable<Measurement> measure() {
+      return Collections.emptyList();
+    }
+
+    @Override public void add(double amount) {
+      count.addAndGet((long) amount);
+    }
+
+    @Override public double actualCount() {
+      return count.get();
+    }
+  }
+
+  private static final class TestRegistry extends AbstractRegistry {
+    /** Set to make the next meter creation block, pinning a thread inside lookup(). */
+    final AtomicBoolean blockNextCreate = new AtomicBoolean();
+    final CountDownLatch insideLookup = new CountDownLatch(1);
+    final CountDownLatch releaseLookup = new CountDownLatch(1);
+
+    TestRegistry() {
+      super(Clock.SYSTEM);
+    }
+
+    @Override protected Counter newCounter(Id id) {
+      if (blockNextCreate.compareAndSet(true, false)) {
+        insideLookup.countDown();
+        try {
+          releaseLookup.await(30, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
+      return new ExpirableCounter(id);
+    }
+
+    @Override protected DistributionSummary newDistributionSummary(Id id) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override protected Timer newTimer(Id id) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override protected Gauge newGauge(Id id) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override protected Gauge newMaxGauge(Id id) {
+      throw new UnsupportedOperationException();
+    }
+
+    /** Remove the expired meters, as a registry cleanup pass would. */
+    void sweep() {
+      Iterator<Meter> it = iterator();
+      while (it.hasNext()) {
+        if (it.next().hasExpired()) {
+          it.remove();
+        }
+      }
+    }
+  }
+
+  /**
+   * Pins the interleaving: one thread is inside the lookup while a second updates the same
+   * wrapper.
+   */
+  @Test
+  @Timeout(60)
+  public void updateIsNotLostWhileAnotherThreadResolves() throws Exception {
+    TestRegistry registry = new TestRegistry();
+    Id id = registry.createId("test");
+
+    // A reference the user holds on to, as in `Counter c = registry.counter(id)`.
+    Counter held = registry.counter(id);
+    held.increment();
+    ExpirableCounter first = (ExpirableCounter) registry.get(id);
+    Assertions.assertEquals(1.0, first.actualCount());
+
+    first.expired = true;
+    registry.sweep();
+
+    // Thread A updates through the held reference and blocks inside lookup().
+    registry.blockNextCreate.set(true);
+    Thread a = new Thread(held::increment);
+    a.start();
+    Assertions.assertTrue(registry.insideLookup.await(30, TimeUnit.SECONDS),
+        "thread A never reached the lookup");
+
+    // Thread B updates the same held reference while A is still resolving.
+    Thread b = new Thread(held::increment);
+    b.start();
+    b.join(30_000);
+    Assertions.assertFalse(b.isAlive(), "thread B did not finish");
+
+    registry.releaseLookup.countDown();
+    a.join(30_000);
+    Assertions.assertFalse(a.isAlive(), "thread A did not finish");
+
+    Assertions.assertEquals(2.0, registry.counter(id).actualCount(),
+        "both updates should land on the registered meter; the removed one received "
+            + (first.actualCount() - 1.0));
+  }
+}

--- a/spectator-api/src/test/java/com/netflix/spectator/api/SwapMeterExpiryReportingTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/SwapMeterExpiryReportingTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2014-2025 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.api;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The registry bumps a version when it removes a meter so that held references know to resolve
+ * again. That signal must not leak into {@code hasExpired()}: callers treat a true result as
+ * licence to discard the meter ({@code PolledMeter} drops it, {@code measurements()} filters it
+ * out, {@code cleanupCachedState()} evicts it), and a {@link CompositeMeter} — which is what
+ * {@code Spectator.globalRegistry()} is — reports expired only when all of its delegates do, so a
+ * version based answer would blank out every meter in it after the first cleanup pass.
+ */
+public class SwapMeterExpiryReportingTest {
+
+  @Test
+  public void cleanupDoesNotExpireHealthyMeters() {
+    ManualClock clock = new ManualClock();
+    ExpiringRegistry registry = new ExpiringRegistry(clock);
+
+    // Counters in this registry expire as soon as the clock moves past their creation time.
+    registry.counter("idle").increment();
+    clock.setWallTime(1);
+
+    Counter active = registry.counter("active");
+    active.increment();
+    Assertions.assertFalse(active.hasExpired(), "precondition: freshly created meter is healthy");
+
+    registry.removeExpiredMeters();
+    Assertions.assertEquals(1, registry.counters().count(), "the idle meter should be gone");
+
+    Assertions.assertFalse(active.hasExpired(),
+        "cleanup of an unrelated meter must not report a healthy meter as expired");
+  }
+
+  /**
+   * The registry version has to be sampled before the meter is looked up, not after; see
+   * {@link com.netflix.spectator.impl.SwapMeter} for why. The registry is subclassed here to run
+   * a removal in exactly that window.
+   */
+  @Test
+  public void versionIsSampledBeforeTheMeterIsResolved() {
+    ManualClock clock = new ManualClock();
+
+    class RacingRegistry extends ExpiringRegistry {
+      private boolean sweepDuringLookup;
+
+      RacingRegistry() {
+        super(clock);
+      }
+
+      void armSweep() {
+        sweepDuringLookup = true;
+      }
+
+      @Override protected <T extends Meter> T getOrCreate(
+          Id id, Class<T> cls, T dflt, java.util.function.Function<Id, T> factory) {
+        T m = super.getOrCreate(id, cls, dflt, factory);
+        if (sweepDuringLookup) {
+          sweepDuringLookup = false;
+          // Simulates the cleanup pass removing this meter right after it was resolved but
+          // before the caller has finished building the wrapper around it.
+          removeExpiredMeters();
+        }
+        return m;
+      }
+    }
+
+    RacingRegistry registry = new RacingRegistry();
+    registry.counter("test").increment();
+
+    // Move past the creation time so the meter is now eligible for removal, then arrange for the
+    // sweep to happen inside the next lookup.
+    clock.setWallTime(1);
+    registry.armSweep();
+
+    Counter held = registry.counter("test");
+    Assertions.assertEquals(0, registry.counters().count(), "the sweep should have removed it");
+
+    held.increment();
+    Assertions.assertEquals(1, registry.counters().count(),
+        "the returned reference must notice the removal and re-register the meter");
+  }
+
+  @Test
+  public void cleanupDoesNotBlankOutACompositeRegistry() {
+    ManualClock clock = new ManualClock();
+    ExpiringRegistry underlying = new ExpiringRegistry(clock);
+    CompositeRegistry composite = new CompositeRegistry(clock);
+    composite.add(underlying);
+
+    composite.counter("idle").increment();
+    clock.setWallTime(1);
+
+    Counter active = composite.counter("active");
+    active.increment();
+
+    underlying.removeExpiredMeters();
+
+    Assertions.assertFalse(active.hasExpired(),
+        "a composite meter must not report expired because the sub registry ran cleanup");
+
+    // The whole point: the meter's data still has to reach the published stream, which filters
+    // on hasExpired().
+    long visible = composite.stream().filter(m -> !m.hasExpired()).count();
+    Assertions.assertTrue(visible > 0,
+        "cleanup must not filter every meter out of the composite's published stream");
+  }
+
+  /**
+   * A composite hands out wrappers keyed on its own version, which only changes when a registry is
+   * added or removed, so a sweep inside a sub registry does not invalidate them. Recovery has to
+   * come from the sub registry's own wrapper nested inside the composite meter, which is why
+   * {@code SwapMeter.unwrap} only flattens wrappers belonging to the same registry.
+   */
+  @Test
+  public void updatesThroughACompositeSurviveASubRegistrySweep() {
+    ManualClock clock = new ManualClock();
+    ExpiringRegistry underlying = new ExpiringRegistry(clock);
+    CompositeRegistry composite = new CompositeRegistry(clock);
+    composite.add(underlying);
+
+    Counter held = composite.counter("test");
+    held.increment();
+    Assertions.assertEquals(1, underlying.counters().count());
+
+    // Make the meter eligible for removal and sweep it. The composite's version is untouched.
+    clock.setWallTime(1);
+    underlying.removeExpiredMeters();
+    Assertions.assertEquals(0, underlying.counters().count(), "the sweep should have removed it");
+
+    // The update has to land on a re-registered meter rather than on the orphaned instance.
+    held.increment();
+    Assertions.assertEquals(1, underlying.counters().count(),
+        "an update through the composite reference must re-register the swept meter");
+    Assertions.assertEquals(
+        1.0,
+        underlying.counters().findFirst().orElseThrow(AssertionError::new).actualCount(),
+        1e-12,
+        "the update must be recorded on the live meter, not lost on the swept one");
+  }
+}

--- a/spectator-api/src/test/java/com/netflix/spectator/api/SwapMeterExpiryReportingTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/SwapMeterExpiryReportingTest.java
@@ -87,12 +87,12 @@ public class SwapMeterExpiryReportingTest {
   }
 
   /**
-   * The registry version has to be sampled before the meter is looked up, not after; see
+   * The removal counter has to be sampled before the meter is looked up, not after; see
    * {@link com.netflix.spectator.impl.SwapMeter} for why. The registry is subclassed here to run
    * a removal in exactly that window.
    */
   @Test
-  public void versionIsSampledBeforeTheMeterIsResolved() {
+  public void removalCounterIsSampledBeforeTheMeterIsResolved() {
     ManualClock clock = new ManualClock();
 
     class RacingRegistry extends ExpiringRegistry {
@@ -149,6 +149,8 @@ public class SwapMeterExpiryReportingTest {
     active.increment();
 
     underlying.removeExpiredMeters();
+    Assertions.assertEquals(1, underlying.counters().count(),
+        "precondition: the sweep must have removed the idle meter and kept the active one");
 
     Assertions.assertFalse(active.hasExpired(),
         "a composite meter must not report expired because the sub registry ran cleanup");

--- a/spectator-api/src/test/java/com/netflix/spectator/api/SwapMeterExpiryReportingTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/SwapMeterExpiryReportingTest.java
@@ -28,6 +28,44 @@ import org.junit.jupiter.api.Test;
  */
 public class SwapMeterExpiryReportingTest {
 
+  /**
+   * The constructor without a dedicated removal signal keeps the original trigger: it re-resolves
+   * when the underlying meter reports expired. {@code CompositeRegistry} still uses it and has no
+   * notion of meter removal, so dropping that trigger would leave its wrappers pinned to a stale
+   * delegate. Pinned here so the behavior cannot be removed silently.
+   */
+  @Test
+  public void legacyConstructorStillResolvesOnUnderlyingExpiry() {
+    ManualClock clock = new ManualClock();
+    ExpiringRegistry registry = new ExpiringRegistry(clock);
+
+    Counter first = registry.counter("test");
+    first.increment();
+
+    // Build a wrapper the way CompositeRegistry does: a constant version and no removal signal.
+    java.util.concurrent.atomic.AtomicInteger lookups =
+        new java.util.concurrent.atomic.AtomicInteger();
+    Id id = registry.createId("test");
+    com.netflix.spectator.impl.SwapMeter<Counter> swap =
+        new com.netflix.spectator.impl.SwapMeter<Counter>(registry, () -> 0L, id, first) {
+          @Override public Counter lookup() {
+            lookups.incrementAndGet();
+            return registry.counter(id);
+          }
+        };
+
+    swap.get();
+    Assertions.assertEquals(0, lookups.get(), "healthy meter must not be re-resolved");
+
+    // Move past the TTL so the underlying meter reports expired without any removal happening.
+    clock.setWallTime(1);
+    Assertions.assertTrue(first.hasExpired(), "precondition: underlying meter is expired");
+
+    swap.get();
+    Assertions.assertEquals(1, lookups.get(),
+        "the version-only constructor must still re-resolve on underlying expiry");
+  }
+
   @Test
   public void cleanupDoesNotExpireHealthyMeters() {
     ManualClock clock = new ManualClock();

--- a/spectator-reg-atlas/src/jmh/java/com/netflix/spectator/atlas/CounterIncrement.java
+++ b/spectator-reg-atlas/src/jmh/java/com/netflix/spectator/atlas/CounterIncrement.java
@@ -19,7 +19,6 @@ import com.netflix.spectator.api.Clock;
 import com.netflix.spectator.api.Counter;
 import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Timer;
-import com.netflix.spectator.impl.StepDouble;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
@@ -31,13 +30,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Measures the {@code Counter.increment()} hot path for the Atlas registry. The layers are
- * benchmarked separately so that the cost of the clock reads, the {@code rollCount} division
- * and the CAS can be attributed rather than inferred from a single aggregate number.
+ * benchmarked separately so that the cost of the {@code SwapMeter} indirection, the registry
+ * lookup and the CAS can be attributed rather than inferred from a single aggregate number.
  *
  * <p>Run the shared-counter benchmarks at {@code -t 1} and again at {@code -t N} to see whether
- * the single-field CAS in {@link StepDouble} is actually contended. {@code perThread} keeps the
- * code path identical but gives every thread its own counter, so it isolates path cost from
- * cache-line contention.</p>
+ * the single-field CAS underneath is actually contended. {@code perThread} keeps the code path
+ * identical but gives every thread its own counter, so it isolates path cost from cache-line
+ * contention.</p>
  */
 public class CounterIncrement {
 
@@ -53,24 +52,11 @@ public class CounterIncrement {
     /** The same meter with the SwapMeter layer stripped off. */
     Counter atlasCounter;
 
-    /** The step value underneath the meter. */
-    StepDouble stepDouble;
-
     /** A timer drives four step values per record, so it pays the rollCount cost four times. */
     Timer timer;
 
     /** Id used to measure the cost of resolving a meter from the registry. */
     Id lookupId;
-
-    /** Fixed timestamp so stepDouble benchmarks measure rollCount + CAS with no clock read. */
-    long now;
-
-    /**
-     * Step of 1ms with a timestamp that advances every call, so every update rolls over: the
-     * adversarial case where the cached boundary read is pure overhead on top of the division.
-     */
-    StepDouble rolling;
-    long rollingNow;
 
     @Setup
     public void setup() {
@@ -80,10 +66,6 @@ public class CounterIncrement {
       clock = registry.clock();
       swapCounter = registry.counter("test.counter");
       atlasCounter = (Counter) registry.get(registry.createId("test.counter"));
-      stepDouble = new StepDouble(0.0, Clock.SYSTEM, 5000L);
-      now = Clock.SYSTEM.wallTime();
-      rolling = new StepDouble(0.0, Clock.SYSTEM, 1L);
-      rollingNow = Clock.SYSTEM.wallTime();
       timer = registry.timer("test.timer");
       lookupId = registry.createId("test.counter");
     }
@@ -112,18 +94,6 @@ public class CounterIncrement {
   @Benchmark
   public void atlasCounter(Shared shared) {
     shared.atlasCounter.increment();
-  }
-
-  /** rollCount + CAS only, with the clock read hoisted out. */
-  @Benchmark
-  public double stepDouble(Shared shared) {
-    return shared.stepDouble.addAndGet(shared.now, 1.0);
-  }
-
-  /** Worst case for the boundary cache; see {@link Shared#rolling}. */
-  @Benchmark
-  public double rollingStepDouble(Shared shared) {
-    return shared.rolling.addAndGet(shared.rollingNow++, 1.0);
   }
 
   /** Timer record through a held reference. */

--- a/spectator-reg-atlas/src/jmh/java/com/netflix/spectator/atlas/CounterIncrement.java
+++ b/spectator-reg-atlas/src/jmh/java/com/netflix/spectator/atlas/CounterIncrement.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2014-2025 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import com.netflix.spectator.api.Clock;
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Timer;
+import com.netflix.spectator.impl.StepDouble;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Measures the {@code Counter.increment()} hot path for the Atlas registry. The layers are
+ * benchmarked separately so that the cost of the clock reads, the {@code rollCount} division
+ * and the CAS can be attributed rather than inferred from a single aggregate number.
+ *
+ * <p>Run the shared-counter benchmarks at {@code -t 1} and again at {@code -t N} to see whether
+ * the single-field CAS in {@link StepDouble} is actually contended. {@code perThread} keeps the
+ * code path identical but gives every thread its own counter, so it isolates path cost from
+ * cache-line contention.</p>
+ */
+public class CounterIncrement {
+
+  /** Shared state: one counter that every benchmark thread increments. */
+  @State(Scope.Benchmark)
+  public static class Shared {
+    AtlasRegistry registry;
+    Clock clock;
+
+    /** The counter a user would hold: a SwapCounter wrapping an AtlasCounter. */
+    Counter swapCounter;
+
+    /** The same meter with the SwapMeter layer stripped off. */
+    Counter atlasCounter;
+
+    /** The step value underneath the meter. */
+    StepDouble stepDouble;
+
+    /** A timer drives four step values per record, so it pays the rollCount cost four times. */
+    Timer timer;
+
+    /** Id used to measure the cost of resolving a meter from the registry. */
+    Id lookupId;
+
+    /** Fixed timestamp so stepDouble benchmarks measure rollCount + CAS with no clock read. */
+    long now;
+
+    /**
+     * Step of 1ms with a timestamp that advances every call, so every update rolls over: the
+     * adversarial case where the cached boundary read is pure overhead on top of the division.
+     */
+    StepDouble rolling;
+    long rollingNow;
+
+    @Setup
+    public void setup() {
+      // Not started: the publishing scheduler is irrelevant to the write path and would
+      // otherwise add background work that shows up as benchmark noise.
+      registry = new AtlasRegistry(Clock.SYSTEM, System::getProperty);
+      clock = registry.clock();
+      swapCounter = registry.counter("test.counter");
+      atlasCounter = (Counter) registry.get(registry.createId("test.counter"));
+      stepDouble = new StepDouble(0.0, Clock.SYSTEM, 5000L);
+      now = Clock.SYSTEM.wallTime();
+      rolling = new StepDouble(0.0, Clock.SYSTEM, 1L);
+      rollingNow = Clock.SYSTEM.wallTime();
+      timer = registry.timer("test.timer");
+      lookupId = registry.createId("test.counter");
+    }
+  }
+
+  /** Per-thread state: each thread gets its own counter, so the CAS is uncontended. */
+  @State(Scope.Thread)
+  public static class PerThread {
+    private static final AtomicInteger NEXT = new AtomicInteger();
+
+    Counter counter;
+
+    @Setup
+    public void setup(Shared shared) {
+      counter = shared.registry.counter("test.perThread." + NEXT.getAndIncrement());
+    }
+  }
+
+  /** The production path: increment through a held reference. */
+  @Benchmark
+  public void swapCounter(Shared shared) {
+    shared.swapCounter.increment();
+  }
+
+  /** Same path without the SwapMeter indirection and its expiry check. */
+  @Benchmark
+  public void atlasCounter(Shared shared) {
+    shared.atlasCounter.increment();
+  }
+
+  /** rollCount + CAS only, with the clock read hoisted out. */
+  @Benchmark
+  public double stepDouble(Shared shared) {
+    return shared.stepDouble.addAndGet(shared.now, 1.0);
+  }
+
+  /** Worst case for the boundary cache; see {@link Shared#rolling}. */
+  @Benchmark
+  public double rollingStepDouble(Shared shared) {
+    return shared.rolling.addAndGet(shared.rollingNow++, 1.0);
+  }
+
+  /** Timer record through a held reference. */
+  @Benchmark
+  public void timerRecord(Shared shared) {
+    shared.timer.record(42L, TimeUnit.NANOSECONDS);
+  }
+
+  /** Cost of resolving a meter from the registry, i.e. what a held reference pays on re-resolve. */
+  @Benchmark
+  public Counter lookupCost(Shared shared) {
+    return shared.registry.counter(shared.lookupId);
+  }
+
+  /** Cost of a single wall clock read, for scale. */
+  @Benchmark
+  public long wallTime(Shared shared) {
+    return shared.clock.wallTime();
+  }
+
+  /** Production path, but with no cache line sharing between threads. */
+  @Benchmark
+  public void perThread(PerThread state) {
+    state.counter.increment();
+  }
+
+  /** Per-thread batch updater feeding the shared counter, amortising the CAS over the batch. */
+  @State(Scope.Thread)
+  public static class Batched {
+    Counter.BatchUpdater updater;
+
+    @Setup
+    public void setup(Shared shared) {
+      updater = shared.swapCounter.batchUpdater(1000);
+    }
+
+    @TearDown
+    public void tearDown() throws Exception {
+      updater.close();
+    }
+  }
+
+  /** Shared counter, but updates are batched per thread. */
+  @Benchmark
+  public void batched(Batched state) {
+    state.updater.increment();
+  }
+}

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasCounterTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasCounterTest.java
@@ -118,6 +118,37 @@ public class AtlasCounterTest {
     Assertions.assertFalse(counter.hasExpired());
   }
 
+  /**
+   * Amounts that are ignored must not refresh the last modified time. That is what allows a
+   * counter that is only ever handed junk to expire and be dropped from the registry rather
+   * than being kept alive forever by calls that record nothing.
+   */
+  @Test
+  public void ignoredAmountsDoNotRefreshExpiry() {
+    long start = clock.wallTime();
+    clock.setWallTime(start + step * 2);
+    Assertions.assertTrue(counter.hasExpired());
+
+    counter.add(0.0);
+    Assertions.assertTrue(counter.hasExpired(), "add(0.0) must not refresh lastUpdated");
+
+    counter.add(-42.0);
+    Assertions.assertTrue(counter.hasExpired(), "add(negative) must not refresh lastUpdated");
+
+    counter.add(Double.NaN);
+    Assertions.assertTrue(counter.hasExpired(), "add(NaN) must not refresh lastUpdated");
+
+    counter.add(Double.POSITIVE_INFINITY);
+    Assertions.assertTrue(counter.hasExpired(), "add(+Inf) must not refresh lastUpdated");
+
+    counter.add(Double.NEGATIVE_INFINITY);
+    Assertions.assertTrue(counter.hasExpired(), "add(-Inf) must not refresh lastUpdated");
+
+    // A real amount does refresh it.
+    counter.add(1.0);
+    Assertions.assertFalse(counter.hasExpired());
+  }
+
   @Test
   public void preferStatisticFromTags() {
     Id id = Id.create("test").withTag(Statistic.percentile);

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasHeldReferenceExpiryTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasHeldReferenceExpiryTest.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2014-2025 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.ManualClock;
+import com.netflix.spectator.api.Meter;
+import com.netflix.spectator.api.Timer;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A user is expected to hold a {@code Counter} reference for the life of the process. If the
+ * meter behind it goes idle long enough to be removed by the cleanup pass, later updates through
+ * that stale reference still have to reach the registry.
+ *
+ * <p>{@code SwapMeter.get()} detects this from the registry version rather than from the TTL of
+ * the underlying meter, so that the update path does not have to read the wall clock. These tests
+ * pin that recovery down through the real Atlas registry.</p>
+ */
+public class AtlasHeldReferenceExpiryTest {
+
+  private static final long STEP = 10_000L;
+  private static final long TTL = 60_000L;
+
+  private AtlasRegistry newRegistry(ManualClock clock) {
+    // The core meter types are created with lwcStep as their step size, not step, so both are
+    // pinned to STEP here to keep the roll forward in these tests exactly one interval.
+    return new AtlasRegistry(clock, k -> {
+      switch (k) {
+        case "atlas.step":      return "PT10S";
+        case "atlas.lwc.step":  return "PT10S";
+        case "atlas.meterTTL":  return "PT1M";
+        case "atlas.enabled":   return "false";
+        default: return null;
+      }
+    });
+  }
+
+  @Test
+  public void heldCounterRecoversAfterMeterIsRemoved() {
+    ManualClock clock = new ManualClock();
+    AtlasRegistry registry = newRegistry(clock);
+
+    Counter held = registry.counter("test.counter");
+    held.increment();
+
+    Id id = registry.createId("test.counter");
+    Meter original = registry.get(id);
+    Assertions.assertNotNull(original);
+
+    // Go idle past the TTL and run the cleanup pass, which drops the meter.
+    clock.setWallTime(TTL * 2);
+    registry.removeExpiredMeters();
+    Assertions.assertNull(registry.get(id), "meter should have been removed");
+
+    // The stale reference must resolve a fresh meter and the update must land on it.
+    held.increment();
+
+    Meter resurrected = registry.get(id);
+    Assertions.assertNotNull(resurrected, "held reference must re-register the meter");
+    Assertions.assertNotSame(original, resurrected);
+    // actualCount reports the last completed interval, so roll forward to publish the update.
+    clock.setWallTime(TTL * 2 + STEP);
+    Assertions.assertEquals(1.0, ((Counter) resurrected).actualCount(), 1e-12);
+
+    // And it must keep working, rather than recovering exactly once.
+    clock.setWallTime(TTL * 4);
+    registry.removeExpiredMeters();
+    Assertions.assertNull(registry.get(id));
+    held.increment();
+    Meter second = registry.get(id);
+    Assertions.assertNotNull(second);
+    clock.setWallTime(TTL * 4 + STEP);
+    Assertions.assertEquals(1.0, ((Counter) second).actualCount(), 1e-12);
+  }
+
+  @Test
+  public void heldTimerRecoversAfterMeterIsRemoved() {
+    ManualClock clock = new ManualClock();
+    AtlasRegistry registry = newRegistry(clock);
+
+    Timer held = registry.timer("test.timer");
+    held.record(5, TimeUnit.MILLISECONDS);
+
+    Id id = registry.createId("test.timer");
+    clock.setWallTime(TTL * 2);
+    registry.removeExpiredMeters();
+    Assertions.assertNull(registry.get(id));
+
+    held.record(5, TimeUnit.MILLISECONDS);
+    Meter resurrected = registry.get(id);
+    Assertions.assertNotNull(resurrected, "held reference must re-register the meter");
+    // count reports the last completed interval, so roll forward to publish the update.
+    clock.setWallTime(TTL * 2 + STEP);
+    Assertions.assertEquals(1L, ((Timer) resurrected).count());
+  }
+
+  /**
+   * Updates through a held reference must not be silently dropped on the floor. Before the
+   * registry tracked a version, removal was noticed via the underlying TTL check; if that check
+   * is removed without a version bump the first update after removal refreshes the orphaned
+   * meter's timestamp, the reference never re-resolves, and every later update is lost.
+   */
+  @Test
+  public void updatesAfterRemovalAreNotLost() {
+    ManualClock clock = new ManualClock();
+    AtlasRegistry registry = newRegistry(clock);
+
+    Counter held = registry.counter("test.counter");
+    Id id = registry.createId("test.counter");
+
+    clock.setWallTime(TTL * 2);
+    registry.removeExpiredMeters();
+
+    // Several updates through the stale reference, all inside one step interval so they
+    // accumulate into the same bucket.
+    for (int i = 0; i < 5; ++i) {
+      held.increment();
+    }
+
+    Meter m = registry.get(id);
+    Assertions.assertNotNull(m, "held reference must re-register the meter");
+    clock.setWallTime(TTL * 2 + STEP);
+    Assertions.assertEquals(5.0, ((Counter) m).actualCount(), 1e-12,
+        "every update through the held reference must reach the registered meter");
+
+    // Repeat across another expiry cycle to confirm recovery is not a one shot.
+    clock.setWallTime(TTL * 4);
+    registry.removeExpiredMeters();
+    Assertions.assertNull(registry.get(id));
+    for (int i = 0; i < 3; ++i) {
+      held.increment();
+    }
+    Meter m2 = registry.get(id);
+    Assertions.assertNotNull(m2);
+    clock.setWallTime(TTL * 4 + STEP);
+    Assertions.assertEquals(3.0, ((Counter) m2).actualCount(), 1e-12);
+  }
+
+  /**
+   * Sweeping one meter must not make unrelated healthy meters report themselves as expired; see
+   * the class javadoc for why that signal is kept out of {@code hasExpired()}.
+   */
+  @Test
+  public void sweepingOneMeterDoesNotExpireOthers() {
+    ManualClock clock = new ManualClock();
+    AtlasRegistry registry = newRegistry(clock);
+
+    Counter idle = registry.counter("test.idle");
+    idle.increment();
+
+    // Let the idle meter age out, then keep the other one active right up to now.
+    clock.setWallTime(TTL * 2);
+    Counter active = registry.counter("test.active");
+    active.increment();
+
+    registry.removeExpiredMeters();
+    Assertions.assertNull(registry.get(registry.createId("test.idle")),
+        "the idle meter should have been swept");
+
+    Assertions.assertFalse(active.hasExpired(),
+        "an active meter must not report expired just because another meter was swept");
+
+    // And its data must still be published rather than filtered out as expired.
+    clock.setWallTime(TTL * 2 + STEP);
+    Assertions.assertTrue(
+        registry.measurements().anyMatch(m -> "test.active".equals(m.id().name())),
+        "an active meter's measurements must not be filtered out of the published stream");
+  }
+
+  /**
+   * A meter that is past its TTL but has not been swept yet must keep accumulating into the same
+   * instance, so that an actively used meter is not reset by the expiry check itself.
+   */
+  @Test
+  public void expiredButNotYetRemovedMeterKeepsSameInstance() {
+    ManualClock clock = new ManualClock();
+    AtlasRegistry registry = newRegistry(clock);
+
+    Counter held = registry.counter("test.counter");
+    held.increment();
+
+    Id id = registry.createId("test.counter");
+    Meter original = registry.get(id);
+
+    // Past the TTL, but no cleanup pass has run.
+    clock.setWallTime(TTL * 2);
+    held.increment();
+
+    Assertions.assertSame(original, registry.get(id));
+    // The update refreshed the meter, so it is no longer a candidate for removal.
+    registry.removeExpiredMeters();
+    Assertions.assertSame(original, registry.get(id));
+  }
+}

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasHeldReferenceExpiryTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasHeldReferenceExpiryTest.java
@@ -30,9 +30,9 @@ import java.util.concurrent.TimeUnit;
  * meter behind it goes idle long enough to be removed by the cleanup pass, later updates through
  * that stale reference still have to reach the registry.
  *
- * <p>{@code SwapMeter.get()} detects this from the registry version rather than from the TTL of
- * the underlying meter, so that the update path does not have to read the wall clock. These tests
- * pin that recovery down through the real Atlas registry.</p>
+ * <p>{@code SwapMeter.get()} detects this from a counter the registry bumps on removal rather than
+ * from the TTL of the underlying meter, so the update path does not have to read the wall clock.
+ * These tests pin that recovery down through the real Atlas registry.</p>
  */
 public class AtlasHeldReferenceExpiryTest {
 
@@ -128,6 +128,7 @@ public class AtlasHeldReferenceExpiryTest {
 
     clock.setWallTime(TTL * 2);
     registry.removeExpiredMeters();
+    Assertions.assertNull(registry.get(id), "precondition: the meter must actually be gone");
 
     // Several updates through the stale reference, all inside one step interval so they
     // accumulate into the same bucket.
@@ -202,6 +203,8 @@ public class AtlasHeldReferenceExpiryTest {
 
     // Past the TTL, but no cleanup pass has run.
     clock.setWallTime(TTL * 2);
+    Assertions.assertTrue(original.hasExpired(),
+        "precondition: the meter must be past its TTL, otherwise this asserts nothing");
     held.increment();
 
     Assertions.assertSame(original, registry.get(id));


### PR DESCRIPTION
## Summary

`SwapMeter.get()` runs on the update path of every meter operation and called `underlying.hasExpired()`. For `AtlasMeter` that is a wall clock read on every update, to evaluate a TTL measured in minutes.

Track meter removal in the registry with a plain counter instead, and have `get()` compare against that. `hasExpired()` itself is unchanged, so destructive callers such as `PolledMeter` still only see real expiry.

## Why removal is a separate signal from the registry version

`SwapMeter` already had a `versionSupplier` feeding `hasExpired()`. Reusing it for removal would be smaller, but it would be wrong: callers treat `hasExpired() == true` as licence to discard the meter (`PolledMeter` drops it, `measurements()` filters it out, `cleanupCachedState()` evicts it), and removal happens on every cleanup pass rather than rarely. Folding routine removals into that signal would report healthy meters as expired once per pass. `SwapMeterExpiryReportingTest.cleanupDoesNotExpireHealthyMeters` pins that down, as does `cleanupDoesNotBlankOutACompositeRegistry` — `CompositeMeter` reports expired only when all delegates do, and `Spectator.globalRegistry()` is one.

The counter is registry-global, so any one removal invalidates every outstanding wrapper rather than only the affected one. That costs each held reference one extra map lookup per cleanup pass, which runs once per step interval. `lookupCost` below is the measurable price.

## Behavior

For a meter **past its TTL but not yet swept**, the old and new triggers are equivalent rather than merely close: `lookup()` goes through `getOrCreate`, a `computeIfAbsent` that does not replace expired entries, so the old re-resolve returned the *same instance* already held. The update lands on the same object either way. `expiredButNotYetRemovedMeterKeepsSameInstance` covers this.

Once the meter is **actually swept**, the counter moves and the next call re-resolves, which is more timely than waiting for the TTL to be observed.

For registries with **no removal signal** — `CompositeRegistry`, which has no notion of meter removal and still uses the version-only constructor — the original `underlying.hasExpired()` trigger is retained, so this change is a no-op there rather than a behavior change that has to be argued from how nested wrappers survive `unwrap()`. `legacyConstructorStillResolvesOnUnderlyingExpiry` pins it; stubbing the flag to `false` makes that test fail.

The sampling order matters and is deliberate: the removal counter is read *before* the meter is resolved. Sampled afterwards, a removal racing the lookup would already be accounted for and the wrapper would stay bound to a meter that is no longer registered, silently dropping every later update. Sampling early can only cost one redundant re-resolution. `versionIsSampledBeforeTheMeterIsResolved` drives a removal in exactly that window.

No public API is added: all five `Swap*` types are package private, and `SwapMeter` is in `impl` and documented as internal.

## Test plan

- `SwapMeterExpiryReportingTest` — routine removal is not conflated with `hasExpired()`, composites are not blanked out, the sampling order is correct, and the version-only path keeps its original trigger.
- `AtlasHeldReferenceExpiryTest` — held references recover after a sweep, updates through a stale reference are not lost, sweeping one meter does not disturb others, and an expired-but-unswept meter keeps the same instance.
- `./gradlew :spectator-api:build :spectator-reg-atlas:build` passes, including checkstyle, spotbugs and the JDK 17/25/26 test tasks.

## Benchmark

`CounterIncrement`, JDK 25, 5 forks x (5 x 1s warmup + 10 x 2s measurement) = 50 measurement iterations, single threaded. Errors are 99.9% confidence intervals including fork-to-fork variance. "Before" is `main` with only the benchmark file added, so both runs measure identical call sequences.

| Benchmark | Before (ops/s) | After (ops/s) | Change | What it isolates |
|---|---:|---:|---:|---|
| `swapCounter` | 17,114,400 ± 9,886 | 30,046,585 ± 44,960 | **+75.6%** | Production path: `increment()` through a held reference |
| `perThread` | 17,118,439 ± 13,348 | 30,000,862 ± 2,547 | **+75.3%** | Same path, no cache-line sharing between threads |
| `timerRecord` | 15,528,856 ± 643,774 | 26,773,658 ± 45,057 | **+72.4%** | `Timer.record()` |
| `batched` | 298,847,938 ± 219,232 | 301,014,358 ± 37,411 | +0.7% | `BatchUpdater` amortising over 1000 updates |
| `wallTime` | 40,218,577 ± 5,317 | 40,221,270 ± 5,707 | +0.0% | Control: one wall clock read, for scale |
| `atlasCounter` | 30,036,643 ± 38,915 | 30,016,521 ± 27,493 | -0.1% | Control: same path with `SwapMeter` stripped off |
| `lookupCost` | 42,628,599 ± 82,656 | 41,239,923 ± 80,697 | **-3.3%** | Cost of re-resolving a meter from the registry |

`atlasCounter` bypasses `SwapMeter` entirely, so it should not move, and it does not — that is the negative control for this change. It is worth flagging that in the combined #1277 this benchmark gained 11.8%; all of that belonged to the `rollCount` change now in #1280, and splitting the two is what made each contribution attributable.

`perThread` tracking `swapCounter` to within 0.1% confirms the gain is per-call path cost and not contention on a shared counter.

`lookupCost` regresses 3.3%, and at these error bars that is a real effect rather than noise. It is the expected trade: constructing a wrapper now samples the removal counter as well and carries one more volatile field. It is paid once per held reference per cleanup pass, against a ~1.75x saving on every single update, but it is a regression and not worth hiding.

Retaining the original trigger for the version-only path costs nothing measurable on the hot paths: `swapCounter` +0.13%, `perThread` -0.09%, `timerRecord` -0.29%, all within noise.

