### PR TITLE
Fix three CompositeRegistry bugs affecting held references and state

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/CompositeRegistry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/CompositeRegistry.java
@@ -274,7 +274,10 @@ public final class CompositeRegistry implements Registry {
   }
 
   @Override public Gauge maxGauge(Id id) {
-    return new SwapGauge(this, versionSupplier, id, newMaxGauge(id));
+    // SwapMaxGauge rather than SwapGauge: the wrapper resolves through its own lookup(), so a
+    // SwapGauge here would resolve as a plain gauge and start reporting the last value written
+    // rather than the max.
+    return new SwapMaxGauge(this, versionSupplier, id, newMaxGauge(id));
   }
 
   @Override public Meter get(Id id) {

--- a/spectator-api/src/main/java/com/netflix/spectator/api/CompositeRegistry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/CompositeRegistry.java
@@ -16,6 +16,8 @@
 package com.netflix.spectator.api;
 
 import com.netflix.spectator.api.patterns.PolledMeter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -38,6 +40,8 @@ import java.util.function.LongSupplier;
  * registry. Otherwise activity will be sent to all registries that are part of the composite.
  */
 public final class CompositeRegistry implements Registry {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(CompositeRegistry.class);
 
   private final Lock lock = new ReentrantLock();
 
@@ -119,7 +123,10 @@ public final class CompositeRegistry implements Registry {
     }
   }
 
-  /** Remove all registries from the composite. */
+  /**
+   * Remove all registries from the composite. Meter references handed out earlier will notice
+   * the change and resolve again, and the {@link #state()} map is closed and cleared.
+   */
   public void removeAll() {
     lock.lock();
     try {
@@ -130,10 +137,36 @@ public final class CompositeRegistry implements Registry {
         registries.set(new Registry[0]);
         version.incrementAndGet();
       }
-      state.clear();
     } finally {
       lock.unlock();
     }
+    // Outside the lock: closing an entry cancels its polling task and runs user supplied cleanup
+    // actions, neither of which should be able to block add() or remove() on another thread. The
+    // state map is a ConcurrentHashMap handed out directly by state(), so the lock never guarded
+    // it in the first place.
+    closeState();
+  }
+
+  /**
+   * Close any {@link AutoCloseable} values in the state map, then clear it. Dropping the entries
+   * without closing them would leave the work they track, for example the background polling
+   * tasks created by {@link PolledMeter}, running with no bookkeeping left to stop it and would
+   * skip any cleanup actions registered for it. Exceptions thrown while closing an individual
+   * entry are caught and logged so the remaining entries are still processed. This mirrors what
+   * {@link AbstractRegistry} does when it is closed.
+   */
+  private void closeState() {
+    for (Map.Entry<Id, Object> entry : state.entrySet()) {
+      Object obj = entry.getValue();
+      if (obj instanceof AutoCloseable) {
+        try {
+          ((AutoCloseable) obj).close();
+        } catch (Exception e) {
+          LOGGER.warn("exception thrown while closing registry state for [{}]", entry.getKey(), e);
+        }
+      }
+    }
+    state.clear();
   }
 
   @Override public Clock clock() {

--- a/spectator-api/src/main/java/com/netflix/spectator/api/CompositeRegistry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/CompositeRegistry.java
@@ -123,7 +123,13 @@ public final class CompositeRegistry implements Registry {
   public void removeAll() {
     lock.lock();
     try {
-      registries.set(new Registry[0]);
+      // Only a real change bumps the version, matching add() and remove(): a no-op call would
+      // otherwise report every outstanding meter as expired, which callers such as PolledMeter
+      // act on by discarding it.
+      if (registries.get().length > 0) {
+        registries.set(new Registry[0]);
+        version.incrementAndGet();
+      }
       state.clear();
     } finally {
       lock.unlock();

--- a/spectator-api/src/test/java/com/netflix/spectator/api/CompositeRegistryTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/CompositeRegistryTest.java
@@ -351,4 +351,27 @@ public class CompositeRegistryTest {
     Assertions.assertEquals(2, r1.counter("test").count());
     Assertions.assertEquals(2, r2.counter("test").count());
   }
+  @Test
+  public void heldMaxGaugeStaysAMaxGaugeAcrossRegistryChange() {
+    CompositeRegistry r = new CompositeRegistry(clock);
+    Registry r1 = new DefaultRegistry(clock);
+    Registry r2 = new DefaultRegistry(clock);
+    r.add(r1);
+
+    Gauge g = r.maxGauge("test");
+    g.set(10.0);
+    Assertions.assertEquals(10.0, r1.maxGauge("test").value(), 1e-12);
+
+    // Adding a registry makes the held reference resolve again. It has to come back as a max
+    // gauge: resolving as a plain gauge would silently change what the id reports.
+    r.add(r2);
+    g.set(1.0);
+    Assertions.assertEquals(1.0, r2.maxGauge("test").value(), 1e-12);
+
+    g.set(5.0);
+    Assertions.assertEquals(5.0, r2.maxGauge("test").value(), 1e-12);
+    g.set(2.0);
+    Assertions.assertEquals(5.0, r2.maxGauge("test").value(), 1e-12);
+  }
+
 }

--- a/spectator-api/src/test/java/com/netflix/spectator/api/CompositeRegistryTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/CompositeRegistryTest.java
@@ -351,6 +351,7 @@ public class CompositeRegistryTest {
     Assertions.assertEquals(2, r1.counter("test").count());
     Assertions.assertEquals(2, r2.counter("test").count());
   }
+
   @Test
   public void heldMaxGaugeStaysAMaxGaugeAcrossRegistryChange() {
     CompositeRegistry r = new CompositeRegistry(clock);
@@ -374,4 +375,31 @@ public class CompositeRegistryTest {
     Assertions.assertEquals(5.0, r2.maxGauge("test").value(), 1e-12);
   }
 
+  @Test
+  public void heldMeterNoticesRemoveAll() {
+    CompositeRegistry r = new CompositeRegistry(clock);
+    Registry r1 = new DefaultRegistry(clock);
+    r.add(r1);
+
+    Counter c = r.counter("test");
+    c.increment();
+    Assertions.assertEquals(1, r1.counter("test").count());
+
+    // removeAll changes the shape, so the held reference must stop reaching r1.
+    r.removeAll();
+    c.increment();
+    Assertions.assertEquals(1, r1.counter("test").count());
+  }
+
+  @Test
+  public void removeAllOnEmptyCompositeDoesNotExpireHeldMeters() {
+    CompositeRegistry r = new CompositeRegistry(clock);
+    Counter c = r.counter("test");
+    Assertions.assertFalse(c.hasExpired());
+
+    // Nothing to remove, so nothing changed: reporting the meter as expired would have callers
+    // such as PolledMeter discard it for no reason.
+    r.removeAll();
+    Assertions.assertFalse(c.hasExpired());
+  }
 }

--- a/spectator-api/src/test/java/com/netflix/spectator/api/CompositeRegistryTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/CompositeRegistryTest.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class CompositeRegistryTest {
 
@@ -397,9 +398,25 @@ public class CompositeRegistryTest {
     Counter c = r.counter("test");
     Assertions.assertFalse(c.hasExpired());
 
-    // Nothing to remove, so nothing changed: reporting the meter as expired would have callers
-    // such as PolledMeter discard it for no reason.
+    // No shape change, so the version does not move and the meter is not reported as expired,
+    // which callers such as PolledMeter act on by discarding it. The state map is still closed
+    // and cleared either way.
     r.removeAll();
     Assertions.assertFalse(c.hasExpired());
+  }
+
+  @Test
+  public void removeAllClosesState() {
+    CompositeRegistry r = new CompositeRegistry(clock);
+    r.add(new DefaultRegistry(clock));
+
+    AtomicBoolean closed = new AtomicBoolean();
+    PolledMeter.monitorResource(r, () -> closed.set(true));
+
+    // Clearing the state map without closing the entries first would leave the work they track
+    // running with no bookkeeping left to stop it.
+    r.removeAll();
+    Assertions.assertTrue(closed.get());
+    Assertions.assertTrue(r.state().isEmpty());
   }
 }


### PR DESCRIPTION
Three independent pre-existing bugs in `CompositeRegistry`, one commit each for bisect. Step 3 of breaking up #1281; none of them depends on that work.

### Max gauges resolve as plain gauges

`maxGauge()` handed out a `SwapGauge`, whose `lookup()` calls `registry.gauge(id)`. The wrapper resolves again whenever the composite's shape changes, so after the first `add()` or `remove()` a held max gauge came back as a plain gauge and reported the last value written rather than the max — the same id silently changing what it means. `SwapMaxGauge` already exists for exactly this and resolves through `maxGauge(id)`.

### removeAll left held references pointed at dropped registries

`removeAll()` replaced the shape with an empty one without bumping the version, unlike `add()` and `remove()`. Meters handed out earlier never noticed and kept writing to the sub-registries that had been removed.

The bump is conditional on there being something to remove. An unconditional one would make a no-op `removeAll()` on an already-empty composite report every outstanding meter as expired, which callers such as `PolledMeter` act on by discarding the meter.

### removeAll dropped state without closing it

`removeAll()` cleared the `state()` map with a bare `clear()`, never closing the `AutoCloseable` values. The work those entries track — notably the background polling tasks `PolledMeter` registers — kept running with no bookkeeping left to stop it, and registered cleanup actions never ran. `AbstractRegistry` already closes before dropping when it is closed; the composite was the one place that did not.

The close runs outside the lock, since it cancels polling tasks and runs user-supplied cleanup actions, neither of which should be able to block `add()`/`remove()` on another thread. The map is a `ConcurrentHashMap` handed out directly by `state()`, so the lock never guarded it.

### Tests

- `heldMaxGaugeStaysAMaxGaugeAcrossRegistryChange` — fails on `main`
- `heldMeterNoticesRemoveAll` — fails on `main`
- `removeAllClosesState` — fails on `main`
- `removeAllOnEmptyCompositeDoesNotExpireHeldMeters` — passes on `main` by accident, since `removeAll()` never bumps there at all. It guards the conditional above; the naive unconditional fix fails it.

### Known residual, not fixed here

Two related holes in the same "an id keeps meaning what it meant" invariant are left alone deliberately, as both are scope growth on a bisect-friendly bugfix PR:

- `get(Id)` resolves any gauge through `gauge(id)`, so iterating the composite can still create a plain gauge in a sub-registry for an id that is a max gauge elsewhere. Fixing it needs an API that distinguishes the two.
- `newMaxGauge()` over multiple sub-registries builds a `CompositeGauge`, whose `value()` returns only the first sub-gauge rather than the max across them. Fixing it needs a `CompositeMaxGauge`.