### PR TITLE
Mark Atlas meters when they are removed

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasMeter.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/AtlasMeter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2026 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,14 +18,14 @@ package com.netflix.spectator.atlas;
 import com.netflix.spectator.api.Clock;
 import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Measurement;
-import com.netflix.spectator.api.Meter;
 import com.netflix.spectator.api.Tag;
+import com.netflix.spectator.impl.RemovableMeter;
 
 import java.util.ArrayList;
 import java.util.List;
 
 /** Base class for core meter types used by AtlasRegistry. */
-abstract class AtlasMeter implements Meter {
+abstract class AtlasMeter implements RemovableMeter {
 
   /**
    * Add the new tags to the id if they are not already present. Tries to minimize the number
@@ -67,6 +67,9 @@ abstract class AtlasMeter implements Meter {
   /** Last time this meter was updated. */
   private volatile long lastUpdated;
 
+  /** Set when the registry removes this meter. */
+  private volatile boolean removed;
+
   /** Create a new instance. */
   AtlasMeter(Id id, Clock clock, long ttl) {
     this.id = id;
@@ -93,6 +96,14 @@ abstract class AtlasMeter implements Meter {
 
   boolean hasExpired(long now) {
     return now - lastUpdated > ttl;
+  }
+
+  @Override public boolean isRemoved() {
+    return removed;
+  }
+
+  @Override public void markRemoved() {
+    removed = true;
   }
 
   @Override public Iterable<Measurement> measure() {

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasMeterRemovalMarkingTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasMeterRemovalMarkingTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2014-2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import com.netflix.spectator.api.ManualClock;
+import com.netflix.spectator.api.Meter;
+import com.netflix.spectator.api.NoopRegistry;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.impl.RemovableMeter;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * The Atlas meters are told when the registry removes them, so a reference held elsewhere can
+ * find out without reading the wall clock. Nothing reads the mark yet.
+ */
+public class AtlasMeterRemovalMarkingTest {
+
+  private static final long TTL = 15 * 60_000L;
+
+  private ManualClock clock;
+  private AtlasRegistry registry;
+
+  /**
+   * Publishing off and a separate debug registry, so the registry under test holds only the
+   * meters the test creates rather than the publisher's own bookkeeping counters.
+   */
+  private AtlasConfig newConfig() {
+    Map<String, String> props = new LinkedHashMap<>();
+    props.put("atlas.enabled", "false");
+    props.put("atlas.meterTTL", Duration.ofMillis(TTL).toString());
+
+    return new AtlasConfig() {
+      @Override public String get(String k) {
+        return props.get(k);
+      }
+
+      @Override public Registry debugRegistry() {
+        return new NoopRegistry();
+      }
+    };
+  }
+
+  @BeforeEach
+  public void init() {
+    clock = new ManualClock();
+    registry = new AtlasRegistry(clock, newConfig());
+  }
+
+  /** One of every meter type the registry can hand out. */
+  private void populate() {
+    registry.counter("counter").increment();
+    registry.timer("timer").record(1, TimeUnit.NANOSECONDS);
+    registry.distributionSummary("summary").record(1);
+    registry.gauge("gauge").set(1.0);
+    registry.maxGauge("maxGauge").set(1.0);
+  }
+
+  private Meter[] snapshot() {
+    Meter[] ms = registry.stream().toArray(Meter[]::new);
+    Assertions.assertEquals(5, ms.length, "expected exactly the five meters created by populate");
+    return ms;
+  }
+
+  @Test
+  public void everyMeterTypeIsRemovable() {
+    populate();
+    Set<String> seen = new HashSet<>();
+    for (Meter m : snapshot()) {
+      Assertions.assertTrue(m instanceof RemovableMeter, m.getClass() + " is not removable");
+      Assertions.assertFalse(((RemovableMeter) m).isRemoved(), m.id() + " is marked already");
+      seen.add(m.getClass().getSimpleName());
+    }
+    // Named explicitly, so a type that stopped being an AtlasMeter is noticed rather than
+    // quietly leaving the loop with nothing to check.
+    Set<String> expected = new HashSet<>();
+    expected.add("AtlasCounter");
+    expected.add("AtlasTimer");
+    expected.add("AtlasDistributionSummary");
+    expected.add("AtlasGauge");
+    expected.add("AtlasMaxGauge");
+    Assertions.assertEquals(expected, seen);
+  }
+
+  @Test
+  public void cleanupPassMarksExpiredMeters() {
+    populate();
+    Meter[] before = snapshot();
+
+    clock.setWallTime(TTL + 1);
+    registry.removeExpiredMeters();
+
+    for (Meter m : before) {
+      Assertions.assertTrue(((RemovableMeter) m).isRemoved(),
+          m.id() + " was removed without being marked");
+      Assertions.assertNull(registry.get(m.id()), m.id() + " is still registered");
+    }
+  }
+
+  @Test
+  public void markSurvivesAClockRewind() {
+    populate();
+    Meter[] before = snapshot();
+
+    clock.setWallTime(TTL + 1);
+    registry.removeExpiredMeters();
+
+    // Wind the clock back so the TTL check no longer fires. The mark has to be independent of
+    // it, which is the whole point of the flag over hasExpired().
+    clock.setWallTime(0L);
+    for (Meter m : before) {
+      Assertions.assertFalse(m.hasExpired(), "precondition: the TTL check no longer fires");
+      Assertions.assertTrue(((RemovableMeter) m).isRemoved(),
+          m.id() + " lost its mark when the clock moved");
+    }
+  }
+
+  @Test
+  public void meterSurvivingTheCleanupPassIsNotMarked() {
+    populate();
+    clock.setWallTime(TTL + 1);
+    // Keep one meter active so the pass leaves it alone.
+    registry.counter("counter").increment();
+
+    registry.removeExpiredMeters();
+
+    Meter kept = registry.get(registry.createId("counter"));
+    Assertions.assertNotNull(kept);
+    Assertions.assertFalse(((RemovableMeter) kept).isRemoved());
+  }
+
+  @Test
+  public void closeMarks() {
+    populate();
+    Meter[] before = snapshot();
+
+    // AtlasRegistry overrides close(), so this covers the one removal path it does not inherit.
+    registry.close();
+
+    for (Meter m : before) {
+      Assertions.assertTrue(((RemovableMeter) m).isRemoved(),
+          m.id() + " was dropped by close() without being marked");
+    }
+  }
+}


### PR DESCRIPTION
`AtlasMeter` implements `RemovableMeter` (added in #1286), so the registry sets a flag on the meter as part of removing it. Nothing reads the flag yet, so behaviour is unchanged. Step 6 of breaking up #1281.

This is the registry the signal exists for. `AtlasMeter` reports expiry as `now - lastUpdated > ttl`, so asking a held reference whether its meter is still current means a wall clock read; the flag answers the same question with a field read, and is set on the cleanup pass rather than the update path.

The flag is deliberately separate from the TTL check rather than folded into it: `hasExpired()` still has to compute expiry for the publishing path, and a meter past its TTL but not yet swept is still registered.

### Cost

No footprint change. With compressed oops `AtlasMeter` is header(12) + ttl(8) + lastUpdated(8) + 2 refs(8) = 36 bytes padded to 40, so the new `boolean` lands in existing padding. It shares a cache line with `lastUpdated`, but it is written once per meter lifetime on the sweep, so there is no meaningful false sharing.

### Tests

All five fail with the change reverted:

- `everyMeterTypeIsRemovable` — asserts the exact set of concrete classes observed (`AtlasCounter`, `AtlasTimer`, `AtlasDistributionSummary`, `AtlasGauge`, `AtlasMaxGauge`), so a type dropping out of the hierarchy is noticed rather than leaving the loop with nothing to check
- `cleanupPassMarksExpiredMeters`
- `markSurvivesAClockRewind` — sweeps with the clock past the TTL, then winds it back so `hasExpired()` is false again, pinning that the mark does not derive from the TTL
- `meterSurvivingTheCleanupPassIsNotMarked`
- `closeMarks` — `AtlasRegistry` overrides `close()`, so this covers the one removal path it does not inherit

The fixture disables publishing and points `debugRegistry()` at a `NoopRegistry`, following `AtlasRegistryTest`. Without that the publisher registers four `spectator.measurements` counters into the registry under test, which was enough to satisfy a "saw at least one meter" guard and let the type assertions pass vacuously.
