### PR TITLE
Ask the meter if it was removed, not if it expired

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/impl/SwapMeter.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/SwapMeter.java
@@ -30,7 +30,7 @@ import java.util.function.LongSupplier;
  * <p><b>This class is an internal implementation detail only intended for use within
  * spectator. It is subject to change without notice.</b></p>
  */
-public abstract class SwapMeter<T extends Meter> implements Meter {
+public abstract class SwapMeter<T extends Meter> implements RemovableMeter {
 
   /** Registry used to lookup values after expiration. */
   protected final Registry registry;
@@ -71,6 +71,25 @@ public abstract class SwapMeter<T extends Meter> implements Meter {
   }
 
   /**
+   * {@inheritDoc}
+   *
+   * <p>Answers for the meter this is wrapping, so a wrapper nested inside another one, as
+   * {@code CompositeRegistry} hands out, passes the cheap flag through rather than forcing the
+   * outer wrapper onto a wall clock read. This wrapper's own version is part of the answer: a
+   * shape change means the outer wrapper has to resolve again too.</p>
+   */
+  @Override public boolean isRemoved() {
+    return isStale(underlying) || currentVersion < versionSupplier.getAsLong();
+  }
+
+  /**
+   * {@inheritDoc} A registry stores the meters it creates, never the wrappers it hands out, so
+   * nothing ever marks one of these: the answer comes from what it wraps.
+   */
+  @Override public void markRemoved() {
+  }
+
+  /**
    * Set the underlying instance of the meter to use. This can be set to {@code null}
    * to indicate that the meter has expired and is no longer in the registry.
    */
@@ -78,13 +97,38 @@ public abstract class SwapMeter<T extends Meter> implements Meter {
     underlying = unwrap(meter);
   }
 
-  /** Return the underlying instance of the meter. */
+  /**
+   * Return the underlying instance of the meter, resolving a new one if the registry no longer
+   * holds the one this is wrapping.
+   *
+   * <p>This runs on every update through a reference the caller holds, so it asks the meter
+   * whether it is still registered rather than whether it has expired. For a meter with a TTL
+   * the second question costs a wall clock read; the first is a flag the registry sets on the
+   * cleanup pass. A meter type that cannot answer it falls back to expiry, which is a safe
+   * over-approximation: one past its TTL but still registered resolves back to itself.</p>
+   */
   public T get() {
-    if (hasExpired()) {
-      currentVersion = versionSupplier.getAsLong();
-      underlying = unwrap(lookup());
+    T meter = underlying;
+    // Read once and reuse: the value stored has to be the one that was compared, otherwise a
+    // bump landing between the two reads is recorded as already seen.
+    final long version = versionSupplier.getAsLong();
+    if (isStale(meter) || currentVersion < version) {
+      currentVersion = version;
+      meter = unwrap(lookup());
+      underlying = meter;
     }
-    return underlying;
+    return meter;
+  }
+
+  /** Whether the meter has to be looked up again before it is used. */
+  private static boolean isStale(Meter meter) {
+    if (meter instanceof RemovableMeter) {
+      return ((RemovableMeter) meter).isRemoved();
+    }
+    // The null check is on this branch rather than in front of the type test so it costs
+    // nothing for a meter that can answer. A null underlying is what set() documents as the
+    // meter being gone from the registry, so it has to resolve rather than be dereferenced.
+    return meter == null || meter.hasExpired();
   }
 
   /**

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/HeldReferenceResolutionTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/HeldReferenceResolutionTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2014-2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.atlas;
+
+import com.netflix.spectator.api.Clock;
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.ManualClock;
+import com.netflix.spectator.api.Meter;
+import com.netflix.spectator.api.NoopRegistry;
+import com.netflix.spectator.api.Registry;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * What a reference the caller holds does on the update path. It has to notice that the registry
+ * removed its meter, and it has to work that out without reading the wall clock.
+ */
+public class HeldReferenceResolutionTest {
+
+  private static final long TTL = 900_000L;
+  private static final long LWC_STEP = 5_000L;
+
+  /**
+   * Clock that records how many times the time was read. Both methods count, so switching the
+   * update path from the wall clock to the monotonic one would still show up as a read rather
+   * than quietly satisfying the assertion.
+   */
+  private static final class CountingClock implements Clock {
+    private final ManualClock delegate = new ManualClock();
+    final AtomicLong reads = new AtomicLong();
+
+    @Override public long wallTime() {
+      reads.incrementAndGet();
+      return delegate.wallTime();
+    }
+
+    @Override public long monotonicTime() {
+      reads.incrementAndGet();
+      return delegate.monotonicTime();
+    }
+
+    void setWallTime(long t) {
+      delegate.setWallTime(t);
+    }
+  }
+
+  private CountingClock clock;
+  private AtlasRegistry registry;
+
+  private AtlasConfig newConfig() {
+    Map<String, String> props = new LinkedHashMap<>();
+    props.put("atlas.enabled", "false");
+    props.put("atlas.meterTTL", Duration.ofMillis(TTL).toString());
+    // Pinned rather than left to the default, because completedCount rolls the clock forward by
+    // exactly this much to read the previous interval.
+    props.put("atlas.lwc.step", Duration.ofMillis(LWC_STEP).toString());
+
+    return new AtlasConfig() {
+      @Override public String get(String k) {
+        return props.get(k);
+      }
+
+      @Override public Registry debugRegistry() {
+        return new NoopRegistry();
+      }
+    };
+  }
+
+  @BeforeEach
+  public void init() {
+    clock = new CountingClock();
+    registry = new AtlasRegistry(clock, newConfig());
+  }
+
+  /** Counters report the previous completed interval, so roll into the next one to read it. */
+  private double completedCount(Id id, long now) {
+    clock.setWallTime(now + LWC_STEP);
+    return ((Counter) registry.get(id)).actualCount();
+  }
+
+  @Test
+  public void heldCounterRecoversAfterItsMeterIsRemoved() {
+    Id id = registry.createId("test");
+    Counter held = registry.counter(id);
+    held.increment();
+    Meter first = registry.get(id);
+
+    clock.setWallTime(TTL + 1);
+    registry.removeExpiredMeters();
+    Assertions.assertNull(registry.get(id));
+
+    // The update has to land on a meter the registry reports, not on the removed instance.
+    held.increment();
+    Meter second = registry.get(id);
+    Assertions.assertNotNull(second, "the update did not register a new meter");
+    Assertions.assertNotSame(first, second);
+    Assertions.assertEquals(1.0, completedCount(id, TTL + 1), 1e-12,
+        "the update did not land on the registered meter");
+  }
+
+  @Test
+  public void updatesDoNotReadTheClockToCheckTheMeterIsCurrent() {
+    Id id = registry.createId("test");
+    Counter held = registry.counter(id);
+    held.increment();
+
+    // AtlasCounter.add() reads the clock once, to stamp the value and record activity. Checking
+    // whether the meter is still the registered one must not add a second read, which is what
+    // asking hasExpired() would cost.
+    long start = clock.reads.get();
+    for (int i = 0; i < 1000; ++i) {
+      held.increment();
+    }
+    long reads = clock.reads.get() - start;
+
+    Assertions.assertEquals(1000, reads,
+        "expected one clock read per update, for recording the value");
+  }
+
+  @Test
+  public void updatesThroughACompositeDoNotReadTheClockEither() {
+    // What Spectator.globalRegistry() hands out: a wrapper around the sub-registry's own
+    // wrapper. The outer one has to get the flag passed through, or the nesting costs a clock
+    // read per update and the cheap path never reaches the common entry point.
+    com.netflix.spectator.api.CompositeRegistry composite =
+        com.netflix.spectator.api.Spectator.globalRegistry();
+    composite.removeAll();
+    composite.add(registry);
+    try {
+      Counter held = composite.counter(composite.createId("test.composite"));
+      held.increment();
+
+      long start = clock.reads.get();
+      for (int i = 0; i < 1000; ++i) {
+        held.increment();
+      }
+      long reads = clock.reads.get() - start;
+
+      Assertions.assertEquals(1000, reads,
+          "expected one clock read per update through the composite, for recording the value");
+    } finally {
+      composite.removeAll();
+    }
+  }
+
+  @Test
+  public void resolvingAgainDoesNotDependOnTheTtl() {
+    Id id = registry.createId("test");
+    Counter held = registry.counter(id);
+    held.increment();
+
+    // Remove the meter without any time passing, so nothing is expired: only the removal itself
+    // can tell the held reference to look the meter up again.
+    Iterator<Meter> it = registry.iterator();
+    while (it.hasNext()) {
+      if (it.next().id().equals(id)) {
+        it.remove();
+        break;
+      }
+    }
+    Assertions.assertNull(registry.get(id));
+
+    held.increment();
+    Assertions.assertNotNull(registry.get(id), "held reference never noticed the removal");
+    Assertions.assertEquals(1.0, completedCount(id, 0L), 1e-12,
+        "the update did not land on the registered meter");
+  }
+}


### PR DESCRIPTION
The payoff commit of the series started in #1284. `SwapMeter.get()` runs on every update through a reference the caller holds, and it asked the underlying meter whether it had *expired* — which for a meter with a TTL is a wall clock read per update. It now asks whether the registry *removed* it, which is a flag set on the cleanup pass (#1286, #1288).

```java
public T get() {
  T meter = underlying;
  final long version = versionSupplier.getAsLong();
  if (isStale(meter) || currentVersion < version) {
    currentVersion = version;
    meter = unwrap(lookup());
    underlying = meter;
  }
  return meter;
}

private static boolean isStale(Meter meter) {
  if (meter instanceof RemovableMeter) {
    return ((RemovableMeter) meter).isRemoved();
  }
  return meter == null || meter.hasExpired();
}
```

### Results

| | main | this branch |
| --- | --- | --- |
| `CounterIncrement.swapCounter` | 24,757,271 ops/s | **43,629,240 ops/s** (+76%) |
| `atlasCounter`, same increment with the wrapper stripped off | 44,885,964 | 44,310,373 |
| clock reads per update | 2 | **1** |

The wrapper now costs about 2% of the achievable throughput, against 45% before. `CleanupPassCost`'s residual — the work updates do only because a pass ran in front of them — stays flat and within noise of zero, so nothing was moved onto the cleanup pass to pay for it.

### Registries that have not adopted the flag

The `instanceof` fallback means `DefaultRegistry`, Stateless, Servo, metrics3/5 and Sidecar behave exactly as they do on `main`. Only the Atlas meters implement `RemovableMeter` today; the rest can adopt it one at a time, and each will pick up the same win when it does. This is deliberately not an all-or-nothing switch.

### Nesting

`SwapMeter` implements `RemovableMeter` itself, answering for the meter it wraps. Without that, a wrapper nested inside another one — which is what `CompositeRegistry`, and therefore `Spectator.globalRegistry()`, hands out — falls back to the clock, and the cheap path never reaches the most common entry point. A registry stores the meters it creates and never the wrappers, so nothing ever marks one of these; `markRemoved()` is inert and the answer always comes from what it wraps.

### hasExpired is unchanged

The public `hasExpired()` still means expiry, so `PolledMeter`, `measurements()` and `cleanupCachedState()` keep acting on it as before. Routine removal is deliberately not part of that signal — callers treat expiry as licence to discard the meter.

### Tests

`HeldReferenceResolutionTest` uses a clock that counts reads, so the mechanism is pinned deterministically rather than inferred from a benchmark:

- `updatesDoNotReadTheClockToCheckTheMeterIsCurrent` — exactly 1000 reads for 1000 updates (2000 on `main`)
- `updatesThroughACompositeDoNotReadTheClockEither` — the same through `globalRegistry()`; 2000 without the nesting fix
- `resolvingAgainDoesNotDependOnTheTtl` — removes a meter with no time passing at all, so only the removal signal can trigger recovery
- `heldCounterRecoversAfterItsMeterIsRemoved` — passes on `main` too, guarding the expired case rather than demonstrating the bug

### Known, unchanged by this commit

`closeState()`'s trailing `meters.clear()` backstop drops a meter registered concurrently with `close()`/`reset()` without marking it. On `main` such a reference recovered once its TTL elapsed; with the flag as the signal it never does. The window needs the backstop to mark as it clears, which is an `AbstractRegistry` change and belongs on its own.
