### PR TITLE
Tell meters when the registry removes them

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/AbstractRegistry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/AbstractRegistry.java
@@ -19,6 +19,7 @@ import com.netflix.spectator.api.patterns.PolledMeter;
 import com.netflix.spectator.impl.Cache;
 import com.netflix.spectator.impl.Config;
 import com.netflix.spectator.impl.Preconditions;
+import com.netflix.spectator.impl.RemovableMeter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -346,7 +347,50 @@ public abstract class AbstractRegistry implements Registry, AutoCloseable {
   }
 
   @Override public final Iterator<Meter> iterator() {
-    return meters.values().iterator();
+    return new MarkingIterator(meters.values().iterator());
+  }
+
+  /**
+   * Iterator that tells a meter it has been removed, for the meter types that support it.
+   * Removal goes through here no matter who performs it: sub-classes such as
+   * {@code AtlasRegistry} run their own cleanup pass on top of {@link #iterator()}, so doing it
+   * here rather than in each caller keeps the mark and the removal together.
+   *
+   * <p>Iterates the values, so there is nothing to allocate per meter, and delegates the removal
+   * itself unchanged. The mark is the only thing added.</p>
+   */
+  private static final class MarkingIterator implements Iterator<Meter> {
+
+    private final Iterator<Meter> delegate;
+    private Meter current;
+
+    MarkingIterator(Iterator<Meter> delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override public boolean hasNext() {
+      return delegate.hasNext();
+    }
+
+    @Override public Meter next() {
+      current = delegate.next();
+      return current;
+    }
+
+    @Override public void remove() {
+      // Delegated first, so the entry is gone before the meter is told: nothing can see the mark
+      // and still find the meter registered. The delegate also keeps the IllegalStateException
+      // behaviour for remove() before next() or a repeated remove().
+      delegate.remove();
+      markRemoved(current);
+    }
+  }
+
+  /** Tell a meter it has been removed, if its type supports being told. */
+  private static void markRemoved(Meter m) {
+    if (m instanceof RemovableMeter) {
+      ((RemovableMeter) m).markRemoved();
+    }
   }
 
   @Override
@@ -361,7 +405,7 @@ public abstract class AbstractRegistry implements Registry, AutoCloseable {
   protected void removeExpiredMeters() {
     int total = 0;
     int expired = 0;
-    Iterator<Meter> it = meters.values().iterator();
+    Iterator<Meter> it = iterator();
     while (it.hasNext()) {
       ++total;
       Meter m = it.next();
@@ -435,6 +479,12 @@ public abstract class AbstractRegistry implements Registry, AutoCloseable {
       }
     }
     state.clear();
+    // Tell the meters they are gone before dropping them. A meter registered after this loop has
+    // passed its bin is cleared without being marked; the map's iterator is weakly consistent, so
+    // closing concurrently with registration cannot be made exact here.
+    for (Meter m : meters.values()) {
+      markRemoved(m);
+    }
     meters.clear();
   }
 }

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/RemovableMeter.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/RemovableMeter.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2014-2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.impl;
+
+import com.netflix.spectator.api.Meter;
+
+/**
+ * Meter that can be told when the registry has removed it, so that code holding a reference can
+ * find out cheaply. The registry marks the meter as part of the removal, which is off the update
+ * path, leaving the read to be a plain field access.
+ *
+ * <p>The alternative signal is {@code hasExpired()}, which for a meter with a TTL means reading
+ * the wall clock. That is fine on a cleanup pass and expensive on a path that runs for every
+ * update.</p>
+ *
+ * <p>Implementing this is optional. {@code AbstractRegistry} marks the meters it removes when
+ * they support it and leaves the rest alone, so a registry can adopt it independently.</p>
+ *
+ * <p><b>This class is an internal implementation detail only intended for use within
+ * spectator. It is subject to change without notice.</b></p>
+ */
+public interface RemovableMeter extends Meter {
+
+  /**
+   * Whether the registry has removed this meter. Treat it as a hint that the meter should be
+   * looked up again rather than as proof it is gone: nothing stops a registry from handing the
+   * same instance back out, and a marked meter that is still reachable is wasteful but not
+   * wrong.
+   */
+  boolean isRemoved();
+
+  /**
+   * Record that the registry has removed this meter. Called after the entry is gone, so anything
+   * that sees the mark can no longer find the meter registered.
+   *
+   * <p>May be called more than once for the same meter, and is not a lifecycle callback: it must
+   * stay cheap and must not release anything the meter still needs, since a reference held
+   * elsewhere can keep being updated afterwards.</p>
+   */
+  void markRemoved();
+}

--- a/spectator-api/src/test/java/com/netflix/spectator/api/RemovableMeterMarkingTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/RemovableMeterMarkingTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2014-2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.api;
+
+import com.netflix.spectator.impl.RemovableMeter;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * The registry tells a meter when it has removed it. Nothing reads the mark yet; these pin the
+ * marking itself so the reader can be added on top of behaviour that is already covered.
+ */
+public class RemovableMeterMarkingTest {
+
+  private static final class TestCounter implements Counter, RemovableMeter {
+    private final Id id;
+    private final AtomicLong count = new AtomicLong();
+    volatile boolean expired;
+    private volatile boolean removed;
+
+    TestCounter(Id id) {
+      this.id = id;
+    }
+
+    @Override public Id id() {
+      return id;
+    }
+
+    @Override public boolean hasExpired() {
+      return expired;
+    }
+
+    @Override public boolean isRemoved() {
+      return removed;
+    }
+
+    @Override public void markRemoved() {
+      removed = true;
+    }
+
+    @Override public Iterable<Measurement> measure() {
+      return Collections.emptyList();
+    }
+
+    @Override public void add(double amount) {
+      count.addAndGet((long) amount);
+    }
+
+    @Override public double actualCount() {
+      return count.get();
+    }
+  }
+
+  /** Counter that does not implement RemovableMeter, to check it is simply left alone. */
+  private static final class PlainCounter implements Counter {
+    private final Id id;
+    volatile boolean expired;
+
+    PlainCounter(Id id) {
+      this.id = id;
+    }
+
+    @Override public Id id() {
+      return id;
+    }
+
+    @Override public boolean hasExpired() {
+      return expired;
+    }
+
+    @Override public Iterable<Measurement> measure() {
+      return Collections.emptyList();
+    }
+
+    @Override public void add(double amount) {
+    }
+
+    @Override public double actualCount() {
+      return 0.0;
+    }
+  }
+
+  private static class TestRegistry extends AbstractRegistry {
+    /** When set, the next counter created is a PlainCounter rather than a TestCounter. */
+    volatile boolean plain;
+
+    TestRegistry() {
+      super(Clock.SYSTEM);
+    }
+
+    @Override protected Counter newCounter(Id id) {
+      return plain ? new PlainCounter(id) : new TestCounter(id);
+    }
+
+    @Override protected DistributionSummary newDistributionSummary(Id id) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override protected Timer newTimer(Id id) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override protected Gauge newGauge(Id id) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override protected Gauge newMaxGauge(Id id) {
+      throw new UnsupportedOperationException();
+    }
+
+    void sweep() {
+      removeExpiredMeters();
+    }
+  }
+
+  private TestCounter registered(TestRegistry r, String name) {
+    r.counter(name).increment();
+    return (TestCounter) r.get(r.createId(name));
+  }
+
+  @Test
+  public void iteratorRemoveMarks() {
+    TestRegistry r = new TestRegistry();
+    TestCounter c = registered(r, "test");
+    Assertions.assertFalse(c.isRemoved());
+
+    Iterator<Meter> it = r.iterator();
+    it.next();
+    it.remove();
+
+    Assertions.assertTrue(c.isRemoved());
+    Assertions.assertNull(r.get(c.id()));
+  }
+
+  @Test
+  public void cleanupPassMarks() {
+    TestRegistry r = new TestRegistry();
+    TestCounter kept = registered(r, "kept");
+    TestCounter dropped = registered(r, "dropped");
+    dropped.expired = true;
+
+    r.sweep();
+
+    Assertions.assertTrue(dropped.isRemoved());
+    Assertions.assertFalse(kept.isRemoved(), "a meter that survived the pass must not be marked");
+    Assertions.assertNull(r.get(dropped.id()));
+    Assertions.assertNotNull(r.get(kept.id()));
+  }
+
+  @Test
+  public void closeMarks() {
+    TestRegistry r = new TestRegistry();
+    TestCounter c = registered(r, "test");
+
+    r.close();
+
+    Assertions.assertTrue(c.isRemoved());
+    Assertions.assertNull(r.get(c.id()));
+  }
+
+  @Test
+  public void resetMarks() {
+    TestRegistry r = new TestRegistry();
+    TestCounter c = registered(r, "test");
+
+    r.reset();
+
+    Assertions.assertTrue(c.isRemoved());
+    Assertions.assertNull(r.get(c.id()));
+  }
+
+  @Test
+  public void meterThatCannotBeMarkedIsLeftAlone() {
+    TestRegistry r = new TestRegistry();
+    r.plain = true;
+    r.counter("plain").increment();
+    PlainCounter plain = (PlainCounter) r.get(r.createId("plain"));
+    r.plain = false;
+    TestCounter markable = registered(r, "markable");
+    plain.expired = true;
+    markable.expired = true;
+
+    r.sweep();
+
+    Assertions.assertNull(r.get(plain.id()), "removal must still happen for a meter it cannot mark");
+    // The unmarkable meter must not stop the rest of the pass from being marked.
+    Assertions.assertTrue(markable.isRemoved());
+    Assertions.assertNull(r.get(markable.id()));
+  }
+}


### PR DESCRIPTION
Adds `RemovableMeter`, an internal interface a meter type can implement to be told it is no longer registered, and marks the meters `AbstractRegistry` removes.

**Nothing reads the mark yet, so behaviour is unchanged.** This lands on its own so the marking is covered before anything depends on it. Step 5 of breaking up #1281.

### Why

`SwapMeter.get()` runs on every update through a reference the caller holds, and currently asks `underlying.hasExpired()`. For a meter with a TTL that is a wall clock read per update. A flag the registry sets as part of the removal — which is off the update path — gives the same answer for the price of a field read.

`Meter` is deliberately left alone. `SwapMeter` can check `instanceof RemovableMeter` directly, so the signal stays out of the public API and registries that do not implement it keep working exactly as they do now.

### What it does

Marking goes in the iterator returned by `iterator()`, because sub-classes such as `AtlasRegistry` run their own cleanup pass on top of it rather than calling `removeExpiredMeters()`. Putting it there keeps the mark and the removal together instead of relying on each caller to remember.

The iterator wraps the map's own value iterator and adds nothing but the mark:

- removal is still `delegate.remove()`, so removal semantics, `IllegalStateException` behaviour for `remove()` before `next()` or a repeated `remove()`, and the weakly-consistent contract are all unchanged
- iterating values rather than entries means nothing is allocated per meter
- the mark is set *after* the entry is gone, so nothing can see the mark and still find the meter registered

On `close()` and `reset()` the meters are marked before the map is cleared. A meter registered concurrently with that can be dropped unmarked; the weakly consistent iterator makes this unavoidable, and no reader depends on it yet.

### What it deliberately does not do

An earlier draft made removal conditional on the value (`meters.remove(m.id(), m)`) to avoid clobbering a meter another thread registers for the same id between `next()` and `remove()`. That turned out to be a regression: a subclass whose factory returns a meter reporting a different `id()` would never be reclaimed at all, since the conditional never matches. `main` handles that correctly because the map's iterator removes by the node's real key. The clobber case is pre-existing, unchanged here, and better addressed when there is a reader that cares.

### Tests

`RemovableMeterMarkingTest` covers iterator removal, a cleanup pass (including that a meter surviving the pass is *not* marked), `close()`, `reset()`, and a registry mixing markable and unmarkable meter types — the last checks both that an unmarkable meter is still removed and that it does not stop the rest of the pass from being marked.
