### PR TITLE
Align the two QueryIndex traversal workers

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/QueryIndex.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/QueryIndex.java
@@ -110,8 +110,10 @@ public final class QueryIndex<T> {
       }
     }
 
-    static <T> DedupConsumer<T> from(Consumer<T> consumer) {
-      return (consumer instanceof DedupConsumer<?>) ? (DedupConsumer<T>) consumer : new DedupConsumer<>(consumer);
+    static <V> DedupConsumer<V> from(Consumer<V> consumer) {
+      return (consumer instanceof DedupConsumer<?>)
+          ? (DedupConsumer<V>) consumer
+          : new DedupConsumer<>(consumer);
     }
   }
 
@@ -643,17 +645,16 @@ public final class QueryIndex<T> {
    *     Function to invoke for values associated with a query that matches the id.
    */
   public void forEachMatch(Id id, Consumer<T> consumer) {
-    forEachMatch(id, 0, DedupConsumer.from(consumer));
+    forEachMatchImpl(id, 0, DedupConsumer.from(consumer));
   }
 
-  private void forEachMatch(Id tags, int i, DedupConsumer<T> consumer) {
+  private void forEachMatchImpl(Id tags, int i, DedupConsumer<T> consumer) {
     // Matches for this level
     matches.forEach(consumer);
 
+    boolean keyPresent = false;
     final String keyRef = key;
     if (keyRef != null) {
-
-      boolean keyPresent = false;
 
       // keyRef is fixed for this node, so the "name" check only needs to be done once
       // here rather than on every comparison within the loop below.
@@ -671,7 +672,7 @@ public final class QueryIndex<T> {
           // Find exact matches
           QueryIndex<T> eqIdx = equalChecks.get(v);
           if (eqIdx != null) {
-            eqIdx.forEachMatch(tags, nextPos, consumer);
+            eqIdx.forEachMatchImpl(tags, nextPos, consumer);
           }
 
           // Scan for matches with other conditions
@@ -681,13 +682,15 @@ public final class QueryIndex<T> {
           // size/get avoids the allocation and has better throughput.
           final int n = otherMatches.size();
           for (int p = 0; p < n; ++p) {
-            otherMatches.get(p).forEachMatch(tags, nextPos, consumer);
+            otherMatches.get(p).forEachMatchImpl(tags, nextPos, consumer);
           }
 
-          // Check matches for has key
+          // Check matches for has key. The sub-tree is built from the queries after the ones
+          // for this key, so its own key sorts after keyRef and the tag at j can never match
+          // it. Start past it, as the other descents from this position do.
           final QueryIndex<T> hasKeyIdxRef = hasKeyIdx;
           if (hasKeyIdxRef != null) {
-            hasKeyIdxRef.forEachMatch(tags, j, consumer);
+            hasKeyIdxRef.forEachMatchImpl(tags, nextPos, consumer);
           }
         }
 
@@ -696,18 +699,18 @@ public final class QueryIndex<T> {
           break;
         }
       }
+    }
 
-      // Check matches with other keys
-      final QueryIndex<T> otherKeysIdxRef = otherKeysIdx;
-      if (otherKeysIdxRef != null) {
-        otherKeysIdxRef.forEachMatch(tags, i, consumer);
-      }
+    // Check matches with other keys
+    final QueryIndex<T> otherKeysIdxRef = otherKeysIdx;
+    if (otherKeysIdxRef != null) {
+      otherKeysIdxRef.forEachMatchImpl(tags, i, consumer);
+    }
 
-      // Check matches with missing keys
-      final QueryIndex<T> missingKeysIdxRef = missingKeysIdx;
-      if (missingKeysIdxRef != null && !keyPresent) {
-        missingKeysIdxRef.forEachMatch(tags, i, consumer);
-      }
+    // Check matches with missing keys
+    final QueryIndex<T> missingKeysIdxRef = missingKeysIdx;
+    if (missingKeysIdxRef != null && !keyPresent) {
+      missingKeysIdxRef.forEachMatchImpl(tags, i, consumer);
     }
   }
 

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/QueryIndexTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/QueryIndexTest.java
@@ -184,6 +184,47 @@ public class QueryIndexTest {
     }
   }
 
+  private static final Query HASKEY_MULTI_QUERY = Parser.parseQuery(
+      "name,a,:eq,b,:has,:and,c,cv,:eq,:and,e,ev,:eq,:and");
+
+  private QueryIndex<Query> hasKeyMultiIdx() {
+    return QueryIndex.newInstance(cacheSupplier).add(HASKEY_MULTI_QUERY, HASKEY_MULTI_QUERY);
+  }
+
+  @Test
+  public void hasKeyWithSeveralKeysAfterIt() {
+    // The has key sub-tree is entered from the position of the tag that matched the has key, so
+    // it has to keep working when more keys follow that need matching inside it.
+    Id match = id("a", "b", "anything", "c", "cv", "e", "ev");
+    assertEquals(list(HASKEY_MULTI_QUERY), hasKeyMultiIdx(), match);
+
+    // Same, with unrelated tags interleaved between the keys the sub-tree looks for.
+    Id spaced = id("a", "aa", "1", "b", "anything", "bb", "2", "c", "cv", "d", "3", "e", "ev");
+    assertEquals(list(HASKEY_MULTI_QUERY), hasKeyMultiIdx(), spaced);
+  }
+
+  @Test
+  public void hasKeyWithSeveralKeysAfterItMissingOne() {
+    // The has key is present, so the sub-tree is entered, but one of the keys inside it is not.
+    Id missingC = id("a", "b", "anything", "e", "ev");
+    assertEquals(Collections.emptyList(), hasKeyMultiIdx(), missingC);
+
+    Id missingE = id("a", "b", "anything", "c", "cv");
+    assertEquals(Collections.emptyList(), hasKeyMultiIdx(), missingE);
+  }
+
+  @Test
+  public void hasKeyIsTheLastTag() {
+    // Boundary for entering the sub-tree: the tag matching the has key is the last one, so there
+    // is nothing left for the sub-tree to scan and it must not report a match.
+    Id id = id("a", "b", "anything");
+    assertEquals(Collections.emptyList(), hasKeyMultiIdx(), id);
+
+    // With the single level query the has key being last is a match, since nothing follows it.
+    Id lastForSimpleQuery = id("a", "c", "12345", "key", "b");
+    assertEquals(list(HASKEY_QUERY), hasKeyIdx(), lastForSimpleQuery);
+  }
+
   private static final Query IN_QUERY = Parser.parseQuery("name,a,:eq,key,(,b,c,),:in,:and");
 
   private QueryIndex<Query> inIdx() {


### PR DESCRIPTION
Three changes to the Id-based traversal in `QueryIndex`, none of which alter what it returns. They remove waste and two divergences from the equivalent Function-based method sitting next to it. Follow-up to #1291.

### The private worker is renamed to `forEachMatchImpl`

It was an arity overload of the public `forEachMatch(Id, Consumer<T>)` — the shape that caused the repeated wrapping #1291 fixed. Dropping the position argument from a recursive call bound to the public method and silently re-wrapped the consumer:

```java
eqIdx.forEachMatch(tags, consumer);   // compiled fine, re-wrapped at every node
```

`DedupConsumer<T>` IS-A `Consumer<T>`, so nothing caught it. After the rename that call does not compile: the only 2-arg `forEachMatchImpl` takes a `Function`. `DedupConsumer.from` becomes a guard rather than the mechanism.

### The has-key descent started one position early

It passed `j`, the position of the tag that matched this node's key, where the exact-match and other-condition descents from the same point pass `j + 1`. That sub-tree is built by `hasKeyIdx.add(queries, j, value)` from the queries *after* the ones for this key, so its own key sorts strictly after `keyRef` and the tag at `j` can never match it — the scan spent one iteration and one `compareTagKey` on it before moving on.

Safe at the boundary too: if the `:has` query is the last one, the sub-tree gets `key == null` and returns after `matches.forEach`, so the start position is irrelevant there.

### The two methods now check the same sub-trees in the same place

`otherKeysIdx`/`missingKeysIdx` were inside the `key != null` guard here and outside it in the Function method, and `keyPresent` was scoped differently to match. The two agree today only because `add()` assigns `key` before it can create either sub-tree, so a node with no key has neither — but nothing recorded that, and the two methods read as though one of them was wrong. This takes the shape that does not depend on the invariant.

### Also

`DedupConsumer.from`'s type parameter was `T`, shadowing the enclosing `DedupConsumer<T>`, so `(DedupConsumer<T>) consumer` read as if it referenced the class parameter. Renamed to `V`, which is what the other static methods on this class use.

### Tests

Three cases for the has-key descent: several keys following the `:has`, one of those keys absent, and the matching tag last so the sub-tree has nothing left to scan.

They pass before the change as well — the behaviour is unchanged, so they are guards rather than bug demonstrations. What makes them worth having is that they constrain the position: an off-by-one in that descent fails **six** tests in the class.

Worth noting the existing `assertEquals` helper already runs every expectation through both `findMatches(Id)` and `findMatches(Function)`, so it cross-checks the two workers against each other automatically — which is what the divergence above needed.
