### PR TITLE
Add benchmarks for the SwapMeter update and cleanup paths

### DIFF
--- a/spectator-reg-atlas/src/jmh/java/com/netflix/spectator/atlas/CleanupPassCost.java
+++ b/spectator-reg-atlas/src/jmh/java/com/netflix/spectator/atlas/CleanupPassCost.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2014-2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.ManualClock;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Measures what a cleanup pass costs the held references that survive it.
+ *
+ * <p>{@code CounterIncrement} never starts the registry and never removes a meter, so it only
+ * measures the steady state where every update takes the cheap path. The question this one asks
+ * is what a pass that removes <i>other</i> meters costs the references that survive it. A design
+ * that signals removal globally makes every outstanding {@code SwapMeter} re-resolve, so that
+ * cost scales with {@code removed x held}; one that signals it per meter should leave the
+ * survivors alone.</p>
+ *
+ * <p>Reading the three arms: {@code sweepOnly} is the pass by itself, which is O(removed + held)
+ * regardless of the design, and {@code updateHeldReferencesOnly} is the updates by themselves.
+ * Neither alone answers the question, because the pass gets more expensive with {@code removed}
+ * either way. What isolates the design is
+ * {@code sweepThenUpdateHeldReferences - sweepOnly - updateHeldReferencesOnly}: the work the
+ * updates do only because a pass ran in front of them. That difference should stay flat as
+ * {@code removed} grows, and grow with it if the signal is global.</p>
+ *
+ * <p>{@code removed} is how many meters the pass expires and {@code held} is how many references
+ * the application keeps updating across it. Note that {@code updateHeldReferencesOnly} does not
+ * depend on {@code removed}, so its four parameter combinations collapse to two distinct
+ * configurations.</p>
+ *
+ * <p>Run as single shot: the per-invocation setup builds a whole registry, and only
+ * {@code SingleShotTime} keeps that out of the measured window.</p>
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.SingleShotTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public class CleanupPassCost {
+
+  private static final long TTL = 15 * 60_000L;
+
+  /** Meters that go idle and are removed by the pass. */
+  @Param({"100", "1000"})
+  public int removed;
+
+  /** References the application holds and keeps updating across the pass. */
+  @Param({"100", "1000"})
+  public int held;
+
+  private ManualClock clock;
+  private AtlasRegistry registry;
+  private List<Counter> heldCounters;
+
+  @Setup(Level.Invocation)
+  public void setup() {
+    clock = new ManualClock();
+    registry = new AtlasRegistry(clock, System::getProperty);
+
+    // Meters that will be idle long enough to expire during the pass below.
+    for (int i = 0; i < removed; ++i) {
+      registry.counter("test.idle." + i).increment();
+    }
+
+    // Push everything created so far past the TTL.
+    clock.setWallTime(TTL + 1);
+
+    // References the application holds. Created after the clock move so they stay live.
+    heldCounters = new ArrayList<>(held);
+    for (int i = 0; i < held; ++i) {
+      Counter c = registry.counter("test.held." + i);
+      c.increment();
+      heldCounters.add(c);
+    }
+  }
+
+  /**
+   * One cleanup pass, then one update through every held reference. The updates are the part that
+   * changes: a held reference re-resolves only if the pass invalidated the meter it is holding.
+   */
+  @Benchmark
+  public void sweepThenUpdateHeldReferences(Blackhole bh) {
+    registry.removeExpiredMeters();
+    for (int i = 0; i < heldCounters.size(); ++i) {
+      heldCounters.get(i).increment();
+    }
+    bh.consume(registry);
+  }
+
+  /**
+   * The pass alone, with no updates after it. Subtracting this and {@link
+   * #updateHeldReferencesOnly} from {@link #sweepThenUpdateHeldReferences} leaves the cost the
+   * pass imposes on the survivors, which is the number the design changes.
+   */
+  @Benchmark
+  public void sweepOnly(Blackhole bh) {
+    registry.removeExpiredMeters();
+    bh.consume(registry);
+  }
+
+  /**
+   * The updates alone, with no pass in front of them.
+   */
+  @Benchmark
+  public void updateHeldReferencesOnly(Blackhole bh) {
+    for (int i = 0; i < heldCounters.size(); ++i) {
+      heldCounters.get(i).increment();
+    }
+    bh.consume(registry);
+  }
+}

