### PR TITLE
Only dedup query index matches when it can help

### DIFF
--- a/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/QueryIndex.java
+++ b/spectator-reg-atlas/src/main/java/com/netflix/spectator/atlas/impl/QueryIndex.java
@@ -28,6 +28,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
@@ -97,24 +98,35 @@ public final class QueryIndex<T> {
   private static final class DedupConsumer<T> implements Consumer<T> {
 
     private final Consumer<T> consumer;
-    private final Set<T> alreadySeen;
+
+    // Most lookups deliver nothing or one value, so the set is deferred until a second distinct
+    // value shows up and there is actually something to compare against. A boolean rather than a
+    // null check on first, so that a null value cannot be mistaken for an empty state.
+    private boolean hasFirst;
+    private T first;
+    private Set<T> alreadySeen;
 
     DedupConsumer(Consumer<T> consumer) {
       this.consumer = consumer;
-      this.alreadySeen = new HashSet<>();
     }
 
     @Override public void accept(T t) {
-      if (alreadySeen.add(t)) {
+      if (alreadySeen != null) {
+        if (alreadySeen.add(t)) {
+          consumer.accept(t);
+        }
+      } else if (!hasFirst) {
+        hasFirst = true;
+        first = t;
+        consumer.accept(t);
+      } else if (!Objects.equals(first, t)) {
+        alreadySeen = new HashSet<>();
+        alreadySeen.add(first);
+        alreadySeen.add(t);
         consumer.accept(t);
       }
     }
 
-    static <V> DedupConsumer<V> from(Consumer<V> consumer) {
-      return (consumer instanceof DedupConsumer<?>)
-          ? (DedupConsumer<V>) consumer
-          : new DedupConsumer<>(consumer);
-    }
   }
 
   /**
@@ -183,6 +195,11 @@ public final class QueryIndex<T> {
   }
 
   private final CacheSupplier<T> cacheSupplier;
+
+  // Set when some value has been registered under more than one term, which is the only way a
+  // traversal can reach the same value twice. Checked once per lookup on the instance the
+  // queries were added to, so the dedup wrapper is only paid for when it can do something.
+  private volatile boolean dedupRequired;
 
   private volatile String key;
 
@@ -398,6 +415,11 @@ public final class QueryIndex<T> {
   /**
    * Add a value that should match for the specified query.
    *
+   * <p>Repeated deliveries of the same value from one lookup are suppressed when a single call
+   * registers it under more than one term, which is what an {@code :or} expands to. Adding the
+   * same value, or two values that are {@code equals}, under separate calls is outside that: a
+   * lookup matching both can then deliver it once for each.</p>
+   *
    * @param query
    *     Query that corresponds to the value.
    * @param value
@@ -406,12 +428,29 @@ public final class QueryIndex<T> {
    *     This index so it can be used in a fluent manner.
    */
   public QueryIndex<T> add(Query query, T value) {
-    for (Query q : query.dnfList()) {
+    final List<Query> dnf = query.dnfList();
+
+    // A value reachable from a single term can only be found once by a traversal, so nothing
+    // needs deduping. Registering it under more than one, which is what an :or expands to, is
+    // the only way a traversal can reach the same value twice.
+    //
+    // Set before the value is registered anywhere, not after: lookups run concurrently with
+    // updates, so a flag written afterwards leaves a window where a lookup can find the value
+    // under two terms and still see the old value of the flag, and deliver it twice. Counting
+    // the terms in the list rather than the ones that end up registered over-approximates -
+    // FALSE and unsatisfiable terms are skipped below - which only costs a dedup that would not
+    // have been needed.
+    //
+    // Sticky: a remove() can only ever make deduping unnecessary, never necessary, and
+    // recomputing it would mean walking the index.
+    if (dnf.size() > 1) {
+      dedupRequired = true;
+    }
+
+    for (Query q : dnf) {
       if (q == Query.TRUE) {
         matches.add(value);
-      } else if (q == Query.FALSE) {
-        continue;
-      } else {
+      } else if (q != Query.FALSE) {
         List<Query.KeyQuery> queries = sort(q);
         if (queries != null) {
           add(queries, 0, value);
@@ -645,10 +684,20 @@ public final class QueryIndex<T> {
    *     Function to invoke for values associated with a query that matches the id.
    */
   public void forEachMatch(Id id, Consumer<T> consumer) {
-    forEachMatchImpl(id, 0, DedupConsumer.from(consumer));
+    forEachMatchImpl(id, 0, dedup(consumer));
   }
 
-  private void forEachMatchImpl(Id tags, int i, DedupConsumer<T> consumer) {
+  /**
+   * Wrap the consumer so repeated deliveries of the same value are suppressed, if this index
+   * can produce them at all. Call on the instance the queries were added to: the flag is set by
+   * {@link #add(Query, Object)}, so a sub-index reached from a cache or from the traversal has
+   * not had it set and would skip the deduping.
+   */
+  private Consumer<T> dedup(Consumer<T> consumer) {
+    return dedupRequired ? new DedupConsumer<>(consumer) : consumer;
+  }
+
+  private void forEachMatchImpl(Id tags, int i, Consumer<T> consumer) {
     // Matches for this level
     matches.forEach(consumer);
 
@@ -741,10 +790,10 @@ public final class QueryIndex<T> {
    *     Function to invoke for values associated with a query that matches the id.
    */
   public void forEachMatch(Function<String, String> tags, Consumer<T> consumer) {
-    forEachMatchImpl(tags, DedupConsumer.from(consumer));
+    forEachMatchImpl(tags, dedup(consumer));
   }
 
-  private void forEachMatchImpl(Function<String, String> tags, DedupConsumer<T> consumer) {
+  private void forEachMatchImpl(Function<String, String> tags, Consumer<T> consumer) {
     // Matches for this level
     matches.forEach(consumer);
 

--- a/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/QueryIndexTest.java
+++ b/spectator-reg-atlas/src/test/java/com/netflix/spectator/atlas/impl/QueryIndexTest.java
@@ -365,6 +365,76 @@ public class QueryIndexTest {
   }
 
   @Test
+  public void orMultiMatchDeliversOnce() {
+    // Both branches match, and they land in different sub-trees, so the traversal reaches the
+    // value twice. The dedup has to collapse that to one delivery.
+    Query q = Parser.parseQuery("name,a,:eq,b,1,:eq,:and,name,a,:eq,c,2,:eq,:and,:or");
+    QueryIndex<Query> idx = QueryIndex.newInstance(cacheSupplier);
+    idx.add(q, q);
+
+    // assertEquals runs both traversals, so a second delivery shows up as a longer list.
+    assertEquals(list(q), idx, id("a", "b", "1", "c", "2"));
+
+    // One branch only, so nothing to collapse.
+    assertEquals(list(q), idx, id("a", "b", "1"));
+    assertEquals(list(q), idx, id("a", "c", "2"));
+  }
+
+  @Test
+  public void andOnlyQueriesStillMatch() {
+    // No value is registered under more than one term here. Results have to be the same whether
+    // the dedup runs or not; that it is skipped is a matter of allocation, which this cannot
+    // see and QueryIndexMatch measures.
+    Query q1 = Parser.parseQuery("name,a,:eq,b,1,:eq,:and");
+    Query q2 = Parser.parseQuery("name,a,:eq,c,2,:eq,:and");
+    QueryIndex<Query> idx = QueryIndex.newInstance(cacheSupplier);
+    idx.add(q1, q1).add(q2, q2);
+
+    assertEquals(list(q1), idx, id("a", "b", "1"));
+    assertEquals(list(q2), idx, id("a", "c", "2"));
+    assertEquals(list(q1, q2), idx, id("a", "b", "1", "c", "2"));
+    assertEquals(Collections.emptyList(), idx, id("a"));
+  }
+
+  @Test
+  public void dedupHandlesASecondValueAfterTheFirst() {
+    // The dedup keeps the first value in a field and only builds a set once a second distinct
+    // value arrives, carrying the first one into it. That carry only matters when the first
+    // value is delivered again after the set exists. Sharing a leaf with the first :or branch
+    // gets that order: the shared node delivers the :or value then the other one, and the
+    // second :or branch delivers the :or value again afterwards.
+    Query or = Parser.parseQuery("name,a,:eq,b,1,:eq,:and,name,a,:eq,d,3,:eq,:and,:or");
+    Query other = Parser.parseQuery("name,a,:eq,b,1,:eq,:and");
+    QueryIndex<Query> idx = QueryIndex.newInstance(cacheSupplier);
+    idx.add(or, or).add(other, other);
+
+    Id all = id("a", "b", "1", "c", "2", "d", "3");
+    assertEquals(list(or, other), idx, all);
+
+    // Same with the other value registered first.
+    QueryIndex<Query> reversed = QueryIndex.newInstance(cacheSupplier);
+    reversed.add(other, other).add(or, or);
+    assertEquals(list(or, other), reversed, all);
+  }
+
+  @Test
+  public void orAddedAfterAndQueriesStillDedups() {
+    // The index starts out not needing dedup, so a query added later has to be able to turn it
+    // on for the whole index.
+    Query and = Parser.parseQuery("name,a,:eq,b,1,:eq,:and");
+    QueryIndex<Query> idx = QueryIndex.newInstance(cacheSupplier);
+    idx.add(and, and);
+    assertEquals(list(and), idx, id("a", "b", "1"));
+
+    Query or = Parser.parseQuery("name,z,:eq,b,1,:eq,:and,name,z,:eq,c,2,:eq,:and,:or");
+    idx.add(or, or);
+
+    List<Query> delivered = new ArrayList<>();
+    idx.forEachMatch(id("z", "b", "1", "c", "2"), delivered::add);
+    Assertions.assertEquals(list(or), delivered, "value was delivered more than once");
+  }
+
+  @Test
   public void manyQueries() {
     // CpuUsage for all instances
     Query cpuUsage = Parser.parseQuery("name,cpuUsage,:eq");


### PR DESCRIPTION
`DedupConsumer` exists for `:or` clauses, where the same value is registered under more than one DNF term and a traversal can reach it twice. Every lookup paid for it: a `DedupConsumer` plus a `HashSet`, and on the first delivery a 16-slot table and a node.

For an index built only from `:and` queries none of that can ever suppress anything. Instrumenting the `QueryIndexMatch` workload — 5,000 subscriptions matched against 200 ids — counted **932 deliveries and 0 suppressions**.

### Two changes

**Only wrap when it can help.** `add()` records whether a value was registered under more than one term; a value reachable from a single term can be found once, so there is nothing to dedup.

The flag is set *before* the value is registered rather than after. Lookups run concurrently with updates — `Evaluator.sync()` adds on the config thread while `update()` runs on recording threads — so setting it afterwards leaves a window where a lookup finds the value under two terms and still reads the old flag, delivering it twice and double-counting that datapoint. It counts the terms in the dnf list rather than the ones that end up registered, which over-approximates and only ever costs a dedup that was not needed.

Sticky: a `remove()` can only make deduping unnecessary, never necessary, and recomputing would mean walking the index.

**Defer the set.** That still leaves the wrapper allocated for an index with any `:or` in it, so `DedupConsumer` now keeps the first value in a field and only builds the set when a second distinct value arrives. Most lookups deliver nothing or one value. A `hasFirst` boolean rather than a null sentinel, so a null value cannot be mistaken for an empty state.

### Numbers

`QueryIndexMatch` with the gc profiler, against 08ac1af1:

| | time | alloc |
| --- | --- | --- |
| **no `:or` in the index** | 126.1 → **116.2** µs/op | 49,953 → **3,201** B/op (−93.6%) |
| **one `:or` among 5,000** | 126.1 → **121.5** µs/op | 49,953 → **39,441** B/op (−21%) |

The residual 3,201 B/op over 200 lookups is 16 B each — the benchmark's own `bh::consume` lambda — so the index itself allocates nothing per lookup in the first case.

The second row is the honest limit: the flag is index-wide, so a single `:or` subscription turns it off for everything and only the deferred set helps there. That is why both changes are here rather than just the flag.

### Also

The private workers now take `Consumer<T>` rather than `DedupConsumer<T>`, since the decision is made once at the public entry, and `DedupConsumer.from` goes with it — the type it guarded against no longer reaches them. The `forEachMatchImpl` naming from #1295 is what keeps a recursive call from reaching the public method and re-wrapping.

`add()`'s javadoc now records that the guarantee is per call: adding the same value, or two `equals` values, under separate single-term calls can deliver it once for each. No in-repo caller does this, but nothing enforced it either.

### Tests

Four cases, and each branch of the change has one that fails when it breaks — hard-wiring the flag off fails 4, always promoting to the set fails 3, and never suppressing fails 1.

`dedupHandlesASecondValueAfterTheFirst` is the one worth explaining. The carry of the first value into the set only matters when that value is delivered *again* after the set exists, which needs the delivery order `X, Y, X`. My first two attempts at it produced `X, X, Y` and passed with the carry deleted; the construction that works has the second query share a leaf with the `:or`'s first branch.

### Known limit, not addressed

`terms > 1` counts registrations, not co-reachable leaves. Terms pinning different `:eq` values for the same key — `name,a,:eq,name,b,:eq,:or`, the shape of the existing `queryNormalization` test — can never co-match, yet turn the flag on for the whole index. Refining that means comparing `Query.exactTags()` across terms to rule out co-matching; it would widen where the win applies but is a separate change.
