### PR TITLE
Mark meters after removal on close and reset

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/AbstractRegistry.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/AbstractRegistry.java
@@ -353,8 +353,9 @@ public abstract class AbstractRegistry implements Registry, AutoCloseable {
   /**
    * Iterator that tells a meter it has been removed, for the meter types that support it.
    * Removal goes through here no matter who performs it: sub-classes such as
-   * {@code AtlasRegistry} run their own cleanup pass on top of {@link #iterator()}, so doing it
-   * here rather than in each caller keeps the mark and the removal together.
+   * {@code AtlasRegistry} run their own cleanup pass on top of {@link #iterator()}, and
+   * {@code close()} and {@code reset()} drain the map through it, so doing it here rather than
+   * in each caller keeps the mark and the removal together.
    *
    * <p>Iterates the values, so there is nothing to allocate per meter, and delegates the removal
    * itself unchanged. The mark is the only thing added.</p>
@@ -382,7 +383,12 @@ public abstract class AbstractRegistry implements Registry, AutoCloseable {
       // and still find the meter registered. The delegate also keeps the IllegalStateException
       // behaviour for remove() before next() or a repeated remove().
       delegate.remove();
-      markRemoved(current);
+      Meter removed = current;
+      // Dropped before the mark so the iterator does not pin the meter it just removed. The
+      // delegate, not this field, is what enforces the IllegalStateException on a repeated
+      // remove(), so clearing it here does not weaken that check.
+      current = null;
+      markRemoved(removed);
     }
   }
 
@@ -479,12 +485,18 @@ public abstract class AbstractRegistry implements Registry, AutoCloseable {
       }
     }
     state.clear();
-    // Tell the meters they are gone before dropping them. A meter registered after this loop has
-    // passed its bin is cleared without being marked; the map's iterator is weakly consistent, so
-    // closing concurrently with registration cannot be made exact here.
-    for (Meter m : meters.values()) {
-      markRemoved(m);
+    // Drained through the marking iterator rather than marked in a pass of its own, so each
+    // meter is told only after its own entry is gone. Marking first and clearing afterwards
+    // would leave a window where a meter reports the mark while a lookup still finds it
+    // registered, which is the one thing markRemoved promises cannot happen.
+    Iterator<Meter> it = iterator();
+    while (it.hasNext()) {
+      it.next();
+      it.remove();
     }
+    // Backstop for anything the drain missed. A meter registered after the weakly consistent
+    // iterator has passed its bin is cleared without being marked; closing concurrently with
+    // registration cannot be made exact here.
     meters.clear();
   }
 }

--- a/spectator-api/src/test/java/com/netflix/spectator/api/RemovableMeterMarkingTest.java
+++ b/spectator-api/src/test/java/com/netflix/spectator/api/RemovableMeterMarkingTest.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.Iterator;
-import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * The registry tells a meter when it has removed it. Nothing reads the mark yet; these pin the
@@ -29,13 +28,16 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public class RemovableMeterMarkingTest {
 
-  private static final class TestCounter implements Counter, RemovableMeter {
+  private static class TestCounter implements Counter, RemovableMeter {
     private final Id id;
-    private final AtomicLong count = new AtomicLong();
+    private final Registry registry;
     volatile boolean expired;
     private volatile boolean removed;
+    /** Whether the registry could still find this meter at the moment it was marked. */
+    volatile boolean foundWhenMarked;
 
-    TestCounter(Id id) {
+    TestCounter(Registry registry, Id id) {
+      this.registry = registry;
       this.id = id;
     }
 
@@ -52,6 +54,9 @@ public class RemovableMeterMarkingTest {
     }
 
     @Override public void markRemoved() {
+      // The mark must only be set once the entry is gone. A reader that sees the mark and can
+      // still resolve the id lands straight back on this instance and never makes progress.
+      foundWhenMarked = registry.get(id) == this;
       removed = true;
     }
 
@@ -60,11 +65,10 @@ public class RemovableMeterMarkingTest {
     }
 
     @Override public void add(double amount) {
-      count.addAndGet((long) amount);
     }
 
     @Override public double actualCount() {
-      return count.get();
+      return 0.0;
     }
   }
 
@@ -98,15 +102,13 @@ public class RemovableMeterMarkingTest {
   }
 
   private static class TestRegistry extends AbstractRegistry {
-    /** When set, the next counter created is a PlainCounter rather than a TestCounter. */
-    volatile boolean plain;
-
     TestRegistry() {
       super(Clock.SYSTEM);
     }
 
     @Override protected Counter newCounter(Id id) {
-      return plain ? new PlainCounter(id) : new TestCounter(id);
+      // Chosen from the id so the factory does not depend on call order.
+      return id.name().startsWith("plain") ? new PlainCounter(id) : new TestCounter(this, id);
     }
 
     @Override protected DistributionSummary newDistributionSummary(Id id) {
@@ -123,10 +125,6 @@ public class RemovableMeterMarkingTest {
 
     @Override protected Gauge newMaxGauge(Id id) {
       throw new UnsupportedOperationException();
-    }
-
-    void sweep() {
-      removeExpiredMeters();
     }
   }
 
@@ -147,6 +145,7 @@ public class RemovableMeterMarkingTest {
 
     Assertions.assertTrue(c.isRemoved());
     Assertions.assertNull(r.get(c.id()));
+    Assertions.assertFalse(c.foundWhenMarked, "marked while still registered");
   }
 
   @Test
@@ -156,9 +155,10 @@ public class RemovableMeterMarkingTest {
     TestCounter dropped = registered(r, "dropped");
     dropped.expired = true;
 
-    r.sweep();
+    r.removeExpiredMeters();
 
     Assertions.assertTrue(dropped.isRemoved());
+    Assertions.assertFalse(dropped.foundWhenMarked, "marked while still registered");
     Assertions.assertFalse(kept.isRemoved(), "a meter that survived the pass must not be marked");
     Assertions.assertNull(r.get(dropped.id()));
     Assertions.assertNotNull(r.get(kept.id()));
@@ -173,6 +173,7 @@ public class RemovableMeterMarkingTest {
 
     Assertions.assertTrue(c.isRemoved());
     Assertions.assertNull(r.get(c.id()));
+    Assertions.assertFalse(c.foundWhenMarked, "marked while still registered");
   }
 
   @Test
@@ -184,24 +185,41 @@ public class RemovableMeterMarkingTest {
 
     Assertions.assertTrue(c.isRemoved());
     Assertions.assertNull(r.get(c.id()));
+    Assertions.assertFalse(c.foundWhenMarked, "marked while still registered");
   }
 
   @Test
   public void meterThatCannotBeMarkedIsLeftAlone() {
     TestRegistry r = new TestRegistry();
-    r.plain = true;
     r.counter("plain").increment();
-    PlainCounter plain = (PlainCounter) r.get(r.createId("plain"));
-    r.plain = false;
+    Meter plainMeter = r.get(r.createId("plain"));
+    Assertions.assertFalse(plainMeter instanceof RemovableMeter, "expected an unmarkable meter");
+    PlainCounter plain = (PlainCounter) plainMeter;
     TestCounter markable = registered(r, "markable");
     plain.expired = true;
     markable.expired = true;
 
-    r.sweep();
+    r.removeExpiredMeters();
 
     Assertions.assertNull(r.get(plain.id()), "removal must still happen for a meter it cannot mark");
     // The unmarkable meter must not stop the rest of the pass from being marked.
     Assertions.assertTrue(markable.isRemoved());
     Assertions.assertNull(r.get(markable.id()));
+  }
+
+  @Test
+  public void iteratorRemoveKeepsIllegalStateBehaviour() {
+    TestRegistry r = new TestRegistry();
+    registered(r, "test");
+
+    Iterator<Meter> before = r.iterator();
+    Assertions.assertThrows(IllegalStateException.class, before::remove,
+        "remove() before next()");
+
+    Iterator<Meter> twice = r.iterator();
+    twice.next();
+    twice.remove();
+    Assertions.assertThrows(IllegalStateException.class, twice::remove,
+        "repeated remove()");
   }
 }


### PR DESCRIPTION
Follow-up to #1286. Still no reader of the mark, so behaviour is unchanged; this fixes the ordering the mark depends on before anything relies on it.

### The bug

`closeState()` marked every meter and *then* cleared the map. Between the two, a meter reports itself removed while a lookup can still find it registered — the one thing `markRemoved()`'s contract says cannot happen. A reader acting on the mark would resolve the id, land straight back on the same already-marked instance, and make no progress until the clear finished.

`iterator().remove()` had it right, marking only after `delegate.remove()`. `close()` and `reset()` were the paths that did not.

### The fix

Drain through the marking iterator, so each meter is told only after its own entry is gone. The trailing `meters.clear()` stays as a backstop for anything registered after the weakly consistent iterator has passed its bin, which cannot be made exact.

An earlier draft of #1286 had this drain and I replaced it with mark-then-clear to avoid the extra pass. That was the wrong trade: close and reset are not hot paths, and the ordering is load-bearing.

### Also

`MarkingIterator` cleared the field holding the meter it last returned, which it had been pinning for the iterator's whole lifetime. `iterator()` is public, so an iterator held past a cleanup pass kept a removed meter, its `Id` and its tag set reachable. The `IllegalStateException` behaviour is unaffected — the delegate enforces that, not this field.

### Tests

The test doubles now record whether the registry could still find them at the moment `markRemoved()` ran, and every marking test asserts it could not. `closeMarks` and `resetMarks` fail on `main` with that assertion; the flag-only assertions they had before passed either way.

Added `iteratorRemoveKeepsIllegalStateBehaviour`, covering `remove()` before `next()` and a repeated `remove()` — the comment in #1286 claimed both were preserved but nothing tested it, so a defensive null guard could have turned them into silent no-ops.