--- a/spectator-reg-atlas/src/jmh/java/com/netflix/spectator/atlas/CounterIncrement.java
+++ b/spectator-reg-atlas/src/jmh/java/com/netflix/spectator/atlas/CounterIncrement.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2014-2025 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import com.netflix.spectator.api.Clock;
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Timer;
+import com.netflix.spectator.impl.StepDouble;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Measures the {@code Counter.increment()} hot path for the Atlas registry. The layers are
+ * benchmarked separately so that the cost of the clock reads, the {@code rollCount} division
+ * and the CAS can be attributed rather than inferred from a single aggregate number.
+ *
+ * <p>Run the shared-counter benchmarks at {@code -t 1} and again at {@code -t N} to see whether
+ * the single-field CAS in {@link StepDouble} is actually contended. {@code perThread} keeps the
+ * code path identical but gives every thread its own counter, so it isolates path cost from
+ * cache-line contention.</p>
+ */
+public class CounterIncrement {
+
+  /** Shared state: one counter that every benchmark thread increments. */
+  @State(Scope.Benchmark)
+  public static class Shared {
+    AtlasRegistry registry;
+    Clock clock;
+
+    /** The counter a user would hold: a SwapCounter wrapping an AtlasCounter. */
+    Counter swapCounter;
+
+    /** The same meter with the SwapMeter layer stripped off. */
+    Counter atlasCounter;
+
+    /** The step value underneath the meter. */
+    StepDouble stepDouble;
+
+    /** A timer drives four step values per record, so it pays the rollCount cost four times. */
+    Timer timer;
+
+    /** Id used to measure the cost of resolving a meter from the registry. */
+    Id lookupId;
+
+    /** Fixed timestamp so stepDouble benchmarks measure rollCount + CAS with no clock read. */
+    long now;
+
+    /**
+     * Step of 1ms with a timestamp that advances every call, so every update rolls over: the
+     * adversarial case where the cached boundary read is pure overhead on top of the division.
+     */
+    StepDouble rolling;
+    long rollingNow;
+
+    @Setup
+    public void setup() {
+      // Not started: the publishing scheduler is irrelevant to the write path and would
+      // otherwise add background work that shows up as benchmark noise.
+      registry = new AtlasRegistry(Clock.SYSTEM, System::getProperty);
+      clock = registry.clock();
+      swapCounter = registry.counter("test.counter");
+      atlasCounter = (Counter) registry.get(registry.createId("test.counter"));
+      stepDouble = new StepDouble(0.0, Clock.SYSTEM, 5000L);
+      now = Clock.SYSTEM.wallTime();
+      rolling = new StepDouble(0.0, Clock.SYSTEM, 1L);
+      rollingNow = Clock.SYSTEM.wallTime();
+      timer = registry.timer("test.timer");
+      lookupId = registry.createId("test.counter");
+    }
+  }
+
+  /** Per-thread state: each thread gets its own counter, so the CAS is uncontended. */
+  @State(Scope.Thread)
+  public static class PerThread {
+    private static final AtomicInteger NEXT = new AtomicInteger();
+
+    Counter counter;
+
+    @Setup
+    public void setup(Shared shared) {
+      counter = shared.registry.counter("test.perThread." + NEXT.getAndIncrement());
+    }
+  }
+
+  /** The production path: increment through a held reference. */
+  @Benchmark
+  public void swapCounter(Shared shared) {
+    shared.swapCounter.increment();
+  }
+
+  /** Same path without the SwapMeter indirection and its expiry check. */
+  @Benchmark
+  public void atlasCounter(Shared shared) {
+    shared.atlasCounter.increment();
+  }
+
+  /** rollCount + CAS only, with the clock read hoisted out. */
+  @Benchmark
+  public double stepDouble(Shared shared) {
+    return shared.stepDouble.addAndGet(shared.now, 1.0);
+  }
+
+  /** Worst case for the boundary cache; see {@link Shared#rolling}. */
+  @Benchmark
+  public double rollingStepDouble(Shared shared) {
+    return shared.rolling.addAndGet(shared.rollingNow++, 1.0);
+  }
+
+  /** Timer record through a held reference. */
+  @Benchmark
+  public void timerRecord(Shared shared) {
+    shared.timer.record(42L, TimeUnit.NANOSECONDS);
+  }
+
+  /** Cost of resolving a meter from the registry, i.e. what a held reference pays on re-resolve. */
+  @Benchmark
+  public Counter lookupCost(Shared shared) {
+    return shared.registry.counter(shared.lookupId);
+  }
+
+  /** Cost of a single wall clock read, for scale. */
+  @Benchmark
+  public long wallTime(Shared shared) {
+    return shared.clock.wallTime();
+  }
+
+  /** Production path, but with no cache line sharing between threads. */
+  @Benchmark
+  public void perThread(PerThread state) {
+    state.counter.increment();
+  }
+
+  /** Per-thread batch updater feeding the shared counter, amortising the CAS over the batch. */
+  @State(Scope.Thread)
+  public static class Batched {
+    Counter.BatchUpdater updater;
+
+    @Setup
+    public void setup(Shared shared) {
+      updater = shared.swapCounter.batchUpdater(1000);
+    }
+
+    @TearDown
+    public void tearDown() throws Exception {
+      updater.close();
+    }
+  }
+
+  /** Shared counter, but updates are batched per thread. */
+  @Benchmark
+  public void batched(Batched state) {
+    state.updater.increment();
+  }
+}


