### PR TITLE
Close gaps in the Atlas removal marking tests

### DIFF
--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasMeterRemovalMarkingTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasMeterRemovalMarkingTest.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.spectator.atlas;
 
+import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.ManualClock;
 import com.netflix.spectator.api.Meter;
 import com.netflix.spectator.api.NoopRegistry;
@@ -139,6 +140,7 @@ public class AtlasMeterRemovalMarkingTest {
   @Test
   public void meterSurvivingTheCleanupPassIsNotMarked() {
     populate();
+    snapshot();
     clock.setWallTime(TTL + 1);
     // Keep one meter active so the pass leaves it alone.
     registry.counter("counter").increment();
@@ -148,6 +150,30 @@ public class AtlasMeterRemovalMarkingTest {
     Meter kept = registry.get(registry.createId("counter"));
     Assertions.assertNotNull(kept);
     Assertions.assertFalse(((RemovableMeter) kept).isRemoved());
+    // The pass has to have removed the other four, otherwise the check above holds for a pass
+    // that did nothing at all.
+    Assertions.assertEquals(1L, registry.stream().count(),
+        "only the meter kept active should be left");
+  }
+
+  @Test
+  public void theReplacementForARemovedMeterIsNotMarked() {
+    populate();
+    Id counterId = registry.createId("counter");
+    Meter original = registry.get(counterId);
+
+    clock.setWallTime(TTL + 1);
+    registry.removeExpiredMeters();
+    Assertions.assertTrue(((RemovableMeter) original).isRemoved());
+
+    // A reader acting on the mark resolves the id again. The instance it lands on has to be a
+    // fresh unmarked one, otherwise it would resolve straight back onto a marked meter and never
+    // make progress.
+    registry.counter("counter").increment();
+    Meter replacement = registry.get(counterId);
+    Assertions.assertNotNull(replacement);
+    Assertions.assertNotSame(original, replacement);
+    Assertions.assertFalse(((RemovableMeter) replacement).isRemoved());
   }
 
   @Test
@@ -161,6 +187,11 @@ public class AtlasMeterRemovalMarkingTest {
     for (Meter m : before) {
       Assertions.assertTrue(((RemovableMeter) m).isRemoved(),
           m.id() + " was dropped by close() without being marked");
+      // Marked and gone, not marked and still findable. This only checks the end state: that
+      // the mark is set after the entry is removed rather than before is pinned in
+      // RemovableMeterMarkingTest, which records what the registry could find from inside
+      // markRemoved().
+      Assertions.assertNull(registry.get(m.id()), m.id() + " is still registered after close()");
     }
   }
 }


### PR DESCRIPTION
Tests only, no production change. Three of the tests added with the Atlas marking in #1288 checked less than their names suggest.

### A no-op sweep satisfied the survivor test

`meterSurvivingTheCleanupPassIsNotMarked` asserted that the meter kept active is present and unmarked — which is also exactly the state a pass that removed nothing produces. It now asserts the other four are gone. Verified: making `AtlasRegistry.removeExpiredMeters()` a no-op fails it, and did not before.

### Nothing covered the replacement for a removed meter

This is the case the reader added in #1290 depends on. `SwapMeter.get()` now resolves again when `isRemoved()` is true, so if a lookup ever returned an already-marked instance — a change that recycled removed meters, or reset the map without resetting the flag — every update would resolve forever instead of making progress, at a full `registry.counter(id)` each time. The existing tests only ever looked at meters that had been removed, never at their replacements.

`theReplacementForARemovedMeterIsNotMarked` sweeps the counter, confirms the original is marked, re-creates it, and asserts the replacement is a different unmarked instance.

### closeMarks read the flag and nothing else

It now also checks the meter is no longer registered after `close()`.

Worth being precise about what that does and does not pin: it is an end-state check. Whether the mark is set *after* the entry is removed rather than before — the invariant `markRemoved()` documents, fixed in #1287 — is only observable from inside `markRemoved()` itself, and stays pinned by `RemovableMeterMarkingTest`, which records what the registry could find at that moment. I confirmed that reverting `closeState()` to the mark-then-clear form does **not** fail this test, so the comment now points at the test that does cover it instead of implying this one does.
