### PR TITLE
Pass the removal flag through composite meters

### DIFF
--- a/spectator-api/src/main/java/com/netflix/spectator/api/CompositeMeter.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/api/CompositeMeter.java
@@ -15,6 +15,8 @@
  */
 package com.netflix.spectator.api;
 
+import com.netflix.spectator.impl.RemovableMeter;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -23,10 +25,13 @@ import java.util.List;
 /**
  * Base class for composite implementations of core meter types.
  */
-class CompositeMeter<T extends Meter> implements Meter {
+class CompositeMeter<T extends Meter> implements RemovableMeter {
 
   /** Identifier for the meter. */
   protected final Id id;
+
+  /** Set if the registry ever tells this composite it was removed. See {@link #markRemoved()}. */
+  private volatile boolean removed;
 
   /** Underlying meters that are keeping the data. */
   protected final Collection<T> meters;
@@ -53,6 +58,46 @@ class CompositeMeter<T extends Meter> implements Meter {
       if (m != null && !m.hasExpired()) return false;
     }
     return true;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>This is what {@link CompositeRegistry} installs underneath the wrapper it hands out once
+   * it holds more than one registry. Answering here rather than leaving {@code SwapMeter} to
+   * fall back on {@link #hasExpired()} keeps the wall clock off the update path for that shape,
+   * to the extent the members can answer without it. A member is only that cheap when its
+   * registry hands out wrappers over meters that carry the flag; one whose meter derives expiry
+   * from a clock still reads it. Since the loop stops at the first member that is not removed,
+   * which members are cheap depends on the order the registries were added.</p>
+   *
+   * <p>Mirrors {@link #hasExpired()} in only reporting when every member does. A member that was
+   * removed on its own resolves through its own wrapper, so there is nothing for the composite to
+   * rebuild until they all have.</p>
+   */
+  @Override public boolean isRemoved() {
+    if (removed) {
+      return true;
+    }
+    for (Meter m : meters) {
+      if (m instanceof RemovableMeter) {
+        if (!((RemovableMeter) m).isRemoved()) return false;
+      } else if (m != null && !m.hasExpired()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * {@inheritDoc} A composite is built for the wrapper that hands it out and is never stored in
+   * a registry, so nothing marks one today and the answer comes from the members. Recorded
+   * anyway rather than dropped: a mark that went nowhere would leave the wrapper holding this
+   * for good, because the flag is preferred over {@link #hasExpired()} and there would be no
+   * other way for the answer to change.
+   */
+  @Override public void markRemoved() {
+    removed = true;
   }
 
   @Override public Iterable<Measurement> measure() {

--- a/spectator-api/src/main/java/com/netflix/spectator/impl/SwapMeter.java
+++ b/spectator-api/src/main/java/com/netflix/spectator/impl/SwapMeter.java
@@ -67,7 +67,13 @@ public abstract class SwapMeter<T extends Meter> implements RemovableMeter {
   }
 
   @Override public boolean hasExpired() {
-    return currentVersion < versionSupplier.getAsLong() || underlying.hasExpired();
+    // Held in a local so the null check and the call are on the same value. set() documents
+    // null as the meter being gone from the registry, so it reports expired rather than being
+    // dereferenced, matching isStale().
+    final Meter meter = underlying;
+    return currentVersion < versionSupplier.getAsLong()
+        || meter == null
+        || meter.hasExpired();
   }
 
   /**
@@ -79,7 +85,10 @@ public abstract class SwapMeter<T extends Meter> implements RemovableMeter {
    * shape change means the outer wrapper has to resolve again too.</p>
    */
   @Override public boolean isRemoved() {
-    return isStale(underlying) || currentVersion < versionSupplier.getAsLong();
+    // Version first: it is a field compare, where the staleness check can walk a composite's
+    // members. If the shape moved, the wrapper is resolving anyway and the walk's answer would
+    // be discarded. Same order as hasExpired().
+    return currentVersion < versionSupplier.getAsLong() || isStale(underlying);
   }
 
   /**

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasMeterRemovalMarkingTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/AtlasMeterRemovalMarkingTest.java
@@ -33,7 +33,8 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * The Atlas meters are told when the registry removes them, so a reference held elsewhere can
- * find out without reading the wall clock. Nothing reads the mark yet.
+ * find out without reading the wall clock. This covers the marking itself; what the update path
+ * does with the mark is covered by {@link HeldReferenceResolutionTest}.
  */
 public class AtlasMeterRemovalMarkingTest {
 

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/HeldReferenceResolutionTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/HeldReferenceResolutionTest.java
@@ -16,12 +16,15 @@
 package com.netflix.spectator.atlas;
 
 import com.netflix.spectator.api.Clock;
+import com.netflix.spectator.api.CompositeRegistry;
 import com.netflix.spectator.api.Counter;
 import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.ManualClock;
 import com.netflix.spectator.api.Meter;
 import com.netflix.spectator.api.NoopRegistry;
 import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Spectator;
+import com.netflix.spectator.impl.SwapMeter;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -143,8 +146,7 @@ public class HeldReferenceResolutionTest {
     // What Spectator.globalRegistry() hands out: a wrapper around the sub-registry's own
     // wrapper. The outer one has to get the flag passed through, or the nesting costs a clock
     // read per update and the cheap path never reaches the common entry point.
-    com.netflix.spectator.api.CompositeRegistry composite =
-        com.netflix.spectator.api.Spectator.globalRegistry();
+    CompositeRegistry composite = Spectator.globalRegistry();
     composite.removeAll();
     composite.add(registry);
     try {
@@ -161,6 +163,44 @@ public class HeldReferenceResolutionTest {
           "expected one clock read per update through the composite, for recording the value");
     } finally {
       composite.removeAll();
+    }
+  }
+
+  @Test
+  public void updatesThroughAMultiRegistryCompositeDoNotReadTheClockEither() {
+    // With more than one sub-registry the composite stops handing back the sub-registry's own
+    // wrapper and installs a CompositeCounter between the wrapper and the meters. That layer has
+    // to pass the flag through as well, otherwise the shape most applications actually run is
+    // back to a wall clock read per update.
+    AtlasRegistry second = new AtlasRegistry(clock, newConfig());
+    CompositeRegistry composite = Spectator.globalRegistry();
+    composite.removeAll();
+    composite.add(registry);
+    composite.add(second);
+    try {
+      Counter held = composite.counter(composite.createId("test.composite.multi"));
+      held.increment();
+      Meter first = ((SwapMeter<?>) held).get();
+
+      long start = clock.reads.get();
+      for (int i = 0; i < 1000; ++i) {
+        held.increment();
+      }
+      long reads = clock.reads.get() - start;
+
+      // Two reads per update and no more: one for each sub-registry's counter recording the
+      // value, and nothing for working out whether the meters are still the registered ones.
+      Assertions.assertEquals(2000, reads,
+          "expected one clock read per sub-registry update and none for the staleness check");
+
+      // The read count alone does not pin this: re-resolving costs no clock reads, because the
+      // lookup finds the existing meters. So also check the composite was not rebuilt, which is
+      // what a staleness answer of "removed" would cause on every single update.
+      Assertions.assertSame(first, ((SwapMeter<?>) held).get(),
+          "the composite was rebuilt while all of its members were live");
+    } finally {
+      composite.removeAll();
+      second.close();
     }
   }
 


### PR DESCRIPTION
Follow-up to #1290. `SwapMeter` reads a removal flag instead of asking whether the meter expired, and answers for the meter it wraps so a nested wrapper passes the flag through. That covered a composite holding **one** registry, where the wrapper sits directly over the sub-registry's own wrapper — but not one holding **two or more**, where it sits over a `CompositeMeter`. A `CompositeMeter` was not a `RemovableMeter`, so the check fell back to `hasExpired()` and read the wall clock.

Measured with a counting clock over a two-registry composite: **3000 reads per 1000 increments, against 2000** once the flag is passed through. One extra read, not one per member — `hasExpired()` stops at the first member that has not expired.

### Semantics

`isRemoved()` mirrors `hasExpired()` in only reporting removed when every member does. A member removed on its own resolves through its own wrapper — every delegation path (`add`, `record`, `set`, and the readers) re-enters the member `SwapMeter` and calls `get()` — so there is nothing for the composite to rebuild until they all have.

How cheap the walk is depends on the members, and the PR should be honest about that: a member whose registry hands out wrappers over flag-carrying meters costs a field read, but one whose meter derives expiry from a clock still reads it, and since the loop stops at the first member that is not removed, which members are cheap depends on the order the registries were added. Atlas, stateless and servo carry the flag (#1288, #1293); `NoopRegistry`, `MicrometerRegistry` and `SidecarRegistry` do not.

`markRemoved()` records the mark even though nothing sets it today. A composite is built for the wrapper that hands it out and is never stored in a registry map — the `newCounter`/`newTimer`/... factories cannot produce one — but dropping the signal would leave the wrapper holding that composite for good, because the flag is preferred over `hasExpired()` and nothing else could change the answer. A volatile boolean makes the invariant self-enforcing instead of relying on an unenforced one.

`SwapMeter.isRemoved()` now compares the version before walking the members, matching `hasExpired()`: if the shape moved, the wrapper resolves regardless and the walk's answer is discarded.

### Also

`SwapMeter.hasExpired()` guards a null `underlying`, which `set()` documents as the meter being gone and which `get()` and `isRemoved()` already handled. It is unreachable in-tree — nothing calls `set()` — but it is public `impl` surface and the three methods should agree.

### Tests

`updatesThroughAMultiRegistryCompositeDoNotReadTheClockEither` asserts both the read count and that the composite was **not rebuilt**.

The second assertion matters: the read count alone does not pin this. Re-resolving costs no clock reads, because the lookup finds the existing meters — so hardcoding `isRemoved()` to `true` or `false` left the count at 2000 and the whole suite green. Verified by mutation. With the identity check, `return true` fails, which is the harmful direction: it would allocate a fresh `ArrayList` plus a `CompositeCounter` plus a wrapper per sub-registry on every increment.