### PR DESCRIPTION
Benchmarks only — no production code changes. This is step 1 of breaking up #1281 into pieces that can each be validated on their own, and it lands first so every later step has a recorded starting point rather than being compared across scratch worktrees by hand.

The change to `SwapMeter`'s per-update expiry check has two sides, and neither was measurable on `main`:

**The gain.** `CounterIncrement` (extracted unchanged from #1281, authored by @michaelbraun) breaks `Counter.increment()` into layers so the wrapper's cost can be attributed rather than inferred. `BatchUpdates` already covers the same registry but has no arm that strips the `SwapMeter` layer, so it cannot show the effect.

**The cost.** `CleanupPassCost` measures what a pass that removes *other* meters costs the references that survive it. A design that signals removal globally makes every outstanding `SwapMeter` re-resolve, so this scales with `removed x held`; one that signals per meter should leave survivors alone.

### Reading CleanupPassCost

Three arms, because neither the pass nor the updates alone answer the question — the pass is `O(removed + held)` under any design, so a two-arm gap widens with `removed` even when nothing is wrong. The isolating quantity is:

```
sweepThenUpdateHeldReferences - sweepOnly - updateHeldReferencesOnly
```

the work the updates do only because a pass ran in front of them.

### Baseline on main

`CleanupPassCost`, µs/op, 2 forks x (10 warmup + 60 measurement) single-shot:

| held | removed | sweep+updates | sweepOnly | updatesOnly | residual |
| --- | --- | --- | --- | --- | --- |
| 100 | 100 | 31.9 | 24.3 | 8.8 | −1.2 |
| 100 | 1000 | 91.7 | 85.4 | 6.7 | −0.4 |
| 1000 | 100 | 122.8 | 64.6 | 54.3 | +3.9 |
| 1000 | 1000 | 153.9 | 103.7 | 53.9 | −3.7 |

The residual is flat and within noise of zero, which is the expected control: on `main` a cleanup pass costs the surviving references nothing.

`CounterIncrement`, ops/s, 2 forks x (3x1s warmup + 5x1s measurement):

| benchmark | ops/s |
| --- | --- |
| `wallTime` | 55,007,981 ± 233,593 |
| `atlasCounter` (no wrapper) | 44,727,150 ± 552,765 |
| `swapCounter` (production path) | 24,575,563 ± 754,099 |
| `lookupCost` | 33,197,941 ± 22,375,069 |

`swapCounter` at 55% of the no-wrapper ceiling is the headroom the expiry-check work is going after; `wallTime` is the read it would remove. Note `lookupCost`'s error bar — one fork JITs differently and it is not currently a number to draw conclusions from.

Single-shot mode for `CleanupPassCost` is deliberate: the per-invocation setup builds a whole registry plus up to 2000 meters, and only `SingleShotTime` keeps that out of the measured window. Run them with explicit `-wi`/`-i` (or adjust the `jmh` block) since the defaults in `build.gradle` are low for single-shot.
