### PR TITLE
Do not store noop meters in the registry map

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/AbstractRegistry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/AbstractRegistry.java
@@ -45,6 +45,13 @@ public abstract class AbstractRegistry implements Registry, AutoCloseable {
   private final Clock clock;
   private final RegistryConfig config;
 
+  // Snapshot taken once at construction. It is checked on every lookup that misses the meter
+  // map, and once the registry is full that is every update for an unregistered id, so it must
+  // not go back to the config each time: the default RegistryConfig is backed by
+  // System.getProperty, which builds a key string and hits the global Properties table on every
+  // call. Reading settings once in the constructor is what the other registries already do.
+  private final int maxNumberOfMeters;
+
   private final ConcurrentHashMap<Id, Meter> meters;
   private final ConcurrentHashMap<Id, Object> state;
 
@@ -80,6 +87,7 @@ public abstract class AbstractRegistry implements Registry, AutoCloseable {
     this.logger = LoggerFactory.getLogger(getClass());
     this.clock = clock;
     this.config = config;
+    this.maxNumberOfMeters = config.maxNumberOfMeters();
     this.meters = new ConcurrentHashMap<>();
     this.state = new ConcurrentHashMap<>();
     this.idNormalizationCache = Cache.lfu(new NoopRegistry(), "spectator-id", 1000, 10000);
@@ -222,8 +230,13 @@ public abstract class AbstractRegistry implements Registry, AutoCloseable {
     propagate(new IllegalStateException(msg));
   }
 
-  private Meter compute(Meter m, Meter fallback) {
-    return (meters.size() >= config.maxNumberOfMeters()) ? fallback : m;
+  /**
+   * Whether the map is full and no further meters should be registered. The size is only a
+   * bound, not a lock: concurrent callers can each see room and register, so the map can end up
+   * slightly over the limit. That is the same tolerance the check has always had.
+   */
+  private boolean isFull() {
+    return meters.size() >= maxNumberOfMeters;
   }
 
   @Deprecated
@@ -274,8 +287,11 @@ public abstract class AbstractRegistry implements Registry, AutoCloseable {
    * @param cls
    *     Type of the meter.
    * @param dflt
-   *     Default value used if there is a failure during the lookup and it is not configured
-   *     to propagate.
+   *     Placeholder returned if there is a failure during the lookup and it is not configured
+   *     to propagate, or if the registry is already at
+   *     {@link RegistryConfig#maxNumberOfMeters()} and the id has no meter yet. It is returned
+   *     as-is and is never stored in the registry, so the id can still get a real meter on a
+   *     later call once there is room.
    * @param factory
    *     Function for creating a new instance of the meter type if one is not already available
    *     in the registry.
@@ -294,7 +310,21 @@ public abstract class AbstractRegistry implements Registry, AutoCloseable {
     try {
       Preconditions.checkNotNull(id, "id");
       Id normId = normalizeId(id);
-      Meter m = Utils.computeIfAbsent(meters, normId, i -> compute(factory.apply(i), dflt));
+      Meter m = meters.get(normId);
+      if (m == null) {
+        // Return the placeholder without storing it. Storing one would occupy a slot for an id
+        // that has no meter, and the placeholder types never expire, so cleanup could not
+        // reclaim it: the map would keep growing past the limit and the id would be pinned to
+        // the placeholder even once there was room again.
+        if (isFull()) {
+          return dflt;
+        }
+        final Meter tmp = factory.apply(normId);
+        m = meters.putIfAbsent(normId, tmp);
+        if (m == null) {
+          m = tmp;
+        }
+      }
       if (!cls.isAssignableFrom(m.getClass())) {
         logTypeError(normId, cls, m.getClass());
         m = dflt;

--- a/spectator-api/src/test/java/com/netflix/spectator/api/RegistryTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/RegistryTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.DoubleSummaryStatistics;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.LongSummaryStatistics;
@@ -577,6 +578,49 @@ public class RegistryTest {
     PolledMeter.update(r);
     Assertions.assertEquals(0, r.stream().count());
     Assertions.assertEquals(0, r.state().size());
+  }
+
+  @Test
+  public void placeholdersAreNotStoredOnceFull() {
+    DefaultRegistry r = newRegistry(false, 10);
+    for (int i = 0; i < 10; ++i) {
+      r.counter("test." + i).increment();
+    }
+    Assertions.assertEquals(10, r.stream().count());
+
+    // Ids past the limit get a placeholder, which must not take up a slot: the placeholder
+    // types never expire, so a stored one could never be reclaimed by a cleanup pass.
+    for (int i = 10; i < 100; ++i) {
+      r.counter("test." + i).increment();
+    }
+    Assertions.assertEquals(10, r.stream().count());
+  }
+
+  @Test
+  public void newLookupGetsRealMeterAfterSpaceFrees() {
+    DefaultRegistry r = newRegistry(false, 10);
+    for (int i = 0; i < 10; ++i) {
+      r.counter("test." + i).increment();
+    }
+
+    // Full, so this id gets a placeholder and the update is dropped.
+    r.counter("late").increment();
+    Assertions.assertNull(r.get(r.createId("late")));
+
+    // Free a slot; the id must now be able to get a real meter. Removing through the iterator
+    // is the only way to drop a live meter from the outside: the DefaultRegistry types never
+    // report hasExpired(), so removeExpiredMeters() would not reclaim anything here.
+    Iterator<Meter> it = r.iterator();
+    it.next();
+    it.remove();
+    Assertions.assertEquals(9, r.stream().count());
+
+    // This is a fresh lookup. A reference obtained while the registry was full is a separate
+    // case that is still pinned: counter(Id) wraps the placeholder using the placeholder's own
+    // id (NoopId), and the placeholder never reports hasExpired(), so the SwapMeter has nothing
+    // to re-resolve against and stays a noop for its lifetime.
+    r.counter("late").increment();
+    Assertions.assertEquals(1, r.counter("late").count());
   }
 
   @Test


### PR DESCRIPTION
When the meter limit is reached, `getOrCreate` stored the noop placeholder under the requested id. The placeholder types report `hasExpired()` as `false`, so a cleanup pass can never reclaim the entry: every new id past the limit adds a permanent entry and the map keeps growing past the bound the check exists to enforce.

Return the placeholder without storing it. Since the lookup has already done the `get`, this uses `putIfAbsent` directly rather than going back through `Utils.computeIfAbsent`, which would repeat it. A later lookup for the same id can then get a real meter once there is room.

The limit is now read once in the constructor. It is checked on every lookup that misses the map, and with the placeholder no longer cached that is every update for an unregistered id in a full registry, so going back to `System.getProperty` each time would put a global lock on the update path during the overload the bound exists to contain. This matches how `AtlasRegistry` already reads `step`, `meterTTL` and friends.

### Scope

This covers the map. A reference the caller obtained while the registry was full is a separate case and stays a noop: `counter(Id)` wraps the placeholder with the placeholder's own `NoopId`, and the placeholder never reports `hasExpired()`, so the `SwapMeter` has nothing to re-resolve against. That is the more common pattern (caching the meter in a field) and it needs changes in `SwapMeter`, so it is deliberately left out of this change.

Hitting the limit remains entirely silent — no log, no counter. This commit creates the one explicit branch where a rate-limited signal would naturally live, but adding one is a behaviour change and is not included here.

### Notes

- `compute()` had exactly one caller, so removing it changes nothing else. The inlined form is semantically identical to `Utils.computeIfAbsent`, including running the factory outside any map lock, which the reentrant test registries in the log4j appender modules rely on.
- Overshoot under concurrency is unchanged: the size check is a bound, not a lock, so racing callers can each see room. The new code is strictly better in that it no longer invokes the factory when full.
- One behaviour change worth noting: a user-supplied `RegistryConfig` that varied `maxNumberOfMeters` at runtime would now be read only at construction. Nothing in-tree does this.

### Tests

Two tests, both verified to fail on `main`:

- `placeholdersAreNotStoredOnceFull` — fill to the limit, request 90 more ids, the map stays at the limit. On `main` it grows to 100.
- `newLookupGetsRealMeterAfterSpaceFrees` — an id that got a placeholder while full gets a real meter once a slot is freed.
