### PR TITLE
Mark stateless and servo meters when removed

### DIFF
--- a/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoCounter.java
+++ b/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2026 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,19 +21,23 @@ import com.netflix.spectator.api.Counter;
 import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Measurement;
 import com.netflix.spectator.impl.AtomicDouble;
+import com.netflix.spectator.impl.RemovableMeter;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
 /** Counter implementation for the servo registry. */
-class ServoCounter implements Counter, ServoMeter {
+class ServoCounter implements Counter, ServoMeter, RemovableMeter {
 
   private final Id id;
   private final Clock clock;
   private final DoubleCounter impl;
   private final AtomicDouble count;
   private final AtomicLong lastUpdated;
+
+  /** Set when the registry removes this meter. */
+  private volatile boolean removed;
 
   /** Create a new instance. */
   ServoCounter(Id id, Clock clock, DoubleCounter impl) {
@@ -55,6 +59,14 @@ class ServoCounter implements Counter, ServoMeter {
   @Override public boolean hasExpired() {
     long now = clock.wallTime();
     return now - lastUpdated.get() > ServoRegistry.EXPIRATION_TIME_MILLIS;
+  }
+
+  @Override public boolean isRemoved() {
+    return removed;
+  }
+
+  @Override public void markRemoved() {
+    removed = true;
   }
 
   @Override public Iterable<Measurement> measure() {

--- a/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoDistributionSummary.java
+++ b/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoDistributionSummary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2026 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,13 +23,14 @@ import com.netflix.spectator.api.DistributionSummary;
 import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Measurement;
 import com.netflix.spectator.api.Statistic;
+import com.netflix.spectator.impl.RemovableMeter;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
 /** Distribution summary implementation for the servo registry. */
-class ServoDistributionSummary implements DistributionSummary, ServoMeter {
+class ServoDistributionSummary implements DistributionSummary, ServoMeter, RemovableMeter {
 
   private final Clock clock;
   private final Id id;
@@ -45,6 +46,9 @@ class ServoDistributionSummary implements DistributionSummary, ServoMeter {
   private final MaxGauge servoMax;
 
   private final AtomicLong lastUpdated;
+
+  /** Set when the registry removes this meter. */
+  private volatile boolean removed;
 
   /** Create a new instance. */
   ServoDistributionSummary(ServoRegistry r, Id id) {
@@ -76,6 +80,14 @@ class ServoDistributionSummary implements DistributionSummary, ServoMeter {
   @Override public boolean hasExpired() {
     long now = clock.wallTime();
     return now - lastUpdated.get() > ServoRegistry.EXPIRATION_TIME_MILLIS;
+  }
+
+  @Override public boolean isRemoved() {
+    return removed;
+  }
+
+  @Override public void markRemoved() {
+    removed = true;
   }
 
   @Override public void record(long amount) {

--- a/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoGauge.java
+++ b/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoGauge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2026 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import com.netflix.spectator.api.Gauge;
 import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Measurement;
 import com.netflix.spectator.impl.AtomicDouble;
+import com.netflix.spectator.impl.RemovableMeter;
 
 import java.util.Collections;
 import java.util.List;
@@ -34,12 +35,15 @@ import java.util.concurrent.atomic.AtomicLong;
  * Reports a constant value passed into the constructor.
  */
 final class ServoGauge<T extends Number> extends AbstractMonitor<Double>
-    implements Gauge, ServoMeter, NumericMonitor<Double> {
+    implements Gauge, ServoMeter, NumericMonitor<Double>, RemovableMeter {
 
   private final Id id;
   private final Clock clock;
   private final AtomicDouble value;
   private final AtomicLong lastUpdated;
+
+  /** Set when the registry removes this meter. */
+  private volatile boolean removed;
 
   /**
    * Create a new monitor that returns {@code value}.
@@ -59,6 +63,14 @@ final class ServoGauge<T extends Number> extends AbstractMonitor<Double>
   @Override public boolean hasExpired() {
     long now = clock.wallTime();
     return now - lastUpdated.get() > ServoRegistry.EXPIRATION_TIME_MILLIS;
+  }
+
+  @Override public boolean isRemoved() {
+    return removed;
+  }
+
+  @Override public void markRemoved() {
+    removed = true;
   }
 
   @Override public Iterable<Measurement> measure() {

--- a/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoMaxGauge.java
+++ b/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoMaxGauge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2026 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import com.netflix.spectator.api.Clock;
 import com.netflix.spectator.api.Gauge;
 import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.impl.RemovableMeter;
 
 import java.util.Collections;
 import java.util.List;
@@ -34,12 +35,15 @@ import java.util.concurrent.atomic.AtomicLong;
  * Reports a constant value passed into the constructor.
  */
 final class ServoMaxGauge<T extends Number> extends AbstractMonitor<Double>
-    implements Gauge, ServoMeter, NumericMonitor<Double> {
+    implements Gauge, ServoMeter, NumericMonitor<Double>, RemovableMeter {
 
   private final Id id;
   private final Clock clock;
   private final MaxGauge impl;
   private final AtomicLong lastUpdated;
+
+  /** Set when the registry removes this meter. */
+  private volatile boolean removed;
 
   /**
    * Create a new monitor that returns {@code value}.
@@ -59,6 +63,14 @@ final class ServoMaxGauge<T extends Number> extends AbstractMonitor<Double>
   @Override public boolean hasExpired() {
     long now = clock.wallTime();
     return now - lastUpdated.get() > ServoRegistry.EXPIRATION_TIME_MILLIS;
+  }
+
+  @Override public boolean isRemoved() {
+    return removed;
+  }
+
+  @Override public void markRemoved() {
+    removed = true;
   }
 
   @Override public Iterable<Measurement> measure() {

--- a/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoTimer.java
+++ b/spectator-reg-servo/src/main/java/com/netflix/spectator/servo/ServoTimer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2026 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Measurement;
 import com.netflix.spectator.api.Statistic;
 import com.netflix.spectator.api.Tag;
+import com.netflix.spectator.impl.RemovableMeter;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,7 +32,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 /** Timer implementation for the servo registry. */
-class ServoTimer extends AbstractTimer implements ServoMeter {
+class ServoTimer extends AbstractTimer implements ServoMeter, RemovableMeter {
 
   private static final double CNV_SECONDS = 1.0 / TimeUnit.SECONDS.toNanos(1L);
   private static final double CNV_SQUARES = CNV_SECONDS * CNV_SECONDS;
@@ -49,6 +50,9 @@ class ServoTimer extends AbstractTimer implements ServoMeter {
   private final MaxGauge servoMax;
 
   private final AtomicLong lastUpdated;
+
+  /** Set when the registry removes this meter. */
+  private volatile boolean removed;
 
   /** Create a new instance. */
   ServoTimer(ServoRegistry r, Id id) {
@@ -83,6 +87,14 @@ class ServoTimer extends AbstractTimer implements ServoMeter {
   @Override public boolean hasExpired() {
     long now = clock.wallTime();
     return now - lastUpdated.get() > ServoRegistry.EXPIRATION_TIME_MILLIS;
+  }
+
+  @Override public boolean isRemoved() {
+    return removed;
+  }
+
+  @Override public void markRemoved() {
+    removed = true;
   }
 
   @Override public void record(long amount, TimeUnit unit) {

--- a/spectator-reg-servo/src/test/java/com/netflix/spectator/servo/ServoRemovalMarkingTest.java
+++ b/spectator-reg-servo/src/test/java/com/netflix/spectator/servo/ServoRemovalMarkingTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2014-2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.servo;
+
+import com.netflix.spectator.api.Clock;
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.ManualClock;
+import com.netflix.spectator.api.Meter;
+import com.netflix.spectator.impl.RemovableMeter;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * The servo meters are told when the registry removes them, so a reference the caller holds
+ * finds out without reading the wall clock.
+ */
+public class ServoRemovalMarkingTest {
+
+  private static final String[] NAMES = {
+      "counter", "timer", "summary", "gauge", "maxGauge"
+  };
+
+  /** Clock that records how many times it was read. */
+  private static final class CountingClock implements Clock {
+    private final ManualClock delegate = new ManualClock();
+    final AtomicLong reads = new AtomicLong();
+
+    @Override public long wallTime() {
+      reads.incrementAndGet();
+      return delegate.wallTime();
+    }
+
+    @Override public long monotonicTime() {
+      reads.incrementAndGet();
+      return delegate.monotonicTime();
+    }
+
+    void setWallTime(long t) {
+      delegate.setWallTime(t);
+    }
+  }
+
+  private CountingClock clock;
+  private ServoRegistry registry;
+
+  @BeforeEach
+  public void init() {
+    clock = new CountingClock();
+    registry = Servo.newRegistry(clock);
+  }
+
+  private void populate() {
+    registry.counter(NAMES[0]).increment();
+    registry.timer(NAMES[1]).record(1, TimeUnit.NANOSECONDS);
+    registry.distributionSummary(NAMES[2]).record(1);
+    registry.gauge(NAMES[3]).set(1.0);
+    registry.maxGauge(NAMES[4]).set(1.0);
+  }
+
+  private Meter[] created() {
+    Meter[] ms = new Meter[NAMES.length];
+    for (int i = 0; i < NAMES.length; ++i) {
+      ms[i] = registry.get(registry.createId(NAMES[i]));
+      Assertions.assertNotNull(ms[i], NAMES[i] + " was not registered");
+    }
+    return ms;
+  }
+
+  @Test
+  public void everyMeterTypeIsRemovable() {
+    populate();
+    Set<String> seen = new HashSet<>();
+    for (Meter m : created()) {
+      Assertions.assertTrue(m instanceof RemovableMeter, m.getClass() + " is not removable");
+      Assertions.assertFalse(((RemovableMeter) m).isRemoved(), m.id() + " is marked already");
+      seen.add(m.getClass().getSimpleName());
+    }
+    Set<String> expected = new HashSet<>();
+    expected.add("ServoCounter");
+    expected.add("ServoTimer");
+    expected.add("ServoDistributionSummary");
+    expected.add("ServoGauge");
+    expected.add("ServoMaxGauge");
+    Assertions.assertEquals(expected, seen);
+  }
+
+  @Test
+  public void cleanupPassMarksExpiredMeters() {
+    populate();
+    Meter[] before = created();
+
+    clock.setWallTime(ServoRegistry.EXPIRATION_TIME_MILLIS + 1);
+    // Driven through getMonitors(), which is the only thing in this registry that runs a
+    // cleanup pass. A hand rolled loop over iterator() would only re-check the base class.
+    registry.getMonitors();
+
+    for (Meter m : before) {
+      Assertions.assertTrue(((RemovableMeter) m).isRemoved(),
+          m.id() + " was removed without being marked");
+      Assertions.assertNull(registry.get(m.id()), m.id() + " is still registered");
+    }
+  }
+
+  @Test
+  public void meterSurvivingTheCleanupPassIsNotMarked() {
+    populate();
+    clock.setWallTime(ServoRegistry.EXPIRATION_TIME_MILLIS + 1);
+    // Keep one meter active so the pass leaves it alone: the mark has to follow the removal
+    // rather than every meter the pass visits.
+    registry.counter(NAMES[0]).increment();
+
+    registry.getMonitors();
+
+    Meter kept = registry.get(registry.createId(NAMES[0]));
+    Assertions.assertNotNull(kept, NAMES[0] + " was removed while still active");
+    Assertions.assertFalse(((RemovableMeter) kept).isRemoved(),
+        NAMES[0] + " was marked without being removed");
+  }
+
+  @Test
+  public void heldReferenceRecoversWithoutTheTtl() {
+    Id id = registry.createId("test");
+    Counter held = registry.counter(id);
+    held.increment();
+    Meter first = registry.get(id);
+
+    // Remove with no time passing, so nothing is expired: only the removal itself can tell the
+    // held reference to resolve again.
+    Iterator<Meter> it = registry.iterator();
+    while (it.hasNext()) {
+      if (it.next().id().equals(id)) {
+        it.remove();
+        break;
+      }
+    }
+    Assertions.assertNull(registry.get(id));
+
+    held.increment();
+    Meter second = registry.get(id);
+    Assertions.assertNotNull(second, "held reference never noticed the removal");
+    Assertions.assertNotSame(first, second);
+    // Resolving again is only half of it: the update has to land on the meter the registry
+    // reports, not on the instance that was removed.
+    Assertions.assertEquals(1.0, ((Counter) second).actualCount(), 1e-12,
+        "the update did not land on the registered meter");
+  }
+
+  @Test
+  public void theWrapperAddsNoClockReadsOfItsOwn() {
+    Id id = registry.createId("test");
+    Counter held = registry.counter(id);
+    held.increment();
+    Counter raw = (Counter) registry.get(id);
+
+    // The raw meter is what the wrapper delegates to, so whatever the meter itself costs is the
+    // floor. Checking the wrapper's staleness must not add to it, which is what asking
+    // hasExpired() would do.
+    long start = clock.reads.get();
+    for (int i = 0; i < 1000; ++i) {
+      raw.increment();
+    }
+    long rawReads = clock.reads.get() - start;
+
+    start = clock.reads.get();
+    for (int i = 0; i < 1000; ++i) {
+      held.increment();
+    }
+    long heldReads = clock.reads.get() - start;
+
+    // Guards the comparison against passing on two zeros: if the meter stopped reading the
+    // clock the floor would be trivial and the assertion below would prove nothing.
+    Assertions.assertTrue(rawReads > 0, "the raw meter never read the clock, nothing to compare");
+    Assertions.assertEquals(rawReads, heldReads,
+        "the wrapper read the clock " + (heldReads - rawReads) + " extra times per 1000 updates");
+  }
+}

--- a/spectator-reg-stateless/src/main/java/com/netflix/spectator/stateless/StatelessMeter.java
+++ b/spectator-reg-stateless/src/main/java/com/netflix/spectator/stateless/StatelessMeter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2026 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,10 @@ package com.netflix.spectator.stateless;
 
 import com.netflix.spectator.api.Clock;
 import com.netflix.spectator.api.Id;
-import com.netflix.spectator.api.Meter;
+import com.netflix.spectator.impl.RemovableMeter;
 
 /** Base class for core meter types used by {@link StatelessRegistry}. */
-abstract class StatelessMeter implements Meter {
+abstract class StatelessMeter implements RemovableMeter {
 
   /** Base identifier for all measurements supplied by this meter. */
   protected final Id id;
@@ -33,6 +33,9 @@ abstract class StatelessMeter implements Meter {
 
   /** Last time this meter was updated. */
   private volatile long lastUpdated;
+
+  /** Set when the registry removes this meter. */
+  private volatile boolean removed;
 
   /** Create a new instance. */
   StatelessMeter(Id id, Clock clock, long ttl) {
@@ -56,5 +59,13 @@ abstract class StatelessMeter implements Meter {
 
   @Override public boolean hasExpired() {
     return clock.wallTime() - lastUpdated > ttl;
+  }
+
+  @Override public boolean isRemoved() {
+    return removed;
+  }
+
+  @Override public void markRemoved() {
+    removed = true;
   }
 }

--- a/spectator-reg-stateless/src/test/java/com/netflix/spectator/stateless/StatelessRemovalMarkingTest.java
+++ b/spectator-reg-stateless/src/test/java/com/netflix/spectator/stateless/StatelessRemovalMarkingTest.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2014-2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spectator.stateless;
+
+import com.netflix.spectator.api.Clock;
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.ManualClock;
+import com.netflix.spectator.api.Meter;
+import com.netflix.spectator.impl.RemovableMeter;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * The stateless meters are told when the registry removes them, so a reference the caller holds
+ * finds out without reading the wall clock.
+ */
+public class StatelessRemovalMarkingTest {
+
+  private static final long TTL = 900_000L;
+
+  /**
+   * One of every meter type. The registry keeps bookkeeping counters of its own, and
+   * ValidationHelper is wired to the registry itself with no way to redirect it, so the tests
+   * work from these ids rather than from everything the registry holds.
+   */
+  private static final String[] NAMES = {
+      "counter", "timer", "summary", "gauge", "maxGauge"
+  };
+
+  /** Clock that records how many times it was read. */
+  private static final class CountingClock implements Clock {
+    private final ManualClock delegate = new ManualClock();
+    final AtomicLong reads = new AtomicLong();
+
+    @Override public long wallTime() {
+      reads.incrementAndGet();
+      return delegate.wallTime();
+    }
+
+    @Override public long monotonicTime() {
+      reads.incrementAndGet();
+      return delegate.monotonicTime();
+    }
+
+    void setWallTime(long t) {
+      delegate.setWallTime(t);
+    }
+  }
+
+  private CountingClock clock;
+  private StatelessRegistry registry;
+
+  @BeforeEach
+  public void init() {
+    clock = new CountingClock();
+    Map<String, String> props = new HashMap<>();
+    props.put("stateless.enabled", "false");
+    props.put("stateless.meterTTL", Duration.ofMillis(TTL).toString());
+    registry = new StatelessRegistry(clock, props::get);
+  }
+
+  /**
+   * The cleanup pass, driven through the same iterator the registry uses for it. The registry's
+   * own entry point, collectData(), is private and posts to the aggregation service first, so
+   * this is as close as a test can get to it.
+   */
+  private void sweep() {
+    Iterator<Meter> it = registry.iterator();
+    while (it.hasNext()) {
+      if (it.next().hasExpired()) {
+        it.remove();
+      }
+    }
+  }
+
+  private void populate() {
+    registry.counter(NAMES[0]).increment();
+    registry.timer(NAMES[1]).record(1, TimeUnit.NANOSECONDS);
+    registry.distributionSummary(NAMES[2]).record(1);
+    registry.gauge(NAMES[3]).set(1.0);
+    registry.maxGauge(NAMES[4]).set(1.0);
+  }
+
+  private Meter[] created() {
+    Meter[] ms = new Meter[NAMES.length];
+    for (int i = 0; i < NAMES.length; ++i) {
+      ms[i] = registry.get(registry.createId(NAMES[i]));
+      Assertions.assertNotNull(ms[i], NAMES[i] + " was not registered");
+    }
+    return ms;
+  }
+
+  @Test
+  public void everyMeterTypeIsRemovable() {
+    populate();
+    Set<String> seen = new HashSet<>();
+    for (Meter m : created()) {
+      Assertions.assertTrue(m instanceof RemovableMeter, m.getClass() + " is not removable");
+      Assertions.assertFalse(((RemovableMeter) m).isRemoved(), m.id() + " is marked already");
+      seen.add(m.getClass().getSimpleName());
+    }
+    Set<String> expected = new HashSet<>();
+    expected.add("StatelessCounter");
+    expected.add("StatelessTimer");
+    expected.add("StatelessDistributionSummary");
+    expected.add("StatelessGauge");
+    expected.add("StatelessMaxGauge");
+    Assertions.assertEquals(expected, seen);
+  }
+
+  @Test
+  public void cleanupPassMarksExpiredMeters() {
+    populate();
+    Meter[] before = created();
+
+    clock.setWallTime(TTL + 1);
+    sweep();
+
+    for (Meter m : before) {
+      Assertions.assertTrue(((RemovableMeter) m).isRemoved(),
+          m.id() + " was removed without being marked");
+      Assertions.assertNull(registry.get(m.id()), m.id() + " is still registered");
+    }
+  }
+
+  @Test
+  public void meterSurvivingTheCleanupPassIsNotMarked() {
+    populate();
+    clock.setWallTime(TTL + 1);
+    // Keep one meter active so the pass leaves it alone: the mark has to follow the removal
+    // rather than every meter the pass visits.
+    registry.counter(NAMES[0]).increment();
+
+    sweep();
+
+    Meter kept = registry.get(registry.createId(NAMES[0]));
+    Assertions.assertNotNull(kept, NAMES[0] + " was removed while still active");
+    Assertions.assertFalse(((RemovableMeter) kept).isRemoved(),
+        NAMES[0] + " was marked without being removed");
+  }
+
+  @Test
+  public void closeMarks() {
+    populate();
+    Meter[] before = created();
+
+    // StatelessRegistry overrides close(), so this covers the one removal path it does not
+    // inherit unchanged.
+    registry.close();
+
+    for (Meter m : before) {
+      Assertions.assertTrue(((RemovableMeter) m).isRemoved(),
+          m.id() + " was dropped by close() without being marked");
+    }
+  }
+
+  @Test
+  public void heldReferenceRecoversWithoutTheTtl() {
+    Id id = registry.createId("test");
+    Counter held = registry.counter(id);
+    held.increment();
+    Meter first = registry.get(id);
+
+    // Remove with no time passing, so nothing is expired: only the removal itself can tell the
+    // held reference to resolve again.
+    Iterator<Meter> it = registry.iterator();
+    while (it.hasNext()) {
+      if (it.next().id().equals(id)) {
+        it.remove();
+        break;
+      }
+    }
+    Assertions.assertNull(registry.get(id));
+
+    held.increment();
+    Meter second = registry.get(id);
+    Assertions.assertNotNull(second, "held reference never noticed the removal");
+    Assertions.assertNotSame(first, second);
+    // Resolving again is only half of it: the update has to land on the meter the registry
+    // reports, not on the instance that was removed.
+    Assertions.assertEquals(1.0, ((Counter) second).actualCount(), 1e-12,
+        "the update did not land on the registered meter");
+  }
+
+  @Test
+  public void theWrapperAddsNoClockReadsOfItsOwn() {
+    Id id = registry.createId("test");
+    Counter held = registry.counter(id);
+    held.increment();
+    Counter raw = (Counter) registry.get(id);
+
+    // The raw meter is what the wrapper delegates to, so whatever the meter itself costs is the
+    // floor. Checking the wrapper's staleness must not add to it, which is what asking
+    // hasExpired() would do.
+    long start = clock.reads.get();
+    for (int i = 0; i < 1000; ++i) {
+      raw.increment();
+    }
+    long rawReads = clock.reads.get() - start;
+
+    start = clock.reads.get();
+    for (int i = 0; i < 1000; ++i) {
+      held.increment();
+    }
+    long heldReads = clock.reads.get() - start;
+
+    // Pinned rather than only compared, so the pair cannot agree on a floor that has itself
+    // drifted: StatelessCounter.add() reads the clock once, to record activity.
+    Assertions.assertEquals(1000, rawReads, "expected one clock read per update on the meter");
+    Assertions.assertEquals(rawReads, heldReads,
+        "the wrapper read the clock " + (heldReads - rawReads) + " extra times per 1000 updates");
+  }
+}


### PR DESCRIPTION
`StatelessMeter` and the five servo meter types implement `RemovableMeter`, so `SwapMeter.get()` reads the flag instead of falling back to `hasExpired()`.

These are the two remaining registries whose expiry check reads the wall clock, so they are the two still paying for it on every update after #1290:

| registry | `hasExpired()` | pays a clock read? |
| --- | --- | --- |
| Atlas | `now - lastUpdated > ttl` | fixed in #1288 |
| **Stateless** | `clock.wallTime() - lastUpdated > ttl` | **yes → fixed here** |
| **Servo** | `now - lastUpdated.get() > EXPIRATION_TIME_MILLIS` | **yes → fixed here** |
| Sidecar | `return false` | no |
| metrics3 / metrics5 | `return false` | no |
| `DefaultRegistry` | `return false` | no |

Servo has no shared meter base — `ServoMeter` is a functional interface for exposing monitors — so the field and two accessors are repeated across `ServoCounter`, `ServoTimer`, `ServoGauge`, `ServoMaxGauge` and `ServoDistributionSummary`. Stateless has a real base class, so it is one place.

### Why the other three are left alone

Their `hasExpired()` is a constant `false`, so the `instanceof` fallback added in #1290 costs them nothing beyond the type test — there is no clock read to remove.

The exclusion is not *purely* about cost, though. Because they are not `RemovableMeter`, `markRemoved` is a no-op for them, so `close()`/`reset()` leaves a held reference bound to an orphan forever. That is unchanged from before this series and is not a regression, but adopting the flag there would be a behaviour improvement rather than a performance one, and belongs on its own terms.

### Tests

`StatelessRemovalMarkingTest` (6) and `ServoRemovalMarkingTest` (5), all 11 failing with the production change reverted:

- every meter type is removable, asserted against the exact set of concrete classes
- a cleanup pass marks what it removes, and the meters are gone afterwards
- a meter that survives the pass is **not** marked, so "marks what it removes" is distinguished from "marks everything it visits"
- a held reference recovers from a removal with **no time passing at all**, so only the removal signal can explain it, and the update is asserted to land on the replacement rather than merely that a new meter appeared
- `close()` marking for stateless, which overrides it
- `theWrapperAddsNoClockReadsOfItsOwn`

The servo cleanup test drives `ServoRegistry.getMonitors()`, the registry's real cleanup entry point, rather than hand-rolling an iterator loop.

On the clock-read test: on servo an absolute count is the wrong assertion, because `ServoCounter.add()` reads the clock three times on its own — one per `ServoPollers.NUM_POLLERS` step bucket in `DoubleCounter.increment`, plus `lastUpdated` — and hard-coding that would break on any unrelated change to servo internals. Comparing the wrapper against the meter it delegates to pins the property that matters, that the wrapper adds nothing, and it fails on `main` where it adds exactly one read. It also asserts the measured floor is non-zero so two zeros cannot satisfy it. On stateless the raw meter reads exactly once, so that side pins the absolute count too.

Both registries keep bookkeeping counters of their own in the registry under test (`ValidationHelper` is wired to `this` with no way to redirect it), so the tests work from the ids they create rather than from everything the registry holds.
